### PR TITLE
DS_Store fix in find_classes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: python
+python: 2.7
+
+install: pip install flake8
+script: flake8

--- a/torchvision/datasets/folder.py
+++ b/torchvision/datasets/folder.py
@@ -15,7 +15,7 @@ def is_image_file(filename):
 
 
 def find_classes(dir):
-    classes = os.listdir(dir)
+    classes = [d for d in os.listdir(dir) if os.path.isdir(os.path.join(dir,d))]
     classes.sort()
     class_to_idx = {classes[i]: i for i in range(len(classes))}
     return classes, class_to_idx

--- a/torchvision/datasets/folder.py
+++ b/torchvision/datasets/folder.py
@@ -15,7 +15,7 @@ def is_image_file(filename):
 
 
 def find_classes(dir):
-    classes = [d for d in os.listdir(dir) if os.path.isdir(os.path.join(dir,d))]
+    classes = [d for d in os.listdir(dir) if os.path.isdir(os.path.join(dir, d))]
     classes.sort()
     class_to_idx = {classes[i]: i for i in range(len(classes))}
     return classes, class_to_idx


### PR DESCRIPTION
small "bug" or annoyance in the `find_classes` function - it picks up '.DS_Store' as a class. simple fix to check if class is actually a directory .. you can see this is done in the keras sampling code https://github.com/fchollet/keras/blob/master/keras/preprocessing/image.py#L778


Example Usage (pretend you have mnist images saved in a main directory w/ sub-directories for each class:
```python
from torchvision.datasets import ImageFolder
folder = ImageFolder(root='/users/ncullen/desktop/data/mnist/train')
print(folder.classes) # previously: ['.DS_Store', '0', '1', ...]
```
