### PR TITLE
Fix py37 warning

### DIFF
--- a/torchvision/transforms/functional.py
+++ b/torchvision/transforms/functional.py
@@ -1,5 +1,6 @@
 from __future__ import division
 import torch
+import sys
 import math
 import random
 from PIL import Image, ImageOps, ImageEnhance, PILLOW_VERSION
@@ -12,6 +13,13 @@ import numbers
 import types
 import collections
 import warnings
+
+if sys.version_info < (3, 3):
+    Sequence = collections.Sequence
+    Iterable = collections.Iterable
+else:
+    Sequence = collections.abc.Sequence
+    Iterable = collections.abc.Iterable
 
 
 def _is_pil_image(img):
@@ -191,7 +199,7 @@ def resize(img, size, interpolation=Image.BILINEAR):
     """
     if not _is_pil_image(img):
         raise TypeError('img should be PIL Image. Got {}'.format(type(img)))
-    if not (isinstance(size, int) or (isinstance(size, collections.Iterable) and len(size) == 2)):
+    if not (isinstance(size, int) or (isinstance(size, Iterable) and len(size) == 2)):
         raise TypeError('Got inappropriate size arg: {}'.format(size))
 
     if isinstance(size, int):
@@ -258,7 +266,7 @@ def pad(img, padding, fill=0, padding_mode='constant'):
     if not isinstance(padding_mode, str):
         raise TypeError('Got inappropriate padding_mode arg')
 
-    if isinstance(padding, collections.Sequence) and len(padding) not in [2, 4]:
+    if isinstance(padding, Sequence) and len(padding) not in [2, 4]:
         raise ValueError("Padding must be an int or a 2, or 4 element tuple, not a " +
                          "{} element tuple".format(len(padding)))
 
@@ -270,10 +278,10 @@ def pad(img, padding, fill=0, padding_mode='constant'):
     else:
         if isinstance(padding, int):
             pad_left = pad_right = pad_top = pad_bottom = padding
-        if isinstance(padding, collections.Sequence) and len(padding) == 2:
+        if isinstance(padding, Sequence) and len(padding) == 2:
             pad_left = pad_right = padding[0]
             pad_top = pad_bottom = padding[1]
-        if isinstance(padding, collections.Sequence) and len(padding) == 4:
+        if isinstance(padding, Sequence) and len(padding) == 4:
             pad_left = padding[0]
             pad_top = padding[1]
             pad_right = padding[2]

--- a/torchvision/transforms/transforms.py
+++ b/torchvision/transforms/transforms.py
@@ -1,6 +1,7 @@
 from __future__ import division
 import torch
 import math
+import sys
 import random
 from PIL import Image, ImageOps, ImageEnhance
 try:
@@ -14,6 +15,14 @@ import collections
 import warnings
 
 from . import functional as F
+
+if sys.version_info < (3, 3):
+    Sequence = collections.Sequence
+    Iterable = collections.Iterable
+else:
+    Sequence = collections.abc.Sequence
+    Iterable = collections.abc.Iterable
+
 
 __all__ = ["Compose", "ToTensor", "ToPILImage", "Normalize", "Resize", "Scale", "CenterCrop", "Pad",
            "Lambda", "RandomApply", "RandomChoice", "RandomOrder", "RandomCrop", "RandomHorizontalFlip",
@@ -163,7 +172,7 @@ class Resize(object):
     """
 
     def __init__(self, size, interpolation=Image.BILINEAR):
-        assert isinstance(size, int) or (isinstance(size, collections.Iterable) and len(size) == 2)
+        assert isinstance(size, int) or (isinstance(size, Iterable) and len(size) == 2)
         self.size = size
         self.interpolation = interpolation
 
@@ -255,7 +264,7 @@ class Pad(object):
         assert isinstance(padding, (numbers.Number, tuple))
         assert isinstance(fill, (numbers.Number, str, tuple))
         assert padding_mode in ['constant', 'edge', 'reflect', 'symmetric']
-        if isinstance(padding, collections.Sequence) and len(padding) not in [2, 4]:
+        if isinstance(padding, Sequence) and len(padding) not in [2, 4]:
             raise ValueError("Padding must be an int or a 2, or 4 element tuple, not a " +
                              "{} element tuple".format(len(padding)))
 


### PR DESCRIPTION
Warning message:
```
/private/home/ssnl/miniconda3/lib/python3.7/site-packages/torchvision-0.2.1-py3.7.egg/torchvision/transforms/functional.py:261: DeprecationWarning: Using or importing the ABCs from 'collections' instead of
from 'collections.abc' is deprecated, and in 3.8 it will stop working
```