### PR TITLE
Add ImageFolderWithoutTargets

### DIFF
--- a/torchvision/datasets/folder.py
+++ b/torchvision/datasets/folder.py
@@ -1,22 +1,33 @@
-import torch.utils.data as data
-
-from PIL import Image
 import os
 import os.path
 
+import torch.utils.data as data
+from PIL import Image
+
 IMG_EXTENSIONS = [
-    '.jpg', '.JPG', '.jpeg', '.JPEG',
-    '.png', '.PNG', '.ppm', '.PPM', '.bmp', '.BMP',
+    '.jpg',
+    '.JPG',
+    '.jpeg',
+    '.JPEG',
+    '.png',
+    '.PNG',
+    '.ppm',
+    '.PPM',
+    '.bmp',
+    '.BMP',
 ]
+
 
 def is_image_file(filename):
     return any(filename.endswith(extension) for extension in IMG_EXTENSIONS)
+
 
 def find_classes(dir):
     classes = os.listdir(dir)
     classes.sort()
     class_to_idx = {classes[i]: i for i in range(len(classes))}
     return classes, class_to_idx
+
 
 def make_dataset(dir, class_to_idx):
     images = []
@@ -39,7 +50,10 @@ def default_loader(path):
 
 
 class ImageFolder(data.Dataset):
-    def __init__(self, root, transform=None, target_transform=None,
+    def __init__(self,
+                 root,
+                 transform=None,
+                 target_transform=None,
                  loader=default_loader):
         classes, class_to_idx = find_classes(root)
         imgs = make_dataset(root, class_to_idx)
@@ -61,6 +75,31 @@ class ImageFolder(data.Dataset):
             target = self.target_transform(target)
 
         return img, target
+
+    def __len__(self):
+        return len(self.imgs)
+
+
+class ImageFolderWithoutTargets(data.Dataset):
+    """ ImageFolderWithoutTargets can be used to load images where there are no labels."""
+
+    def __init__(self, root, transform=None, loader=default_loader):
+        images = []
+        for filename in os.listdir(root):
+            if is_image_file(filename):
+                images.append('{}'.format(filename))
+
+        self.root = root
+        self.imgs = images
+        self.transform = transform
+        self.loader = loader
+
+    def __getitem__(self, index):
+        filename = self.imgs[index]
+        img = self.loader(os.path.join(self.root, filename))
+        if self.transform is not None:
+            img = self.transform(img)
+        return img, filename
 
     def __len__(self):
         return len(self.imgs)


### PR DESCRIPTION
Useful data loading class for [instances](https://github.com/desimone/pytorch-cat-vs-dogs/blob/master/main.py#L251-L282) where you want to want to load data from disk, but don't have labels, or the labels aren't in the form of `{root}/{class}/{image}`. Don't love the class name. 