### PR TITLE
param to cause FakeData to generate different images

### DIFF
--- a/torchvision/datasets/fakedata.py
+++ b/torchvision/datasets/fakedata.py
@@ -19,7 +19,8 @@ class FakeData(data.Dataset):
 
     """
 
-    def __init__(self, size=1000, image_size=(3, 224, 224), num_classes=10, transform=None, target_transform=None, random_offset=0):
+    def __init__(self, size=1000, image_size=(3, 224, 224), num_classes=10,
+                 transform=None, target_transform=None, random_offset=0):
         self.size = size
         self.num_classes = num_classes
         self.image_size = image_size

--- a/torchvision/datasets/fakedata.py
+++ b/torchvision/datasets/fakedata.py
@@ -14,15 +14,18 @@ class FakeData(data.Dataset):
             and returns a transformed version. E.g, ``transforms.RandomCrop``
         target_transform (callable, optional): A function/transform that takes in the
             target and transforms it.
+        random_offset (int): Offsets the index-based random seed used to
+            generate each image. Default: 0
 
     """
 
-    def __init__(self, size=1000, image_size=(3, 224, 224), num_classes=10, transform=None, target_transform=None):
+    def __init__(self, size=1000, image_size=(3, 224, 224), num_classes=10, transform=None, target_transform=None, random_offset=0):
         self.size = size
         self.num_classes = num_classes
         self.image_size = image_size
         self.transform = transform
         self.target_transform = target_transform
+        self.random_offset = random_offset
 
     def __getitem__(self, index):
         """
@@ -34,7 +37,7 @@ class FakeData(data.Dataset):
         """
         # create random image that is consistent with the index id
         rng_state = torch.get_rng_state()
-        torch.manual_seed(index)
+        torch.manual_seed(index + self.random_offset)
         img = torch.randn(*self.image_size)
         target = torch.Tensor(1).random_(0, self.num_classes)[0]
         torch.set_rng_state(rng_state)


### PR DESCRIPTION
I want to make two instance of FakeData that produce different images, but this is currently not possible because the image is deterministically generated based on an index. 

I added a param called `random_offset` that will be added to the index-based seed so it becomes possible to have different FakeData objects generate different results with the same shape without resorting to a transform.