### PR TITLE
Fix issue #409

### DIFF
--- a/torchvision/transforms/functional.py
+++ b/torchvision/transforms/functional.py
@@ -26,7 +26,7 @@ def _is_tensor_image(img):
 
 
 def _is_numpy_image(img):
-    return isinstance(img, np.ndarray) and (img.ndim in {2, 3})
+    return isinstance(img, np.ndarray) and img.ndim == 3
 
 
 def to_tensor(pic):
@@ -41,7 +41,8 @@ def to_tensor(pic):
         Tensor: Converted image.
     """
     if not(_is_pil_image(pic) or _is_numpy_image(pic)):
-        raise TypeError('pic should be PIL Image or ndarray. Got {}'.format(type(pic)))
+        shape_msg = ' with shape {}'.format(pic.shape) if hasattr(pic, 'shape') else ''
+        raise TypeError('pic should be PIL Image or 3D ndarray. Got {}{}'.format(type(pic), shape_msg))
 
     if isinstance(pic, np.ndarray):
         # handle numpy array
@@ -98,7 +99,9 @@ def to_pil_image(pic, mode=None):
         PIL Image: Image converted to PIL Image.
     """
     if not(_is_numpy_image(pic) or _is_tensor_image(pic)):
-        raise TypeError('pic should be Tensor or ndarray. Got {}.'.format(type(pic)))
+        shape_msg = ' with shape {}'.format(tuple(pic.shape)) if hasattr(pic, 'shape') else ''
+        raise TypeError('pic should be 3D Tensor or 3D ndarray. Got {}{}'
+                        .format(type(pic), shape_msg))
 
     npimg = pic
     if isinstance(pic, torch.FloatTensor):


### PR DESCRIPTION
- Improved error message
- Restrict input numpy array to be 3D and not 3D or 2D

Now error messages are :
```python
import torch
import torchvision.transforms.functional as F
a = torch.FloatTensor(10, 12)
a = F.to_pil_image(a)
F.to_tensor(a)
> TypeError: pic should be 3D Tensor or 3D ndarray. Got <class 'torch.FloatTensor'> with shape (10, 12)
```
```python
import numpy as np
import torchvision.transforms.functional as F
a = np.zeros((10, 12), dtype=np.float32)
a = F.to_pil_image(a)
F.to_tensor(None)
> TypeError: pic should be 3D Tensor or 3D ndarray. Got <class 'numpy.ndarray'> with shape (10, 12)
```
```python
import numpy as np
import torchvision.transforms.functional as F
a = np.zeros((10, 12), dtype=np.float32)
F.to_tensor(a)
> TypeError: pic should be PIL Image or 3D ndarray. Got <class 'numpy.ndarray'> with shape (10, 12)
```
```python
F.to_tensor(None)
> TypeError: pic should be PIL Image or 3D ndarray. Got <class 'NoneType'>
```
and 
```python
F.to_pil_image(None)
> TypeError: pic should be 3D Tensor or 3D ndarray. Got <class 'NoneType'>
```