### PR TITLE
make pretrained densenet CPU compatible

### DIFF
--- a/torchvision/models/densenet.py
+++ b/torchvision/models/densenet.py
@@ -8,10 +8,10 @@ __all__ = ['DenseNet', 'densenet121', 'densenet169', 'densenet201', 'densenet161
 
 
 model_urls = {
-    'densenet121': 'https://download.pytorch.org/models/densenet121-241335ed.pth',
-    'densenet169': 'https://download.pytorch.org/models/densenet169-6f0f7f60.pth',
-    'densenet201': 'https://download.pytorch.org/models/densenet201-4c113574.pth',
-    'densenet161': 'https://download.pytorch.org/models/densenet161-17b70270.pth',
+    'densenet121': 'https://download.pytorch.org/models/densenet121-a639ec97.pth',
+    'densenet169': 'https://download.pytorch.org/models/densenet169-b2777c0a.pth',
+    'densenet201': 'https://download.pytorch.org/models/densenet201-c1103571.pth',
+    'densenet161': 'https://download.pytorch.org/models/densenet161-8d451a50.pth',
 }
 
 


### PR DESCRIPTION
Fix for #220 

Models were made CPU compatible with the following: https://gist.github.com/alykhantejani/9494db2c0977542f8c7db3736baf57f9

And have now been uploaded to pytorch.org
