### PR TITLE
allow Pad to take non-number color formats

### DIFF
--- a/torchvision/transforms.py
+++ b/torchvision/transforms.py
@@ -135,7 +135,7 @@ class Pad(object):
     """Pads the given PIL.Image on all sides with the given "pad" value"""
     def __init__(self, padding, fill=0):
         assert isinstance(padding, numbers.Number)
-        assert isinstance(fill, numbers.Number)
+        assert isinstance(fill, numbers.Number) or isinstance(fill, str) or isinstance(fill, tuple)
         self.padding = padding
         self.fill = fill
 


### PR DESCRIPTION
Previous assertion only allows numbers for `fill`, which rules out the possibility to pad multi-channel colors. For example, now fill=(255,255,255) or fill="white" can be used to achieve white padding for rgb inputs.