### PR TITLE
Added the DTD dataset

### DIFF
--- a/torchvision/datasets/__init__.py
+++ b/torchvision/datasets/__init__.py
@@ -13,7 +13,7 @@ from .sbu import SBU
 from .flickr import Flickr8k, Flickr30k
 from .voc import VOCSegmentation, VOCDetection
 from .cityscapes import Cityscapes
-from .dtd import DTD
+from .dtd import DTD, DTDSubset
 
 __all__ = ('LSUN', 'LSUNClass',
            'ImageFolder', 'DatasetFolder', 'FakeData',
@@ -21,4 +21,4 @@ __all__ = ('LSUN', 'LSUNClass',
            'CIFAR10', 'CIFAR100', 'EMNIST', 'FashionMNIST',
            'MNIST', 'KMNIST', 'STL10', 'SVHN', 'PhotoTour', 'SEMEION',
            'Omniglot', 'SBU', 'Flickr8k', 'Flickr30k',
-           'VOCSegmentation', 'VOCDetection', 'Cityscapes', 'DTD')
+           'VOCSegmentation', 'VOCDetection', 'Cityscapes', 'DTD', 'DTDSubset')

--- a/torchvision/datasets/__init__.py
+++ b/torchvision/datasets/__init__.py
@@ -13,6 +13,7 @@ from .sbu import SBU
 from .flickr import Flickr8k, Flickr30k
 from .voc import VOCSegmentation, VOCDetection
 from .cityscapes import Cityscapes
+from .dtd import DTD
 
 __all__ = ('LSUN', 'LSUNClass',
            'ImageFolder', 'DatasetFolder', 'FakeData',
@@ -20,4 +21,4 @@ __all__ = ('LSUN', 'LSUNClass',
            'CIFAR10', 'CIFAR100', 'EMNIST', 'FashionMNIST',
            'MNIST', 'KMNIST', 'STL10', 'SVHN', 'PhotoTour', 'SEMEION',
            'Omniglot', 'SBU', 'Flickr8k', 'Flickr30k',
-           'VOCSegmentation', 'VOCDetection', 'Cityscapes')
+           'VOCSegmentation', 'VOCDetection', 'Cityscapes', 'DTD')

--- a/torchvision/datasets/__init__.py
+++ b/torchvision/datasets/__init__.py
@@ -13,7 +13,7 @@ from .sbu import SBU
 from .flickr import Flickr8k, Flickr30k
 from .voc import VOCSegmentation, VOCDetection
 from .cityscapes import Cityscapes
-from .dtd import DTD, DTDSubset
+from .dtd import DTD
 
 __all__ = ('LSUN', 'LSUNClass',
            'ImageFolder', 'DatasetFolder', 'FakeData',
@@ -21,4 +21,4 @@ __all__ = ('LSUN', 'LSUNClass',
            'CIFAR10', 'CIFAR100', 'EMNIST', 'FashionMNIST',
            'MNIST', 'KMNIST', 'STL10', 'SVHN', 'PhotoTour', 'SEMEION',
            'Omniglot', 'SBU', 'Flickr8k', 'Flickr30k',
-           'VOCSegmentation', 'VOCDetection', 'Cityscapes', 'DTD', 'DTDSubset')
+           'VOCSegmentation', 'VOCDetection', 'Cityscapes', 'DTD')

--- a/torchvision/datasets/dtd.py
+++ b/torchvision/datasets/dtd.py
@@ -4,8 +4,8 @@ from torch.utils.data import Subset
 from .utils import download_url, check_integrity
 
 
-class DTD(ImageFolder):
-    """`DTD <https://www.robots.ox.ac.uk/~vgg/data/dtd/>`_ Dataset.
+class FullDTD(ImageFolder):
+    """Full `DTD <https://www.robots.ox.ac.uk/~vgg/data/dtd/>`_ Dataset.
 
     Args:
         root (string): Root directory of dataset where directory
@@ -73,8 +73,8 @@ class DTD(ImageFolder):
         return fmt_str
 
 
-class DTDSubset(Subset):
-    """`Subset of the DTD <https://www.robots.ox.ac.uk/~vgg/data/dtd/>`_ Dataset.
+class DTD(Subset):
+    """`DTD <https://www.robots.ox.ac.uk/~vgg/data/dtd/>`_ Dataset.
 
         Args:
             root (string): Root directory of dataset where directory
@@ -105,7 +105,7 @@ class DTDSubset(Subset):
         assert fold in range(1, 11), "fold should be integer in [1, 10]"
         self.fold = fold
 
-        dataset = DTD(root, **kwargs)
+        dataset = FullDTD(root, **kwargs)
         indices = self._make_indices(dataset)
         super().__init__(dataset, indices)
 

--- a/torchvision/datasets/dtd.py
+++ b/torchvision/datasets/dtd.py
@@ -1,5 +1,6 @@
 import os
 from .folder import ImageFolder
+from torch.utils.data import Subset
 from .utils import download_url, check_integrity
 
 
@@ -9,9 +10,6 @@ class DTD(ImageFolder):
     Args:
         root (string): Root directory of dataset where directory
             ``dtd`` exists.
-        split (string, optional): The image split to use, ``train``, ``test``
-            or ``val``
-        fold (int, optional): The image fold to use, ``[1 ... 10]``
         download (bool, optional): If true, downloads the dataset from the
             internet and puts it in root directory. If dataset is already
             downloaded, it is not downloaded again.
@@ -24,11 +22,7 @@ class DTD(ImageFolder):
      Attributes:
         classes (list): List of the class names.
         class_to_idx (dict): Dict with items (class_name, class_index).
-        split (string): image split
-        fold (int): image fold
-        imgs (list): List of (image path, class_index) tuples of the complete
-            dataset regardless of the image split and fold
-
+        imgs (list): List of (image path, class_index) tuples
     """
     image_folder = os.path.join('dtd', 'images')
     label_folder = os.path.join('dtd', 'labels')
@@ -36,104 +30,37 @@ class DTD(ImageFolder):
     filename = 'dtd-r1.0.1.tar.gz'
     tgz_md5 = 'fff73e5086ae6bdbea199a49dfb8a4c1'
 
-    def __init__(self, root, split='train', fold=1, download=False,
-                 **kwargs):
-        self.base_folder = os.path.expanduser(root)
-
-        # the input validation is done outside the properties to avoid creation
-        # of the index converter
-        self._validate_split(split)
-        self._validate_fold(fold)
-        self._split = split
-        self._fold = fold
+    def __init__(self, root, download=False, **kwargs):
+        root = self.root = os.path.expanduser(root)
 
         if download:
             self.download()
 
-        super().__init__(os.path.join(self.base_folder, self.image_folder),
-                         **kwargs)
-        self._make_index_converter()
+        super().__init__(os.path.join(self.root, self.image_folder), **kwargs)
+        # super class sets this to the root of the image folder, which is inside
+        # the data folder
+        self.root = root
 
     def download(self):
         import tarfile
 
-        if not check_integrity(os.path.join(self.base_folder, self.filename),
+        if not check_integrity(os.path.join(self.root, self.filename),
                                self.tgz_md5):
-            download_url(self.url, self.base_folder, self.filename,
+            download_url(self.url, self.root, self.filename,
                          self.tgz_md5)
 
         cwd = os.getcwd()
-        tar = tarfile.open(os.path.join(self.base_folder, self.filename),
+        tar = tarfile.open(os.path.join(self.root, self.filename),
                            "r:gz")
-        os.chdir(self.base_folder)
+        os.chdir(self.root)
         tar.extractall()
         tar.close()
         os.chdir(cwd)
 
-    @property
-    def split(self):
-        return self._split
-
-    @split.setter
-    def split(self, split):
-        self._validate_split(split)
-        if split != self._split:
-            self._split = split
-            self._make_index_converter()
-
-    def _validate_split(self, split):
-        assert split in ('train', 'val', 'test'), \
-            "split should be train, val or test"
-
-    @property
-    def fold(self):
-        return self._fold
-
-    @fold.setter
-    def fold(self, fold):
-        self._validate_fold(fold)
-        if fold != self._fold:
-            self._fold = fold
-            self._make_index_converter()
-
-    def _validate_fold(self, fold):
-        assert fold in range(1, 11), "fold should be integer in [1, 10]"
-
-    def _make_index_converter(self):
-        image_paths = [path for path, target in self.imgs]
-
-        file_name = '{}{}.txt'.format(self.split, self.fold)
-        file_path = os.path.join(self.base_folder, self.label_folder, file_name)
-        with open(file_path, 'r') as f:
-            image_paths_partial = f.read()
-        image_paths_partial = [os.path.join(self.base_folder,
-                                            self.image_folder,
-                                            path)
-                               for path in image_paths_partial.splitlines()]
-        self._index_converter = dict(
-            [(idx, image_paths.index(image_paths_partial[idx]))
-             for idx in range(len(image_paths_partial))])
-
-    def __getitem__(self, index):
-        """
-        Args:
-            index (int): Index
-
-        Returns:
-            tuple: (image, target) where target is class_index of the target
-                class.
-        """
-        return super().__getitem__(self._index_converter[index])
-
-    def __len__(self):
-        return len(self._index_converter)
-
     def __repr__(self):
         fmt_str = 'Dataset ' + self.__class__.__name__ + '\n'
         fmt_str += '    Number of datapoints: {}\n'.format(self.__len__())
-        fmt_str += '    Split: {}\n'.format(self.split)
-        fmt_str += '    Fold: {}\n'.format(self.fold)
-        fmt_str += '    Root Location: {}\n'.format(self.base_folder)
+        fmt_str += '    Root Location: {}\n'.format(self.root)
         tmp = '    Transforms (if any): '
         fmt_str += '{0}{1}\n'.format(tmp,
                                      self.transform.__repr__().replace('\n',
@@ -144,3 +71,75 @@ class DTD(ImageFolder):
                                    self.target_transform.__repr__().replace(
                                        '\n', '\n' + ' ' * len(tmp)))
         return fmt_str
+
+
+class DTDSubset(Subset):
+    """`Subset of the DTD <https://www.robots.ox.ac.uk/~vgg/data/dtd/>`_ Dataset.
+
+        Args:
+            root (string): Root directory of dataset where directory
+                ``dtd`` exists.
+            split (string, optional): The image split to use, ``train``, ``test``
+                or ``val``
+            fold (int, optional): The image fold to use, ``[1 ... 10]``
+            download (bool, optional): If true, downloads the dataset from the
+                internet and puts it in root directory. If dataset is already
+                downloaded, it is not downloaded again.
+            transform (callable, optional): A function/transform that  takes in an
+                PIL image and returns a transformed version. E.g,
+                ``transforms.RandomCrop``
+            target_transform (callable, optional): A function/transform that takes
+                in the target and transforms it.
+            loader (callable, optional): A function to load an image given its path.
+         Attributes:
+            classes (list): List of the class names.
+            class_to_idx (dict): Dict with items (class_name, class_index).
+            split (string): image split
+            fold (int): image fold
+        """
+    def __init__(self, root, split='train', fold=1, **kwargs):
+        assert split in ('train', 'val', 'test'), \
+            "split should be train, val or test"
+        self.split = split
+
+        assert fold in range(1, 11), "fold should be integer in [1, 10]"
+        self.fold = fold
+
+        dataset = DTD(root, **kwargs)
+        indices = self._make_indices(dataset)
+        super().__init__(dataset, indices)
+
+    def _make_indices(self, dataset):
+        image_folder = os.path.join(dataset.root, dataset.image_folder)
+        image_paths = [path for path, target in dataset.imgs]
+
+        label_folder = os.path.join(dataset.root, dataset.label_folder)
+        file_name = '{}{}.txt'.format(self.split, self.fold)
+        file_path = os.path.join(label_folder, file_name)
+        with open(file_path, 'r') as f:
+            image_paths_subset = f.read()
+        image_paths_subset = [os.path.join(image_folder, path)
+                              for path in image_paths_subset.splitlines()]
+
+        return [image_paths.index(image_path_subset) for
+                image_path_subset in image_paths_subset]
+
+    def __repr__(self):
+        fmt_str = 'Dataset ' + self.__class__.__name__ + '\n'
+        fmt_str += '    Number of datapoints: {}\n'.format(self.__len__())
+        fmt_str += '    Split: {}\n'.format(self.split)
+        fmt_str += '    Fold: {}\n'.format(self.fold)
+        fmt_str += '    Root Location: {}\n'.format(self.dataset.root)
+        tmp = '    Transforms (if any): '
+        fmt_str += '{0}{1}\n'.format(tmp,
+                                     self.dataset.transform.__repr__().replace('\n',
+                                                                       '\n' + ' ' * len(
+                                                                           tmp)))
+        tmp = '    Target Transforms (if any): '
+        fmt_str += '{0}{1}'.format(tmp,
+                                   self.dataset.target_transform.__repr__().replace(
+                                       '\n', '\n' + ' ' * len(tmp)))
+        return fmt_str
+
+
+

--- a/torchvision/datasets/dtd.py
+++ b/torchvision/datasets/dtd.py
@@ -1,6 +1,6 @@
 import os
 from .folder import ImageFolder
-from torch.utils.data import Subset
+from torch.utils import data
 from .utils import download_url, check_integrity
 
 
@@ -36,7 +36,9 @@ class FullDTD(ImageFolder):
         if download:
             self.download()
 
-        super().__init__(os.path.join(self.root, self.image_folder), **kwargs)
+        super(FullDTD, self).__init__(os.path.join(self.root,
+                                                   self.image_folder),
+                                      **kwargs)
         # super class sets this to the root of the image folder, which is inside
         # the data folder
         self.root = root
@@ -73,7 +75,7 @@ class FullDTD(ImageFolder):
         return fmt_str
 
 
-class DTD(Subset):
+class DTD(data.Subset):
     """`DTD <https://www.robots.ox.ac.uk/~vgg/data/dtd/>`_ Dataset.
 
         Args:
@@ -107,7 +109,7 @@ class DTD(Subset):
 
         dataset = FullDTD(root, **kwargs)
         indices = self._make_indices(dataset)
-        super().__init__(dataset, indices)
+        super(DTD, self).__init__(dataset, indices)
 
     def _make_indices(self, dataset):
         image_folder = os.path.join(dataset.root, dataset.image_folder)

--- a/torchvision/datasets/dtd.py
+++ b/torchvision/datasets/dtd.py
@@ -64,14 +64,11 @@ class FullDTD(ImageFolder):
         fmt_str += '    Number of datapoints: {}\n'.format(self.__len__())
         fmt_str += '    Root Location: {}\n'.format(self.root)
         tmp = '    Transforms (if any): '
-        fmt_str += '{0}{1}\n'.format(tmp,
-                                     self.transform.__repr__().replace('\n',
-                                                                       '\n' + ' ' * len(
-                                                                           tmp)))
+        transform_repr = self.transform.__repr__().replace('\n', '\n' + ' ' * len(tmp))
+        fmt_str += '{0}{1}\n'.format(tmp, transform_repr)
         tmp = '    Target Transforms (if any): '
-        fmt_str += '{0}{1}'.format(tmp,
-                                   self.target_transform.__repr__().replace(
-                                       '\n', '\n' + ' ' * len(tmp)))
+        transform_repr = self.target_transform.__repr__().replace('\n', '\n' + ' ' * len(tmp))
+        fmt_str += '{0}{1}'.format(tmp, transform_repr)
         return fmt_str
 
 
@@ -133,15 +130,9 @@ class DTD(data.Subset):
         fmt_str += '    Fold: {}\n'.format(self.fold)
         fmt_str += '    Root Location: {}\n'.format(self.dataset.root)
         tmp = '    Transforms (if any): '
-        fmt_str += '{0}{1}\n'.format(tmp,
-                                     self.dataset.transform.__repr__().replace('\n',
-                                                                       '\n' + ' ' * len(
-                                                                           tmp)))
+        transform_repr = self.dataset.transform.__repr__().replace('\n', '\n' + ' ' * len(tmp))
+        fmt_str += '{0}{1}\n'.format(tmp, transform_repr)
         tmp = '    Target Transforms (if any): '
-        fmt_str += '{0}{1}'.format(tmp,
-                                   self.dataset.target_transform.__repr__().replace(
-                                       '\n', '\n' + ' ' * len(tmp)))
+        transform_repr = self.dataset.target_transform.__repr__().replace('\n', '\n' + ' ' * len(tmp))
+        fmt_str += '{0}{1}'.format(tmp, transform_repr)
         return fmt_str
-
-
-

--- a/torchvision/datasets/dtd.py
+++ b/torchvision/datasets/dtd.py
@@ -1,0 +1,146 @@
+import os
+from .folder import ImageFolder
+from .utils import download_url, check_integrity
+
+
+class DTD(ImageFolder):
+    """`DTD <https://www.robots.ox.ac.uk/~vgg/data/dtd/>`_ Dataset.
+
+    Args:
+        root (string): Root directory of dataset where directory
+            ``dtd`` exists.
+        split (string, optional): The image split to use, ``train``, ``test``
+            or ``val``
+        fold (int, optional): The image fold to use, ``[1 ... 10]``
+        download (bool, optional): If true, downloads the dataset from the
+            internet and puts it in root directory. If dataset is already
+            downloaded, it is not downloaded again.
+        transform (callable, optional): A function/transform that  takes in an
+            PIL image and returns a transformed version. E.g,
+            ``transforms.RandomCrop``
+        target_transform (callable, optional): A function/transform that takes
+            in the target and transforms it.
+        loader (callable, optional): A function to load an image given its path.
+     Attributes:
+        classes (list): List of the class names.
+        class_to_idx (dict): Dict with items (class_name, class_index).
+        split (string): image split
+        fold (int): image fold
+        imgs (list): List of (image path, class_index) tuples of the complete
+            dataset regardless of the image split and fold
+
+    """
+    image_folder = os.path.join('dtd', 'images')
+    label_folder = os.path.join('dtd', 'labels')
+    url = 'https://www.robots.ox.ac.uk/~vgg/data/dtd/download/dtd-r1.0.1.tar.gz'
+    filename = 'dtd-r1.0.1.tar.gz'
+    tgz_md5 = 'fff73e5086ae6bdbea199a49dfb8a4c1'
+
+    def __init__(self, root, split='train', fold=1, download=False,
+                 **kwargs):
+        self.base_folder = os.path.expanduser(root)
+
+        # the input validation is done outside the properties to avoid creation
+        # of the index converter
+        self._validate_split(split)
+        self._validate_fold(fold)
+        self._split = split
+        self._fold = fold
+
+        if download:
+            self.download()
+
+        super().__init__(os.path.join(self.base_folder, self.image_folder),
+                         **kwargs)
+        self._make_index_converter()
+
+    def download(self):
+        import tarfile
+
+        if not check_integrity(os.path.join(self.base_folder, self.filename),
+                               self.tgz_md5):
+            download_url(self.url, self.base_folder, self.filename,
+                         self.tgz_md5)
+
+        cwd = os.getcwd()
+        tar = tarfile.open(os.path.join(self.base_folder, self.filename),
+                           "r:gz")
+        os.chdir(self.base_folder)
+        tar.extractall()
+        tar.close()
+        os.chdir(cwd)
+
+    @property
+    def split(self):
+        return self._split
+
+    @split.setter
+    def split(self, split):
+        self._validate_split(split)
+        if split != self._split:
+            self._split = split
+            self._make_index_converter()
+
+    def _validate_split(self, split):
+        assert split in ('train', 'val', 'test'), \
+            "split should be train, val or test"
+
+    @property
+    def fold(self):
+        return self._fold
+
+    @fold.setter
+    def fold(self, fold):
+        self._validate_fold(fold)
+        if fold != self._fold:
+            self._fold = fold
+            self._make_index_converter()
+
+    def _validate_fold(self, fold):
+        assert fold in range(1, 11), "fold should be integer in [1, 10]"
+
+    def _make_index_converter(self):
+        image_paths = [path for path, target in self.imgs]
+
+        file_name = '{}{}.txt'.format(self.split, self.fold)
+        file_path = os.path.join(self.base_folder, self.label_folder, file_name)
+        with open(file_path, 'r') as f:
+            image_paths_partial = f.read()
+        image_paths_partial = [os.path.join(self.base_folder,
+                                            self.image_folder,
+                                            path)
+                               for path in image_paths_partial.splitlines()]
+        self._index_converter = dict(
+            [(idx, image_paths.index(image_paths_partial[idx]))
+             for idx in range(len(image_paths_partial))])
+
+    def __getitem__(self, index):
+        """
+        Args:
+            index (int): Index
+
+        Returns:
+            tuple: (image, target) where target is class_index of the target
+                class.
+        """
+        return super().__getitem__(self._index_converter[index])
+
+    def __len__(self):
+        return len(self._index_converter)
+
+    def __repr__(self):
+        fmt_str = 'Dataset ' + self.__class__.__name__ + '\n'
+        fmt_str += '    Number of datapoints: {}\n'.format(self.__len__())
+        fmt_str += '    Split: {}\n'.format(self.split)
+        fmt_str += '    Fold: {}\n'.format(self.fold)
+        fmt_str += '    Root Location: {}\n'.format(self.base_folder)
+        tmp = '    Transforms (if any): '
+        fmt_str += '{0}{1}\n'.format(tmp,
+                                     self.transform.__repr__().replace('\n',
+                                                                       '\n' + ' ' * len(
+                                                                           tmp)))
+        tmp = '    Target Transforms (if any): '
+        fmt_str += '{0}{1}'.format(tmp,
+                                   self.target_transform.__repr__().replace(
+                                       '\n', '\n' + ' ' * len(tmp)))
+        return fmt_str


### PR DESCRIPTION
This adds the [DTD dataset](https://www.robots.ox.ac.uk/~vgg/data/dtd/). At its core it is a `ImageFolder` dataset. Next to a split into `train`, `val` and `test` sets, it contains 10 predefined `fold`s of each partial set.

I've sub-classed `ImageFolder` class and added support to download it from scratch. I can verify the downloaded archive, but I couldn't think of a way to do this for the extracted content. Thus, the `download` flag defaults to `False`.

The index of each image within `self.imgs` depends on `split` and `fold`. I've implemented a converter, which converts the indices between the complete and partial sets. Since the images are only loaded at runtime, `split` and `fold` can also be changed at runtime, which triggers a re-initialization of the converter.