### PR TITLE
Updated inceptionV3 to accept different sized images

### DIFF
--- a/torchvision/models/inception.py
+++ b/torchvision/models/inception.py
@@ -114,7 +114,8 @@ class Inception3(nn.Module):
         # 8 x 8 x 2048
         x = self.Mixed_7c(x)
         # 8 x 8 x 2048
-        x = F.avg_pool2d(x, kernel_size=8)
+        adaptiveAvgPoolWidth = x.shape[2]
+        x = F.avg_pool2d(x, kernel_size=adaptiveAvgPoolWidth)
         # 1 x 1 x 2048
         x = F.dropout(x, training=self.training)
         # 1 x 1 x 2048
@@ -306,6 +307,8 @@ class InceptionAux(nn.Module):
         x = self.conv0(x)
         # 5 x 5 x 128
         x = self.conv1(x)
+        adaptiveAvgPoolWidth = x.shape[2]
+        x = F.avg_pool2d(x, kernel_size=adaptiveAvgPoolWidth)
         # 1 x 1 x 768
         x = x.view(x.size(0), -1)
         # 768


### PR DESCRIPTION
The update allows inceptionV3 to process images larger or smaller than prescribed image size (299x299). Will be useful while finetuning or testing on different resolution images.