### PR TITLE
Fix LSUN IndexError

### DIFF
--- a/torchvision/datasets/lsun.py
+++ b/torchvision/datasets/lsun.py
@@ -114,7 +114,7 @@ class LSUN(data.Dataset):
             if index < ind:
                 break
             target += 1
-            sub += ind
+            sub = ind
 
         db = self.dbs[target]
         index = index - sub


### PR DESCRIPTION
Indices are accumulated twice, which may cause IndexError.

```python
>>> import torchvision.datasets as dset
>>> lsun = dset.LSUN('/path/to/lsun', classes=['bedroom_val', 'bridge_val', 'church_outdoor_val', 'classroom_val'])
>>> len(lsun)
1200
>>> lsun[1100]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<prefix>/lib/python2.7/site-packages/torchvision-0.1.8-py2.7.egg/torchvision/datasets/lsun.py", line 125, in __getitem__
  File "<prefix>/lib/python2.7/site-packages/torchvision-0.1.8-py2.7.egg/torchvision/datasets/lsun.py", line 37, in __getitem__
IndexError: list index out of range
```
