### PR TITLE
Changing to AdaptiveAvgPool2d on Alexnet

### DIFF
--- a/torchvision/models/alexnet.py
+++ b/torchvision/models/alexnet.py
@@ -29,6 +29,7 @@ class AlexNet(nn.Module):
             nn.ReLU(inplace=True),
             nn.MaxPool2d(kernel_size=3, stride=2),
         )
+        self.avgpool = nn.AdaptiveAvgPool2d((6, 6))
         self.classifier = nn.Sequential(
             nn.Dropout(),
             nn.Linear(256 * 6 * 6, 4096),
@@ -41,6 +42,7 @@ class AlexNet(nn.Module):
 
     def forward(self, x):
         x = self.features(x)
+        x = self.avgpool(x)
         x = x.view(x.size(0), 256 * 6 * 6)
         x = self.classifier(x)
         return x


### PR DESCRIPTION
The update allows Alexnet to process images larger than prescribed imagenet size using adaptive average pooling. Will be useful while finetuning or testing on different resolution images. Similar to https://github.com/pytorch/vision/pull/643 and https://github.com/pytorch/vision/pull/672. I did not include adaptive avg pool in features or classifier block so that these predefined blocks can be used as it is.