### PR TITLE
Add model.train() + model.eval() to models docs

### DIFF
--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -36,6 +36,11 @@ These can be constructed by passing ``pretrained=True``:
     densenet = models.densenet161(pretrained=True)
     inception = models.inception_v3(pretrained=True)
 
+Some models use modules which have different training and evaluation
+behavior, such as batch normalization. To switch between these modes, use
+``model.train()`` or ``model.eval()`` as appropriate. See
+:meth:`~torch.nn.Module.train` or :meth:`~torch.nn.Module.eval` for details. 
+
 All pre-trained models expect input images normalized in the same way,
 i.e. mini-batches of 3-channel RGB images of shape (3 x H x W),
 where H and W are expected to be at least 224.


### PR DESCRIPTION
This subtlety is still missed by people using pretrained models who won't be following tutorials closely [for example](https://discuss.pytorch.org/t/pretrained-resnet-constant-output/2760).