### PR TITLE
Fixed save_image to correctly output values in the full byte range.

### DIFF
--- a/torchvision/utils.py
+++ b/torchvision/utils.py
@@ -49,6 +49,6 @@ def save_image(tensor, filename, nrow=8, padding=2):
     from PIL import Image
     tensor = tensor.cpu()
     grid = make_grid(tensor, nrow=nrow, padding=padding)
-    ndarr = grid.mul(0.5).add(0.5).mul(255).byte().transpose(0,2).transpose(0,1).numpy()
+    ndarr = grid.mul(255).byte().transpose(0,2).transpose(0,1).numpy()
     im = Image.fromarray(ndarr)
     im.save(filename)


### PR DESCRIPTION
After changing this I saw the issue #24 which mentions this and mentions adding a range option. For now I've just removed the .mul(0.5).add(0.5) as without it, the follow code does not properly save the image.
```
import torch
import torchvision
from PIL import Image
I  = Image.open( './lena.jpg' )
I2 = torchvision.transforms.ToTensor()( I )
torchvision.utils.save_image( I2, 'test.jpg' )
```