### PR TITLE
[travis] Record code coverage and display on README

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,7 @@
+[run]
+branch = True
+
+[paths]
+source = 
+    torchvision
+    /**/site-packages/torchvision

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ torchvision.egg-info/
 */**/*~
 *~
 docs/build
+.coverage
+htmlcov

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ matrix:
       python: "2.7"
       install: pip install flake8
       script: flake8
+      after_success: []
     - python: "2.7"
       env: IMAGE_BACKEND=Pillow-SIMD
     - python: "2.7"
@@ -13,7 +14,7 @@ matrix:
       env: IMAGE_BACKEND=Pillow-SIMD
     - python: "3.5"
 
-install:
+before_install:
   - sudo apt-get update
   - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
   - bash miniconda.sh -b -p $HOME/miniconda
@@ -26,11 +27,34 @@ install:
 
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION pytorch scipy -c pytorch
   - source activate test-environment
-  - python setup.py install
-  - pip install --upgrade pytest
-  - if [[ "$IMAGE_BACKEND" == "Pillow-SIMD" ]]; then
-      pip uninstall -y pillow && CC="cc -march=native" pip install --force-reinstall pillow-simd;
+  - |
+    if [[ "$IMAGE_BACKEND" == "Pillow-SIMD" ]]; then
+      pip uninstall -y pillow && CC="cc -march=native" pip install --force-reinstall pillow-simd
     fi
-script:
-  - pytest test/
+  - pip install pytest pytest-cov codecov
 
+
+install:
+  # Using pip instead of setup.py ensures we install a non-compressed version of the package
+  # (as opposed to an egg), which is necessary to collect coverage.
+  # We still get the benefit of testing an installed version over the
+  # test version to iron out installation file-inclusion bugs but can
+  # also collect coverage.
+  - pip install .
+  # Move to home dir, otherwise we'll end up with the path to the
+  # package in $PWD rather than the installed v
+  - |
+    cd $HOME
+    export TV_INSTALL_PATH="$(python -c 'import os; import torchvision; print(os.path.dirname(os.path.abspath(torchvision.__file__)))')"
+    echo "$TV_INSTALL_PATH"
+    cd -
+
+script:
+  - pytest --cov-config .coveragerc --cov torchvision --cov $TV_INSTALL_PATH test
+
+after_success:
+  # Necessary to run coverage combine to rewrite paths from
+  # /travis/env/path/site-packages/torchvision to actual path
+  - coverage combine .coverage
+  - coverage report
+  - codecov

--- a/README.rst
+++ b/README.rst
@@ -4,6 +4,9 @@ torchvision
 .. image:: https://travis-ci.org/pytorch/vision.svg?branch=master
     :target: https://travis-ci.org/pytorch/vision
 
+.. image:: https://codecov.io/gh/pytorch/vision/branch/master/graph/badge.svg
+    :target: https://codecov.io/gh/pytorch/vision
+
 The torchvision package consists of popular datasets, model architectures, and common image transformations for computer vision.
 
 Installation


### PR DESCRIPTION
This PR adds code coverage to the travis builds and adds an accompanying badge.

A few details of why I've implemented it the way I have:

To test against the installed version of the package (which is
preferably since this can catch installation file inclusion bugs) we
have to deal with quirks of coverage.py. By default the ecosystem is
set up to do development coverage tests (e.g. in src, or by using `pip
install -e .` or `python setup.py develop`).

We want to test against the version installed, to do this we have to
find the install path which we'll then pass to the `--cov` arg added by
`pytest-cov`. To do this, we have to cd out of the current folder, and
import the installed version and get it's install path (if we don't cd
out, then we end up getting the existing directory in the cwd since by
default cwd is on `sys.path`)

Once we have the install path, we pass that to the `--cov` of pytest,
however we also want to rewrite the paths for codecov to pick them up on
the website, if they don't have to code coverage with local paths, they
don't register is properly.

In order to that, we have a .coveragerc file that has the contents:

```
[paths]
source =
    torchvision
    /**/site-packages/torchvision
```

This tells codecov to treat all paths with those prefixes as the same,
so anything like
`/home/travis/miniconda/envs/test-environment/lib/python2.7/site-packages/torchvision/models/__init__.py`
would be treated the same as
`torchvision/models/__init__.py` after running the coverage combination
command. The first path seems to be special, in that all subsequent
paths are rewritten to that one.

Once we collect coverage, we then run `coverage run` to rewrite the
installation paths in the coverage file, `.coverage`, to those expected
by codecov.

Phew. And that's it.

N.B: Whilst adding test/__init__.py does solve the issue, it also results in
PWD being added to the path, and then we'll test the development version
of the package, and not the installed version (see
https://docs.pytest.org/en/latest/goodpractices.html#tests-as-part-of-application-code)