### PR TITLE
Changing to AdaptiveAvgPool2d on DenseNet

### DIFF
--- a/torchvision/models/densenet.py
+++ b/torchvision/models/densenet.py
@@ -112,7 +112,7 @@ class DenseNet(nn.Module):
     def forward(self, x):
         features = self.features(x)
         out = F.relu(features, inplace=True)
-        out = F.adaptive_avg_pool2d(out, (1,1)).view(features.size(0),-1)
+        out = F.adaptive_avg_pool2d(out, (1,1)).view(features.size(0), -1)
         out = self.classifier(out)
         return out
 

--- a/torchvision/models/densenet.py
+++ b/torchvision/models/densenet.py
@@ -112,7 +112,7 @@ class DenseNet(nn.Module):
     def forward(self, x):
         features = self.features(x)
         out = F.relu(features, inplace=True)
-        out = F.avg_pool2d(out, kernel_size=7, stride=1).view(features.size(0), -1)
+        out = F.adaptive_avg_pool2d(out, (1,1)).view(features.size(0),-1)
         out = self.classifier(out)
         return out
 


### PR DESCRIPTION
Hi,
I`m found that densenet use **avg_pool2d** not **adaptive_avg_pool2d**,this problem has fixed in SqueezeNet and ResNet in #643 so,I made these changes,.
**nn.AvgPool2d** -> **nn.AdaptiveAvgPool2d((1,1))** assures the output's size like (batch_size, num_classes, 1,1) on DenseNet