### PR TITLE
Minor compatibility fix for Python 3 (dict_keys in coco detections)

### DIFF
--- a/torchvision/datasets/coco.py
+++ b/torchvision/datasets/coco.py
@@ -42,7 +42,7 @@ class CocoDetection(data.Dataset):
         from pycocotools.coco import COCO
         self.root = root
         self.coco = COCO(annFile)
-        self.ids = self.coco.imgs.keys()
+        self.ids = list(self.coco.imgs.keys())
         self.transform = transform
         self.target_transform = target_transform
 


### PR DESCRIPTION
This branch makes the CocoDetection class compatible with Python 3, similar to a recent change for the CocoCaptions class: https://github.com/pytorch/vision/pull/66

Without this fix, [self.ids](https://github.com/pytorch/vision/blob/master/torchvision/datasets/coco.py#L45) is a `dict_keys` object in Python 3, which can't be indexed, leading to the following error:

```python
transform=transforms.Compose([transforms.ToTensor(),
                              transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5)),
                              ])

trainset = dset.CocoDetection(root="../coco/train2014/", 
                              annFile="../coco/annotations/instances_train2014.json", 
                              transform=transform)

img, target = trainset[3] # load 4th sample
```

```python
TypeError: 'dict_keys' object does not support indexing
```