### PR TITLE
Easy Feature Extraction

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -282,7 +282,7 @@ These can be constructed by passing ``pretrained=True``:
     vgg16 = models.vgg16(pretrained=True)
     densenet = models.densenet161(pretrained=True)
     inception = models.inception_v3(pretrained=True)
-    
+
 
 All pre-trained models expect input images normalized in the same way, i.e.
 mini-batches of 3-channel RGB images of shape (3 x H x W), where H and W are expected
@@ -292,6 +292,25 @@ The images have to be loaded in to a range of [0, 1] and then
 normalized using `mean=[0.485, 0.456, 0.406]` and `std=[0.229, 0.224, 0.225]`
 
 An example of such normalization can be found in the imagenet example `here <https://github.com/pytorch/examples/blob/42e5b996718797e45c46a25c55b031e6768f8440/imagenet/main.py#L89-L101>`__
+
+Feature Extraction
+~~~~~~~~~~~~~~~~~~
+
+VGG models implement a special method called ``get_feature_extractor()``
+which returns a ``nn.Sequential`` container up to the requested layer name
+for easy feature extraction. The layer names are compatible with the original
+Caffe naming scheme with additional extraction points after each ``BatchNorm``
+and ``ReLU`` layer.
+
+.. code:: python
+
+  import torchvision.models as models
+  vgg16 = models.vgg16(pretrained=True)
+  # Print model to get a sense of layer names
+  print(vgg16)
+  extractor = vgg16.get_feature_extractor('conv5_2+relu')
+  features = extractor(batch)
+
 
 Transforms
 ==========

--- a/torchvision/models/vgg.py
+++ b/torchvision/models/vgg.py
@@ -20,10 +20,12 @@ model_urls = {
     'vgg19_bn': 'https://download.pytorch.org/models/vgg19_bn-c79401a0.pth',
 }
 
+
 class Flatten(nn.Module):
     """Utility class for flattening an incoming input."""
     def forward(self, x):
         return x.view(x.size(0), -1)
+
     def __repr__(self):
         return "Flatten ()"
 
@@ -35,13 +37,13 @@ class VGG(nn.Module):
         # Add top part of the CNN
         layers.update(OrderedDict([
             ('flatten', Flatten()),
-            ('fc6',     nn.Linear(512 * 7 * 7, 4096)),
-            ('relu6',   nn.ReLU(True)),
-            ('drop6',   nn.Dropout()),
-            ('fc7',     nn.Linear(4096, 4096)),
-            ('relu7',   nn.ReLU(True)),
-            ('drop7',   nn.Dropout()),
-            ('fc8',     nn.Linear(4096, num_classes)),
+            ('fc6', nn.Linear(512 * 7 * 7, 4096)),
+            ('relu6', nn.ReLU(True)),
+            ('drop6', nn.Dropout()),
+            ('fc7', nn.Linear(4096, 4096)),
+            ('relu7', nn.ReLU(True)),
+            ('drop7', nn.Dropout()),
+            ('fc8', nn.Linear(4096, num_classes)),
         ]))
 
         # Put all layers inside a single container

--- a/torchvision/models/vgg.py
+++ b/torchvision/models/vgg.py
@@ -27,15 +27,15 @@ class VGG(nn.Module):
     def __init__(self, features, num_classes=1000):
         super(VGG, self).__init__()
         self.features = features
-        self.classifier = nn.Sequential(
-            nn.Linear(512 * 7 * 7, 4096),
-            nn.ReLU(True),
-            nn.Dropout(),
-            nn.Linear(4096, 4096),
-            nn.ReLU(True),
-            nn.Dropout(),
-            nn.Linear(4096, num_classes),
-        )
+        self.classifier = nn.Sequential(OrderedDict([
+            ('fc6',     nn.Linear(512 * 7 * 7, 4096)),
+            ('relu6',   nn.ReLU(True)),
+            ('drop6',   nn.Dropout()),
+            ('fc7',     nn.Linear(4096, 4096)),
+            ('relu7',   nn.ReLU(True)),
+            ('drop7',   nn.Dropout()),
+            ('fc8',     nn.Linear(4096, num_classes)),
+        ]))
         self._initialize_weights()
 
     def forward(self, x):

--- a/torchvision/models/vgg.py
+++ b/torchvision/models/vgg.py
@@ -49,7 +49,7 @@ class VGG(nn.Module):
         self._initialize_weights()
 
     def get_feature_extractor(self, layer_name):
-        """Returns a Sequential wrapping layer until the given one."""
+        """Returns a Sequential() which wraps layers up to the given one."""
         names = [n for (n, _) in self.layers.named_children()]
         if layer_name not in names:
             raise ValueError("%s is not a valid layer name." % layer_name)


### PR DESCRIPTION
Hello,

I added an easy feature extraction logic to VGG networks through a new method called `get_feature_extractor(self, layer_name)` which returns a `nn.Sequential()` container up to the `layer_name`. This also brings layer name support with a Caffe compatible naming scheme.

But since now the main `Sequential()` object is an `OrderedDict` with layer names, the `pretrained` weight initialization fails with `strict=True` :/ (Just noticed this after doing all of these modifications).

How strict are you to update the `.pth` files?

Thanks.