### PR TITLE
Fixing the issue reading 1GB chunk when calculating md5

### DIFF
--- a/torchvision/datasets/utils.py
+++ b/torchvision/datasets/utils.py
@@ -10,7 +10,7 @@ def check_integrity(fpath, md5):
     md5o = hashlib.md5()
     with open(fpath, 'rb') as f:
         # read in 1MB chunks
-        for chunk in iter(lambda: f.read(1024 * 1024 * 1024), b''):
+        for chunk in iter(lambda: f.read(1024 * 1024), b''):
             md5o.update(chunk)
     md5c = md5o.hexdigest()
     if md5c != md5:


### PR DESCRIPTION
According to the comment, this should be 1MB which is 1024*1024 bytes.