### PR TITLE
Add support for .TIFF files in ImageFolder

### DIFF
--- a/torchvision/datasets/folder.py
+++ b/torchvision/datasets/folder.py
@@ -151,7 +151,7 @@ class DatasetFolder(data.Dataset):
         return fmt_str
 
 
-IMG_EXTENSIONS = ['.jpg', '.jpeg', '.png', '.ppm', '.bmp', '.pgm', '.tif']
+IMG_EXTENSIONS = ['.jpg', '.jpeg', '.png', '.ppm', '.bmp', '.pgm', '.tif', '.tiff']
 
 
 def pil_loader(path):


### PR DESCRIPTION
Hello,

While dealing with a dataset containing .TIFF images, I've discovered that torchvision doesn't allow this extension in ImageFolder.

This PR just add '.tiff' in the list of allowed image extensions, as '.tif' is already there and another name for the same format (source : http://www.differencebetween.net/technology/protocols-formats/difference-between-tif-and-tiff/).

I've tried it on my dataset and it works as expected (results are the same when I just edit the extension of my TIFF to change it as TIF).

Thanks