### PR TITLE
Downgrade tqdm version to 4.19 for py2.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,12 +40,14 @@ requirements = [
     'numpy',
     'six',
     'torch',
-    'tqdm'
 ]
 
 pillow_ver = ' >= 4.1.1'
 pillow_req = 'pillow-simd' if get_dist('pillow-simd') is not None else 'pillow'
 requirements.append(pillow_req + pillow_ver)
+
+tqdm_ver = '4.19' if sys.version_info[0] < 3 else ''
+requirements.append('tqdm' + tqdm_ver)
 
 setup(
     # Metadata

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ pillow_ver = ' >= 4.1.1'
 pillow_req = 'pillow-simd' if get_dist('pillow-simd') is not None else 'pillow'
 requirements.append(pillow_req + pillow_ver)
 
-tqdm_ver = ' == 4.19' if sys.version_info[0] < 3 else ''
+tqdm_ver = ' == 4.19.9' if sys.version_info[0] < 3 else ''
 requirements.append('tqdm' + tqdm_ver)
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ pillow_ver = ' >= 4.1.1'
 pillow_req = 'pillow-simd' if get_dist('pillow-simd') is not None else 'pillow'
 requirements.append(pillow_req + pillow_ver)
 
-tqdm_ver = ' = 4.19' if sys.version_info[0] < 3 else ''
+tqdm_ver = ' == 4.19' if sys.version_info[0] < 3 else ''
 requirements.append('tqdm' + tqdm_ver)
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ pillow_ver = ' >= 4.1.1'
 pillow_req = 'pillow-simd' if get_dist('pillow-simd') is not None else 'pillow'
 requirements.append(pillow_req + pillow_ver)
 
-tqdm_ver = '4.19' if sys.version_info[0] < 3 else ''
+tqdm_ver = ' = 4.19' if sys.version_info[0] < 3 else ''
 requirements.append('tqdm' + tqdm_ver)
 
 setup(


### PR DESCRIPTION
This was observed during discussion in #541 . This will prevent spurious error while downloading.

cc @fmassa 