### PR TITLE
Add pad_value argument to make_grid and save_image

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -388,7 +388,7 @@ For example:
 Utils
 =====
 
-make\_grid(tensor, nrow=8, padding=2, normalize=False, range=None, scale\_each=False)
+make\_grid(tensor, nrow=8, padding=2, normalize=False, range=None, scale\_each=False, pad\_value=0)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Given a 4D mini-batch Tensor of shape (B x C x H x W),
@@ -404,9 +404,11 @@ normalize the image.
 scale_each=True will scale each image in the batch of images separately rather than
 computing the (min, max) over all images.
 
+pad_value=<float> sets the value for the padded pixels.
+
 `Example usage is given in this notebook` <https://gist.github.com/anonymous/bf16430f7750c023141c562f3e9f2a91>
 
-save\_image(tensor, filename, nrow=8, padding=2, normalize=False, range=None, scale\_each=False)
+save\_image(tensor, filename, nrow=8, padding=2, normalize=False, range=None, scale\_each=False, pad\_value=0)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Saves a given Tensor into an image file.

--- a/torchvision/utils.py
+++ b/torchvision/utils.py
@@ -3,7 +3,7 @@ import math
 irange = range
 
 
-def make_grid(tensor, nrow=8, padding=2,
+def make_grid(tensor, nrow=8, padding=2, pad_value=0,
               normalize=False, range=None, scale_each=False):
     """
     Given a 4D mini-batch Tensor of shape (B x C x H x W),
@@ -19,6 +19,8 @@ def make_grid(tensor, nrow=8, padding=2,
     scale_each=True will scale each image in the batch of images separately rather than
     computing the (min, max) over all images.
 
+    pad_value=<float> sets the value for the padded pixels.
+ 
     [Example usage is given in this notebook](https://gist.github.com/anonymous/bf16430f7750c023141c562f3e9f2a91)
     """
     # if list of tensors, convert to a 4D mini-batch Tensor
@@ -65,7 +67,7 @@ def make_grid(tensor, nrow=8, padding=2,
     xmaps = min(nrow, nmaps)
     ymaps = int(math.ceil(float(nmaps) / xmaps))
     height, width = int(tensor.size(2) + padding), int(tensor.size(3) + padding)
-    grid = tensor.new(3, height * ymaps + 1 + padding // 2, width * xmaps + 1 + padding // 2).fill_(0)
+    grid = tensor.new(3, height * ymaps + 1 + padding // 2, width * xmaps + 1 + padding // 2).fill_(pad_value)
     k = 0
     for y in irange(ymaps):
         for x in irange(xmaps):

--- a/torchvision/utils.py
+++ b/torchvision/utils.py
@@ -3,8 +3,8 @@ import math
 irange = range
 
 
-def make_grid(tensor, nrow=8, padding=2, pad_value=0,
-              normalize=False, range=None, scale_each=False):
+def make_grid(tensor, nrow=8, padding=2,
+              normalize=False, range=None, scale_each=False, pad_value=0):
     """
     Given a 4D mini-batch Tensor of shape (B x C x H x W),
     or a list of images all of the same size,
@@ -80,8 +80,8 @@ def make_grid(tensor, nrow=8, padding=2, pad_value=0,
     return grid
 
 
-def save_image(tensor, filename, nrow=8, padding=2, pad_value=0,
-               normalize=False, range=None, scale_each=False):
+def save_image(tensor, filename, nrow=8, padding=2,
+               normalize=False, range=None, scale_each=False, pad_value=0):
     """
     Saves a given Tensor into an image file.
     If given a mini-batch tensor, will save the tensor as a grid of images by calling `make_grid`.

--- a/torchvision/utils.py
+++ b/torchvision/utils.py
@@ -80,7 +80,7 @@ def make_grid(tensor, nrow=8, padding=2, pad_value=0,
     return grid
 
 
-def save_image(tensor, filename, nrow=8, padding=2,
+def save_image(tensor, filename, nrow=8, padding=2, pad_value=0,
                normalize=False, range=None, scale_each=False):
     """
     Saves a given Tensor into an image file.
@@ -90,7 +90,7 @@ def save_image(tensor, filename, nrow=8, padding=2,
     """
     from PIL import Image
     tensor = tensor.cpu()
-    grid = make_grid(tensor, nrow=nrow, padding=padding,
+    grid = make_grid(tensor, nrow=nrow, padding=padding, pad_value=pad_value,
                      normalize=normalize, range=range, scale_each=scale_each)
     ndarr = grid.mul(255).clamp(0, 255).byte().permute(1, 2, 0).numpy()
     im = Image.fromarray(ndarr)

--- a/torchvision/utils.py
+++ b/torchvision/utils.py
@@ -20,7 +20,7 @@ def make_grid(tensor, nrow=8, padding=2, pad_value=0,
     computing the (min, max) over all images.
 
     pad_value=<float> sets the value for the padded pixels.
- 
+
     [Example usage is given in this notebook](https://gist.github.com/anonymous/bf16430f7750c023141c562f3e9f2a91)
     """
     # if list of tensors, convert to a 4D mini-batch Tensor


### PR DESCRIPTION
This is useful, especially because 2 month ago the default color for padded pixels was white, while now I see black borders by default and cannot change it.   