### PR TITLE
Changing to AdaptiveAvgPool2d on VGG

### DIFF
--- a/torchvision/models/vgg.py
+++ b/torchvision/models/vgg.py
@@ -25,6 +25,7 @@ class VGG(nn.Module):
     def __init__(self, features, num_classes=1000, init_weights=True):
         super(VGG, self).__init__()
         self.features = features
+        self.avgpool = nn.AdaptiveAvgPool2d((7, 7))
         self.classifier = nn.Sequential(
             nn.Linear(512 * 7 * 7, 4096),
             nn.ReLU(True),
@@ -39,6 +40,7 @@ class VGG(nn.Module):
 
     def forward(self, x):
         x = self.features(x)
+        x = self.avgpool(x)
         x = x.view(x.size(0), -1)
         x = self.classifier(x)
         return x


### PR DESCRIPTION
The update allows VGG to process images larger than prescribed imagenet size using adaptive average pooling. Will be useful while finetuning or testing on different resolution images. Similar to https://github.com/pytorch/vision/pull/643 and https://github.com/pytorch/vision/pull/672. I did not include adaptive avg pool in features or classifier block so that these predefined blocks can be used as it is.