### PR TITLE
Alter division style to prevent error in python3

### DIFF
--- a/torchvision/models/densenet.py
+++ b/torchvision/models/densenet.py
@@ -139,9 +139,9 @@ class DenseNet(nn.Module):
             self.features.add_module('denseblock%d' % (i + 1), block)
             num_features = num_features + num_layers * growth_rate
             if i != len(block_config) - 1:
-                trans = _Transition(num_input_features=num_features, num_output_features=num_features / 2)
+                trans = _Transition(num_input_features=num_features, num_output_features=num_features // 2)
                 self.features.add_module('transition%d' % (i + 1), trans)
-                num_features = num_features / 2
+                num_features = num_features // 2
 
         # Final batch norm
         self.features.add_module('norm5', nn.BatchNorm2d(num_features))


### PR DESCRIPTION
Using python2 style '/' will convert int type to float in python3 which will cause the following error when creating FloatTensor:

> TypeError: torch.FloatTensor constructor received an invalid combination of arguments - got (float, int, int, int), but expected one of:
>  * no arguments
>  * (int ...)
>       didn't match because some of the arguments have invalid types: (float, int, int, int)