### PR TITLE
workaround for tensorboardX visualization

### DIFF
--- a/torchvision/models/resnet.py
+++ b/torchvision/models/resnet.py
@@ -33,9 +33,10 @@ class BasicBlock(nn.Module):
         super(BasicBlock, self).__init__()
         self.conv1 = conv3x3(inplanes, planes, stride)
         self.bn1 = nn.BatchNorm2d(planes)
-        self.relu = nn.ReLU(inplace=True)
+        self.relu1 = nn.ReLU(inplace=True)
         self.conv2 = conv3x3(planes, planes)
         self.bn2 = nn.BatchNorm2d(planes)
+        self.relu2 = nn.ReLU(inplace=True)
         self.downsample = downsample
         self.stride = stride
 
@@ -44,7 +45,7 @@ class BasicBlock(nn.Module):
 
         out = self.conv1(x)
         out = self.bn1(out)
-        out = self.relu(out)
+        out = self.relu1(out)
 
         out = self.conv2(out)
         out = self.bn2(out)
@@ -53,7 +54,7 @@ class BasicBlock(nn.Module):
             identity = self.downsample(x)
 
         out += identity
-        out = self.relu(out)
+        out = self.relu2(out)
 
         return out
 


### PR DESCRIPTION
The original implementation of basicblock uses the `relu` twice. So here's a simple fix, alough I am not sure about the perfomance impact.

before:
<img width="346" alt="screen shot 2019-02-11 at 11 27 05 pm" src="https://user-images.githubusercontent.com/2005323/52573906-17085d00-2e56-11e9-9cc2-7582f1c7d7fe.png">

after:
<img width="356" alt="screen shot 2019-02-11 at 11 31 27 pm" src="https://user-images.githubusercontent.com/2005323/52573912-196ab700-2e56-11e9-8eed-17dae1a90498.png">
