### PR TITLE
Fix documentation and add is_image_file

### DIFF
--- a/torchvision/datasets/folder.py
+++ b/torchvision/datasets/folder.py
@@ -11,12 +11,25 @@ def has_file_allowed_extension(filename, extensions):
 
     Args:
         filename (string): path to a file
+        extensions (iterable of strings): extensions to consider (lowercase)
+
+    Returns:
+        bool: True if the filename ends with one of given extensions
+    """
+    filename_lower = filename.lower()
+    return any(filename_lower.endswith(ext) for ext in extensions)
+
+
+def is_image_file(filename):
+    """Checks if a file is an allowed image extension.
+
+    Args:
+        filename (string): path to a file
 
     Returns:
         bool: True if the filename ends with a known image extension
     """
-    filename_lower = filename.lower()
-    return any(filename_lower.endswith(ext) for ext in extensions)
+    return has_file_allowed_extension(filename, IMG_EXTENSIONS)
 
 
 def find_classes(dir):


### PR DESCRIPTION
Fix documentation on `has_file_allowed_extension` and re-add `is_image_file`. `is_image_file` was removed because it was no longer used within the framework, but it is was a useful enough utility function that it was being used by at least one other project. 

Seems like a helpful utility function to provide as long as it is documented and people are using it.

https://github.com/inferno-pytorch/inferno/issues/104