### PR TITLE
Updated inceptionV3 to accept different sized images (Adaptive avg pool)

### DIFF
--- a/torchvision/models/inception.py
+++ b/torchvision/models/inception.py
@@ -118,6 +118,7 @@ class Inception3(nn.Module):
         # 8 x 8 x 2048
         x = self.Mixed_7c(x)
         # 8 x 8 x 2048
+        # Adaptive average pooling
         x = F.adaptive_avg_pool2d(x, (1, 1))
         # 1 x 1 x 2048
         x = F.dropout(x, training=self.training)
@@ -310,6 +311,7 @@ class InceptionAux(nn.Module):
         x = self.conv0(x)
         # 5 x 5 x 128
         x = self.conv1(x)
+        # 1 x 1 x 768
         # Adaptive average pooling
         x = F.adaptive_avg_pool2d(x, (1, 1))
         # 1 x 1 x 768

--- a/torchvision/models/inception.py
+++ b/torchvision/models/inception.py
@@ -118,7 +118,7 @@ class Inception3(nn.Module):
         # 8 x 8 x 2048
         x = self.Mixed_7c(x)
         # 8 x 8 x 2048
-        x = F.avg_pool2d(x, kernel_size=8)
+        x = F.adaptive_avg_pool2d(x, (1, 1))
         # 1 x 1 x 2048
         x = F.dropout(x, training=self.training)
         # 1 x 1 x 2048
@@ -310,6 +310,8 @@ class InceptionAux(nn.Module):
         x = self.conv0(x)
         # 5 x 5 x 128
         x = self.conv1(x)
+        # Adaptive average pooling
+        x = F.adaptive_avg_pool2d(x, (1, 1))
         # 1 x 1 x 768
         x = x.view(x.size(0), -1)
         # 768


### PR DESCRIPTION
The update allows inceptionV3 to process images larger or smaller than prescribed image size (299x299) using adaptive average pooling. Will be useful while finetuning or testing on different resolution images.