### PR TITLE
Fix get_params in RandomResizedCrop

### DIFF
--- a/torchvision/models/resnet.py
+++ b/torchvision/models/resnet.py
@@ -107,7 +107,7 @@ class ResNet(nn.Module):
         self.layer2 = self._make_layer(block, 128, layers[1], stride=2)
         self.layer3 = self._make_layer(block, 256, layers[2], stride=2)
         self.layer4 = self._make_layer(block, 512, layers[3], stride=2)
-        self.avgpool = nn.AvgPool2d(7, stride=1)
+        self.avgpool = nn.AvgPool2d(7)#, stride=1)
         self.fc = nn.Linear(512 * block.expansion, num_classes)
 
         for m in self.modules():

--- a/torchvision/transforms/transforms.py
+++ b/torchvision/transforms/transforms.py
@@ -341,8 +341,7 @@ class RandomResizedCrop(object):
         self.scale = scale
         self.ratio = ratio
 
-    @staticmethod
-    def get_params(img):
+    def get_params(self, img):
         """Get parameters for ``crop`` for a random sized crop.
 
         Args:


### PR DESCRIPTION
Small fix for PR #343.
The function `get_params` in RandomResizedCrop can't be static anymore.