### PR TITLE
make sure license file is included in distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include README.rst
+include LICENSE
 
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,9 @@
 [bdist_wheel]
 universal=1
 
+[metadata]
+license_file = LICENSE
+
 [pep8]
 max-line-length = 120
 


### PR DESCRIPTION
It's best practice to make sure that a file containing the full license ends up in distributions. The `MANIFEST.in` line adds it to source `.tar.gz` files via `sdist`, the `setup.cfg` change makes sure it ends up in `.whl` from `bdist_wheel`.