### PR TITLE
Determine DenseNet ave_pool kernel based on feature output shape

### DIFF
--- a/torchvision/models/densenet.py
+++ b/torchvision/models/densenet.py
@@ -156,6 +156,7 @@ class DenseNet(nn.Module):
     def forward(self, x):
         features = self.features(x)
         out = F.relu(features, inplace=True)
-        out = F.avg_pool2d(out, kernel_size=7, stride=1).view(features.size(0), -1)
+        kernel_size = tuple(map(int, features.shape[-2:]))
+        out = F.avg_pool2d(out, kernel_size=kernel_size, stride=1).view(features.size(0), -1)
         out = self.classifier(out)
         return out


### PR DESCRIPTION
Not sure if this is desired, feel free to say so and close this PR. 

Previously the DenseNet forward function essentially expected that the output resolution of the final convolutional layer would be 7x7. While this may be the case for the image-net dataset it is not the case for datasets like cifar-100. 

This change simply uses whatever the output resolution of feature extraction is in the average pooling layer. Then the shapes always match up nicely with the FC layer (as long as the input was big enough). 