### PR TITLE
Updated SVHN dataset(Allowing to use the full training set)

### DIFF
--- a/torchvision/datasets/svhn.py
+++ b/torchvision/datasets/svhn.py
@@ -33,8 +33,7 @@ class SVHN(data.Dataset):
         'test': ["http://ufldl.stanford.edu/housenumbers/test_32x32.mat",
                  "test_32x32.mat", "eb5a983be6a315427106f1b164d9cef3"],
         'extra': ["http://ufldl.stanford.edu/housenumbers/extra_32x32.mat",
-                  "extra_32x32.mat", "a93ce644f1a588dc4d68dda5feec44a7"]
-         }
+                  "extra_32x32.mat", "a93ce644f1a588dc4d68dda5feec44a7"]}
 
     def __init__(self, root, split='train',
                  transform=None, target_transform=None, download=False):

--- a/torchvision/datasets/svhn.py
+++ b/torchvision/datasets/svhn.py
@@ -26,9 +26,6 @@ class SVHN(data.Dataset):
             downloaded again.
 
     """
-    url = ""
-    filename = ""
-    file_md5 = ""
 
     split_list = {
         'train': ["http://ufldl.stanford.edu/housenumbers/train_32x32.mat",


### PR DESCRIPTION
I was recently trying to replicate a papers result on Pytorch, but noticed the current implementation only allows for using either `train `or `extra `splits for training, however nearly all papers that have experimented with `SVHN`, use the full dataset, i.e both the train and extra splits together. 
So I added a few changes to the original implementation that allows one to easily train using the full dataset. and thought it would be a good idea to share it with everyone. So here it is. 
The API is backward compatible (everything is the same tbh) so now one can easily do : 
```
import torchvision.datasets as dtset
...
if args.dataset == 'svhn':
     train_dir,val_dir = dtset.SVHN(args.data_path, split='download-all', download=True).create_dataset(args.outputdir)
     num_classes = 10
...
    train_dataset = dset.ImageFolder( train_dir, transforms.Compose([transforms.ToTensor() ]))
    train_loader = torch.utils.data.DataLoader(train_dataset,
        batch_size=args.batch_size, shuffle=True,
        num_workers=args.workers, pin_memory=True, sampler=None)

    test_dataset = dset.ImageFolder(val_dir, transforms.Compose([transforms.ToTensor() ]))
    test_loader = torch.utils.data.DataLoader(test_dataset,
        batch_size=args.batch_size, shuffle=False,
        num_workers=args.workers, pin_memory=True)

```
and utilize the whole training set and easily replicate any papers result on SVHN in Pytorch.

For those who have a huge amount of memory and prefer the in-memory method, they can do : 
```
import torchvision.datasets as dtset
if args.dataset == 'svhn':
    train_data = dtset.SVHN(args.data_path, split='train-extra', transform=train_transform, download=True)
    test_data = dtset.SVHN(args.data_path, split='test', transform=test_transform, download=True)
    num_classes = 10
...
    train_loader = torch.utils.data.DataLoader(train_data, batch_size=args.batch_size, shuffle=True,
                           num_workers=args.workers, pin_memory=True)
    test_loader = torch.utils.data.DataLoader(test_data, batch_size=args.batch_size, shuffle=False,
                          num_workers=args.workers, pin_memory=True)
```

Hope its useful.

Best Regards,
Hossein