### PR TITLE
make size param of Scale (h,w) not (w,h)

### DIFF
--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -28,7 +28,7 @@ class Tester(unittest.TestCase):
         imgnarrow.fill_(0)
         result = transforms.Compose([
             transforms.ToPILImage(),
-            transforms.CenterCrop((owidth, oheight)),
+            transforms.CenterCrop((oheight, owidth)),
             transforms.ToTensor(),
         ])(img)
         assert result.sum() == 0, "height: " + str(height) + " width: " \
@@ -37,7 +37,7 @@ class Tester(unittest.TestCase):
         owidth += 1
         result = transforms.Compose([
             transforms.ToPILImage(),
-            transforms.CenterCrop((owidth, oheight)),
+            transforms.CenterCrop((oheight, owidth)),
             transforms.ToTensor(),
         ])(img)
         sum1 = result.sum()
@@ -47,7 +47,7 @@ class Tester(unittest.TestCase):
         owidth += 1
         result = transforms.Compose([
             transforms.ToPILImage(),
-            transforms.CenterCrop((owidth, oheight)),
+            transforms.CenterCrop((oheight, owidth)),
             transforms.ToTensor(),
         ])(img)
         sum2 = result.sum()
@@ -108,7 +108,7 @@ class Tester(unittest.TestCase):
         img = torch.ones(3, height, width)
         result = transforms.Compose([
             transforms.ToPILImage(),
-            transforms.RandomCrop((owidth, oheight)),
+            transforms.RandomCrop((oheight, owidth)),
             transforms.ToTensor(),
         ])(img)
         assert result.size(1) == oheight
@@ -117,7 +117,7 @@ class Tester(unittest.TestCase):
         padding = random.randint(1, 20)
         result = transforms.Compose([
             transforms.ToPILImage(),
-            transforms.RandomCrop((owidth, oheight), padding=padding),
+            transforms.RandomCrop((oheight, owidth), padding=padding),
             transforms.ToTensor(),
         ])(img)
         assert result.size(1) == oheight

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -86,7 +86,7 @@ class Tester(unittest.TestCase):
         owidth = random.randint(5, 12) * 2
         result = transforms.Compose([
             transforms.ToPILImage(),
-            transforms.Scale((owidth, oheight)),
+            transforms.Scale((oheight, owidth)),
             transforms.ToTensor(),
         ])(img)
         assert result.size(1) == oheight
@@ -94,7 +94,7 @@ class Tester(unittest.TestCase):
 
         result = transforms.Compose([
             transforms.ToPILImage(),
-            transforms.Scale([owidth, oheight]),
+            transforms.Scale([oheight, owidth]),
             transforms.ToTensor(),
         ])(img)
         assert result.size(1) == oheight

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -28,7 +28,7 @@ class Tester(unittest.TestCase):
         imgnarrow.fill_(0)
         result = transforms.Compose([
             transforms.ToPILImage(),
-            transforms.CenterCrop((oheight, owidth)),
+            transforms.CenterCrop((owidth, oheight)),
             transforms.ToTensor(),
         ])(img)
         assert result.sum() == 0, "height: " + str(height) + " width: " \
@@ -37,7 +37,7 @@ class Tester(unittest.TestCase):
         owidth += 1
         result = transforms.Compose([
             transforms.ToPILImage(),
-            transforms.CenterCrop((oheight, owidth)),
+            transforms.CenterCrop((owidth, oheight)),
             transforms.ToTensor(),
         ])(img)
         sum1 = result.sum()
@@ -47,7 +47,7 @@ class Tester(unittest.TestCase):
         owidth += 1
         result = transforms.Compose([
             transforms.ToPILImage(),
-            transforms.CenterCrop((oheight, owidth)),
+            transforms.CenterCrop((owidth, oheight)),
             transforms.ToTensor(),
         ])(img)
         sum2 = result.sum()
@@ -108,7 +108,7 @@ class Tester(unittest.TestCase):
         img = torch.ones(3, height, width)
         result = transforms.Compose([
             transforms.ToPILImage(),
-            transforms.RandomCrop((oheight, owidth)),
+            transforms.RandomCrop((owidth, oheight)),
             transforms.ToTensor(),
         ])(img)
         assert result.size(1) == oheight
@@ -117,7 +117,7 @@ class Tester(unittest.TestCase):
         padding = random.randint(1, 20)
         result = transforms.Compose([
             transforms.ToPILImage(),
-            transforms.RandomCrop((oheight, owidth), padding=padding),
+            transforms.RandomCrop((owidth, oheight), padding=padding),
             transforms.ToTensor(),
         ])(img)
         assert result.size(1) == oheight

--- a/torchvision/transforms.py
+++ b/torchvision/transforms.py
@@ -207,7 +207,7 @@ class CenterCrop(object):
 
     Args:
         size (sequence or int): Desired output size of the crop. If size is an
-            int instead of sequence like (h, w), a square crop (size, size) is
+            int instead of sequence like (w, h), a square crop (size, size) is
             made.
     """
 
@@ -226,7 +226,7 @@ class CenterCrop(object):
             PIL.Image: Cropped image.
         """
         w, h = img.size
-        th, tw = self.size
+        tw, th = self.size
         x1 = int(round((w - tw) / 2.))
         y1 = int(round((h - th) / 2.))
         return img.crop((x1, y1, x1 + tw, y1 + th))
@@ -286,7 +286,7 @@ class RandomCrop(object):
 
     Args:
         size (sequence or int): Desired output size of the crop. If size is an
-            int instead of sequence like (h, w), a square crop (size, size) is
+            int instead of sequence like (w, h), a square crop (size, size) is
             made.
         padding (int or sequence, optional): Optional padding on each border
             of the image. Default is 0, i.e no padding. If a sequence of length
@@ -313,7 +313,7 @@ class RandomCrop(object):
             img = ImageOps.expand(img, border=self.padding, fill=0)
 
         w, h = img.size
-        th, tw = self.size
+        tw, th = self.size
         if w == tw and h == th:
             return img
 

--- a/torchvision/transforms.py
+++ b/torchvision/transforms.py
@@ -165,7 +165,7 @@ class Scale(object):
 
     Args:
         size (sequence or int): Desired output size. If size is a sequence like
-            (w, h), output size will be matched to this. If size is an int,
+            (h, w), output size will be matched to this. If size is an int,
             smaller edge of the image will be matched to this number.
             i.e, if height > width, then image will be rescaled to
             (size * height / width, size)
@@ -199,7 +199,7 @@ class Scale(object):
                 ow = int(self.size * w / h)
                 return img.resize((ow, oh), self.interpolation)
         else:
-            return img.resize(self.size, self.interpolation)
+            return img.resize(self.size[::-1], self.interpolation)
 
 
 class CenterCrop(object):

--- a/torchvision/transforms.py
+++ b/torchvision/transforms.py
@@ -207,7 +207,7 @@ class CenterCrop(object):
 
     Args:
         size (sequence or int): Desired output size of the crop. If size is an
-            int instead of sequence like (w, h), a square crop (size, size) is
+            int instead of sequence like (h, w), a square crop (size, size) is
             made.
     """
 
@@ -226,7 +226,7 @@ class CenterCrop(object):
             PIL.Image: Cropped image.
         """
         w, h = img.size
-        tw, th = self.size
+        th, tw = self.size
         x1 = int(round((w - tw) / 2.))
         y1 = int(round((h - th) / 2.))
         return img.crop((x1, y1, x1 + tw, y1 + th))
@@ -286,7 +286,7 @@ class RandomCrop(object):
 
     Args:
         size (sequence or int): Desired output size of the crop. If size is an
-            int instead of sequence like (w, h), a square crop (size, size) is
+            int instead of sequence like (h, w), a square crop (size, size) is
             made.
         padding (int or sequence, optional): Optional padding on each border
             of the image. Default is 0, i.e no padding. If a sequence of length
@@ -313,7 +313,7 @@ class RandomCrop(object):
             img = ImageOps.expand(img, border=self.padding, fill=0)
 
         w, h = img.size
-        tw, th = self.size
+        th, tw = self.size
         if w == tw and h == th:
             return img
 


### PR DESCRIPTION
**Note: this PR introduces non backwards compatible changes**

Currently, there is some inconsistency in the transforms. For example, the `Scale` transform takes in a `size` param that can be a sequence and is expected to be in format `(w,h)`, but the `CenterCrop` and `RandomCrop` transforms expect `size` to be in `(h,w)`. 

Furthermore, `PIL`'s `Image` class also expects size tuples to be in the format `(w, h)`. We should standardize this across the transforms, and should probably use `(w, h)` as everything it PIL powered. 

This PR changes the expected format of the `size` param in `RandomCrop` and `CenterCrop` however this change is **not backward compatible**. 

An alternative to this would be to make the transforms explicitly accept a `w` and `h` param in the constructor, keeping the `size` param and adding deprecation warnings - however the inconsistency will still exist until we fully remove size in this case.