### PR TITLE
Change the output of the 4th conv layer to 384 channels instead of 256

### DIFF
--- a/torchvision/models/alexnet.py
+++ b/torchvision/models/alexnet.py
@@ -23,9 +23,9 @@ class AlexNet(nn.Module):
             nn.MaxPool2d(kernel_size=3, stride=2),
             nn.Conv2d(192, 384, kernel_size=3, padding=1),
             nn.ReLU(inplace=True),
-            nn.Conv2d(384, 256, kernel_size=3, padding=1),
+            nn.Conv2d(384, 384, kernel_size=3, padding=1),
             nn.ReLU(inplace=True),
-            nn.Conv2d(256, 256, kernel_size=3, padding=1),
+            nn.Conv2d(384, 256, kernel_size=3, padding=1),
             nn.ReLU(inplace=True),
             nn.MaxPool2d(kernel_size=3, stride=2),
         )


### PR DESCRIPTION
I think the 4th convolutional layer outputs 384 channels and not 256. The paper can be found at: https://arxiv.org/pdf/1404.5997.pdf (see footnote 1 on page 5)