### PR TITLE
Replacing scipy.misc.lena() with scipy.misc.face()

### DIFF
--- a/test/sanity_checks.ipynb
+++ b/test/sanity_checks.ipynb
@@ -69,7 +69,7 @@
     }
    ],
    "source": [
-    "lena = scipy.misc.lena()\n",
+    "lena = scipy.misc.face()\n",
     "plt.gray()\n",
     "plt.imshow(lena, interpolation='nearest')\n",
     "lena = lena[:100, 300:]\n",


### PR DESCRIPTION
lena() is no longer included in SciPy, replacing it with face()
https://docs.scipy.org/doc/scipy-0.18.1/reference/generated/scipy.misc.lena.html