### PR TITLE
preconvert to PIL.Image; optionally preconvert to torch.Tensor

### DIFF
--- a/torchvision/datasets/cifar.py
+++ b/torchvision/datasets/cifar.py
@@ -11,7 +11,7 @@ else:
 
 import torch.utils.data as data
 from .utils import download_url, check_integrity
-
+from ..transforms import functional as F
 
 class CIFAR10(data.Dataset):
     """`CIFAR10 <https://www.cs.toronto.edu/~kriz/cifar.html>`_ Dataset.
@@ -46,9 +46,8 @@ class CIFAR10(data.Dataset):
         ['test_batch', '40351d587109b95175f43aff81a1287e'],
     ]
 
-    def __init__(self, root, train=True,
-                 transform=None, target_transform=None,
-                 download=False):
+    def __init__(self, root, train=True, transform=None, target_transform=None,
+                 download=False, pretensor=False):
         self.root = os.path.expanduser(root)
         self.transform = transform
         self.target_transform = target_transform
@@ -83,6 +82,10 @@ class CIFAR10(data.Dataset):
             self.train_data = np.concatenate(self.train_data)
             self.train_data = self.train_data.reshape((50000, 3, 32, 32))
             self.train_data = self.train_data.transpose((0, 2, 3, 1))  # convert to HWC
+            
+            self._train_data = [Image.fromarray(self.train_data[i]) for i in range(self.train_data.shape[0])]
+            if pretensor:
+                self._train_data = [F.to_tensor(img) for img in self._train_data]
         else:
             f = self.test_list[0][0]
             file = os.path.join(self.root, self.base_folder, f)
@@ -99,6 +102,10 @@ class CIFAR10(data.Dataset):
             fo.close()
             self.test_data = self.test_data.reshape((10000, 3, 32, 32))
             self.test_data = self.test_data.transpose((0, 2, 3, 1))  # convert to HWC
+            
+            self._test_data = [Image.fromarray(self.test_data[i]) for i in range(self.test_data.shape[0])]
+            if pretensor:
+                self._test_data = [F.to_tensor(img) for img in self._test_data]
 
     def __getitem__(self, index):
         """
@@ -109,13 +116,9 @@ class CIFAR10(data.Dataset):
             tuple: (image, target) where target is index of the target class.
         """
         if self.train:
-            img, target = self.train_data[index], self.train_labels[index]
+            img, target = self._train_data[index], self.train_labels[index]
         else:
-            img, target = self.test_data[index], self.test_labels[index]
-
-        # doing this so that it is consistent with all other datasets
-        # to return a PIL Image
-        img = Image.fromarray(img)
+            img, target = self._test_data[index], self.test_labels[index]
 
         if self.transform is not None:
             img = self.transform(img)

--- a/torchvision/datasets/mnist.py
+++ b/torchvision/datasets/mnist.py
@@ -7,7 +7,7 @@ import errno
 import numpy as np
 import torch
 import codecs
-
+from ..transforms import functional as F
 
 class MNIST(data.Dataset):
     """`MNIST <http://yann.lecun.com/exdb/mnist/>`_ Dataset.
@@ -36,7 +36,7 @@ class MNIST(data.Dataset):
     training_file = 'training.pt'
     test_file = 'test.pt'
 
-    def __init__(self, root, train=True, transform=None, target_transform=None, download=False):
+    def __init__(self, root, train=True, transform=None, target_transform=None, download=False, pretensor=False):
         self.root = os.path.expanduser(root)
         self.transform = transform
         self.target_transform = target_transform
@@ -52,9 +52,17 @@ class MNIST(data.Dataset):
         if self.train:
             self.train_data, self.train_labels = torch.load(
                 os.path.join(self.root, self.processed_folder, self.training_file))
+            
+            self._train_data = [Image.fromarray(self.train_data[i].numpy(), mode='L') for i in range(self.train_data.shape[0])]
+            if pretensor:
+                self._train_data = [F.to_tensor(img) for img in self._train_data]
         else:
             self.test_data, self.test_labels = torch.load(
                 os.path.join(self.root, self.processed_folder, self.test_file))
+            
+            self._test_data = [Image.fromarray(self.test_data[i].numpy(), mode='L') for i in range(self.test_data.shape[0])]
+            if pretensor:
+                self._test_data = [F.to_tensor(img) for img in self._test_data]
 
     def __getitem__(self, index):
         """
@@ -65,13 +73,9 @@ class MNIST(data.Dataset):
             tuple: (image, target) where target is index of the target class.
         """
         if self.train:
-            img, target = self.train_data[index], self.train_labels[index]
+            img, target = self._train_data[index], self.train_labels[index]
         else:
-            img, target = self.test_data[index], self.test_labels[index]
-
-        # doing this so that it is consistent with all other datasets
-        # to return a PIL Image
-        img = Image.fromarray(img.numpy(), mode='L')
+            img, target = self._test_data[index], self.test_labels[index]
 
         if self.transform is not None:
             img = self.transform(img)

--- a/torchvision/datasets/svhn.py
+++ b/torchvision/datasets/svhn.py
@@ -5,7 +5,7 @@ import os
 import os.path
 import numpy as np
 from .utils import download_url, check_integrity
-
+from ..transforms import functional as F
 
 class SVHN(data.Dataset):
     """`SVHN <http://ufldl.stanford.edu/housenumbers/>`_ Dataset.
@@ -40,7 +40,7 @@ class SVHN(data.Dataset):
                   "extra_32x32.mat", "a93ce644f1a588dc4d68dda5feec44a7"]}
 
     def __init__(self, root, split='train',
-                 transform=None, target_transform=None, download=False):
+                 transform=None, target_transform=None, download=False, pretensor=False):
         self.root = os.path.expanduser(root)
         self.transform = transform
         self.target_transform = target_transform
@@ -80,6 +80,10 @@ class SVHN(data.Dataset):
         # which expect the class labels to be in the range [0, C-1]
         np.place(self.labels, self.labels == 10, 0)
         self.data = np.transpose(self.data, (3, 2, 0, 1))
+        
+        self._data = [Image.fromarray(np.transpose(self.data[i], (1, 2, 0))) for i in range(self.data.shape[0])]
+        if pretensor:
+            self._data = [F.to_tensor(img) for img in self._data]
 
     def __getitem__(self, index):
         """
@@ -89,11 +93,7 @@ class SVHN(data.Dataset):
         Returns:
             tuple: (image, target) where target is index of the target class.
         """
-        img, target = self.data[index], int(self.labels[index])
-
-        # doing this so that it is consistent with all other datasets
-        # to return a PIL Image
-        img = Image.fromarray(np.transpose(img, (1, 2, 0)))
+        img, target = self._data[index], int(self.labels[index])
 
         if self.transform is not None:
             img = self.transform(img)


### PR DESCRIPTION
- For some datasets (cifar, svhn, stl10, mnist, fashionMNIST), conversion from numpy arrays to PIL.Image is done each time an image is requested.  This pull preconverts to PIL.Image, which gives a nontrivial speedup (see below code)
- Further, if you don't need to do any data augmentation that operates on the PIL.Image, you can preconvert to torch.Tensor.  This can give a quite a large speedup (see code).

For some applications, this can make a big difference.  Eg, training a relatively simple CNN for MNIST, you get the following speedups (~25% by precomputing PIL.Image, ~50% by precomputing torch.Tensors)

```
# current torchvision implementation
{'epoch': 0, 'train_score': 0.8918333333333334, 'val_score': 0.9763333333333334, 'test_score': 0.9795, 'time': 6.856365919113159}
{'epoch': 1, 'train_score': 0.967462962962963, 'val_score': 0.9855, 'test_score': 0.986, 'time': 5.420516490936279}
{'epoch': 2, 'train_score': 0.9761296296296297, 'val_score': 0.9855, 'test_score': 0.988, 'time': 5.8416588306427}
{'epoch': 3, 'train_score': 0.9797407407407407, 'val_score': 0.9886666666666667, 'test_score': 0.9898, 'time': 5.751266002655029}

# precompute PIL.Image (automatic in new code)
{'epoch': 0, 'train_score': 0.8918518518518519, 'val_score': 0.9756666666666667, 'test_score': 0.9798, 'time': 4.791485548019409}
{'epoch': 1, 'train_score': 0.9675, 'val_score': 0.9835, 'test_score': 0.9862, 'time': 3.9894304275512695}
{'epoch': 2, 'train_score': 0.9757222222222223, 'val_score': 0.9853333333333333, 'test_score': 0.9887, 'time': 3.690760850906372}
{'epoch': 3, 'train_score': 0.9798333333333333, 'val_score': 0.9878333333333333, 'test_score': 0.99, 'time': 3.920809030532837}

# precompute torch.Tensor (using pretensor flag in new code)
{'epoch': 0, 'train_score': 0.891962962962963, 'val_score': 0.9756666666666667, 'test_score': 0.979, 'time': 3.3365728855133057}
{'epoch': 1, 'train_score': 0.9677037037037037, 'val_score': 0.9825, 'test_score': 0.9846, 'time': 2.4013609886169434}
{'epoch': 2, 'train_score': 0.9757777777777777, 'val_score': 0.9851666666666666, 'test_score': 0.9885, 'time': 2.367426633834839}
{'epoch': 3, 'train_score': 0.9804444444444445, 'val_score': 0.987, 'test_score': 0.9907, 'time': 2.481478214263916}
```


Script illustrating relative speed of loaders is [here](https://gist.github.com/bkj/e76a386c49064bdf4b884cf4a8567e66)