### PR TITLE
Revert "Fix random and center crop docs"

### DIFF
--- a/torchvision/transforms.py
+++ b/torchvision/transforms.py
@@ -204,7 +204,7 @@ class CenterCrop(object):
 
     Args:
         size (sequence or int): Desired output size of the crop. If size is an
-            int instead of sequence like (w, h), a square crop (size, size) is
+            int instead of sequence like (h, w), a square crop (size, size) is
             made.
     """
 
@@ -283,7 +283,7 @@ class RandomCrop(object):
 
     Args:
         size (sequence or int): Desired output size of the crop. If size is an
-            int instead of sequence like (w, h), a square crop (size, size) is
+            int instead of sequence like (h, w), a square crop (size, size) is
             made.
         padding (int or sequence, optional): Optional padding on each border
             of the image. Default is 0, i.e no padding. If a sequence of length


### PR DESCRIPTION
Reverts pytorch/vision#247.

Turns out the size is [accessed as h,w in the crop functions](https://github.com/pytorch/vision/blob/master/torchvision/transforms.py#L316). I will open a new issue for this tonight as we should discuss a way to fix this as now the API is inconsistent with PIL and inconsistent with other transforms (i.e. Scale which expects (w, h))