### PR TITLE
Improve docs of functional transforms

### DIFF
--- a/docs/source/transforms.rst
+++ b/docs/source/transforms.rst
@@ -3,7 +3,11 @@ torchvision.transforms
 
 .. currentmodule:: torchvision.transforms
 
-Transforms are common image transforms. They can be chained together using :class:`Compose`
+Transforms are common image transformations. They can be chained together using :class:`Compose`.
+Additionally, there is the :mod:`torchvision.transforms.functional` module.
+Functional transforms give fine-grained control over the transformations.
+This is useful if you have to build a more complex transformation pipeline
+(e.g. in the case of segmentation tasks).
 
 .. autoclass:: Compose
 
@@ -77,6 +81,25 @@ Generic Transforms
 
 Functional Transforms
 ---------------------
+
+Functional transforms give you fine-grained control of the transformation pipeline.
+As opposed to the transformations above, functional transforms don't contain a random number
+generator for their parameters.
+That means you have to specify/generate all parameters, but you can reuse the functional transform.
+For example, you can apply a functional transform to multiple images like this:
+
+.. code:: python
+
+    import torchvision.transforms.functional as TF
+    import random
+
+    def my_segmentation_transforms(image, segmentation):
+        if random.random() > 5:
+            angle = random.randint(-30, 30)
+            image = TF.rotate(image, angle)
+            segmentation = TF.rotate(segmentation, angle)
+        # more transforms ...
+        return image, segmentation
 
 .. automodule:: torchvision.transforms.functional
     :members:


### PR DESCRIPTION
Inspired by #533, this PR improves the docs of functional transforms. This PR contains **only** the improved api docs, not the tutorial.

The api docs contain a short example of how to build a transform pipeline for a segmentation task.

Let me know if you want more/anything else @fmassa.