### PR TITLE
python 3 fix for cifar test sets.

### DIFF
--- a/torchvision/datasets/cifar.py
+++ b/torchvision/datasets/cifar.py
@@ -66,7 +66,10 @@ class CIFAR10(data.Dataset):
             f = self.test_list[0][0]
             file = os.path.join(root, self.base_folder, f)
             fo = open(file, 'rb')
-            entry = pickle.load(fo)
+            if sys.version_info[0] == 2:
+                entry = pickle.load(fo)
+            else:
+                entry = pickle.load(fo, encoding='latin1')
             self.test_data = entry['data']
             if 'labels' in entry:
                 self.test_labels = entry['labels']


### PR DESCRIPTION
An encoding argument needs to be passed to python 3 pickle. (The training set was fixed before, but the test set seems to have been missed.) Confirmed works properly for both CIFAR10 and CIFAR100.