### PR TITLE
Fully convolutional support for all resnet models

### DIFF
--- a/torchvision/models/resnet.py
+++ b/torchvision/models/resnet.py
@@ -95,8 +95,9 @@ class Bottleneck(nn.Module):
 
 class ResNet(nn.Module):
 
-    def __init__(self, block, layers, num_classes=1000):
+    def __init__(self, block, layers, num_classes=1000, fully_conv=False):
         self.inplanes = 64
+        self.fully_conv = fully_conv
         super(ResNet, self).__init__()
         self.conv1 = nn.Conv2d(3, 64, kernel_size=7, stride=2, padding=3,
                                bias=False)
@@ -107,8 +108,13 @@ class ResNet(nn.Module):
         self.layer2 = self._make_layer(block, 128, layers[1], stride=2)
         self.layer3 = self._make_layer(block, 256, layers[2], stride=2)
         self.layer4 = self._make_layer(block, 512, layers[3], stride=2)
+        
         self.avgpool = nn.AvgPool2d(7)
         self.fc = nn.Linear(512 * block.expansion, num_classes)
+        
+        if self.fully_conv:
+            self.avgpool = nn.AvgPool2d(7, padding=3, stride=1)
+            self.fc = nn.Conv2d(512 * block.expansion, num_classes, 1)
 
         for m in self.modules():
             if isinstance(m, nn.Conv2d):
@@ -147,7 +153,10 @@ class ResNet(nn.Module):
         x = self.layer4(x)
 
         x = self.avgpool(x)
-        x = x.view(x.size(0), -1)
+        
+        if not self.fully_conv:
+            x = x.view(x.size(0), -1)
+            
         x = self.fc(x)
 
         return x


### PR DESCRIPTION
Fully convolutional versions of all resnet models and ability
to regulate the output stride was added. 
https://arxiv.org/pdf/1606.00915.pdf
https://arxiv.org/pdf/1511.07122.pdf

Similar to https://github.com/pytorch/vision/pull/184