### PR TITLE
Add scipy as a dependency to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ VERSION = find_version('torchvision', '__init__.py')
 
 requirements = [
     'numpy',
-    'scipy',
     'six',
     'torch',
 ]
@@ -65,4 +64,7 @@ setup(
 
     zip_safe=True,
     install_requires=requirements,
+    extras_require={
+        "scipy": ["scipy"],
+    },
 )

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ VERSION = find_version('torchvision', '__init__.py')
 
 requirements = [
     'numpy',
+    'scipy',
     'six',
     'torch',
 ]


### PR DESCRIPTION
`scipy` is imported in both the `torchvision.datasets.svhn` module and the `torchvision.models.inception` module.

Alternatively, we could put this under `extras_require` and make the user explicitly request to install `scipy` as an additional dependency.