### PR TITLE
Cifar also returns real data length

### DIFF
--- a/torchvision/datasets/cifar.py
+++ b/torchvision/datasets/cifar.py
@@ -128,9 +128,9 @@ class CIFAR10(data.Dataset):
 
     def __len__(self):
         if self.train:
-            return 50000
+            return len(self.train_data)
         else:
-            return 10000
+            return len(self.test_data)
 
     def _check_integrity(self):
         root = self.root


### PR DESCRIPTION
Same change as MNIST. This was an issue because after changing the dataset length, I could not use `RandomSampler` which depends on the `__len__` of the dataset. It gave index out of bounds error since the length was hardcoded.
