### PR TITLE
Backward compat fix for Pytorch < 0.4

### DIFF
--- a/torchvision/utils.py
+++ b/torchvision/utils.py
@@ -58,7 +58,7 @@ def make_grid(tensor, nrow=8, padding=2,
             if range is not None:
                 norm_ip(t, range[0], range[1])
             else:
-                norm_ip(t, t.min().item(), t.max().item())
+                norm_ip(t, float(t.min()), float(t.max()))
 
         if scale_each is True:
             for t in tensor:  # loop over mini-batch dimension


### PR DESCRIPTION
Our continuous integration fail without this.

cc @SsnL 