### PR TITLE
add scale and ratio params to RandomResizedCrop.get_params

### DIFF
--- a/torchvision/transforms/transforms.py
+++ b/torchvision/transforms/transforms.py
@@ -342,11 +342,13 @@ class RandomResizedCrop(object):
         self.ratio = ratio
 
     @staticmethod
-    def get_params(img):
+    def get_params(img, scale, ratio):
         """Get parameters for ``crop`` for a random sized crop.
 
         Args:
             img (PIL Image): Image to be cropped.
+            scale (tuple): range of size of the origin size cropped
+            ratio (tuple): range of aspect ratio of the origin aspect ratio cropped
 
         Returns:
             tuple: params (i, j, h, w) to be passed to ``crop`` for a random
@@ -354,8 +356,8 @@ class RandomResizedCrop(object):
         """
         for attempt in range(10):
             area = img.size[0] * img.size[1]
-            target_area = random.uniform(*self.scale) * area
-            aspect_ratio = random.uniform(*self.ratio)
+            target_area = random.uniform(*scale) * area
+            aspect_ratio = random.uniform(*ratio)
 
             w = int(round(math.sqrt(target_area * aspect_ratio)))
             h = int(round(math.sqrt(target_area / aspect_ratio)))
@@ -382,7 +384,7 @@ class RandomResizedCrop(object):
         Returns:
             PIL Image: Randomly cropped and resize image.
         """
-        i, j, h, w = self.get_params(img)
+        i, j, h, w = self.get_params(img, self.scale, self.ratio)
         return F.resized_crop(img, i, j, h, w, self.size, self.interpolation)
 
 


### PR DESCRIPTION
#343 made `RandomResizedCrop.get_params` non-static. This makes it static again

cc @fmassa 