### PR TITLE
Fix invalid argument error when using LSUN method in windows

### DIFF
--- a/torchvision/datasets/lsun.py
+++ b/torchvision/datasets/lsun.py
@@ -22,7 +22,7 @@ class LSUNClass(data.Dataset):
                              readahead=False, meminit=False)
         with self.env.begin(write=False) as txn:
             self.length = txn.stat()['entries']
-        cache_file = '_cache_' + root.replace('/', '_')
+        cache_file = '_cache_' + ''.join(c for c in root if c in string.ascii_letters)
         if os.path.isfile(cache_file):
             self.keys = pickle.load(open(cache_file, "rb"))
         else:


### PR DESCRIPTION
I was having issue importing LSUN dataset in windows and turned out this is caused by having back slash `\` in the root argument.

This fix will replace any non-ascii characters with '_' which should be more cross platform.

