### PR TITLE
Add Flickr8k and Flickr30k Datasets

### DIFF
--- a/docs/source/datasets.rst
+++ b/docs/source/datasets.rst
@@ -138,3 +138,14 @@ SBU
   :members: __getitem__
   :special-members:
 
+Flickr
+~~~~~~
+
+
+.. autoclass:: Flickr8k
+  :members: __getitem__
+  :special-members:
+
+.. autoclass:: Flickr30k
+  :members: __getitem__
+  :special-members:

--- a/torchvision/datasets/__init__.py
+++ b/torchvision/datasets/__init__.py
@@ -10,10 +10,11 @@ from .fakedata import FakeData
 from .semeion import SEMEION
 from .omniglot import Omniglot
 from .sbu import SBU
+from .flickr import Flickr8k, Flickr30k
 
 __all__ = ('LSUN', 'LSUNClass',
            'ImageFolder', 'DatasetFolder', 'FakeData',
            'CocoCaptions', 'CocoDetection',
            'CIFAR10', 'CIFAR100', 'EMNIST', 'FashionMNIST',
            'MNIST', 'STL10', 'SVHN', 'PhotoTour', 'SEMEION',
-           'Omniglot', 'SBU')
+           'Omniglot', 'SBU', 'Flickr8k', 'Flickr30k')

--- a/torchvision/datasets/flickr.py
+++ b/torchvision/datasets/flickr.py
@@ -55,21 +55,21 @@ class Flickr8k(data.Dataset):
 
     Args:
         root (string): Root directory where images are downloaded to.
-        annFile (string): Path to annotation file.
+        ann_file (string): Path to annotation file.
         transform (callable, optional): A function/transform that takes in a PIL image
             and returns a transformed version. E.g, ``transforms.ToTensor``
         target_transform (callable, optional): A function/transform that takes in the
             target and transforms it.
     """
-    def __init__(self, root, annFile, transform=None, target_transform=None):
+    def __init__(self, root, ann_file, transform=None, target_transform=None):
         self.root = os.path.expanduser(root)
-        self.annFile = os.path.expanduser(annFile)
+        self.ann_file = os.path.expanduser(ann_file)
         self.transform = transform
         self.target_transform = target_transform
 
         # Read annotations and store in a dict
         parser = Flickr8kParser(self.root)
-        with open(self.annFile) as fh:
+        with open(self.ann_file) as fh:
             parser.feed(fh.read())
         self.annotations = parser.annotations
 
@@ -106,21 +106,21 @@ class Flickr30k(data.Dataset):
 
     Args:
         root (string): Root directory where images are downloaded to.
-        annFile (string): Path to annotation file.
+        ann_file (string): Path to annotation file.
         transform (callable, optional): A function/transform that takes in a PIL image
             and returns a transformed version. E.g, ``transforms.ToTensor``
         target_transform (callable, optional): A function/transform that takes in the
             target and transforms it.
     """
-    def __init__(self, root, annFile, transform=None, target_transform=None):
+    def __init__(self, root, ann_file, transform=None, target_transform=None):
         self.root = os.path.expanduser(root)
-        self.annFile = os.path.expanduser(annFile)
+        self.ann_file = os.path.expanduser(ann_file)
         self.transform = transform
         self.target_transform = target_transform
 
         # Read annotations and store in a dict
         self.annotations = defaultdict(list)
-        with open(self.annFile) as fh:
+        with open(self.ann_file) as fh:
             for line in fh:
                 img_id, caption = line.strip().split('\t')
                 self.annotations[img_id[:-2]].append(caption)

--- a/torchvision/datasets/flickr.py
+++ b/torchvision/datasets/flickr.py
@@ -1,0 +1,152 @@
+from collections import defaultdict
+from PIL import Image
+from six.moves import html_parser
+
+import glob
+import os
+import torch.utils.data as data
+
+
+class Flickr8kParser(html_parser.HTMLParser):
+    """Parser for extracting captions from the Flickr8k dataset web page."""
+
+    def __init__(self):
+        super(Flickr8kParser, self).__init__()
+
+        # Data structure to store captions
+        self.annotations = {}
+
+        # State variables
+        self.in_table = False
+        self.current_tag = None
+        self.current_img = None
+
+    def handle_starttag(self, tag, attrs):
+        self.current_tag = tag
+
+        if tag == 'table':
+            self.in_table = True
+
+    def handle_endtag(self, tag):
+        self.current_tag = None
+
+        if tag == 'table':
+            self.in_table = False
+
+    def handle_data(self, data):
+        if self.in_table:
+            if data == 'Image Not Found':
+                self.current_img = None
+            elif self.current_tag == 'a':
+                img_id = data.split('/')[-2]
+                self.current_img = img_id
+                self.annotations[img_id] = []
+            elif self.current_tag == 'li' and self.current_img:
+                img_id = self.current_img
+                self.annotations[img_id].append(data.strip())
+
+
+class Flickr8k(data.Dataset):
+    """`Flickr8k Entities <http://nlp.cs.illinois.edu/HockenmaierGroup/8k-pictures.html>`_ Dataset.
+
+    Args:
+        root (string): Root directory where images are downloaded to.
+        annFile (string): Path to annotation file.
+        transform (callable, optional): A function/transform that takes in a PIL image
+            and returns a transformed version. E.g, ``transforms.ToTensor``
+        target_transform (callable, optional): A function/transform that takes in the
+            target and transforms it.
+    """
+    def __init__(self, root, annFile, transform=None, target_transform=None):
+        self.root = os.path.expanduser(root)
+        self.annFile = os.path.expanduser(annFile)
+        self.transform = transform
+        self.target_transform = target_transform
+
+        # Read annotations and store in a dict
+        parser = Flickr8kParser()
+        with open(self.annFile) as fh:
+            parser.feed(fh.read())
+        self.annotations = parser.annotations
+
+        self.ids = list(self.annotations.keys())
+
+    def __getitem__(self, index):
+        """
+        Args:
+            index (int): Index
+
+        Returns:
+            tuple: Tuple (image, target). target is a list of captions for the image.
+        """
+        img_id = self.ids[index]
+
+        # Image
+        filename = os.path.join(self.root, img_id + '_*.jpg')
+        filename = glob.glob(filename)[0]
+        img = Image.open(filename).convert('RGB')
+        if self.transform is not None:
+            img = self.transform(img)
+
+        # Captions
+        target = self.annotations[img_id]
+        if self.target_transform is not None:
+            target = self.target_transform(target)
+
+        return img, target
+
+    def __len__(self):
+        return len(self.ids)
+
+
+class Flickr30k(data.Dataset):
+    """`Flickr30k Entities <http://web.engr.illinois.edu/~bplumme2/Flickr30kEntities/>`_ Dataset.
+
+    Args:
+        root (string): Root directory where images are downloaded to.
+        annFile (string): Path to annotation file.
+        transform (callable, optional): A function/transform that takes in a PIL image
+            and returns a transformed version. E.g, ``transforms.ToTensor``
+        target_transform (callable, optional): A function/transform that takes in the
+            target and transforms it.
+    """
+    def __init__(self, root, annFile, transform=None, target_transform=None):
+        self.root = os.path.expanduser(root)
+        self.annFile = os.path.expanduser(annFile)
+        self.transform = transform
+        self.target_transform = target_transform
+
+        # Read annotations and store in a dict
+        self.annotations = defaultdict(list)
+        with open(self.annFile) as fh:
+            for line in fh:
+                img_id, caption = line.strip().split('\t')
+                self.annotations[img_id[:-2]].append(caption)
+
+        self.ids = list(self.annotations.keys())
+
+    def __getitem__(self, index):
+        """
+        Args:
+            index (int): Index
+
+        Returns:
+            tuple: Tuple (image, target). target is a list of captions for the image.
+        """
+        img_id = self.ids[index]
+
+        # Image
+        filename = os.path.join(self.root, img_id)
+        img = Image.open(filename).convert('RGB')
+        if self.transform is not None:
+            img = self.transform(img)
+
+        # Captions
+        target = self.annotations[img_id]
+        if self.target_transform is not None:
+            target = self.target_transform(target)
+
+        return img, target
+
+    def __len__(self):
+        return len(self.ids)

--- a/torchvision/datasets/flickr.py
+++ b/torchvision/datasets/flickr.py
@@ -42,7 +42,7 @@ class Flickr8kParser(html_parser.HTMLParser):
             elif self.current_tag == 'a':
                 img_id = data.split('/')[-2]
                 img_id = os.path.join(self.root, img_id + '_*.jpg')
-                img_id = glob.glob(filename)[0]
+                img_id = glob.glob(img_id)[0]
                 self.current_img = img_id
                 self.annotations[img_id] = []
             elif self.current_tag == 'li' and self.current_img:


### PR DESCRIPTION
Adds the following datasets, with a few caveats.

### Flickr8k

This dataset is fairly problematic. One does not simply download Flickr8k. Much like [SBU](https://github.com/pytorch/vision/pull/665), Flickr8k has a [web page](http://nlp.cs.illinois.edu/HockenmaierGroup/8k-pictures.html) that lists URLs for images and captions. Some of these URLs have been replaced with "Image Not Found". Other URLs are now dead. There is no text file containing caption labels, so I had to write an HTML parser for the web page itself. Another thing to note is that some images appear twice on the web page, meaning they actually have 10 captions. I decided to take the last 5 captions to keep things uniform. I also skipped "Image Not Found" captions. I happen to know someone who knows someone who works in this particular professor's lab and has access to a tarball with all the original images, but for someone without this tarball, this file may require hacking.

### Flickr30k

This dataset was much nicer to package. The only annoying thing is that there is no way to automatically download it, you have to download it yourself from [Google Drive](https://drive.google.com/file/d/0B_PL6p-5reUAZEM4MmRQQ2VVSlk/view). According to the [web page](http://web.engr.illinois.edu/~bplumme2/Flickr30kEntities/), this Google Drive link is supposedly temporary, but from what I've heard, it's been "temporary" for years.