### PR TITLE
Fix FashionMNIST loading MNIST

### DIFF
--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -1,0 +1,22 @@
+import torch
+from torchvision.datasets import MNIST, FashionMNIST
+import unittest
+import tempfile
+import shutil
+import os
+
+
+class Tester(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    def test_fashion_mnist_doesnt_load_mnist(self):
+        MNIST(root=self.test_dir, download=True)
+        FashionMNIST(root=self.test_dir, download=True)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Before this would lead FashionMNIST to contain mnist data:

```
MNIST(root, download=True)
FashionMNIST(root, download=True)
```

As FashionMNIST inherits almost everything from MNIST, the processed
outputs actual ended up to be the same files. This commit now
stores them at different files and also stores the class name when
saving them. I also added md5 sums.