### PR TITLE
Sort images while creating dataset in ImageFolder

### DIFF
--- a/torchvision/datasets/folder.py
+++ b/torchvision/datasets/folder.py
@@ -30,7 +30,7 @@ def make_dataset(dir, class_to_idx):
             continue
 
         for root, _, fnames in sorted(os.walk(d)):
-            for fname in fnames:
+            for fname in sorted(fnames):
                 if is_image_file(fname):
                     path = os.path.join(root, fname)
                     item = (path, class_to_idx[target])


### PR DESCRIPTION
Currently, `ImageFolder` does not sort image files by filename when creating a dataset (even though it sorts the classes and subdirectories). This is problematic when working with video frames, i.e., the order of the images matter. 

Without this change, even while using `shuffle=False` in a `DataLoader`, the user will get a shuffled dataset.

If unsorted/shuffled images is desired, the user can still user `shuffle=True` when feeding the dataset to a `DataLoader`.

