### PR TITLE
VOCSegmentation, VOCDetection, linting passing, examples.

### DIFF
--- a/docs/source/datasets.rst
+++ b/docs/source/datasets.rst
@@ -129,3 +129,15 @@ PhotoTour
 .. autoclass:: PhotoTour
   :members: __getitem__
   :special-members:
+
+VOC
+~~~~~~
+
+
+.. autoclass:: VOCSegmentation
+  :members: __getitem__
+  :special-members:
+
+.. autoclass:: VOCDetection
+  :members: __getitem__
+  :special-members:

--- a/torchvision/datasets/__init__.py
+++ b/torchvision/datasets/__init__.py
@@ -9,10 +9,11 @@ from .phototour import PhotoTour
 from .fakedata import FakeData
 from .semeion import SEMEION
 from .omniglot import Omniglot
+from .voc import VOCSegmentation, VOCDetection
 
 __all__ = ('LSUN', 'LSUNClass',
            'ImageFolder', 'DatasetFolder', 'FakeData',
            'CocoCaptions', 'CocoDetection',
            'CIFAR10', 'CIFAR100', 'EMNIST', 'FashionMNIST',
            'MNIST', 'STL10', 'SVHN', 'PhotoTour', 'SEMEION',
-           'Omniglot')
+           'Omniglot', 'VOCSegmentation', 'VOCDetection')

--- a/torchvision/datasets/voc.py
+++ b/torchvision/datasets/voc.py
@@ -16,6 +16,43 @@ VOC_CLASSES = [
     'person', 'pottedplant', 'sheep', 'sofa', 'train', 'tvmonitor'
 ]
 DATASET_YEAR_DICT = {
+    '2012': {
+        'url': 'http://host.robots.ox.ac.uk/pascal/VOC/voc2012/VOCtrainval_11-May-2012.tar',
+        'filename': 'VOCtrainval_11-May-2012.tar',
+        'md5': '6cd6e144f989b92b3379bac3b3de84fd',
+        'base_dir': 'VOCdevkit/VOC2012'
+    },
+    '2011': {
+        'url': 'http://host.robots.ox.ac.uk/pascal/VOC/voc2011/VOCtrainval_25-May-2011.tar',
+        'filename': 'VOCtrainval_25-May-2011.tar',
+        'md5': '6c3384ef61512963050cb5d687e5bf1e',
+        'base_dir': 'TrainVal/VOCdevkit/VOC2011'
+    },
+    '2010': {
+        'url': 'http://host.robots.ox.ac.uk/pascal/VOC/voc2010/VOCtrainval_03-May-2010.tar',
+        'filename': 'VOCtrainval_03-May-2010.tar,
+        'md5': 'da459979d0c395079b5c75ee67908abb',
+        'base_dir': 'VOCdevkit/VOC2010'
+    },
+    '2009': {
+        'url': 'http://host.robots.ox.ac.uk/pascal/VOC/voc2009/VOCtrainval_11-May-2009.tar',
+        'filename': 'VOCtrainval_11-May-2009.tar'',
+        'md5': '59065e4b188729180974ef6572f6a212',
+        'base_dir': 'VOCdevkit/VOC2009'
+    },
+    '2008': {
+        'url': 'http://host.robots.ox.ac.uk/pascal/VOC/voc2008/VOCtrainval_14-Jul-2008.tar',
+        'filename': 'VOCtrainval_11-May-2012.tar',
+        'md5': '2629fa636546599198acfcfbfcf1904a',
+        'base_dir': 'VOCdevkit/VOC2008'
+    },
+    '2007': {
+        'url': 'http://host.robots.ox.ac.uk/pascal/VOC/voc2007/VOCtrainval_06-Nov-2007.tar',
+        'filename': 'VOCtrainval_06-Nov-2007.tar',
+        'md5': 'c52e279531787c972589f7e41ab4ae64',
+        'base_dir': 'VOCdevkit/VOC2007'
+    }
+}
     '2012': [
         'http://host.robots.ox.ac.uk/pascal/VOC/voc2012/VOCtrainval_11-May-2012.tar',
         'VOCtrainval_11-May-2012.tar', '6cd6e144f989b92b3379bac3b3de84fd',
@@ -74,13 +111,13 @@ class VOCSegmentation(data.Dataset):
                  target_transform=None):
         self.root = root
         self.year = year
-        self.url = DATASET_YEAR_DICT[year][0]
-        self.filename = DATASET_YEAR_DICT[year][1]
-        self.md5 = DATASET_YEAR_DICT[year][2]
+        self.url = DATASET_YEAR_DICT[year]['url']
+        self.filename = DATASET_YEAR_DICT[year]['filename']
+        self.md5 = DATASET_YEAR_DICT[year]['md5']
         self.transform = transform
         self.target_transform = target_transform
         self.image_set = image_set
-        _base_dir = DATASET_YEAR_DICT[year][3]
+        _base_dir = DATASET_YEAR_DICT[year]['base_dir']
         _voc_root = os.path.join(self.root, _base_dir)
         _image_dir = os.path.join(_voc_root, 'JPEGImages')
         _mask_dir = os.path.join(_voc_root, 'SegmentationClass')
@@ -167,16 +204,16 @@ class VOCDetection(data.Dataset):
                  target_transform=None):
         self.root = root
         self.year = year
-        self.url = DATASET_YEAR_DICT[year][0]
-        self.filename = DATASET_YEAR_DICT[year][1]
-        self.md5 = DATASET_YEAR_DICT[year][2]
+        self.url = DATASET_YEAR_DICT[year]['url']
+        self.filename = DATASET_YEAR_DICT[year]['filename']
+        self.md5 = DATASET_YEAR_DICT[year]['md5']
         self.transform = transform
         self.target_transform = target_transform
         self.image_set = image_set
         self.class_to_ind = class_to_ind or dict(
             zip(VOC_CLASSES, range(len(VOC_CLASSES))))
         self.keep_difficult = keep_difficult
-        _base_dir = DATASET_YEAR_DICT[year][3]
+        _base_dir = DATASET_YEAR_DICT[year]['base_dir']
         _voc_root = os.path.join(self.root, _base_dir)
         _image_dir = os.path.join(_voc_root, 'JPEGImages')
         _annotation_dir = os.path.join(_voc_root, 'Annotations')

--- a/torchvision/datasets/voc.py
+++ b/torchvision/datasets/voc.py
@@ -30,13 +30,13 @@ DATASET_YEAR_DICT = {
     },
     '2010': {
         'url': 'http://host.robots.ox.ac.uk/pascal/VOC/voc2010/VOCtrainval_03-May-2010.tar',
-        'filename': 'VOCtrainval_03-May-2010.tar,
+        'filename': 'VOCtrainval_03-May-2010.tar',
         'md5': 'da459979d0c395079b5c75ee67908abb',
         'base_dir': 'VOCdevkit/VOC2010'
     },
     '2009': {
         'url': 'http://host.robots.ox.ac.uk/pascal/VOC/voc2009/VOCtrainval_11-May-2009.tar',
-        'filename': 'VOCtrainval_11-May-2009.tar'',
+        'filename': 'VOCtrainval_11-May-2009.tar',
         'md5': '59065e4b188729180974ef6572f6a212',
         'base_dir': 'VOCdevkit/VOC2009'
     },
@@ -52,37 +52,6 @@ DATASET_YEAR_DICT = {
         'md5': 'c52e279531787c972589f7e41ab4ae64',
         'base_dir': 'VOCdevkit/VOC2007'
     }
-}
-    '2012': [
-        'http://host.robots.ox.ac.uk/pascal/VOC/voc2012/VOCtrainval_11-May-2012.tar',
-        'VOCtrainval_11-May-2012.tar', '6cd6e144f989b92b3379bac3b3de84fd',
-        ' VOCdevkit/VOC2012'
-    ],
-    '2011': [
-        'http://host.robots.ox.ac.uk/pascal/VOC/voc2011/VOCtrainval_25-May-2011.tar',
-        'VOCtrainval_25-May-2011.tar', '6c3384ef61512963050cb5d687e5bf1e',
-        'TrainVal/VOCdevkit/VOC2011'
-    ],
-    '2010': [
-        'http://host.robots.ox.ac.uk/pascal/VOC/voc2010/VOCtrainval_03-May-2010.tar',
-        'VOCtrainval_03-May-2010.tar', 'da459979d0c395079b5c75ee67908abb',
-        'VOCdevkit/VOC2010'
-    ],
-    '2009': [
-        'http://host.robots.ox.ac.uk/pascal/VOC/voc2009/VOCtrainval_11-May-2009.tar',
-        'VOCtrainval_11-May-2009.tar', '59065e4b188729180974ef6572f6a212',
-        'VOCdevkit/VOC2009'
-    ],
-    '2008': [
-        'http://host.robots.ox.ac.uk/pascal/VOC/voc2008/VOCtrainval_14-Jul-2008.tar',
-        'VOCtrainval_14-Jul-2008.tar', '2629fa636546599198acfcfbfcf1904a',
-        'VOCdevkit/VOC2008'
-    ],
-    '2007': [
-        'http://host.robots.ox.ac.uk/pascal/VOC/voc2007/VOCtrainval_06-Nov-2007.tar',
-        'VOCtrainval_06-Nov-2007.tar', 'c52e279531787c972589f7e41ab4ae64',
-        'VOCdevkit/VOC2007'
-    ]
 }
 
 

--- a/torchvision/datasets/voc.py
+++ b/torchvision/datasets/voc.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import tarfile
+import collections
 import torch.utils.data as data
 if sys.version_info[0] == 2:
     import xml.etree.cElementTree as ET
@@ -86,38 +87,32 @@ class VOCSegmentation(data.Dataset):
         self.transform = transform
         self.target_transform = target_transform
         self.image_set = image_set
-        _base_dir = DATASET_YEAR_DICT[year]['base_dir']
-        _voc_root = os.path.join(self.root, _base_dir)
-        _image_dir = os.path.join(_voc_root, 'JPEGImages')
-        _mask_dir = os.path.join(_voc_root, 'SegmentationClass')
+        base_dir = DATASET_YEAR_DICT[year]['base_dir']
+        voc_root = os.path.join(self.root, base_dir)
+        image_dir = os.path.join(voc_root, 'JPEGImages')
+        mask_dir = os.path.join(voc_root, 'SegmentationClass')
 
         if download:
             download_extract(self.url, self.root, self.filename, self.md5)
 
-        if not os.path.isdir(_voc_root):
+        if not os.path.isdir(voc_root):
             raise RuntimeError('Dataset not found or corrupted.' +
                                ' You can use download=True to download it')
 
-        _splits_dir = os.path.join(_voc_root, 'ImageSets/Segmentation')
+        splits_dir = os.path.join(voc_root, 'ImageSets/Segmentation')
 
-        _split_f = os.path.join(_splits_dir, image_set.rstrip('\n') + '.txt')
+        split_f = os.path.join(splits_dir, image_set.rstrip('\n') + '.txt')
 
-        if not os.path.exists(_split_f):
+        if not os.path.exists(split_f):
             raise ValueError(
                 'Wrong image_set entered! Please use image_set="train" '
                 'or image_set="trainval" or image_set="val"')
 
-        self.images = []
-        self.masks = []
-        with open(os.path.join(_split_f), "r") as lines:
-            for line in lines:
-                _image = os.path.join(_image_dir, line.rstrip('\n') + ".jpg")
-                _mask = os.path.join(_mask_dir, line.rstrip('\n') + ".png")
-                assert os.path.isfile(_image)
-                assert os.path.isfile(_mask)
-                self.images.append(_image)
-                self.masks.append(_mask)
+        with open(os.path.join(split_f), "r") as f:
+            file_names = [x.strip() for x in f.readlines()]
 
+        self.images = [os.path.join(image_dir, x + ".jpg") for x in file_names]
+        self.masks = [os.path.join(mask_dir, x + ".png") for x in file_names]
         assert (len(self.images) == len(self.masks))
 
     def __getitem__(self, index):
@@ -128,16 +123,16 @@ class VOCSegmentation(data.Dataset):
         Returns:
             tuple: (image, target) where target is the image segmentation.
         """
-        _img = Image.open(self.images[index]).convert('RGB')
-        _target = Image.open(self.masks[index])
+        img = Image.open(self.images[index]).convert('RGB')
+        target = Image.open(self.masks[index])
 
         if self.transform is not None:
-            _img = self.transform(_img)
+            img = self.transform(img)
 
         if self.target_transform is not None:
-            _target = self.target_transform(_target)
+            target = self.target_transform(target)
 
-        return _img, _target
+        return img, target
 
     def __len__(self):
         return len(self.images)
@@ -155,10 +150,9 @@ class VOCDetection(data.Dataset):
             downloaded again.
         class_to_ind (dict, optional): dictionary lookup of classnames -> indexes
             (default: alphabetic indexing of VOC's 20 classes).
-        keep_difficult (boolean, optional): keep difficult instances or not.
         transform (callable, optional): A function/transform that  takes in an PIL image
             and returns a transformed version. E.g, ``transforms.RandomCrop``
-        target_transform (callable, optional): A function/transform that takes in the
+        target_transform (callable, required): A function/transform that takes in the
             target and transforms it.
     """
 
@@ -168,7 +162,6 @@ class VOCDetection(data.Dataset):
                  image_set='train',
                  download=False,
                  class_to_ind=None,
-                 keep_difficult=False,
                  transform=None,
                  target_transform=None):
         self.root = root
@@ -181,41 +174,33 @@ class VOCDetection(data.Dataset):
         self.image_set = image_set
         self.class_to_ind = class_to_ind or dict(
             zip(VOC_CLASSES, range(len(VOC_CLASSES))))
-        self.keep_difficult = keep_difficult
-        _base_dir = DATASET_YEAR_DICT[year]['base_dir']
-        _voc_root = os.path.join(self.root, _base_dir)
-        _image_dir = os.path.join(_voc_root, 'JPEGImages')
-        _annotation_dir = os.path.join(_voc_root, 'Annotations')
+        base_dir = DATASET_YEAR_DICT[year]['base_dir']
+        voc_root = os.path.join(self.root, base_dir)
+        image_dir = os.path.join(voc_root, 'JPEGImages')
+        annotation_dir = os.path.join(voc_root, 'Annotations')
 
         if download:
             download_extract(self.url, self.root, self.filename, self.md5)
 
-        if not os.path.isdir(_voc_root):
+        if not os.path.isdir(voc_root):
             raise RuntimeError('Dataset not found or corrupted.' +
                                ' You can use download=True to download it')
 
-        _splits_dir = os.path.join(_voc_root, 'ImageSets/Main')
+        splits_dir = os.path.join(voc_root, 'ImageSets/Main')
 
-        _split_f = os.path.join(_splits_dir, image_set.rstrip('\n') + '.txt')
+        split_f = os.path.join(splits_dir, image_set.rstrip('\n') + '.txt')
 
-        if not os.path.exists(_split_f):
+        if not os.path.exists(split_f):
             raise ValueError(
                 'Wrong image_set entered! Please use image_set="train" '
                 'or image_set="trainval" or image_set="val" or a valid'
                 'image_set from the VOC ImageSets/Main folder.')
 
-        self.images = []
-        self.annotations = []
-        with open(os.path.join(_split_f), "r") as lines:
-            for line in lines:
-                _image = os.path.join(_image_dir, line.rstrip('\n') + ".jpg")
-                _annotation = os.path.join(_annotation_dir,
-                                           line.rstrip('\n') + ".xml")
-                assert os.path.isfile(_image)
-                assert os.path.isfile(_annotation)
-                self.images.append(_image)
-                self.annotations.append(_annotation)
+        with open(os.path.join(split_f), "r") as f:
+            file_names = [x.strip() for x in f.readlines()]
 
+        self.images = [os.path.join(image_dir, x + ".jpg") for x in file_names]
+        self.annotations = [os.path.join(annotation_dir, x + ".xml") for x in file_names]
         assert (len(self.images) == len(self.annotations))
 
     def __getitem__(self, index):
@@ -224,44 +209,41 @@ class VOCDetection(data.Dataset):
             index (int): Index
 
         Returns:
-            tuple: (image, target) where target is a list of bounding boxes of
-                relative coordinates like``[[xmin, ymin, xmax, ymax, ind], [...], ...]``.
+            tuple: (image, target) where target is a dictionary of the XML tree.
         """
-        _img = Image.open(self.images[index]).convert('RGB')
-        _target = self._get_bboxes(ET.parse(self.annotations[index]).getroot())
+        img = Image.open(self.images[index]).convert('RGB')
+        target = self.parse_voc_xml(
+            ET.parse(self.annotations[index]).getroot())
 
         if self.transform is not None:
-            _img = self.transform(_img)
+            img = self.transform(img)
 
         if self.target_transform is not None:
-            _target = self.target_transform(_target)
+            target = self.target_transform(target)
 
-        return _img, _target
+        return img, target
 
     def __len__(self):
         return len(self.images)
 
-    def _get_bboxes(self, target):
-        res = []
-        for obj in target.iter('object'):
-            difficult = int(obj.find('difficult').text) == 1
-            if not self.keep_difficult and difficult:
-                continue
-            name = obj.find('name').text.lower().strip()
-            bbox = obj.find('bndbox')
-            width = int(target.find('size').find('width').text)
-            height = int(target.find('size').find('height').text)
-            bndbox = []
-            for i, cur_bb in enumerate(bbox):
-                bb_sz = int(cur_bb.text) - 1
-                # relative coordinates
-                bb_sz = bb_sz / width if i % 2 == 0 else bb_sz / height
-                bndbox.append(bb_sz)
-
-            label_ind = self.class_to_ind[name]
-            bndbox.append(label_ind)
-            res.append(bndbox)  # [xmin, ymin, xmax, ymax, ind]
-        return res
+    def parse_voc_xml(self, node):
+        voc_dict = {}
+        children = list(node)
+        if children:
+            def_dic = collections.defaultdict(list)
+            for dc in map(self.parse_voc_xml, children):
+                for ind, v in dc.items():
+                    def_dic[ind].append(v)
+            voc_dict = {
+                node.tag:
+                {ind: v[0] if len(v) == 1 else v
+                 for ind, v in def_dic.items()}
+            }
+        if node.text:
+            text = node.text.strip()
+            if not children:
+                voc_dict[node.tag] = text
+        return voc_dict
 
 
 def download_extract(url, root, filename, md5):

--- a/torchvision/datasets/voc.py
+++ b/torchvision/datasets/voc.py
@@ -1,0 +1,264 @@
+import os
+import sys
+import tarfile
+import torch.utils.data as data
+if sys.version_info[0] == 2:
+    import xml.etree.cElementTree as ET
+else:
+    import xml.etree.ElementTree as ET
+
+from PIL import Image
+from .utils import download_url, check_integrity
+
+VOC_CLASSES = [
+    'background', 'aeroplane', 'bicycle', 'bird', 'boat', 'bottle', 'bus',
+    'car', 'cat', 'chair', 'cow', 'diningtable', 'dog', 'horse', 'motorbike',
+    'person', 'pottedplant', 'sheep', 'sofa', 'train', 'tvmonitor'
+]
+DATASET_YEAR_DICT = {
+    '2012': [
+        'http://host.robots.ox.ac.uk/pascal/VOC/voc2012/VOCtrainval_11-May-2012.tar',
+        'VOCtrainval_11-May-2012.tar', '6cd6e144f989b92b3379bac3b3de84fd',
+        ' VOCdevkit/VOC2012'
+    ],
+    '2011': [
+        'http://host.robots.ox.ac.uk/pascal/VOC/voc2011/VOCtrainval_25-May-2011.tar',
+        'VOCtrainval_25-May-2011.tar', '6c3384ef61512963050cb5d687e5bf1e',
+        'TrainVal/VOCdevkit/VOC2011'
+    ],
+    '2010': [
+        'http://host.robots.ox.ac.uk/pascal/VOC/voc2010/VOCtrainval_03-May-2010.tar',
+        'VOCtrainval_03-May-2010.tar', 'da459979d0c395079b5c75ee67908abb',
+        'VOCdevkit/VOC2010'
+    ],
+    '2009': [
+        'http://host.robots.ox.ac.uk/pascal/VOC/voc2009/VOCtrainval_11-May-2009.tar',
+        'VOCtrainval_11-May-2009.tar', '59065e4b188729180974ef6572f6a212',
+        'VOCdevkit/VOC2009'
+    ],
+    '2008': [
+        'http://host.robots.ox.ac.uk/pascal/VOC/voc2008/VOCtrainval_14-Jul-2008.tar',
+        'VOCtrainval_14-Jul-2008.tar', '2629fa636546599198acfcfbfcf1904a',
+        'VOCdevkit/VOC2008'
+    ],
+    '2007': [
+        'http://host.robots.ox.ac.uk/pascal/VOC/voc2007/VOCtrainval_06-Nov-2007.tar',
+        'VOCtrainval_06-Nov-2007.tar', 'c52e279531787c972589f7e41ab4ae64',
+        'VOCdevkit/VOC2007'
+    ]
+}
+
+
+class VOCSegmentation(data.Dataset):
+    """`Pascal VOC <http://host.robots.ox.ac.uk/pascal/VOC/>`_ Segmentation Dataset.
+
+    Args:
+        root (string): Root directory of the VOC Dataset.
+        year (string, optional): The dataset year, supports years 2007 to 2012.
+        image_set (string, optional): Select the image_set to use, ``train, trainval or val``
+        download (bool, optional): If true, downloads the dataset from the internet and
+            puts it in root directory. If dataset is already downloaded, it is not
+            downloaded again.
+        transform (callable, optional): A function/transform that  takes in an PIL image
+            and returns a transformed version. E.g, ``transforms.RandomCrop``
+        target_transform (callable, optional): A function/transform that takes in the
+            target and transforms it.
+    """
+
+    def __init__(self,
+                 root,
+                 year='2012',
+                 image_set='train',
+                 download=False,
+                 transform=None,
+                 target_transform=None):
+        self.root = root
+        self.year = year
+        self.url = DATASET_YEAR_DICT[year][0]
+        self.filename = DATASET_YEAR_DICT[year][1]
+        self.md5 = DATASET_YEAR_DICT[year][2]
+        self.transform = transform
+        self.target_transform = target_transform
+        self.image_set = image_set
+        _base_dir = DATASET_YEAR_DICT[year][3]
+        _voc_root = os.path.join(self.root, _base_dir)
+        _image_dir = os.path.join(_voc_root, 'JPEGImages')
+        _mask_dir = os.path.join(_voc_root, 'SegmentationClass')
+
+        if download:
+            download_extract(self.url, self.root, self.filename, self.md5)
+
+        if not os.path.isdir(_voc_root):
+            raise RuntimeError('Dataset not found or corrupted.' +
+                               ' You can use download=True to download it')
+
+        _splits_dir = os.path.join(_voc_root, 'ImageSets/Segmentation')
+
+        _split_f = os.path.join(_splits_dir, image_set.rstrip('\n') + '.txt')
+
+        if not os.path.exists(_split_f):
+            raise ValueError(
+                'Wrong image_set entered! Please use image_set="train" '
+                'or image_set="trainval" or image_set="val"')
+
+        self.images = []
+        self.masks = []
+        with open(os.path.join(_split_f), "r") as lines:
+            for line in lines:
+                _image = os.path.join(_image_dir, line.rstrip('\n') + ".jpg")
+                _mask = os.path.join(_mask_dir, line.rstrip('\n') + ".png")
+                assert os.path.isfile(_image)
+                assert os.path.isfile(_mask)
+                self.images.append(_image)
+                self.masks.append(_mask)
+
+        assert (len(self.images) == len(self.masks))
+
+    def __getitem__(self, index):
+        """
+        Args:
+            index (int): Index
+
+        Returns:
+            tuple: (image, target) where target is the image segmentation.
+        """
+        _img = Image.open(self.images[index]).convert('RGB')
+        _target = Image.open(self.masks[index])
+
+        if self.transform is not None:
+            _img = self.transform(_img)
+
+        if self.target_transform is not None:
+            _target = self.target_transform(_target)
+
+        return _img, _target
+
+    def __len__(self):
+        return len(self.images)
+
+
+class VOCDetection(data.Dataset):
+    """`Pascal VOC <http://host.robots.ox.ac.uk/pascal/VOC/>`_ Detection Dataset.
+
+    Args:
+        root (string): Root directory of the VOC Dataset.
+        year (string, optional): The dataset year, supports years 2007 to 2012.
+        image_set (string, optional): Select the image_set to use, ``train, trainval or val``
+        download (bool, optional): If true, downloads the dataset from the internet and
+            puts it in root directory. If dataset is already downloaded, it is not
+            downloaded again.
+        class_to_ind (dict, optional): dictionary lookup of classnames -> indexes
+            (default: alphabetic indexing of VOC's 20 classes).
+        keep_difficult (boolean, optional): keep difficult instances or not.
+        transform (callable, optional): A function/transform that  takes in an PIL image
+            and returns a transformed version. E.g, ``transforms.RandomCrop``
+        target_transform (callable, optional): A function/transform that takes in the
+            target and transforms it.
+    """
+
+    def __init__(self,
+                 root,
+                 year='2012',
+                 image_set='train',
+                 download=False,
+                 class_to_ind=None,
+                 keep_difficult=False,
+                 transform=None,
+                 target_transform=None):
+        self.root = root
+        self.year = year
+        self.url = DATASET_YEAR_DICT[year][0]
+        self.filename = DATASET_YEAR_DICT[year][1]
+        self.md5 = DATASET_YEAR_DICT[year][2]
+        self.transform = transform
+        self.target_transform = target_transform
+        self.image_set = image_set
+        self.class_to_ind = class_to_ind or dict(
+            zip(VOC_CLASSES, range(len(VOC_CLASSES))))
+        self.keep_difficult = keep_difficult
+        _base_dir = DATASET_YEAR_DICT[year][3]
+        _voc_root = os.path.join(self.root, _base_dir)
+        _image_dir = os.path.join(_voc_root, 'JPEGImages')
+        _annotation_dir = os.path.join(_voc_root, 'Annotations')
+
+        if download:
+            download_extract(self.url, self.root, self.filename, self.md5)
+
+        if not os.path.isdir(_voc_root):
+            raise RuntimeError('Dataset not found or corrupted.' +
+                               ' You can use download=True to download it')
+
+        _splits_dir = os.path.join(_voc_root, 'ImageSets/Main')
+
+        _split_f = os.path.join(_splits_dir, image_set.rstrip('\n') + '.txt')
+
+        if not os.path.exists(_split_f):
+            raise ValueError(
+                'Wrong image_set entered! Please use image_set="train" '
+                'or image_set="trainval" or image_set="val" or a valid'
+                'image_set from the VOC ImageSets/Main folder.')
+
+        self.images = []
+        self.annotations = []
+        with open(os.path.join(_split_f), "r") as lines:
+            for line in lines:
+                _image = os.path.join(_image_dir, line.rstrip('\n') + ".jpg")
+                _annotation = os.path.join(_annotation_dir,
+                                           line.rstrip('\n') + ".xml")
+                assert os.path.isfile(_image)
+                assert os.path.isfile(_annotation)
+                self.images.append(_image)
+                self.annotations.append(_annotation)
+
+        assert (len(self.images) == len(self.annotations))
+
+    def __getitem__(self, index):
+        """
+        Args:
+            index (int): Index
+
+        Returns:
+            tuple: (image, target) where target is a list of bounding boxes of
+                relative coordinates like``[[xmin, ymin, xmax, ymax, ind], [...], ...]``.
+        """
+        _img = Image.open(self.images[index]).convert('RGB')
+        _target = self._get_bboxes(ET.parse(self.annotations[index]).getroot())
+
+        if self.transform is not None:
+            _img = self.transform(_img)
+
+        if self.target_transform is not None:
+            _target = self.target_transform(_target)
+
+        return _img, _target
+
+    def __len__(self):
+        return len(self.images)
+
+    def _get_bboxes(self, target):
+        res = []
+        for obj in target.iter('object'):
+            difficult = int(obj.find('difficult').text) == 1
+            if not self.keep_difficult and difficult:
+                continue
+            name = obj.find('name').text.lower().strip()
+            bbox = obj.find('bndbox')
+            width = int(target.find('size').find('width').text)
+            height = int(target.find('size').find('height').text)
+            bndbox = []
+            for i, cur_bb in enumerate(bbox):
+                bb_sz = int(cur_bb.text) - 1
+                # relative coordinates
+                bb_sz = bb_sz / width if i % 2 == 0 else bb_sz / height
+                bndbox.append(bb_sz)
+
+            label_ind = self.class_to_ind[name]
+            bndbox.append(label_ind)
+            res.append(bndbox)  # [xmin, ymin, xmax, ymax, ind]
+        return res
+
+
+def download_extract(url, root, filename, md5):
+    download_url(url, root, filename, md5)
+    with tarfile.open(os.path.join(root, filename), "r") as tar:
+        tar.extractall(path=root)

--- a/torchvision/datasets/voc.py
+++ b/torchvision/datasets/voc.py
@@ -55,7 +55,7 @@ class VOCSegmentation(data.Dataset):
     Args:
         root (string): Root directory of the VOC Dataset.
         year (string, optional): The dataset year, supports years 2007 to 2012.
-        image_set (string, optional): Select the image_set to use, ``train, trainval or val``
+        image_set (string, optional): Select the image_set to use, ``train``, ``trainval`` or ``val``
         download (bool, optional): If true, downloads the dataset from the internet and
             puts it in root directory. If dataset is already downloaded, it is not
             downloaded again.
@@ -143,7 +143,7 @@ class VOCDetection(data.Dataset):
     Args:
         root (string): Root directory of the VOC Dataset.
         year (string, optional): The dataset year, supports years 2007 to 2012.
-        image_set (string, optional): Select the image_set to use, ``train, trainval or val``
+        image_set (string, optional): Select the image_set to use, ``train``, ``trainval`` or ``val``
         download (bool, optional): If true, downloads the dataset from the internet and
             puts it in root directory. If dataset is already downloaded, it is not
             downloaded again.

--- a/torchvision/datasets/voc.py
+++ b/torchvision/datasets/voc.py
@@ -11,11 +11,6 @@ else:
 from PIL import Image
 from .utils import download_url, check_integrity
 
-VOC_CLASSES = [
-    'background', 'aeroplane', 'bicycle', 'bird', 'boat', 'bottle', 'bus',
-    'car', 'cat', 'chair', 'cow', 'diningtable', 'dog', 'horse', 'motorbike',
-    'person', 'pottedplant', 'sheep', 'sofa', 'train', 'tvmonitor'
-]
 DATASET_YEAR_DICT = {
     '2012': {
         'url': 'http://host.robots.ox.ac.uk/pascal/VOC/voc2012/VOCtrainval_11-May-2012.tar',
@@ -148,7 +143,6 @@ class VOCDetection(data.Dataset):
         download (bool, optional): If true, downloads the dataset from the internet and
             puts it in root directory. If dataset is already downloaded, it is not
             downloaded again.
-        class_to_ind (dict, optional): dictionary lookup of classnames -> indexes
             (default: alphabetic indexing of VOC's 20 classes).
         transform (callable, optional): A function/transform that  takes in an PIL image
             and returns a transformed version. E.g, ``transforms.RandomCrop``
@@ -161,7 +155,6 @@ class VOCDetection(data.Dataset):
                  year='2012',
                  image_set='train',
                  download=False,
-                 class_to_ind=None,
                  transform=None,
                  target_transform=None):
         self.root = root
@@ -172,8 +165,7 @@ class VOCDetection(data.Dataset):
         self.transform = transform
         self.target_transform = target_transform
         self.image_set = image_set
-        self.class_to_ind = class_to_ind or dict(
-            zip(VOC_CLASSES, range(len(VOC_CLASSES))))
+
         base_dir = DATASET_YEAR_DICT[year]['base_dir']
         voc_root = os.path.join(self.root, base_dir)
         image_dir = os.path.join(voc_root, 'JPEGImages')


### PR DESCRIPTION
Hey there guys, I hope this PR can revive some of the efforts that past PRs implemented, I'm referring to:
- #86 by @ellisbrown
- #37 by @desimone

This PR supports VOCSegmentation and VOCDetection for multiple years (2007 to 2012). 2006 and 2005 are not supported due to the very different format.
I tried to address many of the comments of the pasts two PRs. For the VOCDetection part `__getitem__` will return the image and a list of bounding boxes of the format `[[xmin, ymin, xmax, ymax, ind],[...],...]` as PR 37 directly instead of a ET Element.
I think VOC is a very iconic dataset for both detection and segmentation so it'd be very useful to have it ready to use on pytorch/vision.

If there are any comments or suggestions let me know, I can put some time on implementing recommendations or so.
There are two examples (jupyter notebook gist) of the dataset being loaded:
- This one is for [segmentation](https://gist.github.com/bpinaya/3017768b87d93153c42547b84ce052f3)
- This one is for [detection](https://gist.github.com/bpinaya/c39f9f6adf7f4110e3c121155c3d371b)

I've tested for all the years and regarding the transforms, I'm using the same structure other datasets used, I've seen implementations where a `joint_transforms` is passed as argument, and that transform is applied to both input and target, I guess that'd work for segmentation but not much for detection so that's why it's not used.