### PR TITLE
Running sanity checks on cropped parts of scipy.misc.ascent

### DIFF
--- a/test/sanity_checks.ipynb
+++ b/test/sanity_checks.ipynb
@@ -69,14 +69,14 @@
     }
    ],
    "source": [
-    "lena = scipy.misc.face()\n",
+    "lena = scipy.misc.ascent()\n",
     "plt.gray()\n",
     "plt.imshow(lena, interpolation='nearest')\n",
-    "lena = lena[:100, 300:]\n",
-    "plt.imshow(lena, interpolation='nearest')\n",
-    "print(lena.shape)\n",
-    "print(lena[90,90])\n",
-    "print(lena.dtype)"
+    "cropped_lena = lena[:100, 300:]\n",
+    "plt.imshow(cropped_lena, interpolation='nearest')\n",
+    "print(cropped_lena.shape)\n",
+    "print(cropped_lena[90,90])\n",
+    "print(cropped_lena.dtype)"
    ]
   },
   {
@@ -118,7 +118,7 @@
     }
    ],
    "source": [
-    "img = torch.from_numpy(lena.astype(float))\n",
+    "img = torch.from_numpy(cropped_lena.astype(float))\n",
     "print(img.size())\n",
     "print(img[90,90])\n",
     "img = img.clone().view(1,100,212)\n",


### PR DESCRIPTION
Doing this to ensure that the image is of the size 100 x 212 which is being followed throughout the sanity checks