### PR TITLE
Add support for slicing in datasets/cifar.py

### DIFF
--- a/torchvision/datasets/cifar.py
+++ b/torchvision/datasets/cifar.py
@@ -126,7 +126,7 @@ class CIFAR10(data.Dataset):
                 target = [self.target_transform(t) for t in target]
 
             return img, target
-        else:   
+        else:
             img = Image.fromarray(img)
             if self.transform is not None:
                 img = self.transform(img)

--- a/torchvision/datasets/cifar.py
+++ b/torchvision/datasets/cifar.py
@@ -1,6 +1,5 @@
 from __future__ import print_function
 from PIL import Image
-import PIL
 import os
 import os.path
 import errno

--- a/torchvision/datasets/cifar.py
+++ b/torchvision/datasets/cifar.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 from PIL import Image
+import PIL
 import os
 import os.path
 import errno
@@ -104,7 +105,7 @@ class CIFAR10(data.Dataset):
     def __getitem__(self, index):
         """
         Args:
-            index (int): Index
+            index (int): Index or slice
 
         Returns:
             tuple: (image, target) where target is index of the target class.
@@ -116,10 +117,20 @@ class CIFAR10(data.Dataset):
 
         # doing this so that it is consistent with all other datasets
         # to return a PIL Image
-        img = Image.fromarray(img)
+        if isinstance(index, slice):
+            img = [Image.fromarray(image) for image in img]
 
-        if self.transform is not None:
-            img = self.transform(img)
+            if self.transform is not None:
+                img = [self.transform(image) for image in img]
+
+            if self.target_transform is not None:
+                target = [self.target_transform(t) for t in target]
+
+            return img, target
+        else:   
+            img = Image.fromarray(img)
+            if self.transform is not None:
+                img = self.transform(img)
 
         if self.target_transform is not None:
             target = self.target_transform(target)


### PR DESCRIPTION
This is the PR to support slicing in datasets/cifar.py as per https://github.com/pytorch/vision/issues/395. We can also do this in the other dataset classes if this seems like a good idea. The gist of this PR is that instead of treating `img` as a single element, it is instead treated like a list, which is what we receive if the caller passes in a `slice` object. 