### PR TITLE
Add support in transforms.ToTensor for PIL Images mod '1'

### DIFF
--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -404,7 +404,7 @@ class Tester(unittest.TestCase):
             expected_output = ndarray.transpose((2, 0, 1))
             assert np.allclose(output.numpy(), expected_output)
 
-        #separate test for mode '1' PIL images
+        # separate test for mode '1' PIL images
         input_data = torch.ByteTensor(1, height, width).bernoulli_()
         img = transforms.ToPILImage()(input_data.mul(255)).convert('1')
         output = trans(img)

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -404,6 +404,12 @@ class Tester(unittest.TestCase):
             expected_output = ndarray.transpose((2, 0, 1))
             assert np.allclose(output.numpy(), expected_output)
 
+        #separate test for mode '1' PIL images
+        input_data = torch.ByteTensor(1, height, width).bernoulli_()
+        img = transforms.ToPILImage()(input_data.mul(255)).convert('1')
+        output = trans(img)
+        assert np.allclose(input_data.numpy(), output.numpy())
+
     @unittest.skipIf(accimage is None, 'accimage not available')
     def test_accimage_to_tensor(self):
         trans = transforms.ToTensor()

--- a/torchvision/transforms/functional.py
+++ b/torchvision/transforms/functional.py
@@ -65,7 +65,7 @@ def to_tensor(pic):
     elif pic.mode == 'F':
         img = torch.from_numpy(np.array(pic, np.float32, copy=False))
     elif pic.mode == '1':
-        img = 255*torch.from_numpy(np.array(pic, np.uint8, copy=False))
+        img = 255 * torch.from_numpy(np.array(pic, np.uint8, copy=False))
     else:
         img = torch.ByteTensor(torch.ByteStorage.from_buffer(pic.tobytes()))
     # PIL image mode: L, P, I, F, RGB, YCbCr, RGBA, CMYK

--- a/torchvision/transforms/functional.py
+++ b/torchvision/transforms/functional.py
@@ -64,9 +64,11 @@ def to_tensor(pic):
         img = torch.from_numpy(np.array(pic, np.int16, copy=False))
     elif pic.mode == 'F':
         img = torch.from_numpy(np.array(pic, np.float32, copy=False))
+    elif pic.mode == '1':
+        img = 255*torch.from_numpy(np.array(pic, np.uint8, copy=False))
     else:
         img = torch.ByteTensor(torch.ByteStorage.from_buffer(pic.tobytes()))
-    # PIL image mode: 1, L, P, I, F, RGB, YCbCr, RGBA, CMYK
+    # PIL image mode: L, P, I, F, RGB, YCbCr, RGBA, CMYK
     if pic.mode == 'YCbCr':
         nchannel = 3
     elif pic.mode == 'I;16':


### PR DESCRIPTION
Pil images mode '1' are 1-bit, so this line didn't work:

```python
img = torch.ByteTensor(torch.ByteStorage.from_buffer(pic.tobytes()))
```

I added another if to handle mode '1' images and added a test case in test_transforms.py