### PR TITLE
Create `ImageFolder` with the same (sorted) order on different machines

### DIFF
--- a/torchvision/datasets/folder.py
+++ b/torchvision/datasets/folder.py
@@ -24,7 +24,7 @@ def find_classes(dir):
 def make_dataset(dir, class_to_idx):
     images = []
     dir = os.path.expanduser(dir)
-    for target in os.listdir(dir):
+    for target in sorted(os.listdir(dir)):
         d = os.path.join(dir, target)
         if not os.path.isdir(d):
             continue


### PR DESCRIPTION
As mentioned in #192, current `make_dataset` function for `ImageFolder` may create datasets with different orders because `os.listdir(dir)` might produce different results on different machines.

This can be inconvenient if the user wants to compare or ensemble the outputs of the full dataset (for example, the validation set).

A simple modification `for target in sorted(os.listdir(dir)):` solves the problem. And since the loading procedure itself can be shuffled, I have not found the possible problems can be caused by this modification.