### PR TITLE
Make clearer about nrow parameter in make_grid

### DIFF
--- a/torchvision/utils.py
+++ b/torchvision/utils.py
@@ -8,8 +8,8 @@ def make_grid(tensor, nrow=8, padding=2,
     """
     Given a 4D mini-batch Tensor of shape (B x C x H x W),
     or a list of images all of the same size,
-    makes a grid of images
-
+    makes a grid of images of size (B / nrow, nrow).  
+        
     normalize=True will shift the image to the range (0, 1),
     by subtracting the minimum and dividing by the maximum pixel value.
 

--- a/torchvision/utils.py
+++ b/torchvision/utils.py
@@ -9,7 +9,7 @@ def make_grid(tensor, nrow=8, padding=2,
     Given a 4D mini-batch Tensor of shape (B x C x H x W),
     or a list of images all of the same size,
     makes a grid of images of size (B / nrow, nrow).  
-        
+
     normalize=True will shift the image to the range (0, 1),
     by subtracting the minimum and dividing by the maximum pixel value.
 

--- a/torchvision/utils.py
+++ b/torchvision/utils.py
@@ -8,7 +8,7 @@ def make_grid(tensor, nrow=8, padding=2,
     """
     Given a 4D mini-batch Tensor of shape (B x C x H x W),
     or a list of images all of the same size,
-    makes a grid of images of size (B / nrow, nrow).  
+    makes a grid of images of size (B / nrow, nrow).
 
     normalize=True will shift the image to the range (0, 1),
     by subtracting the minimum and dividing by the maximum pixel value.


### PR DESCRIPTION
The name of the parameter is a little weird, `nrow` would generally be explained as `number of rows`. But in this case it is exactly `number of columns`. Please consider changing the name in future releases, the current is really confusing.