### PR TITLE
	Add support for Transforms.Scale([w, h]) with specific width and height

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -307,9 +307,11 @@ Transforms on PIL.Image
 ``Scale(size, interpolation=Image.BILINEAR)``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Rescales the input PIL.Image to the given 'size'. 'size' will be the
-size of the smaller edge.
+Rescales the input PIL.Image to the given 'size'. 
 
+If 'size' is a 2-element tuple, it will be the exactly size to scale.
+
+If 'size' is a number, it will indicate the size of the smaller edge. 
 For example, if height > width, then image will be rescaled to (size \*
 height / width, size) - size: size of the smaller edge - interpolation:
 Default: PIL.Image.BILINEAR

--- a/README.rst
+++ b/README.rst
@@ -309,7 +309,7 @@ Transforms on PIL.Image
 
 Rescales the input PIL.Image to the given 'size'. 
 
-If 'size' is a 2-element tuple, it will be the exactly size to scale.
+If 'size' is a 2-element tuple or list, it will be the exactly size to scale.
 
 If 'size' is a number, it will indicate the size of the smaller edge. 
 For example, if height > width, then image will be rescaled to (size \*

--- a/README.rst
+++ b/README.rst
@@ -309,7 +309,7 @@ Transforms on PIL.Image
 
 Rescales the input PIL.Image to the given 'size'. 
 
-If 'size' is a 2-element tuple or list, it will be the exactly size to scale.
+If 'size' is a 2-element tuple or list in the order of (width, height), it will be the exactly size to scale.
 
 If 'size' is a number, it will indicate the size of the smaller edge. 
 For example, if height > width, then image will be rescaled to (size \*

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -68,6 +68,16 @@ class Tester(unittest.TestCase):
         elif width < height:
             assert result.size(1) >= result.size(2)
 
+        oheight = random.randint(5, 12) * 2
+        owidth = random.randint(5, 12) * 2
+        result = transforms.Compose([
+            transforms.ToPILImage(),
+            transforms.Scale((owidth, oheight)),
+            transforms.ToTensor(),
+        ])(img)
+        assert result.size(1) == oheight
+        assert result.size(2) == owidth
+
     def test_random_crop(self):
         height = random.randint(10, 32) * 2
         width = random.randint(10, 32) * 2

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -78,6 +78,14 @@ class Tester(unittest.TestCase):
         assert result.size(1) == oheight
         assert result.size(2) == owidth
 
+        result = transforms.Compose([
+            transforms.ToPILImage(),
+            transforms.Scale([owidth, oheight]),
+            transforms.ToTensor(),
+        ])(img)
+        assert result.size(1) == oheight
+        assert result.size(2) == owidth
+
     def test_random_crop(self):
         height = random.randint(10, 32) * 2
         width = random.randint(10, 32) * 2

--- a/torchvision/transforms.py
+++ b/torchvision/transforms.py
@@ -6,6 +6,7 @@ from PIL import Image, ImageOps
 import numpy as np
 import numbers
 import types
+import collections
 
 
 class Compose(object):
@@ -115,7 +116,7 @@ class Normalize(object):
 
 class Scale(object):
     """Rescales the input PIL.Image to the given 'size'.
-    If 'size' is a 2-element tuple or list, it will be the exactly size to scale.
+    If 'size' is a 2-element tuple or list in the order of (width, height), it will be the exactly size to scale.
     If 'size' is a number, it will indicate the size of the smaller edge.
     For example, if height > width, then image will be
     rescaled to (size * height / width, size)
@@ -124,7 +125,7 @@ class Scale(object):
     """
 
     def __init__(self, size, interpolation=Image.BILINEAR):
-        assert isinstance(size, int) or ((isinstance(size, tuple) or isinstance(size, list)) and len(size) == 2)
+        assert isinstance(size, int) or (isinstance(size, collections.Iterable) and len(size) == 2)
         self.size = size
         self.interpolation = interpolation
 

--- a/torchvision/transforms.py
+++ b/torchvision/transforms.py
@@ -115,13 +115,10 @@ class Normalize(object):
 
 class Scale(object):
     """Rescales the input PIL.Image to the given 'size'.
-    
     If 'size' is a 2-element tuple, it will be the exactly size to scale.
-    
-    If 'size' is a number, it will indicate the size of the smaller edge. 
+    If 'size' is a number, it will indicate the size of the smaller edge.
     For example, if height > width, then image will be
     rescaled to (size * height / width, size)
-    
     size: size of the exactly size or the smaller edge
     interpolation: Default: PIL.Image.BILINEAR
     """
@@ -132,7 +129,7 @@ class Scale(object):
         self.interpolation = interpolation
 
     def __call__(self, img):
-        if isinstance(self.size, int): 
+        if isinstance(self.size, int):
             w, h = img.size
             if (w <= h and w == self.size) or (h <= w and h == self.size):
                 return img

--- a/torchvision/transforms.py
+++ b/torchvision/transforms.py
@@ -115,7 +115,7 @@ class Normalize(object):
 
 class Scale(object):
     """Rescales the input PIL.Image to the given 'size'.
-    If 'size' is a 2-element tuple, it will be the exactly size to scale.
+    If 'size' is a 2-element tuple or list, it will be the exactly size to scale.
     If 'size' is a number, it will indicate the size of the smaller edge.
     For example, if height > width, then image will be
     rescaled to (size * height / width, size)
@@ -124,7 +124,7 @@ class Scale(object):
     """
 
     def __init__(self, size, interpolation=Image.BILINEAR):
-        assert isinstance(size, int) or (isinstance(size, tuple) and len(size) == 2)
+        assert isinstance(size, int) or ((isinstance(size, tuple) or isinstance(size, list)) and len(size) == 2)
         self.size = size
         self.interpolation = interpolation
 

--- a/torchvision/transforms.py
+++ b/torchvision/transforms.py
@@ -115,14 +115,19 @@ class Normalize(object):
 
 class Scale(object):
     """Rescales the input PIL.Image to the given 'size'.
-    'size' will be the size of the smaller edge.
+    
+    If 'size' is a 2-element tuple, it will be the exactly size to scale.
+    
+    If 'size' is a number, it will indicate the size of the smaller edge. 
     For example, if height > width, then image will be
     rescaled to (size * height / width, size)
-    size: size of the smaller edge
+    
+    size: size of the exactly size or the smaller edge
     interpolation: Default: PIL.Image.BILINEAR
     """
 
     def __init__(self, size, interpolation=Image.BILINEAR):
+        assert isinstance(size, int) or (isinstance(size, tuple) and len(size) == 2)
         self.size = size
         self.interpolation = interpolation
 

--- a/torchvision/transforms.py
+++ b/torchvision/transforms.py
@@ -127,17 +127,20 @@ class Scale(object):
         self.interpolation = interpolation
 
     def __call__(self, img):
-        w, h = img.size
-        if (w <= h and w == self.size) or (h <= w and h == self.size):
-            return img
-        if w < h:
-            ow = self.size
-            oh = int(self.size * h / w)
-            return img.resize((ow, oh), self.interpolation)
+        if isinstance(self.size, int): 
+            w, h = img.size
+            if (w <= h and w == self.size) or (h <= w and h == self.size):
+                return img
+            if w < h:
+                ow = self.size
+                oh = int(self.size * h / w)
+                return img.resize((ow, oh), self.interpolation)
+            else:
+                oh = self.size
+                ow = int(self.size * w / h)
+                return img.resize((ow, oh), self.interpolation)
         else:
-            oh = self.size
-            ow = int(self.size * w / h)
-            return img.resize((ow, oh), self.interpolation)
+            return img.resize(self.size, self.interpolation)
 
 
 class CenterCrop(object):

--- a/torchvision/utils.py
+++ b/torchvision/utils.py
@@ -65,7 +65,7 @@ def make_grid(tensor, nrow=8, padding=2,
     xmaps = min(nrow, nmaps)
     ymaps = int(math.ceil(float(nmaps) / xmaps))
     height, width = int(tensor.size(2) + padding), int(tensor.size(3) + padding)
-    grid = tensor.new(3, height * ymaps, width * xmaps).fill_(0)
+    grid = tensor.new(3, height * ymaps + 1 + padding // 2, width * xmaps + 1 + padding // 2).fill_(0)
     k = 0
     for y in irange(ymaps):
         for x in irange(xmaps):


### PR DESCRIPTION
if self.size is a int then scale the image with the shorter side,
otherwise if self.size is a list then scale the image to self.size
directly