### PR TITLE
Add scipy to the test environment in travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
   # Useful for debugging any issues with conda
   - conda info -a
 
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION pytorch -c soumith
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION pytorch scipy -c soumith
   - source activate test-environment
   - python setup.py install
   - pip install --upgrade pytest


### PR DESCRIPTION
We don't want/need to have `scipy` as a requirement for torchvision just yet, however do need it for testing (for example see PR #262 ). This PR adds `scipy` to the test conda environment