### PR TITLE
fix channels

### DIFF
--- a/torchvision/models/alexnet.py
+++ b/torchvision/models/alexnet.py
@@ -23,9 +23,9 @@ class AlexNet(nn.Module):
             nn.MaxPool2d(kernel_size=3, stride=2),
             nn.Conv2d(192, 384, kernel_size=3, padding=1),
             nn.ReLU(inplace=True),
-            nn.Conv2d(384, 256, kernel_size=3, padding=1),
+            nn.Conv2d(384, 384, kernel_size=3, padding=1),
             nn.ReLU(inplace=True),
-            nn.Conv2d(256, 256, kernel_size=3, padding=1),
+            nn.Conv2d(384, 256, kernel_size=3, padding=1),
             nn.ReLU(inplace=True),
             nn.MaxPool2d(kernel_size=3, stride=2),
         )


### PR DESCRIPTION
In "One weird trick..." <https://arxiv.org/abs/1404.5997> paper, AlexNet has 64, 192, 384, 384, 256 filters on the bottom of page 5.
TensorFlow implementation <https://github.com/tensorflow/models/blob/master/research/slim/nets/alexnet.py> has 64, 192, 384, 384, 256 too.