### PR TITLE
Use integer division in tests/test_transforms for array slice indices + various PEP-8 fixes

### DIFF
--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -1,21 +1,20 @@
 import torch
 import torchvision.transforms as transforms
-import torchvision.datasets as datasets
-import numpy as np
 import unittest
 import random
+
 
 class Tester(unittest.TestCase):
     def test_crop(self):
         height = random.randint(10, 32) * 2
         width = random.randint(10, 32) * 2
         oheight = random.randint(5, (height - 2) / 2) * 2
-        owidth =  random.randint(5, (width - 2) / 2) * 2
-        
+        owidth = random.randint(5, (width - 2) / 2) * 2
+
         img = torch.ones(3, height, width)
-        oh1 = (height - oheight) / 2
-        ow1 = (width - owidth) / 2
-        imgnarrow = img[:, oh1 :oh1 + oheight, ow1 :ow1 + owidth]
+        oh1 = (height - oheight) // 2
+        ow1 = (width - owidth) // 2
+        imgnarrow = img[:, oh1:oh1 + oheight, ow1:ow1 + owidth]
         imgnarrow.fill_(0)
         result = transforms.Compose([
             transforms.ToPILImage(),
@@ -23,7 +22,7 @@ class Tester(unittest.TestCase):
             transforms.ToTensor(),
         ])(img)
         assert result.sum() == 0, "height: " + str(height) + " width: " \
-            + str( width) + " oheight: " + str(oheight) + " owidth: " + str(owidth)
+                                  + str(width) + " oheight: " + str(oheight) + " owidth: " + str(owidth)
         oheight += 1
         owidth += 1
         result = transforms.Compose([
@@ -33,9 +32,9 @@ class Tester(unittest.TestCase):
         ])(img)
         sum1 = result.sum()
         assert sum1 > 1, "height: " + str(height) + " width: " \
-            + str( width) + " oheight: " + str(oheight) + " owidth: " + str(owidth)
+                         + str(width) + " oheight: " + str(oheight) + " owidth: " + str(owidth)
         oheight += 1
-        owidth += 1        
+        owidth += 1
         result = transforms.Compose([
             transforms.ToPILImage(),
             transforms.CenterCrop((oheight, owidth)),
@@ -43,15 +42,15 @@ class Tester(unittest.TestCase):
         ])(img)
         sum2 = result.sum()
         assert sum2 > 0, "height: " + str(height) + " width: " \
-            + str( width) + " oheight: " + str(oheight) + " owidth: " + str(owidth)
+                         + str(width) + " oheight: " + str(oheight) + " owidth: " + str(owidth)
         assert sum2 > sum1, "height: " + str(height) + " width: " \
-            + str( width) + " oheight: " + str(oheight) + " owidth: " + str(owidth)
+                            + str(width) + " oheight: " + str(oheight) + " owidth: " + str(owidth)
 
     def test_scale(self):
         height = random.randint(24, 32) * 2
         width = random.randint(24, 32) * 2
         osize = random.randint(5, 12) * 2
-        
+
         img = torch.ones(3, height, width)
         result = transforms.Compose([
             transforms.ToPILImage(),
@@ -63,7 +62,7 @@ class Tester(unittest.TestCase):
         # print result.size()
         assert osize in result.size()
         if height < width:
-            assert result.size(1) <= result.size(2) 
+            assert result.size(1) <= result.size(2)
         elif width < height:
             assert result.size(1) >= result.size(2)
 
@@ -71,7 +70,7 @@ class Tester(unittest.TestCase):
         height = random.randint(10, 32) * 2
         width = random.randint(10, 32) * 2
         oheight = random.randint(5, (height - 2) / 2) * 2
-        owidth =  random.randint(5, (width - 2) / 2) * 2
+        owidth = random.randint(5, (width - 2) / 2) * 2
         img = torch.ones(3, height, width)
         result = transforms.Compose([
             transforms.ToPILImage(),
@@ -100,20 +99,20 @@ class Tester(unittest.TestCase):
             transforms.Pad(padding),
             transforms.ToTensor(),
         ])(img)
-        assert result.size(1) == height + 2*padding
-        assert result.size(2) == width + 2*padding
+        assert result.size(1) == height + 2 * padding
+        assert result.size(2) == width + 2 * padding
 
     def test_lambda(self):
         trans = transforms.Lambda(lambda x: x.add(10))
         x = torch.randn(10)
         y = trans(x)
-        assert(y.equal(torch.add(x, 10)))
+        assert (y.equal(torch.add(x, 10)))
 
         trans = transforms.Lambda(lambda x: x.add_(10))
         x = torch.randn(10)
         y = trans(x)
-        assert(y.equal(x))
-        
+        assert (y.equal(x))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
`test_transforms` was failing due to non-integer division in the `test_crop` function for variables used as slice indices into the image.

Also added various PEP-8 fixes (spaced, removing unused imports etc.)