### PR TITLE
add minimum requirement for pillow version >= 4.1.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ VERSION = '0.1.9'
 
 requirements = [
     'numpy',
-    'pillow',
+    'pillow >= 4.1.1',
     'six',
     'torch',
 ]


### PR DESCRIPTION
Enforcing pillow > 4.1.1 in response to #151.

For conda builds this requirement will have to be set in the meta.yaml when the next release happens, but this should take care of the wheel builds.