### PR TITLE
change resnet AvgPool2d to Adaptive_AvgPool_2d（global avg pooling） to make the input size changeable

### DIFF
--- a/torchvision/models/resnet.py
+++ b/torchvision/models/resnet.py
@@ -107,7 +107,7 @@ class ResNet(nn.Module):
         self.layer2 = self._make_layer(block, 128, layers[1], stride=2)
         self.layer3 = self._make_layer(block, 256, layers[2], stride=2)
         self.layer4 = self._make_layer(block, 512, layers[3], stride=2)
-        self.avgpool = nn.AvgPool2d(7)
+        self.avgpool = nn.AdaptiveAvgPool2d(1)
         self.fc = nn.Linear(512 * block.expansion, num_classes)
 
         for m in self.modules():


### PR DESCRIPTION
This PR change `resnet` final pooling layer before classifier from fixed `AvgPool2d(7)` to adaptive `Adaptive_AvgPool_2d(1)`
When we use `AvgPool2d(7)`, the input size is forced to be 224*224. Otherwise it will cause the wrong incomplete output, even raise the error `RuntimeError: size mismatch, m1: [1 x 2048], m2: [512 x 1000] at /b/wheel/pytorch-src/torch/lib/TH/generic/THTensorMath.c:1229`