### PR TITLE
Add mode to ToPILImage constructor

### DIFF
--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -341,6 +341,7 @@ class Tester(unittest.TestCase):
 
         assert np.allclose(img_data_short.numpy(), to_tensor(img_short).numpy())
         assert np.allclose(img_data_int.numpy(), to_tensor(img_int).numpy())
+        assert np.allclose(img_data_byte.float().div_(255.0).numpy(), to_tensor(img_byte).numpy())
 
     def test_tensor_rgba_to_pil_image(self):
         trans = transforms.ToPILImage()

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -303,7 +303,6 @@ class Tester(unittest.TestCase):
         assert np.allclose(output.numpy(), expected_output.numpy())
 
     def test_1_channel_tensor_to_pil_image(self):
-        trans = transforms.ToPILImage()
         to_tensor = transforms.ToTensor()
 
         img_data_float = torch.Tensor(1, 4, 4).uniform_()
@@ -325,8 +324,6 @@ class Tester(unittest.TestCase):
                 assert np.allclose(expected_output, to_tensor(img).numpy())
 
     def test_1_channel_ndarray_to_pil_image(self):
-        trans = transforms.ToPILImage()
-
         img_data_float = torch.Tensor(4, 4, 1).uniform_().numpy()
         img_data_byte = torch.ByteTensor(4, 4, 1).random_(0, 255).numpy()
         img_data_short = torch.ShortTensor(4, 4, 1).random_().numpy()
@@ -358,7 +355,7 @@ class Tester(unittest.TestCase):
             verify_img_data(img_data, expected_output, mode=mode)
 
         with self.assertRaises(ValueError):
-            #should raise if we try a mode for 4 or 1 channel images
+            # should raise if we try a mode for 4 or 1 channel images
             transforms.ToPILImage(mode='RGBA')(img_data)
             transforms.ToPILImage(mode='P')(img_data)
 
@@ -379,7 +376,7 @@ class Tester(unittest.TestCase):
             verify_img_data(img_data, mode)
 
         with self.assertRaises(ValueError):
-            #should raise if we try a mode for 4 or 1 channel images
+            # should raise if we try a mode for 4 or 1 channel images
             transforms.ToPILImage(mode='RGBA')(img_data)
             transforms.ToPILImage(mode='P')(img_data)
 
@@ -402,7 +399,7 @@ class Tester(unittest.TestCase):
             verify_img_data(img_data, expected_output, mode)
 
         with self.assertRaises(ValueError):
-            #should raise if we try a mode for 3 or 1 channel images
+            # should raise if we try a mode for 3 or 1 channel images
             transforms.ToPILImage(mode='RGB')(img_data)
             transforms.ToPILImage(mode='P')(img_data)
 
@@ -423,7 +420,7 @@ class Tester(unittest.TestCase):
             verify_img_data(img_data, mode)
 
         with self.assertRaises(ValueError):
-            #should raise if we try a mode for 3 or 1 channel images
+            # should raise if we try a mode for 3 or 1 channel images
             transforms.ToPILImage(mode='RGB')(img_data)
             transforms.ToPILImage(mode='P')(img_data)
 
@@ -434,7 +431,6 @@ class Tester(unittest.TestCase):
             trans(np.ones([4, 4, 1], np.uint16))
             trans(np.ones([4, 4, 1], np.uint32))
             trans(np.ones([4, 4, 1], np.float64))
-
 
     @unittest.skipIf(stats is None, 'scipy.stats not available')
     def test_random_vertical_flip(self):

--- a/torchvision/transforms.py
+++ b/torchvision/transforms.py
@@ -109,26 +109,26 @@ def to_pil_image(pic, mode=None):
         elif npimg.dtype == np.float32:
             expected_mode = 'F'
         if mode is not None and mode != expected_mode:
-            raise ValueError("Incorrect mode supplied for input type {}. Should be
-                             {}".format(np.dtype, expected_mode))
+            raise ValueError("Incorrect mode ({}) supplied for input type {}. Should be {}".format(mode, np.dtype, expected_mode))
         mode = expected_mode
+
     elif npimg.shape[2] == 4:
         permitted_4_channel_modes = ['RGBA', 'CMYK']
         if mode is not None and mode not in permitted_4_channel_modes:
-            raise ValueError("Only modes {} are supported for 4D
-                             inputs".format(permitted_4_channel_modes))
-        if npimg.dtype == np.uint8:
+            raise ValueError("Only modes {} are supported for 4D inputs".format(permitted_4_channel_modes))
+
+        if mode is None and npimg.dtype == np.uint8:
             mode = 'RGBA'
     else:
-        permitted_3_channel_modes = ['RGB', 'YCbCr', 'LAB', 'HSV']
+        permitted_3_channel_modes = ['RGB', 'YCbCr', 'HSV']
         if mode is not None and mode not in permitted_3_channel_modes:
-            raise ValueError("Only modes {} are supported for 3D
-                             inputs".format(permitted_3_channel_modes))
-        if npimg.dtype == np.uint8:
+            raise ValueError("Only modes {} are supported for 3D inputs".format(permitted_3_channel_modes))
+        if mode is None and npimg.dtype == np.uint8:
             mode = 'RGB'
 
-    if mode is not None:
+    if mode is None:
         raise RuntimeError('Input type {} is not supported'.format(npimg.dtype))
+
     return Image.fromarray(npimg, mode=mode)
 
 

--- a/torchvision/transforms.py
+++ b/torchvision/transforms.py
@@ -98,7 +98,12 @@ def to_pil_image(pic, mode=None):
     if torch.is_tensor(pic):
         npimg = np.transpose(pic.numpy(), (1, 2, 0))
 
+    if not isinstance(npimg, np.ndarray):
+        raise TypeError('Input pic must be a torch.Tensor or NumPy ndarray, ' +
+                        'not {}'.format(type(npimg)))
+
     if npimg.shape[2] == 1:
+        expected_mode = None
         npimg = npimg[:, :, 0]
         if npimg.dtype == np.uint8:
             expected_mode = 'L'
@@ -127,7 +132,7 @@ def to_pil_image(pic, mode=None):
             mode = 'RGB'
 
     if mode is None:
-        raise RuntimeError('Input type {} is not supported'.format(npimg.dtype))
+        raise TypeError('Input type {} is not supported'.format(npimg.dtype))
 
     return Image.fromarray(npimg, mode=mode)
 

--- a/torchvision/transforms.py
+++ b/torchvision/transforms.py
@@ -85,6 +85,9 @@ def to_pil_image(pic, mode=None):
 
     Args:
         pic (Tensor or numpy.ndarray): Image to be converted to PIL Image.
+        mode (`PIL.Image mode`_): color space and pixel depth of input data (optional).
+
+    .. _PIL.Image mode: http://pillow.readthedocs.io/en/3.4.x/handbook/concepts.html#modes
 
     Returns:
         PIL Image: Image converted to PIL Image.
@@ -114,7 +117,8 @@ def to_pil_image(pic, mode=None):
         elif npimg.dtype == np.float32:
             expected_mode = 'F'
         if mode is not None and mode != expected_mode:
-            raise ValueError("Incorrect mode ({}) supplied for input type {}. Should be {}".format(mode, np.dtype, expected_mode))
+            raise ValueError("Incorrect mode ({}) supplied for input type {}. Should be {}"
+                             .format(mode, np.dtype, expected_mode))
         mode = expected_mode
 
     elif npimg.shape[2] == 4:
@@ -557,6 +561,16 @@ class ToPILImage(object):
 
     Converts a torch.*Tensor of shape C x H x W or a numpy ndarray of shape
     H x W x C to a PIL Image while preserving the value range.
+
+    Args:
+        mode (`PIL.Image mode`_): color space and pixel depth of input data (optional).
+            If ``mode`` is ``None`` (default) there are some assumptions made about the input data:
+            1. If the input has 3 channels, the ``mode`` is assumed to be ``RGB``.
+            2. If the input has 4 channels, the ``mode`` is assumed to be ``RGBA``.
+            3. If the input has 1 channel, the ``mode`` is determined by the data type (i,e,
+            ``int``, ``float``, ``short``).
+
+    .. _PIL.Image mode: http://pillow.readthedocs.io/en/3.4.x/handbook/concepts.html#modes
     """
     def __init__(self, mode=None):
         self.mode = mode


### PR DESCRIPTION
Addresses #244.

Note, I did not add support for the `LAB` colorspace for 3-channel inputs as `PIL` changes the underlying data in this case (see [here](https://github.com/python-pillow/Pillow/blob/367ce3c1bc78ef865efdcff26396e11a77838152/libImaging/Unpack.c#L936)).