### PR TITLE
Changing to AdaptiveAvgPool2d on SqueezeNet and ResNet

### DIFF
--- a/torchvision/models/resnet.py
+++ b/torchvision/models/resnet.py
@@ -106,7 +106,7 @@ class ResNet(nn.Module):
         self.layer2 = self._make_layer(block, 128, layers[1], stride=2)
         self.layer3 = self._make_layer(block, 256, layers[2], stride=2)
         self.layer4 = self._make_layer(block, 512, layers[3], stride=2)
-        self.avgpool = nn.AvgPool2d(7, stride=1)
+        nn.AdaptiveAvgPool2d((1,1))
         self.fc = nn.Linear(512 * block.expansion, num_classes)
 
         for m in self.modules():

--- a/torchvision/models/resnet.py
+++ b/torchvision/models/resnet.py
@@ -106,7 +106,7 @@ class ResNet(nn.Module):
         self.layer2 = self._make_layer(block, 128, layers[1], stride=2)
         self.layer3 = self._make_layer(block, 256, layers[2], stride=2)
         self.layer4 = self._make_layer(block, 512, layers[3], stride=2)
-        self.avgpool = nn.AdaptiveAvgPool2d((1,1))
+        self.avgpool = nn.AdaptiveAvgPool2d((1, 1))
         self.fc = nn.Linear(512 * block.expansion, num_classes)
 
         for m in self.modules():

--- a/torchvision/models/resnet.py
+++ b/torchvision/models/resnet.py
@@ -106,7 +106,7 @@ class ResNet(nn.Module):
         self.layer2 = self._make_layer(block, 128, layers[1], stride=2)
         self.layer3 = self._make_layer(block, 256, layers[2], stride=2)
         self.layer4 = self._make_layer(block, 512, layers[3], stride=2)
-        nn.AdaptiveAvgPool2d((1,1))
+        self.avgpool = nn.AdaptiveAvgPool2d((1,1))
         self.fc = nn.Linear(512 * block.expansion, num_classes)
 
         for m in self.modules():

--- a/torchvision/models/squeezenet.py
+++ b/torchvision/models/squeezenet.py
@@ -82,7 +82,7 @@ class SqueezeNet(nn.Module):
             nn.Dropout(p=0.5),
             final_conv,
             nn.ReLU(inplace=True),
-            nn.AdaptiveAvgPool2d((1,1))
+            nn.AdaptiveAvgPool2d((1, 1))
         )
 
         for m in self.modules():

--- a/torchvision/models/squeezenet.py
+++ b/torchvision/models/squeezenet.py
@@ -82,7 +82,7 @@ class SqueezeNet(nn.Module):
             nn.Dropout(p=0.5),
             final_conv,
             nn.ReLU(inplace=True),
-            nn.AvgPool2d(13, stride=1)
+            nn.AdaptiveAvgPool2d((1,1))
         )
 
         for m in self.modules():


### PR DESCRIPTION
Hi,

I'm dealing with this problem with the hardcoded **AvgPool2d** on SqueezeNet, some people notice this a year ago, also in ResNet, so I made these changes, Pytorch must be as robust as possible. I left the other AvgPool2d layers because they have another purpose.

**nn.AvgPool2d -> nn.AdaptiveAvgPool2d((1,1))** assures the output's size like (batch_size, num_classes, 1,1) on SqueezeNet and ResNet.