### PR TITLE
updated transforms.ToPILImage, see #105

### DIFF
--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -169,6 +169,12 @@ class Tester(unittest.TestCase):
         l, = img.split()
         assert np.allclose(l, img_data[:, :, 0])
 
+    def test_ndarray16_to_pil_image(self):
+        trans = transforms.ToPILImage()
+        img_data = np.random.randint(0, 65535, [4, 4, 1], np.uint16)
+        img = trans(img_data)
+        assert img.mode == 'I;16'
+        assert np.allclose(img, img_data[:, :, 0])
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -158,22 +158,16 @@ class Tester(unittest.TestCase):
         img_data_byte = torch.ByteTensor(1, 4, 4).random_(0, 255)
         img_data_short = torch.ShortTensor(1, 4, 4).random_()
         img_data_int = torch.IntTensor(1, 4, 4).random_()
-        img_data_float = torch.FloatTensor(1, 4, 4).uniform_()
 
         img_byte = trans(img_data_byte)
         img_short = trans(img_data_short)
         img_int = trans(img_data_int)
-        img_float = trans(img_data_float)
         assert img_byte.mode == 'L'
         assert img_short.mode == 'I;16'
         assert img_int.mode == 'I'
-        #assert img_float.mode == 'F'
 
         assert np.allclose(img_data_short.numpy(), to_tensor(img_short).numpy())
         assert np.allclose(img_data_int.numpy(), to_tensor(img_int).numpy())
-        # would cause breaking changes as ToTensor converts to range [0, 1]
-        #assert np.allclose(img_data_byte.numpy(), to_tensor(img_byte).numpy())
-        #assert np.allclose(img_data_float.numpy(), to_tensor(img_float).numpy())
 
     def test_ndarray_to_pil_image(self):
         trans = transforms.ToPILImage()

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -169,11 +169,33 @@ class Tester(unittest.TestCase):
         l, = img.split()
         assert np.allclose(l, img_data[:, :, 0])
 
-    def test_ndarray16_to_pil_image(self):
+    def test_ndarray_bad_types_to_pil_image(self):
         trans = transforms.ToPILImage()
-        img_data = np.random.randint(0, 65535, [4, 4, 1], np.uint16)
+        with self.assertRaises(AssertionError):
+            trans(np.ones([4, 4, 1], np.int64))
+            trans(np.ones([4, 4, 1], np.uint16))
+            trans(np.ones([4, 4, 1], np.uint32))
+            trans(np.ones([4, 4, 1], np.float64))
+
+    def test_ndarray_gray_float32_to_pil_image(self):
+        trans = transforms.ToPILImage()
+        img_data = torch.FloatTensor(4, 4, 1).random_().numpy()
+        img = trans(img_data)
+        assert img.mode == 'F'
+        assert np.allclose(img, img_data[:, :, 0])
+
+    def test_ndarray_gray_int16_to_pil_image(self):
+        trans = transforms.ToPILImage()
+        img_data = torch.ShortTensor(4, 4, 1).random_().numpy()
         img = trans(img_data)
         assert img.mode == 'I;16'
+        assert np.allclose(img, img_data[:, :, 0])
+
+    def test_ndarray_gray_int32_to_pil_image(self):
+        trans = transforms.ToPILImage()
+        img_data = torch.IntTensor(4, 4, 1).random_().numpy()
+        img = trans(img_data)
+        assert img.mode == 'I'
         assert np.allclose(img, img_data[:, :, 0])
 
 

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -151,6 +151,30 @@ class Tester(unittest.TestCase):
         expected_output = img_data.mul(255).int().float().div(255)
         assert np.allclose(expected_output[0].numpy(), to_tensor(l).numpy())
 
+    def test_tensor_gray_to_pil_image(self):
+        trans = transforms.ToPILImage()
+        to_tensor = transforms.ToTensor()
+
+        img_data_byte = torch.ByteTensor(1, 4, 4).random_(0, 255)
+        img_data_short = torch.ShortTensor(1, 4, 4).random_()
+        img_data_int = torch.IntTensor(1, 4, 4).random_()
+        img_data_float = torch.FloatTensor(1, 4, 4).uniform_()
+
+        img_byte = trans(img_data_byte)
+        img_short = trans(img_data_short)
+        img_int = trans(img_data_int)
+        img_float = trans(img_data_float)
+        assert img_byte.mode == 'L'
+        assert img_short.mode == 'I;16'
+        assert img_int.mode == 'I'
+        #assert img_float.mode == 'F'
+
+        assert np.allclose(img_data_short.numpy(), to_tensor(img_short).numpy())
+        assert np.allclose(img_data_int.numpy(), to_tensor(img_int).numpy())
+        # would cause breaking changes as ToTensor converts to range [0, 1]
+        #assert np.allclose(img_data_byte.numpy(), to_tensor(img_byte).numpy())
+        #assert np.allclose(img_data_float.numpy(), to_tensor(img_float).numpy())
+
     def test_ndarray_to_pil_image(self):
         trans = transforms.ToPILImage()
         img_data = torch.ByteTensor(4, 4, 3).random_(0, 255).numpy()

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -176,5 +176,6 @@ class Tester(unittest.TestCase):
         assert img.mode == 'I;16'
         assert np.allclose(img, img_data[:, :, 0])
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/torchvision/transforms.py
+++ b/torchvision/transforms.py
@@ -39,19 +39,30 @@ class ToTensor(object):
         if isinstance(pic, np.ndarray):
             # handle numpy array
             img = torch.from_numpy(pic.transpose((2, 0, 1)))
+            # backard compability
+            return img.float().div(255)
+        # handle PIL Image
+        if pic.mode == 'I':
+            img = torch.from_numpy(np.array(pic, np.int32))
+        elif pic.mode == 'I;16':
+            img = torch.from_numpy(np.array(pic, np.int16))
         else:
-            # handle PIL Image
             img = torch.ByteTensor(torch.ByteStorage.from_buffer(pic.tobytes()))
-            # PIL image mode: 1, L, P, I, F, RGB, YCbCr, RGBA, CMYK
-            if pic.mode == 'YCbCr':
-                nchannel = 3
-            else:
-                nchannel = len(pic.mode)
-            img = img.view(pic.size[1], pic.size[0], nchannel)
-            # put it from HWC to CHW format
-            # yikes, this transpose takes 80% of the loading time/CPU
-            img = img.transpose(0, 1).transpose(0, 2).contiguous()
-        return img.float().div(255)
+        # PIL image mode: 1, L, P, I, F, RGB, YCbCr, RGBA, CMYK
+        if pic.mode == 'YCbCr':
+            nchannel = 3
+        elif pic.mode == 'I;16':
+            nchannel = 1
+        else:
+            nchannel = len(pic.mode)
+        img = img.view(pic.size[1], pic.size[0], nchannel)
+        # put it from HWC to CHW format
+        # yikes, this transpose takes 80% of the loading time/CPU
+        img = img.transpose(0, 1).transpose(0, 2).contiguous()
+        if isinstance(img, torch.ByteTensor):
+            return img.float().div(255)
+        else:
+            return img
 
 
 class ToPILImage(object):
@@ -67,7 +78,6 @@ class ToPILImage(object):
         if torch.is_tensor(pic):
             npimg = np.transpose(pic.numpy(), (1, 2, 0))
         assert isinstance(npimg, np.ndarray), 'pic should be Tensor or ndarray'
-
         if npimg.shape[2] == 1:
             npimg = npimg[:, :, 0]
 
@@ -83,7 +93,6 @@ class ToPILImage(object):
             if npimg.dtype == np.uint8:
                 mode = 'RGB'
         assert mode is not None, '{} is not supported'.format(npimg.dtype)
-
         return Image.fromarray(npimg, mode=mode)
 
 

--- a/torchvision/transforms.py
+++ b/torchvision/transforms.py
@@ -73,8 +73,10 @@ class ToPILImage(object):
 
             if npimg.dtype == np.uint8:
                 mode = 'L'
-            if npimg.dtype == np.uint16:
+            if npimg.dtype == np.int16:
                 mode = 'I;16'
+            if npimg.dtype == np.int32:
+                mode = 'I'
             elif npimg.dtype == np.float32:
                 mode = 'F'
         else:

--- a/torchvision/transforms.py
+++ b/torchvision/transforms.py
@@ -43,9 +43,9 @@ class ToTensor(object):
             return img.float().div(255)
         # handle PIL Image
         if pic.mode == 'I':
-            img = torch.from_numpy(np.array(pic, np.int32))
+            img = torch.from_numpy(np.array(pic, np.int32, copy=False))
         elif pic.mode == 'I;16':
-            img = torch.from_numpy(np.array(pic, np.int16))
+            img = torch.from_numpy(np.array(pic, np.int16, copy=False))
         else:
             img = torch.ByteTensor(torch.ByteStorage.from_buffer(pic.tobytes()))
         # PIL image mode: 1, L, P, I, F, RGB, YCbCr, RGBA, CMYK


### PR DESCRIPTION
PR for #105. Changes should be backward compatible. Types are interfered from `PIL.Image.mode` when passing single channel images. See PIL modes [here](http://pillow.readthedocs.io/en/4.0.x/handbook/concepts.html#concept-modes)

How does `ToPILImage` handle types?
```
1- channel:
* FloatTensor -> ByteTensor -> 'L' Image (8-bit black and white)
* ShortTensor -> 'I;16' Image
* IntTensor -> 'I' Image
* analog for the respective numpy types (exception: np.float32 will be 'F' Image)
* other types (e.g. signed ints) -> error

3-channel
* same as before with addition that we will have an error for images with precision over 8-bit (because PIL.Image cannot handle more than 8-bit colors).
```

How does `ToTensor` handle types?
```
* np.ndarrays -> FloatTensor of range [0, 1]
* 'I;16' Image -> ShortTensor
* 'I' Image -> IntTensor
* every thing else -> ByteTensor
```