### PR TITLE
Fix densenet models: pass kwargs

### DIFF
--- a/torchvision/models/densenet.py
+++ b/torchvision/models/densenet.py
@@ -22,7 +22,8 @@ def densenet121(pretrained=False, **kwargs):
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
     """
-    model = DenseNet(num_init_features=64, growth_rate=32, block_config=(6, 12, 24, 16))
+    model = DenseNet(num_init_features=64, growth_rate=32, block_config=(6, 12, 24, 16),
+                     **kwargs)
     if pretrained:
         model.load_state_dict(model_zoo.load_url(model_urls['densenet121']))
     return model
@@ -35,7 +36,8 @@ def densenet169(pretrained=False, **kwargs):
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
     """
-    model = DenseNet(num_init_features=64, growth_rate=32, block_config=(6, 12, 32, 32))
+    model = DenseNet(num_init_features=64, growth_rate=32, block_config=(6, 12, 32, 32),
+                     **kwargs)
     if pretrained:
         model.load_state_dict(model_zoo.load_url(model_urls['densenet169']))
     return model
@@ -48,7 +50,8 @@ def densenet201(pretrained=False, **kwargs):
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
     """
-    model = DenseNet(num_init_features=64, growth_rate=32, block_config=(6, 12, 48, 32))
+    model = DenseNet(num_init_features=64, growth_rate=32, block_config=(6, 12, 48, 32),
+                     **kwargs)
     if pretrained:
         model.load_state_dict(model_zoo.load_url(model_urls['densenet201']))
     return model
@@ -61,7 +64,8 @@ def densenet161(pretrained=False, **kwargs):
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
     """
-    model = DenseNet(num_init_features=96, growth_rate=48, block_config=(6, 12, 36, 24))
+    model = DenseNet(num_init_features=96, growth_rate=48, block_config=(6, 12, 36, 24),
+                     **kwargs)
     if pretrained:
         model.load_state_dict(model_zoo.load_url(model_urls['densenet161']))
     return model


### PR DESCRIPTION
``densenet121``  and other functions in ``densenet`` module accept ``**kwargs``, but they are not passed to ``DenseNet`` class, unlike for other models (for example vgg and resnet). They are useful to define e.g. ``num_classes`` different from default ImageNet value.