### PR TITLE
[add] A PairRandomCrop for both input and target.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -332,6 +332,16 @@ integer, in which case the target will be of a square shape (size, size)
 If ``padding`` is non-zero, then the image is first zero-padded on each
 side with ``padding`` pixels.
 
+``PairRandomCrop(size, padding=0)``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Crops the given PIL.Image at a random location to have a region of the
+given size for both input image and its target image. size can be a
+tuple (target\_height, target\_width) or an integer, in which case the
+target will be of a square shape (size, size)
+If ``padding`` is non-zero, then the image is first zero-padded on each
+side with ``padding`` pixels.
+
 ``RandomHorizontalFlip()``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/torchvision/transforms.py
+++ b/torchvision/transforms.py
@@ -319,6 +319,7 @@ class RandomCrop(object):
         y1 = random.randint(0, h - th)
         return img.crop((x1, y1, x1 + tw, y1 + th))
 
+
 class PairRandomCrop(object):
     """Crop the given PIL.Image at a random location for both input and target.
 

--- a/torchvision/transforms.py
+++ b/torchvision/transforms.py
@@ -2,7 +2,6 @@ from __future__ import division
 import torch
 import math
 import random
-import os
 from PIL import Image, ImageOps
 try:
     import accimage
@@ -324,7 +323,7 @@ class PairRandomCrop(object):
             4 is provided, it is used to pad left, top, right, bottom borders
             respectively.
     """
-    image_crop_position = {}
+    last_position = None
 
     def __init__(self, size, padding=0):
         if isinstance(size, numbers.Number):
@@ -348,13 +347,12 @@ class PairRandomCrop(object):
         if w == tw and h == th:
             return img
 
-        pid = os.getpid()
-        if pid in self.image_crop_position:
-            x1, y1 = self.image_crop_position.pop(pid)
+        if self.last_position is not None:
+            (x1, y1), self.last_position = self.last_position, None
         else:
             x1 = random.randint(0, w - tw)
             y1 = random.randint(0, h - th)
-            self.image_crop_position[pid] = (x1, y1)
+            self.last_position = (x1, y1)
         return img.crop((x1, y1, x1 + tw, y1 + th))
 
 

--- a/torchvision/transforms.py
+++ b/torchvision/transforms.py
@@ -310,6 +310,51 @@ class RandomCrop(object):
         y1 = random.randint(0, h - th)
         return img.crop((x1, y1, x1 + tw, y1 + th))
 
+class PairRandomCrop(object):
+    """Crop the given PIL.Image at a random location for both input and target.
+
+    Args:
+        size (sequence or int): Desired output size of the crop. If size is an
+            int instead of sequence like (h, w), a square crop (size, size) is
+            made.
+        padding (int or sequence, optional): Optional padding on each border
+            of the image. Default is 0, i.e no padding. If a sequence of length
+            4 is provided, it is used to pad left, top, right, bottom borders
+            respectively.
+    """
+    image_crop_position = {}
+
+    def __init__(self, size, padding=0):
+        if isinstance(size, numbers.Number):
+            self.size = (int(size), int(size))
+        else:
+            self.size = size
+        self.padding = padding
+
+    def __call__(self, img):
+        """
+        Args:
+            img (PIL.Image): Image to be cropped.
+        Returns:
+            PIL.Image: Cropped image.
+        """
+        if self.padding > 0:
+            img = ImageOps.expand(img, border=self.padding, fill=0)
+
+        w, h = img.size
+        th, tw = self.size
+        if w == tw and h == th:
+            return img
+
+        pid = os.getpid()
+        if pid in self.image_crop_position:
+            x1, y1 = self.image_crop_position.pop(pid)
+        else:
+            x1 = random.randint(0, w - tw)
+            y1 = random.randint(0, h - th)
+            self.image_crop_position[pid] = (x1, y1)
+        return img.crop((x1, y1, x1 + tw, y1 + th))
+
 
 class RandomHorizontalFlip(object):
     """Horizontally flip the given PIL.Image randomly with a probability of 0.5."""

--- a/torchvision/transforms.py
+++ b/torchvision/transforms.py
@@ -1,11 +1,3 @@
-#!/usr/local/bin/python3
-# coding: UTF-8
-# Author: David
-# Email: youchen.du@gmail.com
-# Created: 2017-08-08 21:13
-# Last modified: 2017-08-08 21:13
-# Filename: transforms.py
-# Description:
 from __future__ import division
 import torch
 import math

--- a/torchvision/transforms.py
+++ b/torchvision/transforms.py
@@ -1,7 +1,16 @@
+#!/usr/local/bin/python3
+# coding: UTF-8
+# Author: David
+# Email: youchen.du@gmail.com
+# Created: 2017-08-08 21:13
+# Last modified: 2017-08-08 21:13
+# Filename: transforms.py
+# Description:
 from __future__ import division
 import torch
 import math
 import random
+import os
 from PIL import Image, ImageOps
 try:
     import accimage


### PR DESCRIPTION
RandomCrop does not support crop both image and target at same position, each time we call RandomCrop it will generate a new position which is not what we want.
This PairRandomCrop will remember the crop position of the image and use this same position to crop the target(vice versa).
It follows this idea:
> Crop in the same worker process is sequential. Crop happens in different workers should not bother each other.

A dict is used to remember the crop position of the image, key is the os.getpid() and value is the position.
So each time we crop a image, PairRandomCrop will generate a new position, when it comes to the target, it will pop and reuse the position.