### PR TITLE
Support for ROIAlign Layer

### DIFF
--- a/test/test_layers.py
+++ b/test/test_layers.py
@@ -95,7 +95,7 @@ class ROIPoolTester(unittest.TestCase):
         assert torch.equal(x.grad, gt_grad), 'gradient incorrect for roi_pool'
 
     @unittest.skipIf(not torch.cuda.is_available(), "CUDA unavailable")
-    def test_roi_pool_basic_gpu(self):
+    def test_roi_pool_basic_cuda(self):
         dtype = torch.float32
         device = torch.device('cuda')
         x = torch.rand(1, 1, 10, 10, dtype=dtype, device=device)
@@ -120,7 +120,7 @@ class ROIPoolTester(unittest.TestCase):
         assert torch.equal(gt_y.cuda(), y), 'ROIPool layer incorrect'
 
     @unittest.skipIf(not torch.cuda.is_available(), "CUDA unavailable")
-    def test_roi_pool_gpu(self):
+    def test_roi_pool_cuda(self):
         dtype = torch.float32
         device = torch.device('cuda') if torch.cuda.is_available() else torch.device('cpu')
         x = torch.rand(2, 1, 10, 10, dtype=dtype, device=device)
@@ -153,7 +153,7 @@ class ROIPoolTester(unittest.TestCase):
         assert torch.equal(gt_y.cuda(), y), 'ROIPool layer incorrect'
 
     @unittest.skipIf(not torch.cuda.is_available(), "CUDA unavailable")
-    def test_roi_pool_gradient_gpu(self):
+    def test_roi_pool_gradient_cuda(self):
         dtype = torch.float32
         device = torch.device('cuda')
         layer = layers.ROIPool((5, 5), 1).to(dtype=dtype, device=device)
@@ -184,6 +184,92 @@ class ROIPoolTester(unittest.TestCase):
                                   [1., 1., 1., 1., 1., 0., 0., 0., 0., 0.]]]], device=device)
 
         assert torch.equal(x.grad, gt_grad), 'gradient incorrect for roi_pool'
+
+
+class ROIAlignTester(unittest.TestCase):
+    @classmethod
+    def setup_class(cls):
+        torch.manual_seed(123)
+        cls.dtype = torch.float32
+        cls.x = torch.rand(1, 1, 10, 10, dtype=cls.dtype)
+        cls.single_roi = torch.tensor([[0, 0, 0, 4, 4]],  # format is (xyxy)
+                                      dtype=cls.dtype)
+        cls.rois = torch.tensor([[0, 0, 0, 9, 9],  # format is (xyxy)
+                                 [0, 0, 5, 4, 9],
+                                 [0, 5, 5, 9, 9]],
+                                dtype=torch.float32)
+
+        cls.gt_y_single = torch.tensor([[[[0.41617328, 0.5040753, 0.25266218, 0.4296828, 0.29928464],
+                                          [0.5210769, 0.57222337, 0.2524979, 0.32063985, 0.32635176],
+                                          [0.73108256, 0.6114335, 0.62033176, 0.8188273, 0.5562218],
+                                          [0.83115816, 0.70803946, 0.7084047, 0.74928707, 0.7769296],
+                                          [0.54266506, 0.45964524, 0.5780159, 0.80522037, 0.7321807]]]])
+
+        cls.gt_y_multiple = torch.tensor([[[[0.49311584, 0.35972416, 0.40843594, 0.3638034, 0.49751836],
+                                            [0.70881474, 0.75481665, 0.5826779, 0.34767765, 0.46865487],
+                                            [0.4740328, 0.69306874, 0.3617804, 0.47145438, 0.66130304],
+                                            [0.6861706, 0.17634538, 0.47194335, 0.42473823, 0.37930614],
+                                            [0.62666404, 0.49973848, 0.37911576, 0.5842756, 0.7176864]]],
+                                          [[[0.67499936, 0.6607055, 0.42656037, 0.46134934, 0.42144877],
+                                            [0.7471722, 0.7235433, 0.14512213, 0.13031253, 0.289369],
+                                              [0.8443615, 0.6659734, 0.23614208, 0.14719573, 0.4268827],
+                                              [0.69429564, 0.5621515, 0.5019923, 0.40678093, 0.34556213],
+                                              [0.51315194, 0.7177093, 0.6494485, 0.6775592, 0.43865064]]],
+                                          [[[0.24465509, 0.36108392, 0.64635646, 0.4051828, 0.33956185],
+                                            [0.49006107, 0.42982674, 0.34184104, 0.15493104, 0.49633422],
+                                              [0.54400194, 0.5265246, 0.22381854, 0.3929715, 0.6757667],
+                                              [0.32961223, 0.38482672, 0.68877804, 0.71822757, 0.711909],
+                                              [0.561259, 0.71047884, 0.84651315, 0.8541089, 0.644432]]]])
+
+    def test_roi_align_basic_cpu(self):
+        device = torch.device('cpu')
+        self.x = self.x.to(device)
+        self.single_roi = self.single_roi.to(device)
+        self.gt_y_multiple = self.gt_y_multiple.to(device)
+
+        pool_h, pool_w = (5, 5)
+        roi_align = layers.ROIAlign((pool_h, pool_w), spatial_scale=1, sampling_ratio=2.0)
+        y = roi_align(self.x, self.single_roi)
+
+        assert torch.equal(self.gt_y_single, y), 'ROIAlign layer incorrect for single ROI on CPU'
+
+    def test_roi_align_cpu(self):
+        device = torch.device('cpu')
+        self.x = self.x.to(device)
+        self.rois = self.rois.to(device)
+        self.gt_y_multiple = self.gt_y_multiple.to(device)
+
+        pool_h, pool_w = (5, 5)
+        roi_align = layers.ROIAlign((pool_h, pool_w), spatial_scale=1, sampling_ratio=2.0)
+        y = roi_align(self.x, self.rois)
+
+        assert torch.equal(self.gt_y_multiple, y), 'ROIAlign layer incorrect for multiple ROIs on CPU'
+
+    @unittest.skipIf(not torch.cuda.is_available(), "CUDA unavailable")
+    def test_roi_align_basic_cuda(self):
+        device = torch.device('cuda')
+        self.x = self.x.to(device)
+        self.single_roi = self.single_roi.to(device)
+        self.gt_y_single = self.gt_y_single.to(device)
+
+        pool_h, pool_w = (5, 5)
+        roi_align = layers.ROIAlign((pool_h, pool_w), spatial_scale=1, sampling_ratio=2.0)
+        y = roi_align(self.x, self.single_roi)
+
+        assert torch.allclose(self.gt_y_single, y), 'ROIAlign layer incorrect for single ROI on CUDA'
+
+    @unittest.skipIf(not torch.cuda.is_available(), "CUDA unavailable")
+    def test_roi_align_cuda(self):
+        device = torch.device('cuda')
+        self.x = self.x.to(device)
+        self.rois = self.rois.to(device)
+        self.gt_y_multiple = self.gt_y_multiple.to(device)
+
+        pool_h, pool_w = (5, 5)
+        roi_align = layers.ROIAlign((pool_h, pool_w), spatial_scale=1, sampling_ratio=2.0)
+        y = roi_align(self.x, self.rois)
+
+        assert torch.allclose(self.gt_y_multiple, y), 'ROIAlign layer incorrect for multiple ROIs on CUDA'
 
 
 if __name__ == '__main__':

--- a/torchvision/csrc/ROIAlign.h
+++ b/torchvision/csrc/ROIAlign.h
@@ -7,12 +7,13 @@
 #endif
 
 // Interface for Python
-at::Tensor ROIAlign_forward(const at::Tensor& input,
-                            const at::Tensor& rois,
-                            const float spatial_scale,
-                            const int pooled_height,
-                            const int pooled_width,
-                            const int sampling_ratio) {
+at::Tensor ROIAlign_forward(const at::Tensor& input,    // Input feature map.
+                            const at::Tensor& rois,     // List of ROIs to pool over.
+                            const float spatial_scale,  // The scale of the image features. ROIs will be scaled to this.
+                            const int pooled_height,    // The height of the pooled feature map.
+                            const int pooled_width,     // The width of the pooled feature
+                            const int sampling_ratio)   // The number of points to sample in each bin along each axis.
+{                   
   if (input.type().is_cuda()) {
 #ifdef WITH_CUDA
     return ROIAlign_forward_cuda(input, rois, spatial_scale, pooled_height, pooled_width, sampling_ratio);
@@ -40,6 +41,6 @@ at::Tensor ROIAlign_backward(const at::Tensor& grad,
     AT_ERROR("Not compiled with GPU support");
 #endif
   }
-  AT_ERROR("Not implemented on the CPU");
+  return ROIAlign_backward_cpu(grad, rois, spatial_scale, pooled_height, pooled_width, batch_size, channels, height, width, sampling_ratio);
 }
 

--- a/torchvision/csrc/cpu/ROIAlign_cpu.cpp
+++ b/torchvision/csrc/cpu/ROIAlign_cpu.cpp
@@ -369,7 +369,7 @@ at::Tensor ROIAlign_forward_cpu(const at::Tensor& input,
   if (output.numel() == 0)
     return output;
 
-  AT_DISPATCH_FLOATING_TYPES(input.type(), "ROIAlign_forward", [&] {
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.type(), "ROIAlign_forward", [&] {
     ROIAlignForward<scalar_t>(
          output_size,
          input.data<scalar_t>(),
@@ -414,7 +414,7 @@ at::Tensor ROIAlign_backward_cpu(const at::Tensor& grad,
   int h_stride = grad.stride(2);
   int w_stride = grad.stride(3);
 
-  AT_DISPATCH_FLOATING_TYPES(grad.type(), "ROIAlign_forward", [&] {
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(grad.type(), "ROIAlign_forward", [&] {
     ROIAlignBackward<scalar_t>(
         grad.numel(),
         grad.data<scalar_t>(),

--- a/torchvision/csrc/cpu/ROIAlign_cpu.cpp
+++ b/torchvision/csrc/cpu/ROIAlign_cpu.cpp
@@ -110,7 +110,7 @@ void pre_calc_for_bilinear_interpolate(
 }
 
 template <typename T>
-void ROIAlignForward_cpu_kernel(
+void ROIAlignForward(
     const int nthreads,
     const T* input,
     const T& spatial_scale,
@@ -121,11 +121,7 @@ void ROIAlignForward_cpu_kernel(
     const int pooled_width,
     const int sampling_ratio,
     const T* rois,
-    //int roi_cols,
     T* output) {
-  //AT_ASSERT(roi_cols == 4 || roi_cols == 5);
-  int roi_cols = 5;
-
   int n_rois = nthreads / channels / pooled_width / pooled_height;
   // (n, c, ph, pw) is an element in the pooled output
   // can be parallelized using omp
@@ -133,19 +129,14 @@ void ROIAlignForward_cpu_kernel(
   for (int n = 0; n < n_rois; n++) {
     int index_n = n * channels * pooled_width * pooled_height;
 
-    // roi could have 4 or 5 columns
-    const T* offset_rois = rois + n * roi_cols;
-    int roi_batch_ind = 0;
-    if (roi_cols == 5) {
-      roi_batch_ind = offset_rois[0];
-      offset_rois++;
-    }
+    const T* offset_rois = rois + n * 5;
+    int roi_batch_ind = offset_rois[0];
 
     // Do not using rounding; this implementation detail is critical
-    T roi_start_w = offset_rois[0] * spatial_scale;
-    T roi_start_h = offset_rois[1] * spatial_scale;
-    T roi_end_w = offset_rois[2] * spatial_scale;
-    T roi_end_h = offset_rois[3] * spatial_scale;
+    T roi_start_w = offset_rois[1] * spatial_scale;
+    T roi_start_h = offset_rois[2] * spatial_scale;
+    T roi_end_w = offset_rois[3] * spatial_scale;
+    T roi_end_h = offset_rois[4] * spatial_scale;
     // T roi_start_w = round(offset_rois[0] * spatial_scale);
     // T roi_start_h = round(offset_rois[1] * spatial_scale);
     // T roi_end_w = round(offset_rois[2] * spatial_scale);
@@ -217,14 +208,154 @@ void ROIAlignForward_cpu_kernel(
   } // for n
 }
 
+template <typename T>
+void bilinear_interpolate_gradient(
+    const int height, const int width,
+    T y, T x,
+    T& w1, T& w2, T& w3, T& w4,
+    int& x_low, int& x_high, int& y_low, int& y_high,
+    const int index /* index for debug only*/) {
+
+  // deal with cases that inverse elements are out of feature map boundary
+  if (y < -1.0 || y > height || x < -1.0 || x > width) {
+    // empty
+    w1 = w2 = w3 = w4 = 0.;
+    x_low = x_high = y_low = y_high = -1;
+    return;
+  }
+
+  if (y <= 0) y = 0;
+  if (x <= 0) x = 0;
+
+  y_low = (int)y;
+  x_low = (int)x;
+
+  if (y_low >= height - 1) {
+    y_high = y_low = height - 1;
+    y = (T)y_low;
+  } else {
+    y_high = y_low + 1;
+  }
+
+  if (x_low >= width - 1) {
+    x_high = x_low = width - 1;
+    x = (T)x_low;
+  } else {
+    x_high = x_low + 1;
+  }
+
+  T ly = y - y_low;
+  T lx = x - x_low;
+  T hy = 1. - ly, hx = 1. - lx;
+
+  // reference in forward
+  // T v1 = input[y_low * width + x_low];
+  // T v2 = input[y_low * width + x_high];
+  // T v3 = input[y_high * width + x_low];
+  // T v4 = input[y_high * width + x_high];
+  // T val = (w1 * v1 + w2 * v2 + w3 * v3 + w4 * v4);
+
+  w1 = hy * hx, w2 = hy * lx, w3 = ly * hx, w4 = ly * lx;
+
+  return;
+}
+
+template <class T>
+inline void add(T* address, const T& val) {
+  *address += val;
+}
+
+template <typename T>
+void ROIAlignBackward(
+    const int nthreads,
+    const T* grad_output,
+    const T& spatial_scale,
+    const int channels,
+    const int height, 
+    const int width,
+    const int pooled_height, 
+    const int pooled_width,
+    const int sampling_ratio,
+    T* grad_input,
+    const T* rois,
+    const int n_stride, const int c_stride,
+    const int h_stride, const int w_stride) {
+  for (int index = 0; index < nthreads; index++) {
+    // (n, c, ph, pw) is an element in the pooled output
+    int pw = index % pooled_width;
+    int ph = (index / pooled_width) % pooled_height;
+    int c = (index / pooled_width / pooled_height) % channels;
+    int n = index / pooled_width / pooled_height / channels;
+
+    const T* offset_rois = rois + n * 5;
+    int roi_batch_ind  = offset_rois[0];
+    
+    // Do not using rounding; this implementation detail is critical
+    T roi_start_w = offset_rois[1] * spatial_scale;
+    T roi_start_h = offset_rois[2] * spatial_scale;
+    T roi_end_w = offset_rois[3] * spatial_scale;
+    T roi_end_h = offset_rois[4] * spatial_scale;
+    
+    // Force malformed ROIs to be 1x1
+    T roi_width = std::max(roi_end_w - roi_start_w, (T)1.);
+    T roi_height = std::max(roi_end_h - roi_start_h, (T)1.);
+    T bin_size_h = static_cast<T>(roi_height) / static_cast<T>(pooled_height);
+    T bin_size_w = static_cast<T>(roi_width) / static_cast<T>(pooled_width);
+
+    T* offset_grad_input = grad_input + ((roi_batch_ind * channels + c) * height * width);
+
+    int output_offset = n*n_stride + c*c_stride;
+    const T* offset_grad_output = grad_output + output_offset;
+    const T grad_output_this_bin = offset_grad_output[ph*h_stride + pw*w_stride];
+
+    // We use roi_bin_grid to sample the grid and mimic integral
+    int roi_bin_grid_h = (sampling_ratio > 0) ? sampling_ratio : ceil(roi_height / pooled_height); // e.g., = 2
+    int roi_bin_grid_w = (sampling_ratio > 0) ? sampling_ratio : ceil(roi_width / pooled_width);
+
+    // We do average (integral) pooling inside a bin
+    const T count = roi_bin_grid_h * roi_bin_grid_w; // e.g. = 4
+
+    for (int iy = 0; iy < roi_bin_grid_h; iy++) 
+    {
+      const T y = roi_start_h + ph * bin_size_h + static_cast<T>(iy + .5f) * bin_size_h / static_cast<T>(roi_bin_grid_h); // e.g., 0.5, 1.5
+      for (int ix = 0; ix < roi_bin_grid_w; ix++) 
+      {
+        const T x = roi_start_w + pw * bin_size_w + static_cast<T>(ix + .5f) * bin_size_w / static_cast<T>(roi_bin_grid_w);
+
+        T w1, w2, w3, w4;
+        int x_low, x_high, y_low, y_high;
+
+        bilinear_interpolate_gradient(height, width, y, x,
+            w1, w2, w3, w4,
+            x_low, x_high, y_low, y_high,
+            index);
+
+        T g1 = grad_output_this_bin * w1 / count;
+        T g2 = grad_output_this_bin * w2 / count;
+        T g3 = grad_output_this_bin * w3 / count;
+        T g4 = grad_output_this_bin * w4 / count;
+
+        if (x_low >= 0 && x_high >= 0 && y_low >= 0 && y_high >= 0) {
+          // atomic add is not needed for now since it is single threaded
+          add(offset_grad_input + y_low * width + x_low, static_cast<T>(g1));
+          add(offset_grad_input + y_low * width + x_high, static_cast<T>(g2));
+          add(offset_grad_input + y_high * width + x_low, static_cast<T>(g3));
+          add(offset_grad_input + y_high * width + x_high, static_cast<T>(g4));
+        } // if
+      } // ix
+    } // iy
+  } // for
+} // ROIAlignBackward
+
+
 at::Tensor ROIAlign_forward_cpu(const at::Tensor& input,
                                 const at::Tensor& rois,
                                 const float spatial_scale,
                                 const int pooled_height,
                                 const int pooled_width,
                                 const int sampling_ratio) {
-  AT_ASSERTM(!input.type().is_cuda(), "input must be a CPU tensor");
-  AT_ASSERTM(!rois.type().is_cuda(), "rois must be a CPU tensor");
+  AT_ASSERTM(input.device().is_cpu(), "input must be a CPU tensor");
+  AT_ASSERTM(rois.device().is_cpu(), "rois must be a CPU tensor");
 
   auto num_rois = rois.size(0);
   auto channels = input.size(1);
@@ -239,7 +370,7 @@ at::Tensor ROIAlign_forward_cpu(const at::Tensor& input,
     return output;
 
   AT_DISPATCH_FLOATING_TYPES(input.type(), "ROIAlign_forward", [&] {
-    ROIAlignForward_cpu_kernel<scalar_t>(
+    ROIAlignForward<scalar_t>(
          output_size,
          input.data<scalar_t>(),
          spatial_scale,
@@ -253,4 +384,53 @@ at::Tensor ROIAlign_forward_cpu(const at::Tensor& input,
          output.data<scalar_t>());
   });
   return output;
+}
+
+
+at::Tensor ROIAlign_backward_cpu(const at::Tensor& grad,
+                                 const at::Tensor& rois,
+                                 const float spatial_scale,
+                                 const int pooled_height,
+                                 const int pooled_width,
+                                 const int batch_size,
+                                 const int channels,
+                                 const int height,
+                                 const int width,
+                                 const int sampling_ratio) {
+  AT_ASSERTM(grad.device().is_cpu(), "grad must be a CPU tensor");
+  AT_ASSERTM(rois.device().is_cpu(), "rois must be a CPU tensor");
+
+  at::Tensor grad_input = at::zeros({batch_size, channels, height, width}, grad.options());
+
+  // handle possibly empty gradients
+  if (grad.numel() == 0)
+  {
+    return grad_input;
+  }
+
+  // get stride values to ensure indexing into gradients is correct.
+  int n_stride = grad.stride(0);
+  int c_stride = grad.stride(1);
+  int h_stride = grad.stride(2);
+  int w_stride = grad.stride(3);
+
+  AT_DISPATCH_FLOATING_TYPES(grad.type(), "ROIAlign_forward", [&] {
+    ROIAlignBackward<scalar_t>(
+        grad.numel(),
+        grad.data<scalar_t>(),
+        spatial_scale,
+        channels,
+        height, 
+        width,
+        pooled_height, 
+        pooled_width,
+        sampling_ratio,
+        grad_input.data<scalar_t>(),
+        rois.data<scalar_t>(),
+        n_stride, 
+        c_stride,
+        h_stride, 
+        w_stride);
+  });
+  return grad_input;
 }

--- a/torchvision/csrc/cpu/ROIAlign_cpu.cpp
+++ b/torchvision/csrc/cpu/ROIAlign_cpu.cpp
@@ -362,7 +362,7 @@ at::Tensor ROIAlign_forward_cpu(const at::Tensor& input,
   auto height = input.size(2);
   auto width = input.size(3);
 
-  at::Tensor output = at::zeros({num_rois, channels, pooled_height, pooled_width}, input.type());
+  at::Tensor output = at::zeros({num_rois, channels, pooled_height, pooled_width}, input.options());
   
   auto output_size = num_rois * pooled_height * pooled_width * channels;
 

--- a/torchvision/csrc/cpu/ROIPool_cpu.cpp
+++ b/torchvision/csrc/cpu/ROIPool_cpu.cpp
@@ -16,8 +16,8 @@ std::tuple<at::Tensor, at::Tensor> ROIPool_forward_cpu(const at::Tensor &input,
     int input_height = input.size(2);
     int input_width = input.size(3);
 
-    at::Tensor output = at::zeros({num_rois, channels, pooled_height, pooled_width}, input.type());
-    at::Tensor argmax = at::zeros({num_rois, channels, pooled_height, pooled_width}, input.type().toScalarType(at::kInt));
+    at::Tensor output = at::zeros({num_rois, channels, pooled_height, pooled_width}, input.options());
+    at::Tensor argmax = at::zeros({num_rois, channels, pooled_height, pooled_width}, input.options().dtype(at::kInt));
 
     // define accessors for indexing
     auto input_a = input.accessor<float, 4>();
@@ -107,7 +107,7 @@ at::Tensor ROIPool_backward_cpu(const at::Tensor &grad,
 
     auto num_rois = rois.size(0);
 
-    at::Tensor grad_input = at::zeros({batch_size, channels, height, width}, grad.type());
+    at::Tensor grad_input = at::zeros({batch_size, channels, height, width}, grad.options());
 
     // handle possibly empty gradients
     if (grad.numel() == 0)

--- a/torchvision/csrc/cpu/vision.h
+++ b/torchvision/csrc/cpu/vision.h
@@ -25,6 +25,17 @@ at::Tensor ROIAlign_forward_cpu(const at::Tensor &input,
                                 const int pooled_width,
                                 const int sampling_ratio);
 
+at::Tensor ROIAlign_backward_cpu(const at::Tensor &grad,
+                                 const at::Tensor &rois,
+                                 const float spatial_scale,
+                                 const int pooled_height,
+                                 const int pooled_width,
+                                 const int batch_size,
+                                 const int channels,
+                                 const int height,
+                                 const int width,
+                                 const int sampling_ratio);
+
 at::Tensor nms_cpu(const at::Tensor &dets,
                    const at::Tensor &scores,
                    const float threshold);

--- a/torchvision/csrc/cuda/ROIAlign_cuda.cu
+++ b/torchvision/csrc/cuda/ROIAlign_cuda.cu
@@ -273,7 +273,7 @@ at::Tensor ROIAlign_forward_cuda(const at::Tensor& input,
     return output;
   }
 
-  AT_DISPATCH_FLOATING_TYPES(input.type(), "ROIAlign_forward", [&] {
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.type(), "ROIAlign_forward", [&] {
     RoIAlignForward<scalar_t><<<grid, block, 0, stream>>>(
          output_size,
          input.data<scalar_t>(),
@@ -323,7 +323,7 @@ at::Tensor ROIAlign_backward_cuda(const at::Tensor& grad,
   int h_stride = grad.stride(2);
   int w_stride = grad.stride(3);
 
-  AT_DISPATCH_FLOATING_TYPES(grad.type(), "ROIAlign_backward", [&] {
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(grad.type(), "ROIAlign_backward", [&] {
     RoIAlignBackward<scalar_t><<<grid, block, 0, stream>>>(
          grad.numel(),
          grad.data<scalar_t>(),

--- a/torchvision/csrc/cuda/ROIAlign_cuda.cu
+++ b/torchvision/csrc/cuda/ROIAlign_cuda.cu
@@ -12,7 +12,7 @@
 
 
 template <typename T>
-__device__ T bilinear_interpolate(const T* bottom_data,
+__device__ T bilinear_interpolate(const T* input,
     const int height, const int width,
     T y, T x,
     const int index /* index for debug only*/) {
@@ -48,11 +48,12 @@ __device__ T bilinear_interpolate(const T* bottom_data,
   T ly = y - y_low;
   T lx = x - x_low;
   T hy = 1. - ly, hx = 1. - lx;
+
   // do bilinear interpolation
-  T v1 = bottom_data[y_low * width + x_low];
-  T v2 = bottom_data[y_low * width + x_high];
-  T v3 = bottom_data[y_high * width + x_low];
-  T v4 = bottom_data[y_high * width + x_high];
+  T v1 = input[y_low * width + x_low];
+  T v2 = input[y_low * width + x_high];
+  T v3 = input[y_high * width + x_low];
+  T v4 = input[y_high * width + x_high];
   T w1 = hy * hx, w2 = hy * lx, w3 = ly * hx, w4 = ly * lx;
 
   T val = (w1 * v1 + w2 * v2 + w3 * v3 + w4 * v4);
@@ -61,12 +62,12 @@ __device__ T bilinear_interpolate(const T* bottom_data,
 }
 
 template <typename T>
-__global__ void RoIAlignForward(const int nthreads, const T* bottom_data,
+__global__ void RoIAlignForward(const int nthreads, const T* input,
     const T spatial_scale, const int channels,
     const int height, const int width,
     const int pooled_height, const int pooled_width,
     const int sampling_ratio,
-    const T* bottom_rois, T* top_data) {
+    const T* rois, T* output) {
   CUDA_1D_KERNEL_LOOP(index, nthreads) {
     // (n, c, ph, pw) is an element in the pooled output
     int pw = index % pooled_width;
@@ -74,18 +75,14 @@ __global__ void RoIAlignForward(const int nthreads, const T* bottom_data,
     int c = (index / pooled_width / pooled_height) % channels;
     int n = index / pooled_width / pooled_height / channels;
 
-    const T* offset_bottom_rois = bottom_rois + n * 5;
-    int roi_batch_ind = offset_bottom_rois[0];
+    const T* offset_rois = rois + n * 5;
+    int roi_batch_ind = offset_rois[0];
 
     // Do not using rounding; this implementation detail is critical
-    T roi_start_w = offset_bottom_rois[1] * spatial_scale;
-    T roi_start_h = offset_bottom_rois[2] * spatial_scale;
-    T roi_end_w = offset_bottom_rois[3] * spatial_scale;
-    T roi_end_h = offset_bottom_rois[4] * spatial_scale;
-    // T roi_start_w = round(offset_bottom_rois[1] * spatial_scale);
-    // T roi_start_h = round(offset_bottom_rois[2] * spatial_scale);
-    // T roi_end_w = round(offset_bottom_rois[3] * spatial_scale);
-    // T roi_end_h = round(offset_bottom_rois[4] * spatial_scale);
+    T roi_start_w = offset_rois[1] * spatial_scale;
+    T roi_start_h = offset_rois[2] * spatial_scale;
+    T roi_end_w = offset_rois[3] * spatial_scale;
+    T roi_end_h = offset_rois[4] * spatial_scale;
 
     // Force malformed ROIs to be 1x1
     T roi_width = max(roi_end_w - roi_start_w, (T)1.);
@@ -93,7 +90,7 @@ __global__ void RoIAlignForward(const int nthreads, const T* bottom_data,
     T bin_size_h = static_cast<T>(roi_height) / static_cast<T>(pooled_height);
     T bin_size_w = static_cast<T>(roi_width) / static_cast<T>(pooled_width);
 
-    const T* offset_bottom_data = bottom_data + (roi_batch_ind * channels + c) * height * width;
+    const T* offset_input = input + (roi_batch_ind * channels + c) * height * width;
 
     // We use roi_bin_grid to sample the grid and mimic integral
     int roi_bin_grid_h = (sampling_ratio > 0) ? sampling_ratio : ceil(roi_height / pooled_height); // e.g., = 2
@@ -110,13 +107,13 @@ __global__ void RoIAlignForward(const int nthreads, const T* bottom_data,
       {
         const T x = roi_start_w + pw * bin_size_w + static_cast<T>(ix + .5f) * bin_size_w / static_cast<T>(roi_bin_grid_w);
 
-        T val = bilinear_interpolate(offset_bottom_data, height, width, y, x, index);
+        T val = bilinear_interpolate(offset_input, height, width, y, x, index);
         output_val += val;
       }
     }
     output_val /= count;
 
-    top_data[index] = output_val;
+    output[index] = output_val;
   }
 }
 
@@ -162,10 +159,10 @@ __device__ void bilinear_interpolate_gradient(
   T hy = 1. - ly, hx = 1. - lx;
 
   // reference in forward
-  // T v1 = bottom_data[y_low * width + x_low];
-  // T v2 = bottom_data[y_low * width + x_high];
-  // T v3 = bottom_data[y_high * width + x_low];
-  // T v4 = bottom_data[y_high * width + x_high];
+  // T v1 = input[y_low * width + x_low];
+  // T v2 = input[y_low * width + x_high];
+  // T v3 = input[y_high * width + x_low];
+  // T v4 = input[y_high * width + x_high];
   // T val = (w1 * v1 + w2 * v2 + w3 * v3 + w4 * v4);
 
   w1 = hy * hx, w2 = hy * lx, w3 = ly * hx, w4 = ly * lx;
@@ -174,13 +171,15 @@ __device__ void bilinear_interpolate_gradient(
 }
 
 template <typename T>
-__global__ void RoIAlignBackwardFeature(const int nthreads, const T* top_diff,
+__global__ void RoIAlignBackwardFeature(const int nthreads, const T* grad_output,
     const int num_rois, const T spatial_scale,
     const int channels, const int height, const int width,
     const int pooled_height, const int pooled_width,
     const int sampling_ratio,
-    T* bottom_diff,
-    const T* bottom_rois) {
+    T* grad_input,
+    const T* rois,
+    const int n_stride, const int c_stride,
+    const int h_stride, const int w_stride) {
   CUDA_1D_KERNEL_LOOP(index, nthreads) {
     // (n, c, ph, pw) is an element in the pooled output
     int pw = index % pooled_width;
@@ -188,30 +187,26 @@ __global__ void RoIAlignBackwardFeature(const int nthreads, const T* top_diff,
     int c = (index / pooled_width / pooled_height) % channels;
     int n = index / pooled_width / pooled_height / channels;
 
-    const T* offset_bottom_rois = bottom_rois + n * 5;
-    int roi_batch_ind = offset_bottom_rois[0];
+    const T* offset_rois = rois + n * 5;
+    int roi_batch_ind = offset_rois[0];
 
     // Do not using rounding; this implementation detail is critical
-    T roi_start_w = offset_bottom_rois[1] * spatial_scale;
-    T roi_start_h = offset_bottom_rois[2] * spatial_scale;
-    T roi_end_w = offset_bottom_rois[3] * spatial_scale;
-    T roi_end_h = offset_bottom_rois[4] * spatial_scale;
-    // T roi_start_w = round(offset_bottom_rois[1] * spatial_scale);
-    // T roi_start_h = round(offset_bottom_rois[2] * spatial_scale);
-    // T roi_end_w = round(offset_bottom_rois[3] * spatial_scale);
-    // T roi_end_h = round(offset_bottom_rois[4] * spatial_scale);
-
+    T roi_start_w = offset_rois[1] * spatial_scale;
+    T roi_start_h = offset_rois[2] * spatial_scale;
+    T roi_end_w = offset_rois[3] * spatial_scale;
+    T roi_end_h = offset_rois[4] * spatial_scale;
+    
     // Force malformed ROIs to be 1x1
     T roi_width = max(roi_end_w - roi_start_w, (T)1.);
     T roi_height = max(roi_end_h - roi_start_h, (T)1.);
     T bin_size_h = static_cast<T>(roi_height) / static_cast<T>(pooled_height);
     T bin_size_w = static_cast<T>(roi_width) / static_cast<T>(pooled_width);
 
-    T* offset_bottom_diff = bottom_diff + (roi_batch_ind * channels + c) * height * width;
+    T* offset_grad_input = grad_input + (roi_batch_ind * channels + c) * height * width;
 
-    int top_offset    = (n * channels + c) * pooled_height * pooled_width;
-    const T* offset_top_diff = top_diff + top_offset;
-    const T top_diff_this_bin = offset_top_diff[ph * pooled_width + pw];
+    int top_offset = (n * channels + c) * pooled_height * pooled_width;
+    const T* offset_grad_output = grad_output + top_offset;
+    const T grad_output_this_bin = offset_grad_output[ph * pooled_width + pw];
 
     // We use roi_bin_grid to sample the grid and mimic integral
     int roi_bin_grid_h = (sampling_ratio > 0) ? sampling_ratio : ceil(roi_height / pooled_height); // e.g., = 2
@@ -235,17 +230,17 @@ __global__ void RoIAlignBackwardFeature(const int nthreads, const T* top_diff,
             x_low, x_high, y_low, y_high,
             index);
 
-        T g1 = top_diff_this_bin * w1 / count;
-        T g2 = top_diff_this_bin * w2 / count;
-        T g3 = top_diff_this_bin * w3 / count;
-        T g4 = top_diff_this_bin * w4 / count;
+        T g1 = grad_output_this_bin * w1 / count;
+        T g2 = grad_output_this_bin * w2 / count;
+        T g3 = grad_output_this_bin * w3 / count;
+        T g4 = grad_output_this_bin * w4 / count;
 
         if (x_low >= 0 && x_high >= 0 && y_low >= 0 && y_high >= 0)
         {
-          atomicAdd(offset_bottom_diff + y_low * width + x_low, static_cast<T>(g1));
-          atomicAdd(offset_bottom_diff + y_low * width + x_high, static_cast<T>(g2));
-          atomicAdd(offset_bottom_diff + y_high * width + x_low, static_cast<T>(g3));
-          atomicAdd(offset_bottom_diff + y_high * width + x_high, static_cast<T>(g4));
+          atomicAdd(offset_grad_input + y_low * width + x_low, static_cast<T>(g1));
+          atomicAdd(offset_grad_input + y_low * width + x_high, static_cast<T>(g2));
+          atomicAdd(offset_grad_input + y_high * width + x_low, static_cast<T>(g3));
+          atomicAdd(offset_grad_input + y_high * width + x_high, static_cast<T>(g4));
         } // if
       } // ix
     } // iy
@@ -326,6 +321,11 @@ at::Tensor ROIAlign_backward_cuda(const at::Tensor& grad,
     return grad_input;
   }
 
+  int n_stride = grad.stride(0);
+  int c_stride = grad.stride(1);
+  int h_stride = grad.stride(2);
+  int w_stride = grad.stride(3);
+  
   AT_DISPATCH_FLOATING_TYPES(grad.type(), "ROIAlign_backward", [&] {
     RoIAlignBackwardFeature<scalar_t><<<grid, block, 0, stream>>>(
          grad.numel(),
@@ -339,7 +339,11 @@ at::Tensor ROIAlign_backward_cuda(const at::Tensor& grad,
          pooled_width,
          sampling_ratio,
          grad_input.data<scalar_t>(),
-         rois.data<scalar_t>());
+         rois.data<scalar_t>(),
+         n_stride,
+         c_stride,
+         h_stride,
+         w_stride);
   });
   THCudaCheck(cudaGetLastError());
   return grad_input;

--- a/torchvision/csrc/cuda/ROIPool_cuda.cu
+++ b/torchvision/csrc/cuda/ROIPool_cuda.cu
@@ -108,16 +108,16 @@ std::tuple<at::Tensor, at::Tensor> ROIPool_forward_cuda(const at::Tensor& input,
                                 const float spatial_scale,
                                 const int pooled_height,
                                 const int pooled_width) {
-  AT_ASSERTM(input.type().is_cuda(), "input must be a CUDA tensor");
-  AT_ASSERTM(rois.type().is_cuda(), "rois must be a CUDA tensor");
+  AT_ASSERTM(input.device().is_cuda(), "input must be a CUDA tensor");
+  AT_ASSERTM(rois.device().is_cuda(), "rois must be a CUDA tensor");
 
   auto num_rois = rois.size(0);
   auto channels = input.size(1);
   auto height = input.size(2);
   auto width = input.size(3);
 
-  at::Tensor output = at::zeros({num_rois, channels, pooled_height, pooled_width}, input.type());
-  at::Tensor argmax = at::zeros({num_rois, channels, pooled_height, pooled_width}, input.type().toScalarType(at::kInt));
+  at::Tensor output = at::zeros({num_rois, channels, pooled_height, pooled_width}, input.options());
+  at::Tensor argmax = at::zeros({num_rois, channels, pooled_height, pooled_width}, input.options().dtype(at::kInt));
 
   auto output_size = num_rois * pooled_height * pooled_width * channels;
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();
@@ -159,13 +159,13 @@ at::Tensor ROIPool_backward_cuda(const at::Tensor& grad,
                                  const int height,
                                  const int width) {
   // Check if input tensors are CUDA tensors
-  AT_ASSERTM(grad.type().is_cuda(), "grad must be a CUDA tensor");
-  AT_ASSERTM(rois.type().is_cuda(), "rois must be a CUDA tensor");
-  AT_ASSERTM(argmax.type().is_cuda(), "argmax must be a CUDA tensor");
+  AT_ASSERTM(grad.device().is_cuda(), "grad must be a CUDA tensor");
+  AT_ASSERTM(rois.device().is_cuda(), "rois must be a CUDA tensor");
+  AT_ASSERTM(argmax.device().is_cuda(), "argmax must be a CUDA tensor");
 
   auto num_rois = rois.size(0);
     
-  at::Tensor grad_input = at::zeros({batch_size, channels, height, width}, grad.type());
+  at::Tensor grad_input = at::zeros({batch_size, channels, height, width}, grad.options());
 
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 


### PR DESCRIPTION
- Fixes and improvements to ROIAlign forward pass.
- Working implementation and improvements of ROIAlign backwards for GPU & CPU.
- Tests based on results from Caffe2 to verify correctness.

Support for `autograd.gradcheck` is still needed.