### PR TITLE
Added support for center crop and resizing

### DIFF
--- a/torchvision/transforms/functional.py
+++ b/torchvision/transforms/functional.py
@@ -261,13 +261,21 @@ def crop(img, i, j, h, w):
 
 
 def center_crop(img, output_size):
-    if isinstance(output_size, numbers.Number):
-        output_size = (int(output_size), int(output_size))
-    w, h = img.size
-    th, tw = output_size
-    i = int(round((h - th) / 2.))
-    j = int(round((w - tw) / 2.))
-    return crop(img, i, j, th, tw)
+    if isinstance(output_size, float):
+        w, h = img.size
+        th, tw = int(h*output_size), int(w*output_size)
+
+        i = int(round((h - th) / 2.))
+        j = int(round((w - tw) / 2.))
+        return crop(img, i, j, th, tw)
+    else:
+        if isinstance(output_size, numbers.Number):
+            output_size = (int(output_size), int(output_size))
+        w, h = img.size
+        th, tw = output_size
+        i = int(round((h - th) / 2.))
+        j = int(round((w - tw) / 2.))
+        return crop(img, i, j, th, tw)
 
 
 def resized_crop(img, i, j, h, w, size, interpolation=Image.BILINEAR):
@@ -291,6 +299,25 @@ def resized_crop(img, i, j, h, w, size, interpolation=Image.BILINEAR):
     img = crop(img, i, j, h, w)
     img = resize(img, size, interpolation)
     return img
+
+
+def resized_center_crop(img, scale, size, interpolation=Image.BILINEAR):
+    """Center Crop the given PIL Image and resize it to desired size.
+
+    Notably used in CenterResizedCrop.
+
+    Args:
+        img (PIL Image): Image to be cropped.
+        size (sequence or int): Desired output size. Same semantics as ``scale``.
+        interpolation (int, optional): Desired interpolation. Default is
+            ``PIL.Image.BILINEAR``.
+    Returns:
+        PIL Image: Center cropped then resized image.
+    """
+    assert _is_pil_image(img), 'img should be PIL Image'
+    img = center_crop(img, scale)
+    img = resize(img, size, interpolation)
+    return img    
 
 
 def hflip(img):


### PR DESCRIPTION
I've added some support for performing central crop with a specific fraction, since this is a common preprocessing technique used in ImageNet classification (2012) validation preprocessing. I have tested the performance with **Inception V3** pretrained and with the preprocessing transformation seen below, I can get a validation accuracy of up till **77.61% for all 50k images**, which is close to the original reported **78.0% accuracy from Google**. This should be close enough for the sake of reproducibility. 

```
transform = transforms.Compose([
    transforms.CenterResizedCrop(299),
    transforms.ToTensor(),  
])
```
On top of the transformation above, I also needed to perform something as simple as `(input - 0.5)  * 2.0` in my data loading, in order to match the preprocessing operation used by google as seen here:
https://github.com/tensorflow/models/blob/master/research/slim/preprocessing/inception_preprocessing.py#L243-L281

This got the val accuracy up by another 0.3%. I believe the remaining difference in val accuracy could be attributed to training differences between the 2 frameworks.

----
### Regarding changes
To prevent breaking programs using existing function, I created the new `resized_center_crop` function instead of editing the RandomResizedCrop (which can technically achieve the same thing, although you would have to ignore many paramters and set the scale to a tight bound). I think this will be a nice addition to researchers working on the ImageNet dataset esp. when they want to replicate the performance seen in TensorFlow.

Please check if there are any issues with this pull request -- I'll figure a way to fix any issues as soon as I can.