### PR TITLE
Make tests run faster

### DIFF
--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -990,10 +990,10 @@ class Tester(unittest.TestCase):
         assert np.all(np.array(result_a) == np.array(result_b))
 
     def test_affine(self):
-        input_img = np.zeros((200, 200, 3), dtype=np.uint8)
+        input_img = np.zeros((40, 40, 3), dtype=np.uint8)
         pts = []
-        cnt = [100, 100]
-        for pt in [(80, 80), (100, 80), (100, 100)]:
+        cnt = [20, 20]
+        for pt in [(16, 16), (20, 16), (20, 20)]:
             for i in range(-5, 5):
                 for j in range(-5, 5):
                     input_img[pt[0] + i, pt[1] + j, :] = [255, 155, 55]
@@ -1028,7 +1028,7 @@ class Tester(unittest.TestCase):
                                                                      translate=t, scale=s, shear=sh))
             assert np.sum(np.abs(true_matrix - result_matrix)) < 1e-10
             # 2) Perform inverse mapping:
-            true_result = np.zeros((200, 200, 3), dtype=np.uint8)
+            true_result = np.zeros((40, 40, 3), dtype=np.uint8)
             inv_true_matrix = np.linalg.inv(true_matrix)
             for y in range(true_result.shape[0]):
                 for x in range(true_result.shape[1]):


### PR DESCRIPTION
The tests were previously taking 2 minutes, now they take 4 seconds