### PR TITLE
Apply clipping in save_image

### DIFF
--- a/torchvision/utils.py
+++ b/torchvision/utils.py
@@ -90,6 +90,6 @@ def save_image(tensor, filename, nrow=8, padding=2,
     tensor = tensor.cpu()
     grid = make_grid(tensor, nrow=nrow, padding=padding,
                      normalize=normalize, range=range, scale_each=scale_each)
-    ndarr = grid.mul(255).byte().transpose(0, 2).transpose(0, 1).numpy()
+    ndarr = grid.mul(255).clip(0, 255).byte().permute(1, 2, 0).numpy()
     im = Image.fromarray(ndarr)
     im.save(filename)


### PR DESCRIPTION
Without clipping, any values larger than 255 will be replaced with
int(v mod 256) by byte(), which results in high freq noise in image.