### PR TITLE
Fixed typo in the doc of RandomResizedCrop

### DIFF
--- a/torchvision/transforms/transforms.py
+++ b/torchvision/transforms/transforms.py
@@ -417,10 +417,10 @@ class RandomResizedCrop(object):
     def __call__(self, img):
         """
         Args:
-            img (PIL Image): Image to be flipped.
+            img (PIL Image): Image to be cropped and resized.
 
         Returns:
-            PIL Image: Randomly cropped and resize image.
+            PIL Image: Randomly cropped and resized image.
         """
         i, j, h, w = self.get_params(img, self.scale, self.ratio)
         return F.resized_crop(img, i, j, h, w, self.size, self.interpolation)


### PR DESCRIPTION
Updated the doc of RandomResizedCrop.__call__() from 'Image to be flipped' to 'Image to be cropped and resized'