### PR TITLE
adjust the layer sequence in alexnet.classifier

### DIFF
--- a/torchvision/models/alexnet.py
+++ b/torchvision/models/alexnet.py
@@ -30,12 +30,12 @@ class AlexNet(nn.Module):
             nn.MaxPool2d(kernel_size=3, stride=2),
         )
         self.classifier = nn.Sequential(
-            nn.Dropout(),
             nn.Linear(256 * 6 * 6, 4096),
             nn.ReLU(inplace=True),
             nn.Dropout(),
             nn.Linear(4096, 4096),
             nn.ReLU(inplace=True),
+            nn.Dropout(),
             nn.Linear(4096, num_classes),
         )
 


### PR DESCRIPTION
Adjust the layer sequence in `alexnet.classifier` to fc6-relu-dropout-fc7-relu-dropout-fc8, see issue #549  

The new model file is temporarily stored in my google drive, [alexnet.pth](https://drive.google.com/file/d/1SKLyYaU69LKBE_3VZ6AdafPmlvOExPQa/view?usp=sharing)

I write a script to convert the previous pre-trained model to the new model file, but I don't know if I should include it in the PR.