### PR TITLE
Fix random and center crop docs

### DIFF
--- a/torchvision/models/densenet.py
+++ b/torchvision/models/densenet.py
@@ -25,7 +25,7 @@ def densenet121(pretrained=False, **kwargs):
     model = DenseNet(num_init_features=64, growth_rate=32, block_config=(6, 12, 24, 16),
                      **kwargs)
     if pretrained:
-        model.load_state_dict(model_zoo.load_url(model_urls['densenet121']))
+        model.load_state_dict(model_zoo.load_url(model_urls['densenet121'], map_location=lambda storage, loc: storage))
     return model
 
 
@@ -39,7 +39,7 @@ def densenet169(pretrained=False, **kwargs):
     model = DenseNet(num_init_features=64, growth_rate=32, block_config=(6, 12, 32, 32),
                      **kwargs)
     if pretrained:
-        model.load_state_dict(model_zoo.load_url(model_urls['densenet169']))
+        model.load_state_dict(model_zoo.load_url(model_urls['densenet169'], map_location=lambda storage, loc: storage))
     return model
 
 
@@ -53,7 +53,7 @@ def densenet201(pretrained=False, **kwargs):
     model = DenseNet(num_init_features=64, growth_rate=32, block_config=(6, 12, 48, 32),
                      **kwargs)
     if pretrained:
-        model.load_state_dict(model_zoo.load_url(model_urls['densenet201']))
+        model.load_state_dict(model_zoo.load_url(model_urls['densenet201'], map_location=lambda storage, loc: storage))
     return model
 
 
@@ -67,7 +67,7 @@ def densenet161(pretrained=False, **kwargs):
     model = DenseNet(num_init_features=96, growth_rate=48, block_config=(6, 12, 36, 24),
                      **kwargs)
     if pretrained:
-        model.load_state_dict(model_zoo.load_url(model_urls['densenet161']))
+        model.load_state_dict(model_zoo.load_url(model_urls['densenet161'], map_location=lambda storage, loc: storage))
     return model
 
 

--- a/torchvision/models/densenet.py
+++ b/torchvision/models/densenet.py
@@ -25,7 +25,7 @@ def densenet121(pretrained=False, **kwargs):
     model = DenseNet(num_init_features=64, growth_rate=32, block_config=(6, 12, 24, 16),
                      **kwargs)
     if pretrained:
-        model.load_state_dict(model_zoo.load_url(model_urls['densenet121'], map_location=lambda storage, loc: storage))
+        model.load_state_dict(model_zoo.load_url(model_urls['densenet121']))
     return model
 
 
@@ -39,7 +39,7 @@ def densenet169(pretrained=False, **kwargs):
     model = DenseNet(num_init_features=64, growth_rate=32, block_config=(6, 12, 32, 32),
                      **kwargs)
     if pretrained:
-        model.load_state_dict(model_zoo.load_url(model_urls['densenet169'], map_location=lambda storage, loc: storage))
+        model.load_state_dict(model_zoo.load_url(model_urls['densenet169']))
     return model
 
 
@@ -53,7 +53,7 @@ def densenet201(pretrained=False, **kwargs):
     model = DenseNet(num_init_features=64, growth_rate=32, block_config=(6, 12, 48, 32),
                      **kwargs)
     if pretrained:
-        model.load_state_dict(model_zoo.load_url(model_urls['densenet201'], map_location=lambda storage, loc: storage))
+        model.load_state_dict(model_zoo.load_url(model_urls['densenet201']))
     return model
 
 
@@ -67,7 +67,7 @@ def densenet161(pretrained=False, **kwargs):
     model = DenseNet(num_init_features=96, growth_rate=48, block_config=(6, 12, 36, 24),
                      **kwargs)
     if pretrained:
-        model.load_state_dict(model_zoo.load_url(model_urls['densenet161'], map_location=lambda storage, loc: storage))
+        model.load_state_dict(model_zoo.load_url(model_urls['densenet161']))
     return model
 
 

--- a/torchvision/transforms.py
+++ b/torchvision/transforms.py
@@ -204,7 +204,7 @@ class CenterCrop(object):
 
     Args:
         size (sequence or int): Desired output size of the crop. If size is an
-            int instead of sequence like (h, w), a square crop (size, size) is
+            int instead of sequence like (w, h), a square crop (size, size) is
             made.
     """
 
@@ -283,7 +283,7 @@ class RandomCrop(object):
 
     Args:
         size (sequence or int): Desired output size of the crop. If size is an
-            int instead of sequence like (h, w), a square crop (size, size) is
+            int instead of sequence like (w, h), a square crop (size, size) is
             made.
         padding (int or sequence, optional): Optional padding on each border
             of the image. Default is 0, i.e no padding. If a sequence of length


### PR DESCRIPTION
Fix for #235, the docs for `RandomCrop` and `CenterCrop` were showing size to be `(h,w)` however `PIL.Imgae.size` is `(w,h)`, and in the `__call__` method it [is accessed as `(w,h)`](https://github.com/pytorch/vision/blob/master/torchvision/transforms.py#L312)