### PR TITLE
Add single channel image support to ToPILImage + tests

### DIFF
--- a/torchvision/transforms.py
+++ b/torchvision/transforms.py
@@ -52,14 +52,18 @@ class ToPILImage(object):
     to a PIL.Image of range [0, 255]
     """
     def __call__(self, pic):
-        if isinstance(pic, np.ndarray):
-            # handle numpy array
-            img = Image.fromarray(pic)
-        else:
+        npimg = pic
+        mode = None
+        if not isinstance(npimg, np.ndarray):
             npimg = pic.mul(255).byte().numpy()
             npimg = np.transpose(npimg, (1,2,0))
-            img = Image.fromarray(npimg)
-        return img
+
+        if npimg.shape[2] == 1:
+            npimg = npimg[:, :, 0]
+            mode = "L"
+
+        return Image.fromarray(npimg, mode=mode)
+
 
 class Normalize(object):
     """Given mean: (R, G, B) and std: (R, G, B),


### PR DESCRIPTION
Currently you cannot use `ToPILImage` on single channel image inputs in the form of `tensors` or `np.ndarrays`, for example:

```python
from torchvision.transforms import ToPILImage
img_data = torch.Tensor(4, 4, 1).uniform_()
ToPILImage()(img_data)
Out[1]: <PIL.Image.Image image mode=RGBA size=1x4 at 0x7FC2CC25DBE0>
```

returns an `RGBA` image of size `1x4` instead of a greyscale image of size `4x4`.

Similarly for `np.ndarray` inputs, it results in an error e.g.:
```
img_data = torch.ByteTensor(1, 4, 4).random_(0, 255)
ToPILImage()(img_data)
>>> TypeError: Cannot handle this data type
```

This PR addresses both of these issues and allows for single channel inputs to be converted. I've also added tests for the `ToPILImage` transform (as they didn't exist)
