### PR TITLE
add stride=1 for average pooling in models

### DIFF
--- a/torchvision/models/densenet.py
+++ b/torchvision/models/densenet.py
@@ -156,6 +156,6 @@ class DenseNet(nn.Module):
     def forward(self, x):
         features = self.features(x)
         out = F.relu(features, inplace=True)
-        out = F.avg_pool2d(out, kernel_size=7).view(features.size(0), -1)
+        out = F.avg_pool2d(out, kernel_size=7, stride=1).view(features.size(0), -1)
         out = self.classifier(out)
         return out

--- a/torchvision/models/resnet.py
+++ b/torchvision/models/resnet.py
@@ -107,7 +107,7 @@ class ResNet(nn.Module):
         self.layer2 = self._make_layer(block, 128, layers[1], stride=2)
         self.layer3 = self._make_layer(block, 256, layers[2], stride=2)
         self.layer4 = self._make_layer(block, 512, layers[3], stride=2)
-        self.avgpool = nn.AvgPool2d(7)
+        self.avgpool = nn.AvgPool2d(7, stride=1)
         self.fc = nn.Linear(512 * block.expansion, num_classes)
 
         for m in self.modules():

--- a/torchvision/models/squeezenet.py
+++ b/torchvision/models/squeezenet.py
@@ -83,7 +83,7 @@ class SqueezeNet(nn.Module):
             nn.Dropout(p=0.5),
             final_conv,
             nn.ReLU(inplace=True),
-            nn.AvgPool2d(13)
+            nn.AvgPool2d(13, stride=1)
         )
 
         for m in self.modules():


### PR DESCRIPTION
As discussed with @fmassa this addresses #304 and makes the __repr__ of these models consistent with other frameworks (caffe, TF, Keras etc)