### PR TITLE
Adapted SqueezeNet for Variable Size Input Images

### DIFF
--- a/torchvision/models/squeezenet.py
+++ b/torchvision/models/squeezenet.py
@@ -83,7 +83,7 @@ class SqueezeNet(nn.Module):
             nn.Dropout(p=0.5),
             final_conv,
             nn.ReLU(inplace=True),
-            nn.AvgPool2d(13)
+            nn.AdaptiveAvgPool2d(1)
         )
 
         for m in self.modules():


### PR DESCRIPTION
Replaced final AveragePooling layer with an AdaptiveAveragePooling layer to allow for no code changes when switching from 255x255 images to other image sizes.