### PR TITLE
Add missing lmdb package and pin the version numbers of other third party dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-numpy
-pillow
-six
-torch
+pillow==4.0.0
+numpy==1.12.0
+six==1.10.0
+torch==0.1
+lmdb==0.92


### PR DESCRIPTION
Currently `lmdb` is being imported in `lsun` datasets, but this is not part of third party dependency in the requirements file. 
https://github.com/pytorch/vision/blob/master/torchvision/datasets/lsun.py#L15

Also, it is a good practice to pin the version numbers of third party dependencies to protect backwards incompatibility that third party packages can introduce.
