### PR TITLE
Improved image extension robustness

### DIFF
--- a/torchvision/datasets/folder.py
+++ b/torchvision/datasets/folder.py
@@ -4,14 +4,20 @@ from PIL import Image
 import os
 import os.path
 
-IMG_EXTENSIONS = [
-    '.jpg', '.JPG', '.jpeg', '.JPEG',
-    '.png', '.PNG', '.ppm', '.PPM', '.bmp', '.BMP',
-]
+IMG_EXTENSIONS = ['.jpg', '.jpeg', '.png', '.ppm', '.bmp', '.pgm']
 
 
 def is_image_file(filename):
-    return any(filename.endswith(extension) for extension in IMG_EXTENSIONS)
+    """Checks if a file is an image.
+
+    Args:
+        filename (string): path to a file
+
+    Returns:
+        bool: True if the filename ends with a known image extension
+    """
+    filename_lower = filename.lower()
+    return any(filename_lower.endswith(ext) for ext in IMG_EXTENSIONS)
 
 
 def find_classes(dir):


### PR DESCRIPTION
I had an issue with loading pgm images when using the ATT Faces dataset. The `.pgm` extension was missing from `IMG_EXTENSIONS`. As far as I know, PIL can read this format without any trouble, so it should be safe to add. Let me know if I'm wrong about this. 

While I was there, I noticed all the extensions were duplicated for caps and lower case, so I made them all lowercase in the variable and changed `is_image_file` to transform the input string into lower case. This adds robustness to weird corner cases like `img.Jpeg`. 

Lastly, I added a docstring. 