### PR TITLE
modified transforms.py to accept list of PIL images 

### DIFF
--- a/torchvision/transforms/transforms.py
+++ b/torchvision/transforms/transforms.py
@@ -477,6 +477,17 @@ class RandomHorizontalFlip(object):
     def __init__(self, p=0.5):
         self.p = p
 
+    @staticmethod
+    def get_params(p):
+        """Get parameters for ``crop`` for a random crop.
+
+        Args:
+            p : probability of flipping
+        Returns:
+            tuple: bool that would determine the flip
+        """
+        return random.random() < p
+    
     def __call__(self, img):
         """
         Args:
@@ -485,7 +496,8 @@ class RandomHorizontalFlip(object):
         Returns:
             PIL Image: Randomly flipped image.
         """
-        if random.random() < self.p:
+        to_flip = self.get_params(self.p)
+        if to_flip :
             return F.hflip(img)
         return img
 
@@ -503,6 +515,16 @@ class RandomVerticalFlip(object):
     def __init__(self, p=0.5):
         self.p = p
 
+    def get_params(p):
+        """Get parameters for ``crop`` for a random crop.
+
+        Args:
+            p : probability of flipping
+        Returns:
+            tuple: bool that would determine the flip
+        """
+        return random.random() < p
+
     def __call__(self, img):
         """
         Args:
@@ -511,7 +533,8 @@ class RandomVerticalFlip(object):
         Returns:
             PIL Image: Randomly flipped image.
         """
-        if random.random() < self.p:
+        to_flip = self.get_params(self.p)
+        if to_flip :
             return F.vflip(img)
         return img
 
@@ -1037,6 +1060,7 @@ class Grayscale(object):
     def __init__(self, num_output_channels=1):
         self.num_output_channels = num_output_channels
 
+
     def __call__(self, img):
         """
         Args:
@@ -1068,6 +1092,16 @@ class RandomGrayscale(object):
     def __init__(self, p=0.1):
         self.p = p
 
+    def get_params(p):
+        """Get parameters for ``crop`` for a random crop.
+
+        Args:
+            p : probability of converting to grayscale
+        Returns:
+            tuple: bool that would determine the flip
+        """
+        return random.random() < p
+
     def __call__(self, img):
         """
         Args:
@@ -1077,7 +1111,8 @@ class RandomGrayscale(object):
             PIL Image: Randomly grayscaled image.
         """
         num_output_channels = 1 if img.mode == 'L' else 3
-        if random.random() < self.p:
+        to_convert = self.get_params(self.p)
+        if to_convert :
             return F.to_grayscale(img, num_output_channels=num_output_channels)
         return img
 

--- a/torchvision/transforms/transforms.py
+++ b/torchvision/transforms/transforms.py
@@ -1061,7 +1061,6 @@ class Grayscale(object):
     def __init__(self, num_output_channels=1):
         self.num_output_channels = num_output_channels
 
-
     def __call__(self, img):
         """
         Args:

--- a/torchvision/transforms/transforms.py
+++ b/torchvision/transforms/transforms.py
@@ -1092,6 +1092,7 @@ class RandomGrayscale(object):
     def __init__(self, p=0.1):
         self.p = p
 
+    @staticmethod
     def get_params(p):
         """Get parameters for ``crop`` for a random crop.
 

--- a/torchvision/transforms/transforms.py
+++ b/torchvision/transforms/transforms.py
@@ -515,6 +515,7 @@ class RandomVerticalFlip(object):
     def __init__(self, p=0.5):
         self.p = p
 
+    @staticmethod
     def get_params(p):
         """Get parameters for ``crop`` for a random crop.
 

--- a/torchvision/transforms/transforms.py
+++ b/torchvision/transforms/transforms.py
@@ -484,7 +484,7 @@ class RandomHorizontalFlip(object):
         Args:
             p : probability of flipping
         Returns:
-            tuple: bool that would determine the flip
+            tuple: bool
         """
         return random.random() < p
     
@@ -521,7 +521,7 @@ class RandomVerticalFlip(object):
         Args:
             p : probability of flipping
         Returns:
-            tuple: bool that would determine the flip
+            tuple: bool 
         """
         return random.random() < p
 
@@ -1098,7 +1098,7 @@ class RandomGrayscale(object):
         Args:
             p : probability of converting to grayscale
         Returns:
-            tuple: bool that would determine the flip
+            tuple: bool
         """
         return random.random() < p
 

--- a/torchvision/transforms/transforms.py
+++ b/torchvision/transforms/transforms.py
@@ -497,7 +497,7 @@ class RandomHorizontalFlip(object):
             PIL Image: Randomly flipped image.
         """
         to_flip = self.get_params(self.p)
-        if to_flip :
+        if to_flip:
             return F.hflip(img)
         return img
 
@@ -535,7 +535,7 @@ class RandomVerticalFlip(object):
             PIL Image: Randomly flipped image.
         """
         to_flip = self.get_params(self.p)
-        if to_flip :
+        if to_flip:
             return F.vflip(img)
         return img
 
@@ -1114,7 +1114,7 @@ class RandomGrayscale(object):
         """
         num_output_channels = 1 if img.mode == 'L' else 3
         to_convert = self.get_params(self.p)
-        if to_convert :
+        if to_convert:
             return F.to_grayscale(img, num_output_channels=num_output_channels)
         return img
 


### PR DESCRIPTION
if input is a list of images then output is a list of images else old behaviour is retained
if params need to be computed for every img, then they are computed based on the fist img of the list
this was done to apply the same random transform on each img for example - image segmentation