### PR TITLE
Deprecate Scale in favour of Resize

### DIFF
--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -123,7 +123,7 @@ class Tester(unittest.TestCase):
                 assert len(results) == 10
                 assert expected_output == results
 
-    def test_scale(self):
+    def test_resize(self):
         height = random.randint(24, 32) * 2
         width = random.randint(24, 32) * 2
         osize = random.randint(5, 12) * 2
@@ -131,7 +131,7 @@ class Tester(unittest.TestCase):
         img = torch.ones(3, height, width)
         result = transforms.Compose([
             transforms.ToPILImage(),
-            transforms.Scale(osize),
+            transforms.Resize(osize),
             transforms.ToTensor(),
         ])(img)
         assert osize in result.size()
@@ -142,7 +142,7 @@ class Tester(unittest.TestCase):
 
         result = transforms.Compose([
             transforms.ToPILImage(),
-            transforms.Scale([osize, osize]),
+            transforms.Resize([osize, osize]),
             transforms.ToTensor(),
         ])(img)
         assert osize in result.size()
@@ -153,7 +153,7 @@ class Tester(unittest.TestCase):
         owidth = random.randint(5, 12) * 2
         result = transforms.Compose([
             transforms.ToPILImage(),
-            transforms.Scale((oheight, owidth)),
+            transforms.Resize((oheight, owidth)),
             transforms.ToTensor(),
         ])(img)
         assert result.size(1) == oheight
@@ -161,7 +161,7 @@ class Tester(unittest.TestCase):
 
         result = transforms.Compose([
             transforms.ToPILImage(),
-            transforms.Scale([oheight, owidth]),
+            transforms.Resize([oheight, owidth]),
             transforms.ToTensor(),
         ])(img)
         assert result.size(1) == oheight
@@ -265,7 +265,7 @@ class Tester(unittest.TestCase):
     @unittest.skipIf(accimage is None, 'accimage not available')
     def test_accimage_resize(self):
         trans = transforms.Compose([
-            transforms.Scale(256, interpolation=Image.LINEAR),
+            transforms.Resize(256, interpolation=Image.LINEAR),
             transforms.ToTensor(),
         ])
 

--- a/torchvision/transforms.py
+++ b/torchvision/transforms.py
@@ -238,7 +238,7 @@ def crop(img, i, j, h, w):
 def resized_crop(img, i, j, h, w, size, interpolation=Image.BILINEAR):
     """Crop the given PIL.Image and resize it to desired size.
 
-    Notably used in RandomSizedCrop.
+    Notably used in RandomResizedCrop.
 
     Args:
         img (PIL.Image): Image to be cropped.
@@ -659,7 +659,7 @@ class RandomVerticalFlip(object):
         return img
 
 
-class RandomSizedCrop(object):
+class RandomResizedCrop(object):
     """Crop the given PIL.Image to random size and aspect ratio.
 
     A crop of random size of (0.08 to 1.0) of the original size and a random
@@ -719,6 +719,13 @@ class RandomSizedCrop(object):
         """
         i, j, h, w = self.get_params(img)
         return resized_crop(img, i, j, h, w, self.size, self.interpolation)
+
+
+class RandomSizedCrop(RandomResizedCrop):
+    def __init__(self, *args, **kwargs):
+        warnings.warn("The use of the transforms.RandomSizedCrop transform is deprecated, " +
+                      "please use transforms.RandomResizedCrop instead.")
+        super(RandomSizedCrop, self).__init__(*args, **kwargs)
 
 
 class FiveCrop(object):

--- a/torchvision/transforms.py
+++ b/torchvision/transforms.py
@@ -234,7 +234,7 @@ def crop(img, i, j, h, w):
     return img.crop((j, i, j + w, i + h))
 
 
-def scaled_crop(img, i, j, h, w, size, interpolation=Image.BILINEAR):
+def resized_crop(img, i, j, h, w, size, interpolation=Image.BILINEAR):
     """Crop the given PIL.Image and resize it to desired size.
 
     Notably used in RandomSizedCrop.
@@ -714,10 +714,10 @@ class RandomSizedCrop(object):
             img (PIL.Image): Image to be flipped.
 
         Returns:
-            PIL.Image: Randomly cropped and scaled image.
+            PIL.Image: Randomly cropped and resize image.
         """
         i, j, h, w = self.get_params(img)
-        return scaled_crop(img, i, j, h, w, self.size, self.interpolation)
+        return resized_crop(img, i, j, h, w, self.size, self.interpolation)
 
 
 class FiveCrop(object):

--- a/torchvision/transforms.py
+++ b/torchvision/transforms.py
@@ -13,6 +13,7 @@ import types
 import collections
 import warnings
 
+
 def _is_pil_image(img):
     if accimage is not None:
         return isinstance(img, (Image.Image, accimage.Image))
@@ -179,7 +180,7 @@ def resize(img, size, interpolation=Image.BILINEAR):
 
 
 def scale(*args, **kwargs):
-    warnings.warn("The use of the transforms.Scale transform is deprecated, " + \
+    warnings.warn("The use of the transforms.Scale transform is deprecated, " +
                   "please use transforms.Resize instead.")
     return resize(*args, **kwargs)
 
@@ -472,8 +473,8 @@ class Resize(object):
 
 class Scale(Resize):
     def __init__(self, *args, **kwargs):
-        warnings.warn("The use of the transforms.Scale transform is deprecated, " + \
-                  "please use transforms.Resize instead.")
+        warnings.warn("The use of the transforms.Scale transform is deprecated, " +
+                      "please use transforms.Resize instead.")
         super(Scale, self).__init__(*args, **kwargs)
 
 


### PR DESCRIPTION
In response to #264 `transforms.Scale` should be renamed to `Resize` - this is also in line with what `PIL` and `scipy` call this transform.

I have added a deprecation warning to the `Scale` constructor and function. 

I've also renamed `scaled_crop` to `resized_crop` as this is what it's actually doing (if we change `scale` -> `resize`). I didn't deprecate this as it was added only today and is not a public function in the latest release.