### PR TITLE
Add densenet models

### DIFF
--- a/torchvision/models/__init__.py
+++ b/torchvision/models/__init__.py
@@ -5,6 +5,7 @@ architectures:
 -  `VGG`_
 -  `ResNet`_
 -  `SqueezeNet`_
+-  `DenseNet`_
 
 You can construct a model with random weights by calling its constructor:
 
@@ -14,6 +15,7 @@ You can construct a model with random weights by calling its constructor:
     resnet18 = models.resnet18()
     alexnet = models.alexnet()
     squeezenet = models.squeezenet1_0()
+    densenet = models.densenet_161()
 
 We provide pre-trained models for the ResNet variants and AlexNet, using the
 PyTorch :mod:`torch.utils.model_zoo`. These can  constructed by passing
@@ -43,6 +45,10 @@ VGG-16                   28.41           9.62
 VGG-19                   27.62           9.12
 SqueezeNet 1.0           41.90           19.58
 SqueezeNet 1.1           41.81           19.38
+Densenet-121             25.35           7.83
+Densenet-169             24.00           7.00
+Densenet-201             22.80           6.43
+Densenet-161             22.35           6.20
 ======================== =============   =============
 
 
@@ -50,6 +56,7 @@ SqueezeNet 1.1           41.81           19.38
 .. _VGG: https://arxiv.org/abs/1409.1556
 .. _ResNet: https://arxiv.org/abs/1512.03385
 .. _SqueezeNet: https://arxiv.org/abs/1602.07360
+.. _DenseNet: https://arxiv.org/abs/1608.06993
 """
 
 from .alexnet import *
@@ -57,3 +64,4 @@ from .resnet import *
 from .vgg import *
 from .squeezenet import *
 from .inception import *
+from .densenet import *

--- a/torchvision/models/densenet.py
+++ b/torchvision/models/densenet.py
@@ -1,9 +1,18 @@
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+import torch.utils.model_zoo as model_zoo
 from collections import OrderedDict
 
 __all__ = ['DenseNet', 'densenet121', 'densenet169', 'densenet201', 'densenet161']
+
+
+model_urls = {
+    'densenet121': 'https://download.pytorch.org/models/densenet121-241335ed.pth',
+    'densenet169': 'https://download.pytorch.org/models/densenet169-6f0f7f60.pth',
+    'densenet201': 'https://download.pytorch.org/models/densenet201-4c113574.pth',
+    'densenet161': 'https://download.pytorch.org/models/densenet161-17b70270.pth',
+}
 
 
 def densenet121(pretrained=False, **kwargs):
@@ -13,9 +22,10 @@ def densenet121(pretrained=False, **kwargs):
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
     """
+    model = DenseNet(num_init_features=64, growth_rate=32, block_config=(6, 12, 24, 16))
     if pretrained:
-        raise NotImplementedError('Sorry, model not yet uploaded :(')
-    return DenseNet(num_init_features=64, growth_rate=32, block_config=(6, 12, 24, 16))
+        model.load_state_dict(model_zoo.load_url(model_urls['densenet121']))
+    return model
 
 
 def densenet169(pretrained=False, **kwargs):
@@ -25,9 +35,10 @@ def densenet169(pretrained=False, **kwargs):
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
     """
+    model = DenseNet(num_init_features=64, growth_rate=32, block_config=(6, 12, 32, 32))
     if pretrained:
-        raise NotImplementedError('Sorry, model not yet uploaded :(')
-    return DenseNet(num_init_features=64, growth_rate=32, block_config=(6, 12, 32, 32))
+        model.load_state_dict(model_zoo.load_url(model_urls['densenet169']))
+    return model
 
 
 def densenet201(pretrained=False, **kwargs):
@@ -37,9 +48,10 @@ def densenet201(pretrained=False, **kwargs):
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
     """
+    model = DenseNet(num_init_features=64, growth_rate=32, block_config=(6, 12, 48, 32))
     if pretrained:
-        raise NotImplementedError('Sorry, model not yet uploaded :(')
-    return DenseNet(num_init_features=64, growth_rate=32, block_config=(6, 12, 48, 32))
+        model.load_state_dict(model_zoo.load_url(model_urls['densenet201']))
+    return model
 
 
 def densenet161(pretrained=False, **kwargs):
@@ -49,9 +61,10 @@ def densenet161(pretrained=False, **kwargs):
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
     """
+    model = DenseNet(num_init_features=96, growth_rate=48, block_config=(6, 12, 36, 24))
     if pretrained:
-        raise NotImplementedError('Sorry, model not yet uploaded :(')
-    return DenseNet(num_init_features=96, growth_rate=48, block_config=(6, 12, 36, 24))
+        model.load_state_dict(model_zoo.load_url(model_urls['densenet161']))
+    return model
 
 
 class _DenseLayer(nn.Sequential):

--- a/torchvision/models/densenet.py
+++ b/torchvision/models/densenet.py
@@ -1,0 +1,144 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from collections import OrderedDict
+
+__all__ = ['DenseNet', 'densenet121', 'densenet169', 'densenet201', 'densenet161']
+
+
+def densenet121(pretrained=False, **kwargs):
+    r"""Densenet-121 model from
+    `"Densely Connected Convolutional Networks" <https://arxiv.org/pdf/1608.06993.pdf>`
+
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNet
+    """
+    if pretrained:
+        raise NotImplementedError('Sorry, model not yet uploaded :(')
+    return DenseNet(num_init_features=64, growth_rate=32, block_config=(6, 12, 24, 16))
+
+
+def densenet169(pretrained=False, **kwargs):
+    r"""Densenet-169 model from
+    `"Densely Connected Convolutional Networks" <https://arxiv.org/pdf/1608.06993.pdf>`
+
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNet
+    """
+    if pretrained:
+        raise NotImplementedError('Sorry, model not yet uploaded :(')
+    return DenseNet(num_init_features=64, growth_rate=32, block_config=(6, 12, 32, 32))
+
+
+def densenet201(pretrained=False, **kwargs):
+    r"""Densenet-201 model from
+    `"Densely Connected Convolutional Networks" <https://arxiv.org/pdf/1608.06993.pdf>`
+
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNet
+    """
+    if pretrained:
+        raise NotImplementedError('Sorry, model not yet uploaded :(')
+    return DenseNet(num_init_features=64, growth_rate=32, block_config=(6, 12, 48, 32))
+
+
+def densenet161(pretrained=False, **kwargs):
+    r"""Densenet-201 model from
+    `"Densely Connected Convolutional Networks" <https://arxiv.org/pdf/1608.06993.pdf>`
+
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNet
+    """
+    if pretrained:
+        raise NotImplementedError('Sorry, model not yet uploaded :(')
+    return DenseNet(num_init_features=96, growth_rate=48, block_config=(6, 12, 36, 24))
+
+
+class _DenseLayer(nn.Sequential):
+    def __init__(self, num_input_features, growth_rate, bn_size, drop_rate):
+        super(_DenseLayer, self).__init__()
+        self.add_module('norm.1', nn.BatchNorm2d(num_input_features)),
+        self.add_module('relu.1', nn.ReLU(inplace=True)),
+        self.add_module('conv.1', nn.Conv2d(num_input_features, bn_size *
+                        growth_rate, kernel_size=1, stride=1, bias=False)),
+        self.add_module('norm.2', nn.BatchNorm2d(bn_size * growth_rate)),
+        self.add_module('relu.2', nn.ReLU(inplace=True)),
+        self.add_module('conv.2', nn.Conv2d(bn_size * growth_rate, growth_rate,
+                        kernel_size=3, stride=1, padding=1, bias=False)),
+        self.drop_rate = drop_rate
+
+    def forward(self, x):
+        new_features = super(_DenseLayer, self).forward(x)
+        if self.drop_rate > 0:
+            new_features = F.dropout(new_features, p=self.drop_rate, training=self.training)
+        return torch.cat([x, new_features], 1)
+
+
+class _DenseBlock(nn.Sequential):
+    def __init__(self, num_layers, num_input_features, bn_size, growth_rate, drop_rate):
+        super(_DenseBlock, self).__init__()
+        for i in range(num_layers):
+            layer = _DenseLayer(num_input_features + i * growth_rate, growth_rate, bn_size, drop_rate)
+            self.add_module('denselayer%d' % (i + 1), layer)
+
+
+class _Transition(nn.Sequential):
+    def __init__(self, num_input_features, num_output_features):
+        super(_Transition, self).__init__()
+        self.add_module('norm', nn.BatchNorm2d(num_input_features))
+        self.add_module('relu', nn.ReLU(inplace=True))
+        self.add_module('conv', nn.Conv2d(num_input_features, num_output_features,
+                                          kernel_size=1, stride=1, bias=False))
+        self.add_module('pool', nn.AvgPool2d(kernel_size=2, stride=2))
+
+
+class DenseNet(nn.Module):
+    r"""Densenet-BC model class, based on
+    `"Densely Connected Convolutional Networks" <https://arxiv.org/pdf/1608.06993.pdf>`
+
+    Args:
+        growth_rate (int) - how many filters to add each layer (`k` in paper)
+        block_config (list of 4 ints) - how many layers in each pooling block
+        num_init_features (int) - the number of filters to learn in the first convolution layer
+        bn_size (int) - multiplicative factor for number of bottle neck layers
+          (i.e. bn_size * k features in the bottleneck layer)
+        drop_rate (float) - dropout rate after each dense layer
+        num_classes (int) - number of classification classes
+    """
+    def __init__(self, growth_rate=32, block_config=(6, 12, 24, 16),
+                 num_init_features=64, bn_size=4, drop_rate=0, num_classes=1000):
+
+        super(DenseNet, self).__init__()
+
+        # First convolution
+        self.features = nn.Sequential(OrderedDict([
+            ('conv0', nn.Conv2d(3, num_init_features, kernel_size=7, stride=2, padding=3, bias=False)),
+            ('norm0', nn.BatchNorm2d(num_init_features)),
+            ('relu0', nn.ReLU(inplace=True)),
+            ('pool0', nn.MaxPool2d(kernel_size=3, stride=2, padding=1)),
+        ]))
+
+        # Each denseblock
+        num_features = num_init_features
+        for i, num_layers in enumerate(block_config):
+            block = _DenseBlock(num_layers=num_layers, num_input_features=num_features,
+                                bn_size=bn_size, growth_rate=growth_rate, drop_rate=drop_rate)
+            self.features.add_module('denseblock%d' % (i + 1), block)
+            num_features = num_features + num_layers * growth_rate
+            if i != len(block_config) - 1:
+                trans = _Transition(num_input_features=num_features, num_output_features=num_features / 2)
+                self.features.add_module('transition%d' % (i + 1), trans)
+                num_features = num_features / 2
+
+        # Final batch norm
+        self.features.add_module('norm5', nn.BatchNorm2d(num_features))
+
+        # Linear layer
+        self.classifier = nn.Linear(num_features, num_classes)
+
+    def forward(self, x):
+        features = self.features(x)
+        out = F.relu(features, inplace=True)
+        out = F.avg_pool2d(out, kernel_size=7).view(features.size(0), -1)
+        out = self.classifier(out)
+        return out


### PR DESCRIPTION
See issue #97.

It's not super-memory optimized (i.e. there's a concatenation at every layer). This is consistent with [the original Torch implementation](https://github.com/liuzhuang13/DenseNet), and prevents some gross autograd hacks. 

Pretrained models for the model zoo are available [here](https://drive.google.com/drive/folders/0B0Y2k_mEJpY9R3dSSGQ0YXhfa2c?usp=sharing). They're converted over from the original Torch implementation.