### PR TITLE
Added size information for inception v3

### DIFF
--- a/torchvision/models/inception.py
+++ b/torchvision/models/inception.py
@@ -18,7 +18,7 @@ def inception_v3(pretrained=False, **kwargs):
     `"Rethinking the Inception Architecture for Computer Vision" <http://arxiv.org/abs/1512.00567>`_.
 
     .. note::
-        **Important**: In contrast to the other models the inception_v3 expects tensors with a size of 
+        **Important**: In contrast to the other models the inception_v3 expects tensors with a size of
         299x299x3, so ensure your images are sized accordingly.
 
     Args:

--- a/torchvision/models/inception.py
+++ b/torchvision/models/inception.py
@@ -17,6 +17,8 @@ def inception_v3(pretrained=False, **kwargs):
     r"""Inception v3 model architecture from
     `"Rethinking the Inception Architecture for Computer Vision" <http://arxiv.org/abs/1512.00567>`_.
 
+    **Important**: In contrast to the other models the inception_v3 expects tensors with a size of 299x299x3, so ensure your images are sized accordingly.
+
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
     """

--- a/torchvision/models/inception.py
+++ b/torchvision/models/inception.py
@@ -17,7 +17,9 @@ def inception_v3(pretrained=False, **kwargs):
     r"""Inception v3 model architecture from
     `"Rethinking the Inception Architecture for Computer Vision" <http://arxiv.org/abs/1512.00567>`_.
 
-    **Important**: In contrast to the other models the inception_v3 expects tensors with a size of 299x299x3, so ensure your images are sized accordingly.
+    .. note::
+        **Important**: In contrast to the other models the inception_v3 expects tensors with a size of 
+        299x299x3, so ensure your images are sized accordingly.
 
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet


### PR DESCRIPTION
Since inception v3 expects in contrast to the other models a size
of 299x299x3 I added a small note in the docstring to point that out
(addresses #560)