### PR TITLE
fixing densenet161 reference

### DIFF
--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -20,7 +20,7 @@ You can construct a model with random weights by calling its constructor:
     alexnet = models.alexnet()
     vgg16 = models.vgg16()
     squeezenet = models.squeezenet1_0()
-    densenet = models.densenet_161()
+    densenet = models.densenet161()
     inception = models.inception_v3()
 
 We provide pre-trained models, using the PyTorch :mod:`torch.utils.model_zoo`.
@@ -33,7 +33,7 @@ These can be constructed by passing ``pretrained=True``:
     alexnet = models.alexnet(pretrained=True)
     squeezenet = models.squeezenet1_0(pretrained=True)
     vgg16 = models.vgg16(pretrained=True)
-    densenet = models.densenet_161(pretrained=True)
+    densenet = models.densenet161(pretrained=True)
     inception = models.inception_v3(pretrained=True)
 
 All pre-trained models expect input images normalized in the same way,


### PR DESCRIPTION
a miss typed underscore in the models.densenet_161() and models.densenet_161(pretrained=True)