### PR TITLE
Use consistent datatypes in Dataset targets

### DIFF
--- a/torchvision/datasets/semeion.py
+++ b/torchvision/datasets/semeion.py
@@ -60,7 +60,7 @@ class SEMEION(data.Dataset):
         Returns:
             tuple: (image, target) where target is index of the target class.
         """
-        img, target = self.data[index], self.labels[index]
+        img, target = self.data[index], int(self.labels[index])
 
         # doing this so that it is consistent with all other datasets
         # to return a PIL Image

--- a/torchvision/datasets/svhn.py
+++ b/torchvision/datasets/svhn.py
@@ -89,7 +89,7 @@ class SVHN(data.Dataset):
         Returns:
             tuple: (image, target) where target is index of the target class.
         """
-        img, target = self.data[index], self.labels[index]
+        img, target = self.data[index], int(self.labels[index])
 
         # doing this so that it is consistent with all other datasets
         # to return a PIL Image


### PR DESCRIPTION
Fixes https://github.com/pytorch/vision/issues/388 . Looked through the Datasets and added casts so that all datasets that return a single target value consistently return an `int`. 

Should I also add a test for this? It would seem that testing the Dataset classes is difficult since they need to download multiple gigabytes of data. To validate my changes, I did something like 

```python
from torchvision.datasets import *

datasets  = [CIFAR10, CIFAR100, FashionMNIST, MNIST, SEMEION, SVHN]

for ds in datasets:
    dataset = ds('./data', download=True)
    x, y = dataset[0]
    print(type(y))
```
