### PR TITLE
Removed the +1 and divide by 2 to allow for random offset padding

### DIFF
--- a/torchvision/transforms/transforms.py
+++ b/torchvision/transforms/transforms.py
@@ -445,10 +445,10 @@ class RandomCrop(object):
 
         # pad the width if needed
         if self.pad_if_needed and img.size[0] < self.size[1]:
-            img = F.pad(img, (int((1 + self.size[1] - img.size[0]) / 2), 0), self.fill, self.padding_mode)
+            img = F.pad(img, (self.size[1] - img.size[0], 0), self.fill, self.padding_mode)
         # pad the height if needed
         if self.pad_if_needed and img.size[1] < self.size[0]:
-            img = F.pad(img, (0, int((1 + self.size[0] - img.size[1]) / 2)), self.fill, self.padding_mode)
+            img = F.pad(img, (0, self.size[0] - img.size[1]), self.fill, self.padding_mode)
 
         i, j, h, w = self.get_params(img, self.size)
 


### PR DESCRIPTION
In reference to Issue #562 

I learned that RandomCrop, when you set `pad_if_needed` to `True` does not RandomPad. a-la, whereas random crop applies a crop at a random offset to the image, pad_if_needed performs a centered padding, which does not randomly place the image in the padded image. The goal for this method, regardless of whether or not the image is too big or too small, is that the resulting image should be the right size, contain as much of the image as possible, and at random offset.

Imagine the image, whatever size, on an infinite canvas.
Apply a random offset, and a random crop, to that canvas, such that:
if the crop is bigger than the original image, all of the original image remains in the output.
if the crop is smaller than the original image, all of the output is part of the original image.

The fix is just to pad the image by double the previous amount, such that there is enough padding for the random cropping function to apply the offset.