### PR TITLE
Fix bug in LSUN dataset for test split.

### DIFF
--- a/torchvision/datasets/lsun.py
+++ b/torchvision/datasets/lsun.py
@@ -81,7 +81,7 @@ class LSUN(data.Dataset):
                 classes = [classes]
             else:
                 classes = [c + '_' + classes for c in categories]
-        if type(classes) == list:
+        elif type(classes) == list:
             for c in classes:
                 c_short = c.split('_')
                 c_short.pop(len(c_short) - 1)


### PR DESCRIPTION
Both conditional branches in `__init__` were executed, since `classes` for test
becomes a list and `if` was used instead of `elif`.