### PR TITLE
Fix bug with to_tensor on the input of ndarray of float32

### DIFF
--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -269,9 +269,14 @@ class Tester(unittest.TestCase):
             output = trans(img)
             assert np.allclose(input_data.numpy(), output.numpy())
 
-            ndarray = np.random.randint(low=0, high=255, size=(height, width, channels))
+            ndarray = np.random.randint(low=0, high=255, size=(height, width, channels)).astype(np.uint8)
             output = trans(ndarray)
             expected_output = ndarray.transpose((2, 0, 1)) / 255.0
+            assert np.allclose(output.numpy(), expected_output)
+
+            ndarray = np.random.rand(height, width, channels).astype(np.float32)
+            output = trans(ndarray)
+            expected_output = ndarray.transpose((2, 0, 1))
             assert np.allclose(output.numpy(), expected_output)
 
     @unittest.skipIf(accimage is None, 'accimage not available')

--- a/torchvision/transforms/functional.py
+++ b/torchvision/transforms/functional.py
@@ -47,7 +47,10 @@ def to_tensor(pic):
         # handle numpy array
         img = torch.from_numpy(pic.transpose((2, 0, 1)))
         # backward compatibility
-        return img.float().div(255)
+        if isinstance(img, torch.ByteTensor):
+            return img.float().div(255)
+        else:
+            return img
 
     if accimage is not None and isinstance(pic, accimage.Image):
         nppic = np.zeros([pic.channels, pic.height, pic.width], dtype=np.float32)


### PR DESCRIPTION
Fix bug with `to_tensor` when the input is numpy array of type np.float32.
Bug is the following:
```
import numpy as np
from PIL import Image
from torchvision.transforms.functional import to_pil_image, to_tensor

a = np.random.rand(4, 4, 1).astype(np.float32)
print(a.dtype, a.shape)

a_ = to_tensor(a)
print(a_)

b = to_pil_image(a)
b_ = to_tensor(b)
print(b_)
```
and results are
```
float32 (4, 4, 1)

(0 ,.,.) = 
1.00000e-03 *
   1.3041  2.5746  0.9634  3.5018
   2.3763  0.7882  3.7558  1.6860
   3.0672  3.3926  3.4646  2.3841
   2.8028  1.4471  2.2046  2.1124
[torch.FloatTensor of size 1x4x4]


(0 ,.,.) = 
  0.3326  0.6565  0.2457  0.8930
  0.6060  0.2010  0.9577  0.4299
  0.7821  0.8651  0.8835  0.6080
  0.7147  0.3690  0.5622  0.5387
[torch.FloatTensor of size 1x4x4]
```

