### PR TITLE
add RandomVerticalFlip transform

### DIFF
--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -1,7 +1,6 @@
 import torch
 import torchvision.transforms as transforms
 import unittest
-from unittest.mock import patch
 import random
 import numpy as np
 from PIL import Image

--- a/torchvision/transforms.py
+++ b/torchvision/transforms.py
@@ -338,6 +338,22 @@ class RandomHorizontalFlip(object):
         return img
 
 
+class RandomVerticalFlip(object):
+    """Vertically flip the given PIL.Image randomly with a probability of 0.5"""
+
+    def __call__(self, img):
+        """
+        Args:
+            img (PIL.Image): Image to be flipped.
+
+        Returns:
+            PIL.Image: Randomly flipped image.
+        """
+        if random.random() < 0.5:
+            return img.transpose(Image.FLIP_TOP_BOTTOM)
+        return img
+
+
 class RandomSizedCrop(object):
     """Crop the given PIL.Image to random size and aspect ratio.
 


### PR DESCRIPTION
Closes #257. 

I've currently done the same as `RandomHorizontalFlip` which uses a fixed probability of flipping of 50% and I've only used this probability in the tests. 

This is easy to extend to have the probability of flipping be different - but not sure if this is a valuable feature?

Also note, the tests for these require `scipy` which, at current, is an optional dependency for torchvision. @soumith Do we have `scipy` on the build box/ is there a way to have it installed for test runs?