### PR TITLE
Add support for images with other than 3 channels

### DIFF
--- a/torchvision/transforms.py
+++ b/torchvision/transforms.py
@@ -34,7 +34,7 @@ class ToTensor(object):
         else:
             # handle PIL Image
             img = torch.ByteTensor(torch.ByteStorage.from_buffer(pic.tobytes()))
-            img = img.view(pic.size[1], pic.size[0], 3)
+            img = img.view(pic.size[1], pic.size[0], len(pic.mode))
             # put it from HWC to CHW format
             # yikes, this transpose takes 80% of the loading time/CPU
             img = img.transpose(0, 1).transpose(0, 2).contiguous()


### PR DESCRIPTION
Also, we might want to avoid the division by 255 depending on the mode of the image.
For example, if the image is in 'P' mode (having a color palette, as is semantic segmentation ground truths) we want to keep the original integer values (corresponding to labels).