### PR TITLE
Fully convolutional version of all vgg models via constructor argument

### DIFF
--- a/torchvision/models/vgg.py
+++ b/torchvision/models/vgg.py
@@ -23,40 +23,42 @@ model_urls = {
 
 class VGG(nn.Module):
 
-    def __init__(self, features, num_classes=1000):
+    def __init__(self, features, num_classes=1000, fully_conv=False):
         super(VGG, self).__init__()
-    self.features = features
-    self.fully_conv = fully_conv
-    
-    self.classifier = nn.Sequential(
-        nn.Linear(512 * 7 * 7, 4096),
-        nn.ReLU(True),
-        nn.Dropout(),
-        nn.Linear(4096, 4096),
-        nn.ReLU(True),
-        nn.Dropout(),
-        nn.Linear(4096, num_classes),
-    )
-
-    if fully_conv:
+        self.features = features
+        self.fully_conv = fully_conv
 
         self.classifier = nn.Sequential(
-            nn.Conv2d(512, 4096, 7, 1, 3),
+            nn.Linear(512 * 7 * 7, 4096),
             nn.ReLU(True),
             nn.Dropout(),
-            nn.Conv2d(4096, 4096, 1),
+            nn.Linear(4096, 4096),
             nn.ReLU(True),
             nn.Dropout(),
-            nn.Conv2d(4096, num_classes, 1)
+            nn.Linear(4096, num_classes),
         )
-    self._initialize_weights()
+
+        if fully_conv:
+
+            self.classifier = nn.Sequential(
+                nn.Conv2d(512, 4096, 7, 1, 3),
+                nn.ReLU(True),
+                nn.Dropout(),
+                nn.Conv2d(4096, 4096, 1),
+                nn.ReLU(True),
+                nn.Dropout(),
+                nn.Conv2d(4096, num_classes, 1)
+            )
+        
+        self._initialize_weights()
 
     def new_forward(self, x):
-    x = self.features(x)
-    if not self.fully_conv:
-        x = x.view(x.size(0), -1)
-    x = self.classifier(x)
-    return x
+        x = self.features(x)
+        if not self.fully_conv:
+            x = x.view(x.size(0), -1)
+        x = self.classifier(x)
+
+        return x
 
     def _initialize_weights(self):
         for m in self.modules():

--- a/torchvision/models/vgg.py
+++ b/torchvision/models/vgg.py
@@ -25,23 +25,38 @@ class VGG(nn.Module):
 
     def __init__(self, features, num_classes=1000):
         super(VGG, self).__init__()
-        self.features = features
-        self.classifier = nn.Sequential(
-            nn.Linear(512 * 7 * 7, 4096),
-            nn.ReLU(True),
-            nn.Dropout(),
-            nn.Linear(4096, 4096),
-            nn.ReLU(True),
-            nn.Dropout(),
-            nn.Linear(4096, num_classes),
-        )
-        self._initialize_weights()
+    self.features = features
+    self.fully_conv = fully_conv
+    
+    self.classifier = nn.Sequential(
+        nn.Linear(512 * 7 * 7, 4096),
+        nn.ReLU(True),
+        nn.Dropout(),
+        nn.Linear(4096, 4096),
+        nn.ReLU(True),
+        nn.Dropout(),
+        nn.Linear(4096, num_classes),
+    )
 
-    def forward(self, x):
-        x = self.features(x)
+    if fully_conv:
+
+        self.classifier = nn.Sequential(
+            nn.Conv2d(512, 4096, 7, 1, 3),
+            nn.ReLU(True),
+            nn.Dropout(),
+            nn.Conv2d(4096, 4096, 1),
+            nn.ReLU(True),
+            nn.Dropout(),
+            nn.Conv2d(4096, num_classes, 1)
+        )
+    self._initialize_weights()
+
+    def new_forward(self, x):
+    x = self.features(x)
+    if not self.fully_conv:
         x = x.view(x.size(0), -1)
-        x = self.classifier(x)
-        return x
+    x = self.classifier(x)
+    return x
 
     def _initialize_weights(self):
         for m in self.modules():


### PR DESCRIPTION
Added a feature to use any existing vgg model in a fully convolutional manner.
Backwards compatible, works as an argument ```fully_conv``` to any vgg model creator function.
Also the weights are loaded correctly (conversion between ```Linear``` to ```Conv2d```. which can be seen in the example images below).
```
fcn = vgg16(pretrained=True, fully_conv=True)
fcn = fcn.eval()
```

```
from torch.autograd import Variable
import torch.nn as nn

import skimage.io as io
import skimage.transform
import numpy as np
import torch

img = skimage.img_as_float(io.imread('bus.jpg'))
img = img - [0.485, 0.456, 0.406]
img = img / [0.229, 0.224, 0.225]
img = img.transpose((2, 0, 1))
img = np.expand_dims(img, 0)
img = img.astype(np.float32)
final_img = torch.from_numpy(img)

fcn.cuda()
final_img = Variable(final_img.cuda())
res = fcn(final_img)

boo = res.cpu().data.numpy()
final = boo.squeeze().argmax(axis=0)
# 779 -- is a class for a bus from imagenet
io.imshow(final == 779)
```
The following image was evaluated and respective prediction for a bus region was acquired,
which proves that weights from imagenet vgg model were correctly loaded after converting ```Linear``` layers to ```Conv2d```.

![pytorch_bus](https://user-images.githubusercontent.com/2501383/26992120-733627be-4d5d-11e7-9022-1dcb4a318982.png)
![pytorch_bus_pred](https://user-images.githubusercontent.com/2501383/26992121-7339bd98-4d5d-11e7-8493-e04c61dfa8e6.png)

Feel free to leave feedback. I can wrap it up with tests if you like it.