### PR TITLE
Add reflect, symmetric and edge padding

### DIFF
--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -235,6 +235,37 @@ class Tester(unittest.TestCase):
         # Checking if Padding can be printed as string
         transforms.Pad(padding).__repr__()
 
+    def test_pad_with_non_constant_padding_modes(self):
+        """Unit tests for edge, reflect, symmetric padding"""
+        img = torch.zeros(3, 27, 27)
+        img[:, :, 0] = 1  # Constant value added to leftmost edge
+        img = transforms.ToPILImage()(img)
+        img = F.pad(img, 1, (200, 200, 200))
+
+        # pad 3 to all sidess
+        edge_padded_img = F.pad(img, 3, padding_mode='edge')
+        # First 6 elements of leftmost edge in the middle of the image, values are in order:
+        # edge_pad, edge_pad, edge_pad, constant_pad, constant value added to leftmost edge, 0
+        edge_middle_slice = np.asarray(edge_padded_img).transpose(2, 0, 1)[0][17][:6]
+        assert np.all(edge_middle_slice == np.asarray([200, 200, 200, 200, 255, 0]))
+        assert transforms.ToTensor()(edge_padded_img).size() == (3, 35, 35)
+
+        # Pad 3 to left/right, 2 to top/bottom
+        reflect_padded_img = F.pad(img, (3, 2), padding_mode='reflect')
+        # First 6 elements of leftmost edge in the middle of the image, values are in order:
+        # reflect_pad, reflect_pad, reflect_pad, constant_pad, constant value added to leftmost edge, 0
+        reflect_middle_slice = np.asarray(reflect_padded_img).transpose(2, 0, 1)[0][17][:6]
+        assert np.all(reflect_middle_slice == np.asarray([0, 0, 255, 200, 255, 0]))
+        assert transforms.ToTensor()(reflect_padded_img).size() == (3, 33, 35)
+
+        # Pad 3 to left, 2 to top, 2 to right, 1 to bottom
+        symmetric_padded_img = F.pad(img, (3, 2, 2, 1), padding_mode='symmetric')
+        # First 6 elements of leftmost edge in the middle of the image, values are in order:
+        # sym_pad, sym_pad, sym_pad, constant_pad, constant value added to leftmost edge, 0
+        symmetric_middle_slice = np.asarray(symmetric_padded_img).transpose(2, 0, 1)[0][17][:6]
+        assert np.all(symmetric_middle_slice == np.asarray([0, 255, 200, 200, 255, 0]))
+        assert transforms.ToTensor()(symmetric_padded_img).size() == (3, 32, 34)
+
     def test_pad_raises_with_invalid_pad_sequence_len(self):
         with self.assertRaises(ValueError):
             transforms.Pad(())

--- a/torchvision/transforms/functional.py
+++ b/torchvision/transforms/functional.py
@@ -211,7 +211,7 @@ def scale(*args, **kwargs):
 
 
 def pad(img, padding, fill=0, padding_mode='constant'):
-    """Pad the given PIL Image on all sides with the given "pad" value.
+    """Pad the given PIL Image on all sides with speficified padding mode and fill value.
 
     Args:
         img (PIL Image): Image to be padded.
@@ -222,8 +222,17 @@ def pad(img, padding, fill=0, padding_mode='constant'):
             respectively.
         fill: Pixel fill value for constant fill. Default is 0. If a tuple of
             length 3, it is used to fill R, G, B channels respectively.
-        padding_mode: Type of padding. Should be: constant, edge, reflect or symmetric.
-            default value is constant fill.
+            This value is only used when the padding_mode is constant
+        padding_mode: Type of padding. Should be: constant, edge, reflect or symmetric. Default is constant.
+            constant: pads with a constant value, this value is specified with fill
+            edge: pads with the last value on the edge of the image
+            reflect: pads with reflection of image (without repeating the last value on the edge)
+                padding [1, 2, 3, 4] with 2 elements on both sides in reflect mode
+                will result in [3, 2, 1, 2, 3, 4, 3, 2]
+            symmetric: pads with reflection of image (repeating the last value on the edge)
+                padding [1, 2, 3, 4] with 2 elements on both sides in symmetric mode
+                will result in [2, 1, 1, 2, 3, 4, 4, 3]
+
     Returns:
         PIL Image: Padded image.
     """

--- a/torchvision/transforms/transforms.py
+++ b/torchvision/transforms/transforms.py
@@ -227,8 +227,18 @@ class Pad(object):
             on left/right and top/bottom respectively. If a tuple of length 4 is provided
             this is the padding for the left, top, right and bottom borders
             respectively.
-        fill: Pixel fill value. Default is 0. If a tuple of
+        fill: Pixel fill value for constant fill. Default is 0. If a tuple of
             length 3, it is used to fill R, G, B channels respectively.
+            This value is only used when the padding_mode is constant
+        padding_mode: Type of padding. Should be: constant, edge, reflect or symmetric. Default is constant.
+            constant: pads with a constant value, this value is specified with fill
+            edge: pads with the last value at the edge of the image
+            reflect: pads with reflection of image (without repeating the last value on the edge)
+                padding [1, 2, 3, 4] with 2 elements on both sides in reflect mode
+                will result in [3, 2, 1, 2, 3, 4, 3, 2]
+            symmetric: pads with reflection of image (repeating the last value on the edge)
+                padding [1, 2, 3, 4] with 2 elements on both sides in symmetric mode
+                will result in [2, 1, 1, 2, 3, 4, 4, 3]
     """
 
     def __init__(self, padding, fill=0, padding_mode='constant'):

--- a/torchvision/transforms/transforms.py
+++ b/torchvision/transforms/transforms.py
@@ -231,15 +231,17 @@ class Pad(object):
             length 3, it is used to fill R, G, B channels respectively.
     """
 
-    def __init__(self, padding, fill=0):
+    def __init__(self, padding, fill=0, padding_mode='constant'):
         assert isinstance(padding, (numbers.Number, tuple))
         assert isinstance(fill, (numbers.Number, str, tuple))
+        assert padding_mode in ['constant', 'edge', 'reflect', 'symmetric']
         if isinstance(padding, collections.Sequence) and len(padding) not in [2, 4]:
             raise ValueError("Padding must be an int or a 2, or 4 element tuple, not a " +
                              "{} element tuple".format(len(padding)))
 
         self.padding = padding
         self.fill = fill
+        self.padding_mode = padding_mode
 
     def __call__(self, img):
         """
@@ -249,10 +251,11 @@ class Pad(object):
         Returns:
             PIL Image: Padded image.
         """
-        return F.pad(img, self.padding, self.fill)
+        return F.pad(img, self.padding, self.fill, self.padding_mode)
 
     def __repr__(self):
-        return self.__class__.__name__ + '(padding={0}, fill={1})'.format(self.padding, self.fill)
+        return self.__class__.__name__ + '(padding={0}, fill={1}, padding_mode={2})'.\
+            format(self.padding, self.fill, self.padding_mode)
 
 
 class Lambda(object):


### PR DESCRIPTION
Added reflect, symmetric and edge padding options.

This option was requested by #400. PR #213 was sent to include the same functionality but still awaiting response from the author since Sep 20, 2017.

The new padding options also work the same way with how it is for the constant one.
If `padding` is an int: it pads all sides.
if `padding` is a tuple with two elements: it pads left/right and top/bottom respectively.
if `padding` is a tuple with four elements: it pads left, top, right, bottom borders respectively.
It also does not break or change the behavior of existing code.

In #213  @alykhantejani suggested that the function should be
`pad(img, padding,  padding_mode='constant', fill=0)` instead of 
`pad(img, padding, fill=0, padding_mode='constant')` because when the `padding_mode` is not _constant_, fill is irrelevant/not used. This is correct, but doing so might break existing code for some people so I did not change the positions.

Below are some tests:
RGB test image:
![test_image](https://user-images.githubusercontent.com/19213588/38188971-0fcead9c-3699-11e8-954f-740e8725d155.png)

`pad(img, 20, padding_mode = 'reflect')`
![20reflect](https://user-images.githubusercontent.com/19213588/38188978-18d02984-3699-11e8-83e8-e0e4cd0780d0.png)

`pad(img, (0, 50), padding_mode = 'edge')`
![0-50-edge](https://user-images.githubusercontent.com/19213588/38189097-83311a0e-3699-11e8-9696-07fde0fa5691.png)

`pad(img, (1, 10, 20, 30), padding_mode = 'symmetric')`
![1-10-20-30](https://user-images.githubusercontent.com/19213588/38189152-bec5f21a-3699-11e8-9e03-b349f2ddad31.png)

Grayscale test image:
![cat](https://user-images.githubusercontent.com/19213588/38189245-2ddb9272-369a-11e8-8533-f8559a8bad99.jpg)

`pad(img, (5,10,20,50), padding_mode = 'symmetric')`

![5-10-20-50-sym](https://user-images.githubusercontent.com/19213588/38189267-535dfeb8-369a-11e8-8a19-7129e2b36d46.png)








