### PR TITLE
recursive dir walking in ImageFolder

### DIFF
--- a/torchvision/datasets/folder.py
+++ b/torchvision/datasets/folder.py
@@ -28,11 +28,12 @@ def make_dataset(dir, class_to_idx):
         if not os.path.isdir(d):
             continue
 
-        for filename in os.listdir(d):
-            if is_image_file(filename):
-                path = '{0}/{1}'.format(target, filename)
-                item = (path, class_to_idx[target])
-                images.append(item)
+        for root, _, fnames in sorted(os.walk(d)):
+            for fname in fnames:
+                if is_image_file(fname):
+                    path = os.path.join(root, fname)
+                    item = (path, class_to_idx[target])
+                    images.append(item)
 
     return images
 


### PR DESCRIPTION
Sorry for the unsolicited PR, but this adds support to pick up images in sub-sub-..-directories. It shouldn't alter the normal functionality. Feel free to deny or save for future consideration. 

PS: what's the status on writing unit tests for the ImageFolder class ? 

e.g.

```
main_dir/
     class1/
         img1.png
         img2.png
         class1_subdir/
             img3.png
     ...
```