### PR TITLE
Refactoring of the datasets

### DIFF
--- a/torchvision/datasets/cifar.py
+++ b/torchvision/datasets/cifar.py
@@ -56,7 +56,9 @@ class CIFAR10(VisionDataset):
                  transform=None, target_transform=None,
                  download=False):
 
-        super(CIFAR10, self).__init__(root, transform, target_transform)
+        super(CIFAR10, self).__init__(root)
+        self.transform = transform
+        self.target_transform = target_transform
 
         self.train = train  # training set or test set
 

--- a/torchvision/datasets/cifar.py
+++ b/torchvision/datasets/cifar.py
@@ -56,7 +56,7 @@ class CIFAR10(VisionDataset):
                  transform=None, target_transform=None,
                  download=False):
 
-        super().__init__(root, transform, target_transform)
+        super(VisionDataset, self).__init__(root, transform, target_transform)
 
         self.train = train  # training set or test set
 

--- a/torchvision/datasets/cifar.py
+++ b/torchvision/datasets/cifar.py
@@ -56,7 +56,7 @@ class CIFAR10(VisionDataset):
                  transform=None, target_transform=None,
                  download=False):
 
-        super(VisionDataset, self).__init__(root, transform, target_transform)
+        super(CIFAR10, self).__init__(root, transform, target_transform)
 
         self.train = train  # training set or test set
 

--- a/torchvision/datasets/cifar.py
+++ b/torchvision/datasets/cifar.py
@@ -4,16 +4,17 @@ import os
 import os.path
 import numpy as np
 import sys
+
 if sys.version_info[0] == 2:
     import cPickle as pickle
 else:
     import pickle
 
-import torch.utils.data as data
+from .vision import VisionDataset
 from .utils import download_url, check_integrity
 
 
-class CIFAR10(data.Dataset):
+class CIFAR10(VisionDataset):
     """`CIFAR10 <https://www.cs.toronto.edu/~kriz/cifar.html>`_ Dataset.
 
     Args:
@@ -54,9 +55,9 @@ class CIFAR10(data.Dataset):
     def __init__(self, root, train=True,
                  transform=None, target_transform=None,
                  download=False):
-        self.root = os.path.expanduser(root)
-        self.transform = transform
-        self.target_transform = target_transform
+
+        super().__init__(root, transform, target_transform)
+
         self.train = train  # training set or test set
 
         if download:
@@ -150,20 +151,12 @@ class CIFAR10(data.Dataset):
         download_url(self.url, self.root, self.filename, self.tgz_md5)
 
         # extract file
-        with tarfile.open(os.path.join(self.root, self.filename), "r:gz") as tar:
+        with tarfile.open(os.path.join(self.root, self.filename),
+                          "r:gz") as tar:
             tar.extractall(path=self.root)
 
-    def __repr__(self):
-        fmt_str = 'Dataset ' + self.__class__.__name__ + '\n'
-        fmt_str += '    Number of datapoints: {}\n'.format(self.__len__())
-        tmp = 'train' if self.train is True else 'test'
-        fmt_str += '    Split: {}\n'.format(tmp)
-        fmt_str += '    Root Location: {}\n'.format(self.root)
-        tmp = '    Transforms (if any): '
-        fmt_str += '{0}{1}\n'.format(tmp, self.transform.__repr__().replace('\n', '\n' + ' ' * len(tmp)))
-        tmp = '    Target Transforms (if any): '
-        fmt_str += '{0}{1}'.format(tmp, self.target_transform.__repr__().replace('\n', '\n' + ' ' * len(tmp)))
-        return fmt_str
+    def extra_repr(self):
+        return "Split: {}".format("Train" if self.train is True else "Test")
 
 
 class CIFAR100(CIFAR10):

--- a/torchvision/datasets/cifar.py
+++ b/torchvision/datasets/cifar.py
@@ -151,8 +151,7 @@ class CIFAR10(VisionDataset):
         download_url(self.url, self.root, self.filename, self.tgz_md5)
 
         # extract file
-        with tarfile.open(os.path.join(self.root, self.filename),
-                          "r:gz") as tar:
+        with tarfile.open(os.path.join(self.root, self.filename), "r:gz") as tar:
             tar.extractall(path=self.root)
 
     def extra_repr(self):

--- a/torchvision/datasets/cityscapes.py
+++ b/torchvision/datasets/cityscapes.py
@@ -50,10 +50,8 @@ class Cityscapes(VisionDataset):
     """
 
     # Based on https://github.com/mcordts/cityscapesScripts
-    CityscapesClass = namedtuple('CityscapesClass',
-                                 ['name', 'id', 'train_id', 'category',
-                                  'category_id', 'has_instances',
-                                  'ignore_in_eval', 'color'])
+    CityscapesClass = namedtuple('CityscapesClass', ['name', 'id', 'train_id', 'category', 'category_id',
+                                                     'has_instances', 'ignore_in_eval', 'color'])
 
     classes = [
         CityscapesClass('unlabeled', 0, 255, 'void', 0, False, True, (0, 0, 0)),

--- a/torchvision/datasets/cityscapes.py
+++ b/torchvision/datasets/cityscapes.py
@@ -2,11 +2,11 @@ import json
 import os
 from collections import namedtuple
 
-import torch.utils.data as data
+from .vision import VisionDataset
 from PIL import Image
 
 
-class Cityscapes(data.Dataset):
+class Cityscapes(VisionDataset):
     """`Cityscapes <http://www.cityscapes-dataset.com/>`_ Dataset.
 
     Args:
@@ -50,80 +50,113 @@ class Cityscapes(data.Dataset):
     """
 
     # Based on https://github.com/mcordts/cityscapesScripts
-    CityscapesClass = namedtuple('CityscapesClass', ['name', 'id', 'train_id', 'category', 'category_id',
-                                                     'has_instances', 'ignore_in_eval', 'color'])
+    CityscapesClass = namedtuple('CityscapesClass',
+                                 ['name', 'id', 'train_id', 'category',
+                                  'category_id',
+                                  'has_instances', 'ignore_in_eval', 'color'])
 
     classes = [
         CityscapesClass('unlabeled', 0, 255, 'void', 0, False, True, (0, 0, 0)),
-        CityscapesClass('ego vehicle', 1, 255, 'void', 0, False, True, (0, 0, 0)),
-        CityscapesClass('rectification border', 2, 255, 'void', 0, False, True, (0, 0, 0)),
-        CityscapesClass('out of roi', 3, 255, 'void', 0, False, True, (0, 0, 0)),
+        CityscapesClass('ego vehicle', 1, 255, 'void', 0, False, True,
+                        (0, 0, 0)),
+        CityscapesClass('rectification border', 2, 255, 'void', 0, False, True,
+                        (0, 0, 0)),
+        CityscapesClass('out of roi', 3, 255, 'void', 0, False, True,
+                        (0, 0, 0)),
         CityscapesClass('static', 4, 255, 'void', 0, False, True, (0, 0, 0)),
-        CityscapesClass('dynamic', 5, 255, 'void', 0, False, True, (111, 74, 0)),
+        CityscapesClass('dynamic', 5, 255, 'void', 0, False, True,
+                        (111, 74, 0)),
         CityscapesClass('ground', 6, 255, 'void', 0, False, True, (81, 0, 81)),
         CityscapesClass('road', 7, 0, 'flat', 1, False, False, (128, 64, 128)),
-        CityscapesClass('sidewalk', 8, 1, 'flat', 1, False, False, (244, 35, 232)),
-        CityscapesClass('parking', 9, 255, 'flat', 1, False, True, (250, 170, 160)),
-        CityscapesClass('rail track', 10, 255, 'flat', 1, False, True, (230, 150, 140)),
-        CityscapesClass('building', 11, 2, 'construction', 2, False, False, (70, 70, 70)),
-        CityscapesClass('wall', 12, 3, 'construction', 2, False, False, (102, 102, 156)),
-        CityscapesClass('fence', 13, 4, 'construction', 2, False, False, (190, 153, 153)),
-        CityscapesClass('guard rail', 14, 255, 'construction', 2, False, True, (180, 165, 180)),
-        CityscapesClass('bridge', 15, 255, 'construction', 2, False, True, (150, 100, 100)),
-        CityscapesClass('tunnel', 16, 255, 'construction', 2, False, True, (150, 120, 90)),
-        CityscapesClass('pole', 17, 5, 'object', 3, False, False, (153, 153, 153)),
-        CityscapesClass('polegroup', 18, 255, 'object', 3, False, True, (153, 153, 153)),
-        CityscapesClass('traffic light', 19, 6, 'object', 3, False, False, (250, 170, 30)),
-        CityscapesClass('traffic sign', 20, 7, 'object', 3, False, False, (220, 220, 0)),
-        CityscapesClass('vegetation', 21, 8, 'nature', 4, False, False, (107, 142, 35)),
-        CityscapesClass('terrain', 22, 9, 'nature', 4, False, False, (152, 251, 152)),
+        CityscapesClass('sidewalk', 8, 1, 'flat', 1, False, False,
+                        (244, 35, 232)),
+        CityscapesClass('parking', 9, 255, 'flat', 1, False, True,
+                        (250, 170, 160)),
+        CityscapesClass('rail track', 10, 255, 'flat', 1, False, True,
+                        (230, 150, 140)),
+        CityscapesClass('building', 11, 2, 'construction', 2, False, False,
+                        (70, 70, 70)),
+        CityscapesClass('wall', 12, 3, 'construction', 2, False, False,
+                        (102, 102, 156)),
+        CityscapesClass('fence', 13, 4, 'construction', 2, False, False,
+                        (190, 153, 153)),
+        CityscapesClass('guard rail', 14, 255, 'construction', 2, False, True,
+                        (180, 165, 180)),
+        CityscapesClass('bridge', 15, 255, 'construction', 2, False, True,
+                        (150, 100, 100)),
+        CityscapesClass('tunnel', 16, 255, 'construction', 2, False, True,
+                        (150, 120, 90)),
+        CityscapesClass('pole', 17, 5, 'object', 3, False, False,
+                        (153, 153, 153)),
+        CityscapesClass('polegroup', 18, 255, 'object', 3, False, True,
+                        (153, 153, 153)),
+        CityscapesClass('traffic light', 19, 6, 'object', 3, False, False,
+                        (250, 170, 30)),
+        CityscapesClass('traffic sign', 20, 7, 'object', 3, False, False,
+                        (220, 220, 0)),
+        CityscapesClass('vegetation', 21, 8, 'nature', 4, False, False,
+                        (107, 142, 35)),
+        CityscapesClass('terrain', 22, 9, 'nature', 4, False, False,
+                        (152, 251, 152)),
         CityscapesClass('sky', 23, 10, 'sky', 5, False, False, (70, 130, 180)),
-        CityscapesClass('person', 24, 11, 'human', 6, True, False, (220, 20, 60)),
+        CityscapesClass('person', 24, 11, 'human', 6, True, False,
+                        (220, 20, 60)),
         CityscapesClass('rider', 25, 12, 'human', 6, True, False, (255, 0, 0)),
         CityscapesClass('car', 26, 13, 'vehicle', 7, True, False, (0, 0, 142)),
         CityscapesClass('truck', 27, 14, 'vehicle', 7, True, False, (0, 0, 70)),
         CityscapesClass('bus', 28, 15, 'vehicle', 7, True, False, (0, 60, 100)),
-        CityscapesClass('caravan', 29, 255, 'vehicle', 7, True, True, (0, 0, 90)),
-        CityscapesClass('trailer', 30, 255, 'vehicle', 7, True, True, (0, 0, 110)),
-        CityscapesClass('train', 31, 16, 'vehicle', 7, True, False, (0, 80, 100)),
-        CityscapesClass('motorcycle', 32, 17, 'vehicle', 7, True, False, (0, 0, 230)),
-        CityscapesClass('bicycle', 33, 18, 'vehicle', 7, True, False, (119, 11, 32)),
-        CityscapesClass('license plate', -1, -1, 'vehicle', 7, False, True, (0, 0, 142)),
+        CityscapesClass('caravan', 29, 255, 'vehicle', 7, True, True,
+                        (0, 0, 90)),
+        CityscapesClass('trailer', 30, 255, 'vehicle', 7, True, True,
+                        (0, 0, 110)),
+        CityscapesClass('train', 31, 16, 'vehicle', 7, True, False,
+                        (0, 80, 100)),
+        CityscapesClass('motorcycle', 32, 17, 'vehicle', 7, True, False,
+                        (0, 0, 230)),
+        CityscapesClass('bicycle', 33, 18, 'vehicle', 7, True, False,
+                        (119, 11, 32)),
+        CityscapesClass('license plate', -1, -1, 'vehicle', 7, False, True,
+                        (0, 0, 142)),
     ]
 
     def __init__(self, root, split='train', mode='fine', target_type='instance',
                  transform=None, target_transform=None):
-        self.root = os.path.expanduser(root)
+        super().__init__(root, transform, target_transform)
         self.mode = 'gtFine' if mode == 'fine' else 'gtCoarse'
         self.images_dir = os.path.join(self.root, 'leftImg8bit', split)
         self.targets_dir = os.path.join(self.root, self.mode, split)
-        self.transform = transform
-        self.target_transform = target_transform
         self.target_type = target_type
         self.split = split
         self.images = []
         self.targets = []
 
         if mode not in ['fine', 'coarse']:
-            raise ValueError('Invalid mode! Please use mode="fine" or mode="coarse"')
+            raise ValueError(
+                'Invalid mode! Please use mode="fine" or mode="coarse"')
 
         if mode == 'fine' and split not in ['train', 'test', 'val']:
-            raise ValueError('Invalid split for mode "fine"! Please use split="train", split="test"'
-                             ' or split="val"')
+            raise ValueError(
+                'Invalid split for mode "fine"! Please use split="train", split="test"'
+                ' or split="val"')
         elif mode == 'coarse' and split not in ['train', 'train_extra', 'val']:
-            raise ValueError('Invalid split for mode "coarse"! Please use split="train", split="train_extra"'
-                             ' or split="val"')
+            raise ValueError(
+                'Invalid split for mode "coarse"! Please use split="train", split="train_extra"'
+                ' or split="val"')
 
         if not isinstance(target_type, list):
             self.target_type = [target_type]
 
-        if not all(t in ['instance', 'semantic', 'polygon', 'color'] for t in self.target_type):
-            raise ValueError('Invalid value for "target_type"! Valid values are: "instance", "semantic", "polygon"'
-                             ' or "color"')
+        if not all(t in ['instance', 'semantic', 'polygon', 'color'] for t in
+                   self.target_type):
+            raise ValueError(
+                'Invalid value for "target_type"! Valid values are: "instance", "semantic", "polygon"'
+                ' or "color"')
 
-        if not os.path.isdir(self.images_dir) or not os.path.isdir(self.targets_dir):
-            raise RuntimeError('Dataset not found or incomplete. Please make sure all required folders for the'
-                               ' specified "split" and "mode" are inside the "root" directory')
+        if not os.path.isdir(self.images_dir) or not os.path.isdir(
+                self.targets_dir):
+            raise RuntimeError(
+                'Dataset not found or incomplete. Please make sure all required folders for the'
+                ' specified "split" and "mode" are inside the "root" directory')
 
         for city in os.listdir(self.images_dir):
             img_dir = os.path.join(self.images_dir, city)
@@ -131,8 +164,9 @@ class Cityscapes(data.Dataset):
             for file_name in os.listdir(img_dir):
                 target_types = []
                 for t in self.target_type:
-                    target_name = '{}_{}'.format(file_name.split('_leftImg8bit')[0],
-                                                 self._get_target_suffix(self.mode, t))
+                    target_name = '{}_{}'.format(
+                        file_name.split('_leftImg8bit')[0],
+                        self._get_target_suffix(self.mode, t))
                     target_types.append(os.path.join(target_dir, target_name))
 
                 self.images.append(os.path.join(img_dir, file_name))
@@ -171,18 +205,9 @@ class Cityscapes(data.Dataset):
     def __len__(self):
         return len(self.images)
 
-    def __repr__(self):
-        fmt_str = 'Dataset ' + self.__class__.__name__ + '\n'
-        fmt_str += '    Number of datapoints: {}\n'.format(self.__len__())
-        fmt_str += '    Split: {}\n'.format(self.split)
-        fmt_str += '    Mode: {}\n'.format(self.mode)
-        fmt_str += '    Type: {}\n'.format(self.target_type)
-        fmt_str += '    Root Location: {}\n'.format(self.root)
-        tmp = '    Transforms (if any): '
-        fmt_str += '{0}{1}\n'.format(tmp, self.transform.__repr__().replace('\n', '\n' + ' ' * len(tmp)))
-        tmp = '    Target Transforms (if any): '
-        fmt_str += '{0}{1}'.format(tmp, self.target_transform.__repr__().replace('\n', '\n' + ' ' * len(tmp)))
-        return fmt_str
+    def extra_repr(self):
+        lines = ["Split: {split}", "Mode: {mode}", "Type: {target_type}"]
+        return '\n'.join(lines).format(**self.__dict__)
 
     def _load_json(self, path):
         with open(path, 'r') as file:

--- a/torchvision/datasets/cityscapes.py
+++ b/torchvision/datasets/cityscapes.py
@@ -52,71 +52,45 @@ class Cityscapes(VisionDataset):
     # Based on https://github.com/mcordts/cityscapesScripts
     CityscapesClass = namedtuple('CityscapesClass',
                                  ['name', 'id', 'train_id', 'category',
-                                  'category_id',
-                                  'has_instances', 'ignore_in_eval', 'color'])
+                                  'category_id', 'has_instances',
+                                  'ignore_in_eval', 'color'])
 
     classes = [
         CityscapesClass('unlabeled', 0, 255, 'void', 0, False, True, (0, 0, 0)),
-        CityscapesClass('ego vehicle', 1, 255, 'void', 0, False, True,
-                        (0, 0, 0)),
-        CityscapesClass('rectification border', 2, 255, 'void', 0, False, True,
-                        (0, 0, 0)),
-        CityscapesClass('out of roi', 3, 255, 'void', 0, False, True,
-                        (0, 0, 0)),
+        CityscapesClass('ego vehicle', 1, 255, 'void', 0, False, True, (0, 0, 0)),
+        CityscapesClass('rectification border', 2, 255, 'void', 0, False, True, (0, 0, 0)),
+        CityscapesClass('out of roi', 3, 255, 'void', 0, False, True, (0, 0, 0)),
         CityscapesClass('static', 4, 255, 'void', 0, False, True, (0, 0, 0)),
-        CityscapesClass('dynamic', 5, 255, 'void', 0, False, True,
-                        (111, 74, 0)),
+        CityscapesClass('dynamic', 5, 255, 'void', 0, False, True, (111, 74, 0)),
         CityscapesClass('ground', 6, 255, 'void', 0, False, True, (81, 0, 81)),
         CityscapesClass('road', 7, 0, 'flat', 1, False, False, (128, 64, 128)),
-        CityscapesClass('sidewalk', 8, 1, 'flat', 1, False, False,
-                        (244, 35, 232)),
-        CityscapesClass('parking', 9, 255, 'flat', 1, False, True,
-                        (250, 170, 160)),
-        CityscapesClass('rail track', 10, 255, 'flat', 1, False, True,
-                        (230, 150, 140)),
-        CityscapesClass('building', 11, 2, 'construction', 2, False, False,
-                        (70, 70, 70)),
-        CityscapesClass('wall', 12, 3, 'construction', 2, False, False,
-                        (102, 102, 156)),
-        CityscapesClass('fence', 13, 4, 'construction', 2, False, False,
-                        (190, 153, 153)),
-        CityscapesClass('guard rail', 14, 255, 'construction', 2, False, True,
-                        (180, 165, 180)),
-        CityscapesClass('bridge', 15, 255, 'construction', 2, False, True,
-                        (150, 100, 100)),
-        CityscapesClass('tunnel', 16, 255, 'construction', 2, False, True,
-                        (150, 120, 90)),
-        CityscapesClass('pole', 17, 5, 'object', 3, False, False,
-                        (153, 153, 153)),
-        CityscapesClass('polegroup', 18, 255, 'object', 3, False, True,
-                        (153, 153, 153)),
-        CityscapesClass('traffic light', 19, 6, 'object', 3, False, False,
-                        (250, 170, 30)),
-        CityscapesClass('traffic sign', 20, 7, 'object', 3, False, False,
-                        (220, 220, 0)),
-        CityscapesClass('vegetation', 21, 8, 'nature', 4, False, False,
-                        (107, 142, 35)),
-        CityscapesClass('terrain', 22, 9, 'nature', 4, False, False,
-                        (152, 251, 152)),
+        CityscapesClass('sidewalk', 8, 1, 'flat', 1, False, False, (244, 35, 232)),
+        CityscapesClass('parking', 9, 255, 'flat', 1, False, True, (250, 170, 160)),
+        CityscapesClass('rail track', 10, 255, 'flat', 1, False, True, (230, 150, 140)),
+        CityscapesClass('building', 11, 2, 'construction', 2, False, False, (70, 70, 70)),
+        CityscapesClass('wall', 12, 3, 'construction', 2, False, False, (102, 102, 156)),
+        CityscapesClass('fence', 13, 4, 'construction', 2, False, False, (190, 153, 153)),
+        CityscapesClass('guard rail', 14, 255, 'construction', 2, False, True, (180, 165, 180)),
+        CityscapesClass('bridge', 15, 255, 'construction', 2, False, True, (150, 100, 100)),
+        CityscapesClass('tunnel', 16, 255, 'construction', 2, False, True, (150, 120, 90)),
+        CityscapesClass('pole', 17, 5, 'object', 3, False, False, (153, 153, 153)),
+        CityscapesClass('polegroup', 18, 255, 'object', 3, False, True, (153, 153, 153)),
+        CityscapesClass('traffic light', 19, 6, 'object', 3, False, False, (250, 170, 30)),
+        CityscapesClass('traffic sign', 20, 7, 'object', 3, False, False, (220, 220, 0)),
+        CityscapesClass('vegetation', 21, 8, 'nature', 4, False, False, (107, 142, 35)),
+        CityscapesClass('terrain', 22, 9, 'nature', 4, False, False, (152, 251, 152)),
         CityscapesClass('sky', 23, 10, 'sky', 5, False, False, (70, 130, 180)),
-        CityscapesClass('person', 24, 11, 'human', 6, True, False,
-                        (220, 20, 60)),
+        CityscapesClass('person', 24, 11, 'human', 6, True, False, (220, 20, 60)),
         CityscapesClass('rider', 25, 12, 'human', 6, True, False, (255, 0, 0)),
         CityscapesClass('car', 26, 13, 'vehicle', 7, True, False, (0, 0, 142)),
         CityscapesClass('truck', 27, 14, 'vehicle', 7, True, False, (0, 0, 70)),
         CityscapesClass('bus', 28, 15, 'vehicle', 7, True, False, (0, 60, 100)),
-        CityscapesClass('caravan', 29, 255, 'vehicle', 7, True, True,
-                        (0, 0, 90)),
-        CityscapesClass('trailer', 30, 255, 'vehicle', 7, True, True,
-                        (0, 0, 110)),
-        CityscapesClass('train', 31, 16, 'vehicle', 7, True, False,
-                        (0, 80, 100)),
-        CityscapesClass('motorcycle', 32, 17, 'vehicle', 7, True, False,
-                        (0, 0, 230)),
-        CityscapesClass('bicycle', 33, 18, 'vehicle', 7, True, False,
-                        (119, 11, 32)),
-        CityscapesClass('license plate', -1, -1, 'vehicle', 7, False, True,
-                        (0, 0, 142)),
+        CityscapesClass('caravan', 29, 255, 'vehicle', 7, True, True, (0, 0, 90)),
+        CityscapesClass('trailer', 30, 255, 'vehicle', 7, True, True, (0, 0, 110)),
+        CityscapesClass('train', 31, 16, 'vehicle', 7, True, False, (0, 80, 100)),
+        CityscapesClass('motorcycle', 32, 17, 'vehicle', 7, True, False, (0, 0, 230)),
+        CityscapesClass('bicycle', 33, 18, 'vehicle', 7, True, False, (119, 11, 32)),
+        CityscapesClass('license plate', -1, -1, 'vehicle', 7, False, True, (0, 0, 142)),
     ]
 
     def __init__(self, root, split='train', mode='fine', target_type='instance',
@@ -131,32 +105,25 @@ class Cityscapes(VisionDataset):
         self.targets = []
 
         if mode not in ['fine', 'coarse']:
-            raise ValueError(
-                'Invalid mode! Please use mode="fine" or mode="coarse"')
+            raise ValueError('Invalid mode! Please use mode="fine" or mode="coarse"')
 
         if mode == 'fine' and split not in ['train', 'test', 'val']:
-            raise ValueError(
-                'Invalid split for mode "fine"! Please use split="train", split="test"'
-                ' or split="val"')
+            raise ValueError('Invalid split for mode "fine"! Please use split="train", split="test"'
+                             ' or split="val"')
         elif mode == 'coarse' and split not in ['train', 'train_extra', 'val']:
-            raise ValueError(
-                'Invalid split for mode "coarse"! Please use split="train", split="train_extra"'
-                ' or split="val"')
+            raise ValueError('Invalid split for mode "coarse"! Please use split="train", split="train_extra"'
+                             ' or split="val"')
 
         if not isinstance(target_type, list):
             self.target_type = [target_type]
 
-        if not all(t in ['instance', 'semantic', 'polygon', 'color'] for t in
-                   self.target_type):
-            raise ValueError(
-                'Invalid value for "target_type"! Valid values are: "instance", "semantic", "polygon"'
-                ' or "color"')
+        if not all(t in ['instance', 'semantic', 'polygon', 'color'] for t in self.target_type):
+            raise ValueError('Invalid value for "target_type"! Valid values are: "instance", "semantic", "polygon"'
+                             ' or "color"')
 
-        if not os.path.isdir(self.images_dir) or not os.path.isdir(
-                self.targets_dir):
-            raise RuntimeError(
-                'Dataset not found or incomplete. Please make sure all required folders for the'
-                ' specified "split" and "mode" are inside the "root" directory')
+        if not os.path.isdir(self.images_dir) or not os.path.isdir(self.targets_dir):
+            raise RuntimeError('Dataset not found or incomplete. Please make sure all required folders for the'
+                               ' specified "split" and "mode" are inside the "root" directory')
 
         for city in os.listdir(self.images_dir):
             img_dir = os.path.join(self.images_dir, city)
@@ -164,9 +131,8 @@ class Cityscapes(VisionDataset):
             for file_name in os.listdir(img_dir):
                 target_types = []
                 for t in self.target_type:
-                    target_name = '{}_{}'.format(
-                        file_name.split('_leftImg8bit')[0],
-                        self._get_target_suffix(self.mode, t))
+                    target_name = '{}_{}'.format(file_name.split('_leftImg8bit')[0],
+                                                 self._get_target_suffix(self.mode, t))
                     target_types.append(os.path.join(target_dir, target_name))
 
                 self.images.append(os.path.join(img_dir, file_name))

--- a/torchvision/datasets/cityscapes.py
+++ b/torchvision/datasets/cityscapes.py
@@ -93,7 +93,7 @@ class Cityscapes(VisionDataset):
 
     def __init__(self, root, split='train', mode='fine', target_type='instance',
                  transform=None, target_transform=None):
-        super(VisionDataset, self).__init__(root, transform, target_transform)
+        super(Cityscapes, self).__init__(root, transform, target_transform)
         self.mode = 'gtFine' if mode == 'fine' else 'gtCoarse'
         self.images_dir = os.path.join(self.root, 'leftImg8bit', split)
         self.targets_dir = os.path.join(self.root, self.mode, split)

--- a/torchvision/datasets/cityscapes.py
+++ b/torchvision/datasets/cityscapes.py
@@ -93,7 +93,7 @@ class Cityscapes(VisionDataset):
 
     def __init__(self, root, split='train', mode='fine', target_type='instance',
                  transform=None, target_transform=None):
-        super().__init__(root, transform, target_transform)
+        super(VisionDataset, self).__init__(root, transform, target_transform)
         self.mode = 'gtFine' if mode == 'fine' else 'gtCoarse'
         self.images_dir = os.path.join(self.root, 'leftImg8bit', split)
         self.targets_dir = os.path.join(self.root, self.mode, split)

--- a/torchvision/datasets/cityscapes.py
+++ b/torchvision/datasets/cityscapes.py
@@ -93,7 +93,9 @@ class Cityscapes(VisionDataset):
 
     def __init__(self, root, split='train', mode='fine', target_type='instance',
                  transform=None, target_transform=None):
-        super(Cityscapes, self).__init__(root, transform, target_transform)
+        super(Cityscapes, self).__init__(root)
+        self.transform = transform
+        self.target_transform = target_transform
         self.mode = 'gtFine' if mode == 'fine' else 'gtCoarse'
         self.images_dir = os.path.join(self.root, 'leftImg8bit', split)
         self.targets_dir = os.path.join(self.root, self.mode, split)

--- a/torchvision/datasets/coco.py
+++ b/torchvision/datasets/coco.py
@@ -44,7 +44,7 @@ class CocoCaptions(VisionDataset):
     """
 
     def __init__(self, root, annFile, transform=None, target_transform=None):
-        super().__init__(root, transform, target_transform)
+        super(VisionDataset, self).__init__(root, transform, target_transform)
         from pycocotools.coco import COCO
         self.coco = COCO(annFile)
         self.ids = list(self.coco.imgs.keys())
@@ -91,7 +91,7 @@ class CocoDetection(VisionDataset):
     """
 
     def __init__(self, root, annFile, transform=None, target_transform=None):
-        super().__init__(root, transform, target_transform)
+        super(VisionDataset, self).__init__(root, transform, target_transform)
         from pycocotools.coco import COCO
         self.coco = COCO(annFile)
         self.ids = list(self.coco.imgs.keys())

--- a/torchvision/datasets/coco.py
+++ b/torchvision/datasets/coco.py
@@ -1,10 +1,10 @@
-import torch.utils.data as data
+from .vision import VisionDataset
 from PIL import Image
 import os
 import os.path
 
 
-class CocoCaptions(data.Dataset):
+class CocoCaptions(VisionDataset):
     """`MS Coco Captions <http://mscoco.org/dataset/#captions-challenge2015>`_ Dataset.
 
     Args:
@@ -42,13 +42,12 @@ class CocoCaptions(data.Dataset):
             u'A mountain view with a plume of smoke in the background']
 
     """
+
     def __init__(self, root, annFile, transform=None, target_transform=None):
+        super().__init__(root, transform, target_transform)
         from pycocotools.coco import COCO
-        self.root = os.path.expanduser(root)
         self.coco = COCO(annFile)
         self.ids = list(self.coco.imgs.keys())
-        self.transform = transform
-        self.target_transform = target_transform
 
     def __getitem__(self, index):
         """
@@ -79,7 +78,7 @@ class CocoCaptions(data.Dataset):
         return len(self.ids)
 
 
-class CocoDetection(data.Dataset):
+class CocoDetection(VisionDataset):
     """`MS Coco Detection <http://mscoco.org/dataset/#detections-challenge2016>`_ Dataset.
 
     Args:
@@ -92,12 +91,10 @@ class CocoDetection(data.Dataset):
     """
 
     def __init__(self, root, annFile, transform=None, target_transform=None):
+        super().__init__(root, transform, target_transform)
         from pycocotools.coco import COCO
-        self.root = root
         self.coco = COCO(annFile)
         self.ids = list(self.coco.imgs.keys())
-        self.transform = transform
-        self.target_transform = target_transform
 
     def __getitem__(self, index):
         """
@@ -125,13 +122,3 @@ class CocoDetection(data.Dataset):
 
     def __len__(self):
         return len(self.ids)
-
-    def __repr__(self):
-        fmt_str = 'Dataset ' + self.__class__.__name__ + '\n'
-        fmt_str += '    Number of datapoints: {}\n'.format(self.__len__())
-        fmt_str += '    Root Location: {}\n'.format(self.root)
-        tmp = '    Transforms (if any): '
-        fmt_str += '{0}{1}\n'.format(tmp, self.transform.__repr__().replace('\n', '\n' + ' ' * len(tmp)))
-        tmp = '    Target Transforms (if any): '
-        fmt_str += '{0}{1}'.format(tmp, self.target_transform.__repr__().replace('\n', '\n' + ' ' * len(tmp)))
-        return fmt_str

--- a/torchvision/datasets/coco.py
+++ b/torchvision/datasets/coco.py
@@ -44,7 +44,7 @@ class CocoCaptions(VisionDataset):
     """
 
     def __init__(self, root, annFile, transform=None, target_transform=None):
-        super(VisionDataset, self).__init__(root, transform, target_transform)
+        super(CocoCaptions, self).__init__(root, transform, target_transform)
         from pycocotools.coco import COCO
         self.coco = COCO(annFile)
         self.ids = list(self.coco.imgs.keys())
@@ -91,7 +91,7 @@ class CocoDetection(VisionDataset):
     """
 
     def __init__(self, root, annFile, transform=None, target_transform=None):
-        super(VisionDataset, self).__init__(root, transform, target_transform)
+        super(CocoDetection, self).__init__(root, transform, target_transform)
         from pycocotools.coco import COCO
         self.coco = COCO(annFile)
         self.ids = list(self.coco.imgs.keys())

--- a/torchvision/datasets/coco.py
+++ b/torchvision/datasets/coco.py
@@ -44,7 +44,9 @@ class CocoCaptions(VisionDataset):
     """
 
     def __init__(self, root, annFile, transform=None, target_transform=None):
-        super(CocoCaptions, self).__init__(root, transform, target_transform)
+        super(CocoCaptions, self).__init__(root)
+        self.transform = transform
+        self.target_transform = target_transform
         from pycocotools.coco import COCO
         self.coco = COCO(annFile)
         self.ids = list(self.coco.imgs.keys())

--- a/torchvision/datasets/coco.py
+++ b/torchvision/datasets/coco.py
@@ -91,7 +91,9 @@ class CocoDetection(VisionDataset):
     """
 
     def __init__(self, root, annFile, transform=None, target_transform=None):
-        super(CocoDetection, self).__init__(root, transform, target_transform)
+        super(CocoDetection, self).__init__(root)
+        self.transform = transform
+        self.target_transform = target_transform
         from pycocotools.coco import COCO
         self.coco = COCO(annFile)
         self.ids = list(self.coco.imgs.keys())

--- a/torchvision/datasets/fakedata.py
+++ b/torchvision/datasets/fakedata.py
@@ -21,7 +21,7 @@ class FakeData(VisionDataset):
 
     def __init__(self, size=1000, image_size=(3, 224, 224), num_classes=10,
                  transform=None, target_transform=None, random_offset=0):
-        super().__init__(None, transform, target_transform)
+        super(VisionDataset, self).__init__(None, transform, target_transform)
         self.size = size
         self.num_classes = num_classes
         self.image_size = image_size

--- a/torchvision/datasets/fakedata.py
+++ b/torchvision/datasets/fakedata.py
@@ -21,7 +21,7 @@ class FakeData(VisionDataset):
 
     def __init__(self, size=1000, image_size=(3, 224, 224), num_classes=10,
                  transform=None, target_transform=None, random_offset=0):
-        super(VisionDataset, self).__init__(None, transform, target_transform)
+        super(FakeData, self).__init__(None, transform, target_transform)
         self.size = size
         self.num_classes = num_classes
         self.image_size = image_size

--- a/torchvision/datasets/fakedata.py
+++ b/torchvision/datasets/fakedata.py
@@ -1,9 +1,9 @@
 import torch
-import torch.utils.data as data
+from .vision import VisionDataset
 from .. import transforms
 
 
-class FakeData(data.Dataset):
+class FakeData(VisionDataset):
     """A fake dataset that returns randomly generated images and returns them as PIL images
 
     Args:
@@ -21,6 +21,7 @@ class FakeData(data.Dataset):
 
     def __init__(self, size=1000, image_size=(3, 224, 224), num_classes=10,
                  transform=None, target_transform=None, random_offset=0):
+        super().__init__(None, transform, target_transform)
         self.size = size
         self.num_classes = num_classes
         self.image_size = image_size
@@ -40,7 +41,8 @@ class FakeData(data.Dataset):
         rng_state = torch.get_rng_state()
         torch.manual_seed(index + self.random_offset)
         img = torch.randn(*self.image_size)
-        target = torch.randint(0, self.num_classes, size=(1,), dtype=torch.long)[0]
+        target = \
+            torch.randint(0, self.num_classes, size=(1,), dtype=torch.long)[0]
         torch.set_rng_state(rng_state)
 
         # convert to PIL Image
@@ -54,12 +56,3 @@ class FakeData(data.Dataset):
 
     def __len__(self):
         return self.size
-
-    def __repr__(self):
-        fmt_str = 'Dataset ' + self.__class__.__name__ + '\n'
-        fmt_str += '    Number of datapoints: {}\n'.format(self.__len__())
-        tmp = '    Transforms (if any): '
-        fmt_str += '{0}{1}\n'.format(tmp, self.transform.__repr__().replace('\n', '\n' + ' ' * len(tmp)))
-        tmp = '    Target Transforms (if any): '
-        fmt_str += '{0}{1}'.format(tmp, self.target_transform.__repr__().replace('\n', '\n' + ' ' * len(tmp)))
-        return fmt_str

--- a/torchvision/datasets/fakedata.py
+++ b/torchvision/datasets/fakedata.py
@@ -41,8 +41,7 @@ class FakeData(VisionDataset):
         rng_state = torch.get_rng_state()
         torch.manual_seed(index + self.random_offset)
         img = torch.randn(*self.image_size)
-        target = \
-            torch.randint(0, self.num_classes, size=(1,), dtype=torch.long)[0]
+        target = torch.randint(0, self.num_classes, size=(1,), dtype=torch.long)[0]
         torch.set_rng_state(rng_state)
 
         # convert to PIL Image

--- a/torchvision/datasets/fakedata.py
+++ b/torchvision/datasets/fakedata.py
@@ -21,7 +21,9 @@ class FakeData(VisionDataset):
 
     def __init__(self, size=1000, image_size=(3, 224, 224), num_classes=10,
                  transform=None, target_transform=None, random_offset=0):
-        super(FakeData, self).__init__(None, transform, target_transform)
+        super(FakeData, self).__init__(None)
+        self.transform = transform
+        self.target_transform = target_transform
         self.size = size
         self.num_classes = num_classes
         self.image_size = image_size

--- a/torchvision/datasets/flickr.py
+++ b/torchvision/datasets/flickr.py
@@ -63,7 +63,7 @@ class Flickr8k(VisionDataset):
     """
 
     def __init__(self, root, ann_file, transform=None, target_transform=None):
-        super().__init__(root, transform, target_transform)
+        super(VisionDataset, self).__init__(root, transform, target_transform)
         self.ann_file = os.path.expanduser(ann_file)
 
         # Read annotations and store in a dict
@@ -113,7 +113,7 @@ class Flickr30k(VisionDataset):
     """
 
     def __init__(self, root, ann_file, transform=None, target_transform=None):
-        super().__init__(root, transform, target_transform)
+        super(VisionDataset, self).__init__(root, transform, target_transform)
         self.ann_file = os.path.expanduser(ann_file)
 
         # Read annotations and store in a dict

--- a/torchvision/datasets/flickr.py
+++ b/torchvision/datasets/flickr.py
@@ -4,7 +4,7 @@ from six.moves import html_parser
 
 import glob
 import os
-import torch.utils.data as data
+from .vision import VisionDataset
 
 
 class Flickr8kParser(html_parser.HTMLParser):
@@ -50,7 +50,7 @@ class Flickr8kParser(html_parser.HTMLParser):
                 self.annotations[img_id].append(data.strip())
 
 
-class Flickr8k(data.Dataset):
+class Flickr8k(VisionDataset):
     """`Flickr8k Entities <http://nlp.cs.illinois.edu/HockenmaierGroup/8k-pictures.html>`_ Dataset.
 
     Args:
@@ -61,11 +61,10 @@ class Flickr8k(data.Dataset):
         target_transform (callable, optional): A function/transform that takes in the
             target and transforms it.
     """
+
     def __init__(self, root, ann_file, transform=None, target_transform=None):
-        self.root = os.path.expanduser(root)
+        super().__init__(root, transform, target_transform)
         self.ann_file = os.path.expanduser(ann_file)
-        self.transform = transform
-        self.target_transform = target_transform
 
         # Read annotations and store in a dict
         parser = Flickr8kParser(self.root)
@@ -101,7 +100,7 @@ class Flickr8k(data.Dataset):
         return len(self.ids)
 
 
-class Flickr30k(data.Dataset):
+class Flickr30k(VisionDataset):
     """`Flickr30k Entities <http://web.engr.illinois.edu/~bplumme2/Flickr30kEntities/>`_ Dataset.
 
     Args:
@@ -112,11 +111,10 @@ class Flickr30k(data.Dataset):
         target_transform (callable, optional): A function/transform that takes in the
             target and transforms it.
     """
+
     def __init__(self, root, ann_file, transform=None, target_transform=None):
-        self.root = os.path.expanduser(root)
+        super().__init__(root, transform, target_transform)
         self.ann_file = os.path.expanduser(ann_file)
-        self.transform = transform
-        self.target_transform = target_transform
 
         # Read annotations and store in a dict
         self.annotations = defaultdict(list)

--- a/torchvision/datasets/flickr.py
+++ b/torchvision/datasets/flickr.py
@@ -63,7 +63,7 @@ class Flickr8k(VisionDataset):
     """
 
     def __init__(self, root, ann_file, transform=None, target_transform=None):
-        super(VisionDataset, self).__init__(root, transform, target_transform)
+        super(Flickr8k, self).__init__(root, transform, target_transform)
         self.ann_file = os.path.expanduser(ann_file)
 
         # Read annotations and store in a dict
@@ -113,7 +113,7 @@ class Flickr30k(VisionDataset):
     """
 
     def __init__(self, root, ann_file, transform=None, target_transform=None):
-        super(VisionDataset, self).__init__(root, transform, target_transform)
+        super(Flickr30k, self).__init__(root, transform, target_transform)
         self.ann_file = os.path.expanduser(ann_file)
 
         # Read annotations and store in a dict

--- a/torchvision/datasets/flickr.py
+++ b/torchvision/datasets/flickr.py
@@ -63,7 +63,9 @@ class Flickr8k(VisionDataset):
     """
 
     def __init__(self, root, ann_file, transform=None, target_transform=None):
-        super(Flickr8k, self).__init__(root, transform, target_transform)
+        super(Flickr8k, self).__init__(root)
+        self.transform = transform
+        self.target_transform = target_transform
         self.ann_file = os.path.expanduser(ann_file)
 
         # Read annotations and store in a dict

--- a/torchvision/datasets/flickr.py
+++ b/torchvision/datasets/flickr.py
@@ -113,7 +113,9 @@ class Flickr30k(VisionDataset):
     """
 
     def __init__(self, root, ann_file, transform=None, target_transform=None):
-        super(Flickr30k, self).__init__(root, transform, target_transform)
+        super(Flickr30k, self).__init__(root)
+        self.transform = transform
+        self.target_transform = target_transform
         self.ann_file = os.path.expanduser(ann_file)
 
         # Read annotations and store in a dict

--- a/torchvision/datasets/folder.py
+++ b/torchvision/datasets/folder.py
@@ -85,8 +85,7 @@ class DatasetFolder(VisionDataset):
         samples = make_dataset(root, class_to_idx, extensions)
         if len(samples) == 0:
             raise (RuntimeError("Found 0 files in subfolders of: " + root + "\n"
-                                "Supported extensions are: " + ",".join(
-                extensions)))
+                                "Supported extensions are: " + ",".join(extensions)))
 
         self.loader = loader
         self.extensions = extensions

--- a/torchvision/datasets/folder.py
+++ b/torchvision/datasets/folder.py
@@ -79,14 +79,13 @@ class DatasetFolder(VisionDataset):
         targets (list): The class_index value for each image in the dataset
     """
 
-    def __init__(self, root, loader, extensions, transform=None,
-                 target_transform=None):
+    def __init__(self, root, loader, extensions, transform=None, target_transform=None):
         super().__init__(root, transform, target_transform)
         classes, class_to_idx = self._find_classes(root)
         samples = make_dataset(root, class_to_idx, extensions)
         if len(samples) == 0:
             raise (RuntimeError("Found 0 files in subfolders of: " + root + "\n"
-                                                                            "Supported extensions are: " + ",".join(
+                                "Supported extensions are: " + ",".join(
                 extensions)))
 
         self.loader = loader
@@ -114,8 +113,7 @@ class DatasetFolder(VisionDataset):
             # Faster and available in Python 3.5 and above
             classes = [d.name for d in os.scandir(dir) if d.is_dir()]
         else:
-            classes = [d for d in os.listdir(dir) if
-                       os.path.isdir(os.path.join(dir, d))]
+            classes = [d for d in os.listdir(dir) if os.path.isdir(os.path.join(dir, d))]
         classes.sort()
         class_to_idx = {classes[i]: i for i in range(len(classes))}
         return classes, class_to_idx
@@ -141,8 +139,7 @@ class DatasetFolder(VisionDataset):
         return len(self.samples)
 
 
-IMG_EXTENSIONS = ['.jpg', '.jpeg', '.png', '.ppm', '.bmp', '.pgm', '.tif',
-                  '.tiff', 'webp']
+IMG_EXTENSIONS = ['.jpg', '.jpeg', '.png', '.ppm', '.bmp', '.pgm', '.tif', '.tiff', 'webp']
 
 
 def pil_loader(path):

--- a/torchvision/datasets/folder.py
+++ b/torchvision/datasets/folder.py
@@ -80,7 +80,9 @@ class DatasetFolder(VisionDataset):
     """
 
     def __init__(self, root, loader, extensions, transform=None, target_transform=None):
-        super(DatasetFolder, self).__init__(root, transform, target_transform)
+        super(DatasetFolder, self).__init__(root)
+        self.transform = transform
+        self.target_transform = target_transform
         classes, class_to_idx = self._find_classes(root)
         samples = make_dataset(root, class_to_idx, extensions)
         if len(samples) == 0:

--- a/torchvision/datasets/folder.py
+++ b/torchvision/datasets/folder.py
@@ -80,7 +80,7 @@ class DatasetFolder(VisionDataset):
     """
 
     def __init__(self, root, loader, extensions, transform=None, target_transform=None):
-        super().__init__(root, transform, target_transform)
+        super(VisionDataset, self).__init__(root, transform, target_transform)
         classes, class_to_idx = self._find_classes(root)
         samples = make_dataset(root, class_to_idx, extensions)
         if len(samples) == 0:

--- a/torchvision/datasets/folder.py
+++ b/torchvision/datasets/folder.py
@@ -80,7 +80,7 @@ class DatasetFolder(VisionDataset):
     """
 
     def __init__(self, root, loader, extensions, transform=None, target_transform=None):
-        super(VisionDataset, self).__init__(root, transform, target_transform)
+        super(DatasetFolder, self).__init__(root, transform, target_transform)
         classes, class_to_idx = self._find_classes(root)
         samples = make_dataset(root, class_to_idx, extensions)
         if len(samples) == 0:

--- a/torchvision/datasets/folder.py
+++ b/torchvision/datasets/folder.py
@@ -1,4 +1,4 @@
-import torch.utils.data as data
+from .vision import VisionDataset
 
 from PIL import Image
 
@@ -51,7 +51,7 @@ def make_dataset(dir, class_to_idx, extensions):
     return images
 
 
-class DatasetFolder(data.Dataset):
+class DatasetFolder(VisionDataset):
     """A generic data loader where the samples are arranged in this way: ::
 
         root/class_x/xxx.ext
@@ -79,14 +79,16 @@ class DatasetFolder(data.Dataset):
         targets (list): The class_index value for each image in the dataset
     """
 
-    def __init__(self, root, loader, extensions, transform=None, target_transform=None):
+    def __init__(self, root, loader, extensions, transform=None,
+                 target_transform=None):
+        super().__init__(root, transform, target_transform)
         classes, class_to_idx = self._find_classes(root)
         samples = make_dataset(root, class_to_idx, extensions)
         if len(samples) == 0:
-            raise(RuntimeError("Found 0 files in subfolders of: " + root + "\n"
-                               "Supported extensions are: " + ",".join(extensions)))
+            raise (RuntimeError("Found 0 files in subfolders of: " + root + "\n"
+                                                                            "Supported extensions are: " + ",".join(
+                extensions)))
 
-        self.root = root
         self.loader = loader
         self.extensions = extensions
 
@@ -94,9 +96,6 @@ class DatasetFolder(data.Dataset):
         self.class_to_idx = class_to_idx
         self.samples = samples
         self.targets = [s[1] for s in samples]
-
-        self.transform = transform
-        self.target_transform = target_transform
 
     def _find_classes(self, dir):
         """
@@ -115,7 +114,8 @@ class DatasetFolder(data.Dataset):
             # Faster and available in Python 3.5 and above
             classes = [d.name for d in os.scandir(dir) if d.is_dir()]
         else:
-            classes = [d for d in os.listdir(dir) if os.path.isdir(os.path.join(dir, d))]
+            classes = [d for d in os.listdir(dir) if
+                       os.path.isdir(os.path.join(dir, d))]
         classes.sort()
         class_to_idx = {classes[i]: i for i in range(len(classes))}
         return classes, class_to_idx
@@ -140,18 +140,9 @@ class DatasetFolder(data.Dataset):
     def __len__(self):
         return len(self.samples)
 
-    def __repr__(self):
-        fmt_str = 'Dataset ' + self.__class__.__name__ + '\n'
-        fmt_str += '    Number of datapoints: {}\n'.format(self.__len__())
-        fmt_str += '    Root Location: {}\n'.format(self.root)
-        tmp = '    Transforms (if any): '
-        fmt_str += '{0}{1}\n'.format(tmp, self.transform.__repr__().replace('\n', '\n' + ' ' * len(tmp)))
-        tmp = '    Target Transforms (if any): '
-        fmt_str += '{0}{1}'.format(tmp, self.target_transform.__repr__().replace('\n', '\n' + ' ' * len(tmp)))
-        return fmt_str
 
-
-IMG_EXTENSIONS = ['.jpg', '.jpeg', '.png', '.ppm', '.bmp', '.pgm', '.tif', '.tiff', 'webp']
+IMG_EXTENSIONS = ['.jpg', '.jpeg', '.png', '.ppm', '.bmp', '.pgm', '.tif',
+                  '.tiff', 'webp']
 
 
 def pil_loader(path):
@@ -202,6 +193,7 @@ class ImageFolder(DatasetFolder):
         class_to_idx (dict): Dict with items (class_name, class_index).
         imgs (list): List of (image path, class_index) tuples
     """
+
     def __init__(self, root, transform=None, target_transform=None,
                  loader=default_loader):
         super(ImageFolder, self).__init__(root, loader, IMG_EXTENSIONS,

--- a/torchvision/datasets/lsun.py
+++ b/torchvision/datasets/lsun.py
@@ -68,7 +68,9 @@ class LSUN(VisionDataset):
 
     def __init__(self, root, classes='train',
                  transform=None, target_transform=None):
-        super(LSUN, self).__init__(root, transform, target_transform)
+        super(LSUN, self).__init__(root)
+        self.transform = transform
+        self.target_transform = target_transform
         categories = ['bedroom', 'bridge', 'church_outdoor', 'classroom',
                       'conference_room', 'dining_room', 'kitchen',
                       'living_room', 'restaurant', 'tower']

--- a/torchvision/datasets/lsun.py
+++ b/torchvision/datasets/lsun.py
@@ -15,7 +15,7 @@ else:
 class LSUNClass(VisionDataset):
     def __init__(self, root, transform=None, target_transform=None):
         import lmdb
-        super().__init__(root, transform, target_transform)
+        super(LSUNClass, self).__init__(root, transform, target_transform)
 
         self.env = lmdb.open(root, max_readers=1, readonly=True, lock=False,
                              readahead=False, meminit=False)
@@ -68,7 +68,7 @@ class LSUN(VisionDataset):
 
     def __init__(self, root, classes='train',
                  transform=None, target_transform=None):
-        super(VisionDataset, self).__init__(root, transform, target_transform)
+        super(LSUN, self).__init__(root, transform, target_transform)
         categories = ['bedroom', 'bridge', 'church_outdoor', 'classroom',
                       'conference_room', 'dining_room', 'kitchen',
                       'living_room', 'restaurant', 'tower']

--- a/torchvision/datasets/lsun.py
+++ b/torchvision/datasets/lsun.py
@@ -86,8 +86,7 @@ class LSUN(VisionDataset):
                 c_short = '_'.join(c_short)
                 if c_short not in categories:
                     raise (ValueError('Unknown LSUN class: ' + c_short + '.'
-                                      'Options are: ' + str(
-                        categories)))
+                                      'Options are: ' + str(categories)))
                 c_short = c.split('_')
                 c_short = c_short.pop(len(c_short) - 1)
                 if c_short not in dset_opts:

--- a/torchvision/datasets/lsun.py
+++ b/torchvision/datasets/lsun.py
@@ -21,8 +21,7 @@ class LSUNClass(VisionDataset):
                              readahead=False, meminit=False)
         with self.env.begin(write=False) as txn:
             self.length = txn.stat()['entries']
-        cache_file = '_cache_' + ''.join(
-            c for c in root if c in string.ascii_letters)
+        cache_file = '_cache_' + ''.join(c for c in root if c in string.ascii_letters)
         if os.path.isfile(cache_file):
             self.keys = pickle.load(open(cache_file, "rb"))
         else:
@@ -87,14 +86,13 @@ class LSUN(VisionDataset):
                 c_short = '_'.join(c_short)
                 if c_short not in categories:
                     raise (ValueError('Unknown LSUN class: ' + c_short + '.'
-                                                                         'Options are: ' + str(
+                                      'Options are: ' + str(
                         categories)))
                 c_short = c.split('_')
                 c_short = c_short.pop(len(c_short) - 1)
                 if c_short not in dset_opts:
                     raise (ValueError('Unknown postfix: ' + c_short + '.'
-                                                                      'Options are: ' + str(
-                        dset_opts)))
+                                      'Options are: ' + str(dset_opts)))
         else:
             raise (ValueError('Unknown option for classes'))
         self.classes = classes

--- a/torchvision/datasets/lsun.py
+++ b/torchvision/datasets/lsun.py
@@ -68,7 +68,7 @@ class LSUN(VisionDataset):
 
     def __init__(self, root, classes='train',
                  transform=None, target_transform=None):
-        super().__init__(root, transform, target_transform)
+        super(VisionDataset, self).__init__(root, transform, target_transform)
         categories = ['bedroom', 'bridge', 'church_outdoor', 'classroom',
                       'conference_room', 'dining_room', 'kitchen',
                       'living_room', 'restaurant', 'tower']

--- a/torchvision/datasets/lsun.py
+++ b/torchvision/datasets/lsun.py
@@ -15,7 +15,9 @@ else:
 class LSUNClass(VisionDataset):
     def __init__(self, root, transform=None, target_transform=None):
         import lmdb
-        super(LSUNClass, self).__init__(root, transform, target_transform)
+        super(LSUNClass, self).__init__(root)
+        self.transform = transform
+        self.target_transform = target_transform
 
         self.env = lmdb.open(root, max_readers=1, readonly=True, lock=False,
                              readahead=False, meminit=False)

--- a/torchvision/datasets/mnist.py
+++ b/torchvision/datasets/mnist.py
@@ -218,7 +218,7 @@ class EMNIST(MNIST):
     def __init__(self, root, split, **kwargs):
         if split not in self.splits:
             raise ValueError('Split "{}" not found. Valid splits are: {}'.format(
-                    split, ', '.join(self.splits),
+                split, ', '.join(self.splits),
             ))
         self.split = split
         self.training_file = self._training_file(split)
@@ -247,8 +247,7 @@ class EMNIST(MNIST):
         # download files
         filename = self.url.rpartition('/')[2]
         file_path = os.path.join(self.raw_folder, filename)
-        download_url(self.url, root=self.raw_folder, filename=filename,
-                     md5=None)
+        download_url(self.url, root=self.raw_folder, filename=filename, md5=None)
 
         print('Extracting zip archive')
         with zipfile.ZipFile(file_path) as zip_f:

--- a/torchvision/datasets/mnist.py
+++ b/torchvision/datasets/mnist.py
@@ -59,7 +59,7 @@ class MNIST(VisionDataset):
         return self.data
 
     def __init__(self, root, train=True, transform=None, target_transform=None, download=False):
-        super(VisionDataset, self).__init__(root, transform, target_transform)
+        super(MNIST, self).__init__(root, transform, target_transform)
         self.train = train  # training set or test set
 
         if download:

--- a/torchvision/datasets/mnist.py
+++ b/torchvision/datasets/mnist.py
@@ -37,8 +37,7 @@ class MNIST(VisionDataset):
     classes = ['0 - zero', '1 - one', '2 - two', '3 - three', '4 - four',
                '5 - five', '6 - six', '7 - seven', '8 - eight', '9 - nine']
 
-    def __init__(self, root, train=True, transform=None, target_transform=None,
-                 download=False):
+    def __init__(self, root, train=True, transform=None, target_transform=None, download=False):
         super().__init__(root, transform, target_transform)
         self.train = train  # training set or test set
 
@@ -53,8 +52,7 @@ class MNIST(VisionDataset):
             data_file = self.training_file
         else:
             data_file = self.test_file
-        self.data, self.targets = torch.load(
-            os.path.join(self.processed_folder, data_file))
+        self.data, self.targets = torch.load(os.path.join(self.processed_folder, data_file))
 
     def __getitem__(self, index):
         """
@@ -94,10 +92,8 @@ class MNIST(VisionDataset):
         return {_class: i for i, _class in enumerate(self.classes)}
 
     def _check_exists(self):
-        return os.path.exists(
-            os.path.join(self.processed_folder, self.training_file)) and \
-               os.path.exists(
-                   os.path.join(self.processed_folder, self.test_file))
+        return os.path.exists(os.path.join(self.processed_folder, self.training_file)) and \
+               os.path.exists(os.path.join(self.processed_folder, self.test_file))
 
     @staticmethod
     def extract_gzip(gzip_path, remove_finished=False):
@@ -128,22 +124,16 @@ class MNIST(VisionDataset):
         print('Processing...')
 
         training_set = (
-            read_image_file(
-                os.path.join(self.raw_folder, 'train-images-idx3-ubyte')),
-            read_label_file(
-                os.path.join(self.raw_folder, 'train-labels-idx1-ubyte'))
+            read_image_file(os.path.join(self.raw_folder, 'train-images-idx3-ubyte')),
+            read_label_file(os.path.join(self.raw_folder, 'train-labels-idx1-ubyte'))
         )
         test_set = (
-            read_image_file(
-                os.path.join(self.raw_folder, 't10k-images-idx3-ubyte')),
-            read_label_file(
-                os.path.join(self.raw_folder, 't10k-labels-idx1-ubyte'))
+            read_image_file(os.path.join(self.raw_folder, 't10k-images-idx3-ubyte')),
+            read_label_file(os.path.join(self.raw_folder, 't10k-labels-idx1-ubyte'))
         )
-        with open(os.path.join(self.processed_folder, self.training_file),
-                  'wb') as f:
+        with open(os.path.join(self.processed_folder, self.training_file), 'wb') as f:
             torch.save(training_set, f)
-        with open(os.path.join(self.processed_folder, self.test_file),
-                  'wb') as f:
+        with open(os.path.join(self.processed_folder, self.test_file), 'wb') as f:
             torch.save(test_set, f)
 
         print('Done!')
@@ -227,10 +217,9 @@ class EMNIST(MNIST):
 
     def __init__(self, root, split, **kwargs):
         if split not in self.splits:
-            raise ValueError(
-                'Split "{}" not found. Valid splits are: {}'.format(
+            raise ValueError('Split "{}" not found. Valid splits are: {}'.format(
                     split, ', '.join(self.splits),
-                ))
+            ))
         self.split = split
         self.training_file = self._training_file(split)
         self.test_file = self._test_file(split)
@@ -268,34 +257,22 @@ class EMNIST(MNIST):
         gzip_folder = os.path.join(self.raw_folder, 'gzip')
         for gzip_file in os.listdir(gzip_folder):
             if gzip_file.endswith('.gz'):
-                self.extract_gzip(
-                    gzip_path=os.path.join(gzip_folder, gzip_file))
+                self.extract_gzip(gzip_path=os.path.join(gzip_folder, gzip_file))
 
         # process and save as torch files
         for split in self.splits:
             print('Processing ' + split)
             training_set = (
-                read_image_file(os.path.join(gzip_folder,
-                                             'emnist-{}-train-images-idx3-ubyte'.format(
-                                                 split))),
-                read_label_file(os.path.join(gzip_folder,
-                                             'emnist-{}-train-labels-idx1-ubyte'.format(
-                                                 split)))
+                read_image_file(os.path.join(gzip_folder, 'emnist-{}-train-images-idx3-ubyte'.format(split))),
+                read_label_file(os.path.join(gzip_folder, 'emnist-{}-train-labels-idx1-ubyte'.format(split)))
             )
             test_set = (
-                read_image_file(os.path.join(gzip_folder,
-                                             'emnist-{}-test-images-idx3-ubyte'.format(
-                                                 split))),
-                read_label_file(os.path.join(gzip_folder,
-                                             'emnist-{}-test-labels-idx1-ubyte'.format(
-                                                 split)))
+                read_image_file(os.path.join(gzip_folder, 'emnist-{}-test-images-idx3-ubyte'.format(split))),
+                read_label_file(os.path.join(gzip_folder, 'emnist-{}-test-labels-idx1-ubyte'.format(split)))
             )
-            with open(os.path.join(self.processed_folder,
-                                   self._training_file(split)), 'wb') as f:
+            with open(os.path.join(self.processed_folder, self._training_file(split)), 'wb') as f:
                 torch.save(training_set, f)
-            with open(
-                    os.path.join(self.processed_folder, self._test_file(split)),
-                    'wb') as f:
+            with open(os.path.join(self.processed_folder, self._test_file(split)), 'wb') as f:
                 torch.save(test_set, f)
         shutil.rmtree(gzip_folder)
 

--- a/torchvision/datasets/mnist.py
+++ b/torchvision/datasets/mnist.py
@@ -115,8 +115,10 @@ class MNIST(VisionDataset):
         return {_class: i for i, _class in enumerate(self.classes)}
 
     def _check_exists(self):
-        return os.path.exists(os.path.join(self.processed_folder, self.training_file)) and \
-               os.path.exists(os.path.join(self.processed_folder, self.test_file))
+        return (os.path.exists(os.path.join(self.processed_folder,
+                                            self.training_file)) and
+                os.path.exists(os.path.join(self.processed_folder,
+                                            self.test_file)))
 
     @staticmethod
     def extract_gzip(gzip_path, remove_finished=False):

--- a/torchvision/datasets/mnist.py
+++ b/torchvision/datasets/mnist.py
@@ -59,7 +59,9 @@ class MNIST(VisionDataset):
         return self.data
 
     def __init__(self, root, train=True, transform=None, target_transform=None, download=False):
-        super(MNIST, self).__init__(root, transform, target_transform)
+        super(MNIST, self).__init__(root)
+        self.transform = transform
+        self.target_transform = target_transform
         self.train = train  # training set or test set
 
         if download:

--- a/torchvision/datasets/mnist.py
+++ b/torchvision/datasets/mnist.py
@@ -38,7 +38,7 @@ class MNIST(VisionDataset):
                '5 - five', '6 - six', '7 - seven', '8 - eight', '9 - nine']
 
     def __init__(self, root, train=True, transform=None, target_transform=None, download=False):
-        super().__init__(root, transform, target_transform)
+        super(VisionDataset, self).__init__(root, transform, target_transform)
         self.train = train  # training set or test set
 
         if download:

--- a/torchvision/datasets/omniglot.py
+++ b/torchvision/datasets/omniglot.py
@@ -47,8 +47,7 @@ class Omniglot(VisionDataset):
         self._characters = sum([[join(a, c) for c in list_dir(join(self.target_folder, a))]
                                 for a in self._alphabets], [])
         self._character_images = [[(image, idx) for image in list_files(join(self.target_folder, character), '.png')]
-                                  for idx, character in
-                                  enumerate(self._characters)]
+                                  for idx, character in enumerate(self._characters)]
         self._flat_character_images = sum(self._character_images, [])
 
     def __len__(self):

--- a/torchvision/datasets/omniglot.py
+++ b/torchvision/datasets/omniglot.py
@@ -31,8 +31,9 @@ class Omniglot(VisionDataset):
     def __init__(self, root, background=True,
                  transform=None, target_transform=None,
                  download=False):
-        super(Omniglot, self).__init__(join(os.path.expanduser(root), self.folder),
-                         transform, target_transform)
+        super(Omniglot, self).__init__(join(os.path.expanduser(root), self.folder))
+        self.transform = transform
+        self.target_transform = target_transform
         self.background = background
 
         if download:

--- a/torchvision/datasets/omniglot.py
+++ b/torchvision/datasets/omniglot.py
@@ -31,7 +31,7 @@ class Omniglot(VisionDataset):
     def __init__(self, root, background=True,
                  transform=None, target_transform=None,
                  download=False):
-        super(VisionDataset, self).__init__(join(os.path.expanduser(root), self.folder),
+        super(Omniglot, self).__init__(join(os.path.expanduser(root), self.folder),
                          transform, target_transform)
         self.background = background
 

--- a/torchvision/datasets/omniglot.py
+++ b/torchvision/datasets/omniglot.py
@@ -44,11 +44,9 @@ class Omniglot(VisionDataset):
 
         self.target_folder = join(self.root, self._get_target_folder())
         self._alphabets = list_dir(self.target_folder)
-        self._characters = sum(
-            [[join(a, c) for c in list_dir(join(self.target_folder, a))]
-             for a in self._alphabets], [])
-        self._character_images = [[(image, idx) for image in list_files(
-            join(self.target_folder, character), '.png')]
+        self._characters = sum([[join(a, c) for c in list_dir(join(self.target_folder, a))]
+                                for a in self._alphabets], [])
+        self._character_images = [[(image, idx) for image in list_files(join(self.target_folder, character), '.png')]
                                   for idx, character in
                                   enumerate(self._characters)]
         self._flat_character_images = sum(self._character_images, [])
@@ -65,8 +63,7 @@ class Omniglot(VisionDataset):
             tuple: (image, target) where target is index of the target character class.
         """
         image_name, character_class = self._flat_character_images[index]
-        image_path = join(self.target_folder, self._characters[character_class],
-                          image_name)
+        image_path = join(self.target_folder, self._characters[character_class], image_name)
         image = Image.open(image_path, mode='r').convert('L')
 
         if self.transform:
@@ -79,8 +76,7 @@ class Omniglot(VisionDataset):
 
     def _check_integrity(self):
         zip_filename = self._get_target_folder()
-        if not check_integrity(join(self.root, zip_filename + '.zip'),
-                               self.zips_md5[zip_filename]):
+        if not check_integrity(join(self.root, zip_filename + '.zip'), self.zips_md5[zip_filename]):
             return False
         return True
 

--- a/torchvision/datasets/omniglot.py
+++ b/torchvision/datasets/omniglot.py
@@ -31,7 +31,7 @@ class Omniglot(VisionDataset):
     def __init__(self, root, background=True,
                  transform=None, target_transform=None,
                  download=False):
-        super().__init__(join(os.path.expanduser(root), self.folder),
+        super(VisionDataset, self).__init__(join(os.path.expanduser(root), self.folder),
                          transform, target_transform)
         self.background = background
 

--- a/torchvision/datasets/phototour.py
+++ b/torchvision/datasets/phototour.py
@@ -55,14 +55,11 @@ class PhotoTour(VisionDataset):
         ],
     }
     mean = {'notredame': 0.4854, 'yosemite': 0.4844, 'liberty': 0.4437,
-            'notredame_harris': 0.4854, 'yosemite_harris': 0.4844,
-            'liberty_harris': 0.4437}
+            'notredame_harris': 0.4854, 'yosemite_harris': 0.4844, 'liberty_harris': 0.4437}
     std = {'notredame': 0.1864, 'yosemite': 0.1818, 'liberty': 0.2019,
-           'notredame_harris': 0.1864, 'yosemite_harris': 0.1818,
-           'liberty_harris': 0.2019}
+           'notredame_harris': 0.1864, 'yosemite_harris': 0.1818, 'liberty_harris': 0.2019}
     lens = {'notredame': 468159, 'yosemite': 633587, 'liberty': 450092,
-            'liberty_harris': 379587, 'yosemite_harris': 450912,
-            'notredame_harris': 325295}
+            'liberty_harris': 379587, 'yosemite_harris': 450912, 'notredame_harris': 325295}
     image_ext = 'bmp'
     info_file = 'info.txt'
     matches_files = 'm50_100000_100000_0.txt'
@@ -145,8 +142,7 @@ class PhotoTour(VisionDataset):
         print('# Caching data {}'.format(self.data_file))
 
         dataset = (
-            read_image_file(self.data_dir, self.image_ext,
-                            self.lens[self.name]),
+            read_image_file(self.data_dir, self.image_ext, self.lens[self.name]),
             read_info_file(self.data_dir, self.info_file),
             read_matches_files(self.data_dir, self.matches_files)
         )

--- a/torchvision/datasets/phototour.py
+++ b/torchvision/datasets/phototour.py
@@ -65,7 +65,7 @@ class PhotoTour(VisionDataset):
     matches_files = 'm50_100000_100000_0.txt'
 
     def __init__(self, root, name, train=True, transform=None, download=False):
-        super().__init__(root, transform, None)
+        super(VisionDataset, self).__init__(root, transform, None)
         self.name = name
         self.data_dir = os.path.join(self.root, name)
         self.data_down = os.path.join(self.root, '{}.zip'.format(name))

--- a/torchvision/datasets/phototour.py
+++ b/torchvision/datasets/phototour.py
@@ -65,7 +65,7 @@ class PhotoTour(VisionDataset):
     matches_files = 'm50_100000_100000_0.txt'
 
     def __init__(self, root, name, train=True, transform=None, download=False):
-        super(VisionDataset, self).__init__(root, transform, None)
+        super(PhotoTour, self).__init__(root, transform, None)
         self.name = name
         self.data_dir = os.path.join(self.root, name)
         self.data_down = os.path.join(self.root, '{}.zip'.format(name))

--- a/torchvision/datasets/phototour.py
+++ b/torchvision/datasets/phototour.py
@@ -65,7 +65,8 @@ class PhotoTour(VisionDataset):
     matches_files = 'm50_100000_100000_0.txt'
 
     def __init__(self, root, name, train=True, transform=None, download=False):
-        super(PhotoTour, self).__init__(root, transform, None)
+        super(PhotoTour, self).__init__(root)
+        self.transform = transform
         self.name = name
         self.data_dir = os.path.join(self.root, name)
         self.data_down = os.path.join(self.root, '{}.zip'.format(name))

--- a/torchvision/datasets/sbu.py
+++ b/torchvision/datasets/sbu.py
@@ -26,7 +26,9 @@ class SBU(VisionDataset):
 
     def __init__(self, root, transform=None, target_transform=None,
                  download=True):
-        super(SBU, self).__init__(root, transform, target_transform)
+        super(SBU, self).__init__(root)
+        self.transform = transform
+        self.target_transform = target_transform
 
         if download:
             self.download()

--- a/torchvision/datasets/sbu.py
+++ b/torchvision/datasets/sbu.py
@@ -26,7 +26,7 @@ class SBU(VisionDataset):
 
     def __init__(self, root, transform=None, target_transform=None,
                  download=True):
-        super().__init__(root, transform, target_transform)
+        super(VisionDataset, self).__init__(root, transform, target_transform)
 
         if download:
             self.download()

--- a/torchvision/datasets/sbu.py
+++ b/torchvision/datasets/sbu.py
@@ -26,7 +26,7 @@ class SBU(VisionDataset):
 
     def __init__(self, root, transform=None, target_transform=None,
                  download=True):
-        super(VisionDataset, self).__init__(root, transform, target_transform)
+        super(SBU, self).__init__(root, transform, target_transform)
 
         if download:
             self.download()

--- a/torchvision/datasets/sbu.py
+++ b/torchvision/datasets/sbu.py
@@ -39,10 +39,8 @@ class SBU(VisionDataset):
         self.photos = []
         self.captions = []
 
-        file1 = os.path.join(self.root, 'dataset',
-                             'SBU_captioned_photo_dataset_urls.txt')
-        file2 = os.path.join(self.root, 'dataset',
-                             'SBU_captioned_photo_dataset_captions.txt')
+        file1 = os.path.join(self.root, 'dataset', 'SBU_captioned_photo_dataset_urls.txt')
+        file2 = os.path.join(self.root, 'dataset', 'SBU_captioned_photo_dataset_captions.txt')
 
         for line1, line2 in zip(open(file1), open(file2)):
             url = line1.rstrip()
@@ -95,13 +93,11 @@ class SBU(VisionDataset):
         download_url(self.url, self.root, self.filename, self.md5_checksum)
 
         # Extract file
-        with tarfile.open(os.path.join(self.root, self.filename),
-                          'r:gz') as tar:
+        with tarfile.open(os.path.join(self.root, self.filename), 'r:gz') as tar:
             tar.extractall(path=self.root)
 
         # Download individual photos
-        with open(os.path.join(self.root, 'dataset',
-                               'SBU_captioned_photo_dataset_urls.txt')) as fh:
+        with open(os.path.join(self.root, 'dataset', 'SBU_captioned_photo_dataset_urls.txt')) as fh:
             for line in fh:
                 url = line.rstrip()
                 try:

--- a/torchvision/datasets/sbu.py
+++ b/torchvision/datasets/sbu.py
@@ -3,10 +3,10 @@ from six.moves import zip
 from .utils import download_url, check_integrity
 
 import os
-import torch.utils.data as data
+from .vision import VisionDataset
 
 
-class SBU(data.Dataset):
+class SBU(VisionDataset):
     """`SBU Captioned Photo <http://www.cs.virginia.edu/~vicente/sbucaptions/>`_ Dataset.
 
     Args:
@@ -24,10 +24,9 @@ class SBU(data.Dataset):
     filename = "SBUCaptionedPhotoDataset.tar.gz"
     md5_checksum = '9aec147b3488753cf758b4d493422285'
 
-    def __init__(self, root, transform=None, target_transform=None, download=True):
-        self.root = os.path.expanduser(root)
-        self.transform = transform
-        self.target_transform = target_transform
+    def __init__(self, root, transform=None, target_transform=None,
+                 download=True):
+        super().__init__(root, transform, target_transform)
 
         if download:
             self.download()
@@ -40,8 +39,10 @@ class SBU(data.Dataset):
         self.photos = []
         self.captions = []
 
-        file1 = os.path.join(self.root, 'dataset', 'SBU_captioned_photo_dataset_urls.txt')
-        file2 = os.path.join(self.root, 'dataset', 'SBU_captioned_photo_dataset_captions.txt')
+        file1 = os.path.join(self.root, 'dataset',
+                             'SBU_captioned_photo_dataset_urls.txt')
+        file2 = os.path.join(self.root, 'dataset',
+                             'SBU_captioned_photo_dataset_captions.txt')
 
         for line1, line2 in zip(open(file1), open(file2)):
             url = line1.rstrip()
@@ -94,11 +95,13 @@ class SBU(data.Dataset):
         download_url(self.url, self.root, self.filename, self.md5_checksum)
 
         # Extract file
-        with tarfile.open(os.path.join(self.root, self.filename), 'r:gz') as tar:
+        with tarfile.open(os.path.join(self.root, self.filename),
+                          'r:gz') as tar:
             tar.extractall(path=self.root)
 
         # Download individual photos
-        with open(os.path.join(self.root, 'dataset', 'SBU_captioned_photo_dataset_urls.txt')) as fh:
+        with open(os.path.join(self.root, 'dataset',
+                               'SBU_captioned_photo_dataset_urls.txt')) as fh:
             for line in fh:
                 url = line.rstrip()
                 try:

--- a/torchvision/datasets/semeion.py
+++ b/torchvision/datasets/semeion.py
@@ -26,7 +26,7 @@ class SEMEION(VisionDataset):
 
     def __init__(self, root, transform=None, target_transform=None,
                  download=True):
-        super(VisionDataset, self).__init__(root, transform, target_transform)
+        super(SEMEION, self).__init__(root, transform, target_transform)
 
         if download:
             self.download()

--- a/torchvision/datasets/semeion.py
+++ b/torchvision/datasets/semeion.py
@@ -3,11 +3,11 @@ from PIL import Image
 import os
 import os.path
 import numpy as np
-import torch.utils.data as data
+from .vision import VisionDataset
 from .utils import download_url, check_integrity
 
 
-class SEMEION(data.Dataset):
+class SEMEION(VisionDataset):
     """`SEMEION <http://archive.ics.uci.edu/ml/datasets/semeion+handwritten+digit>`_ Dataset.
     Args:
         root (string): Root directory of dataset where directory
@@ -24,10 +24,9 @@ class SEMEION(data.Dataset):
     filename = "semeion.data"
     md5_checksum = 'cb545d371d2ce14ec121470795a77432'
 
-    def __init__(self, root, transform=None, target_transform=None, download=True):
-        self.root = os.path.expanduser(root)
-        self.transform = transform
-        self.target_transform = target_transform
+    def __init__(self, root, transform=None, target_transform=None,
+                 download=True):
+        super().__init__(root, transform, target_transform)
 
         if download:
             self.download()
@@ -84,13 +83,3 @@ class SEMEION(data.Dataset):
 
         root = self.root
         download_url(self.url, root, self.filename, self.md5_checksum)
-
-    def __repr__(self):
-        fmt_str = 'Dataset ' + self.__class__.__name__ + '\n'
-        fmt_str += '    Number of datapoints: {}\n'.format(self.__len__())
-        fmt_str += '    Root Location: {}\n'.format(self.root)
-        tmp = '    Transforms (if any): '
-        fmt_str += '{0}{1}\n'.format(tmp, self.transform.__repr__().replace('\n', '\n' + ' ' * len(tmp)))
-        tmp = '    Target Transforms (if any): '
-        fmt_str += '{0}{1}'.format(tmp, self.target_transform.__repr__().replace('\n', '\n' + ' ' * len(tmp)))
-        return fmt_str

--- a/torchvision/datasets/semeion.py
+++ b/torchvision/datasets/semeion.py
@@ -26,7 +26,9 @@ class SEMEION(VisionDataset):
 
     def __init__(self, root, transform=None, target_transform=None,
                  download=True):
-        super(SEMEION, self).__init__(root, transform, target_transform)
+        super(SEMEION, self).__init__(root)
+        self.transform = transform
+        self.target_transform = target_transform
 
         if download:
             self.download()

--- a/torchvision/datasets/semeion.py
+++ b/torchvision/datasets/semeion.py
@@ -26,7 +26,7 @@ class SEMEION(VisionDataset):
 
     def __init__(self, root, transform=None, target_transform=None,
                  download=True):
-        super().__init__(root, transform, target_transform)
+        super(VisionDataset, self).__init__(root, transform, target_transform)
 
         if download:
             self.download()

--- a/torchvision/datasets/stl10.py
+++ b/torchvision/datasets/stl10.py
@@ -129,3 +129,5 @@ class STL10(CIFAR10):
 
         return images, labels
 
+    def extra_repr(self):
+        return "Split: {split}".format(**self.__dict__)

--- a/torchvision/datasets/stl10.py
+++ b/torchvision/datasets/stl10.py
@@ -128,14 +128,3 @@ class STL10(CIFAR10):
             images = np.transpose(images, (0, 1, 3, 2))
 
         return images, labels
-
-    def __repr__(self):
-        fmt_str = 'Dataset ' + self.__class__.__name__ + '\n'
-        fmt_str += '    Number of datapoints: {}\n'.format(self.__len__())
-        fmt_str += '    Split: {}\n'.format(self.split)
-        fmt_str += '    Root Location: {}\n'.format(self.root)
-        tmp = '    Transforms (if any): '
-        fmt_str += '{0}{1}\n'.format(tmp, self.transform.__repr__().replace('\n', '\n' + ' ' * len(tmp)))
-        tmp = '    Target Transforms (if any): '
-        fmt_str += '{0}{1}'.format(tmp, self.target_transform.__repr__().replace('\n', '\n' + ' ' * len(tmp)))
-        return fmt_str

--- a/torchvision/datasets/stl10.py
+++ b/torchvision/datasets/stl10.py
@@ -128,3 +128,4 @@ class STL10(CIFAR10):
             images = np.transpose(images, (0, 1, 3, 2))
 
         return images, labels
+

--- a/torchvision/datasets/svhn.py
+++ b/torchvision/datasets/svhn.py
@@ -41,7 +41,7 @@ class SVHN(VisionDataset):
 
     def __init__(self, root, split='train',
                  transform=None, target_transform=None, download=False):
-        super(VisionDataset, self).__init__(root, transform, target_transform)
+        super(SVHN, self).__init__(root, transform, target_transform)
         self.split = split  # training set or test set or extra set
 
         if self.split not in self.split_list:

--- a/torchvision/datasets/svhn.py
+++ b/torchvision/datasets/svhn.py
@@ -1,5 +1,5 @@
 from __future__ import print_function
-import torch.utils.data as data
+from .vision import VisionDataset
 from PIL import Image
 import os
 import os.path
@@ -7,7 +7,7 @@ import numpy as np
 from .utils import download_url, check_integrity
 
 
-class SVHN(data.Dataset):
+class SVHN(VisionDataset):
     """`SVHN <http://ufldl.stanford.edu/housenumbers/>`_ Dataset.
     Note: The SVHN dataset assigns the label `10` to the digit `0`. However, in this Dataset,
     we assign the label `0` to the digit `0` to be compatible with PyTorch loss functions which
@@ -41,9 +41,7 @@ class SVHN(data.Dataset):
 
     def __init__(self, root, split='train',
                  transform=None, target_transform=None, download=False):
-        self.root = os.path.expanduser(root)
-        self.transform = transform
-        self.target_transform = target_transform
+        super().__init__(root, transform, target_transform)
         self.split = split  # training set or test set or extra set
 
         if self.split not in self.split_list:
@@ -116,13 +114,5 @@ class SVHN(data.Dataset):
         md5 = self.split_list[self.split][2]
         download_url(self.url, self.root, self.filename, md5)
 
-    def __repr__(self):
-        fmt_str = 'Dataset ' + self.__class__.__name__ + '\n'
-        fmt_str += '    Number of datapoints: {}\n'.format(self.__len__())
-        fmt_str += '    Split: {}\n'.format(self.split)
-        fmt_str += '    Root Location: {}\n'.format(self.root)
-        tmp = '    Transforms (if any): '
-        fmt_str += '{0}{1}\n'.format(tmp, self.transform.__repr__().replace('\n', '\n' + ' ' * len(tmp)))
-        tmp = '    Target Transforms (if any): '
-        fmt_str += '{0}{1}'.format(tmp, self.target_transform.__repr__().replace('\n', '\n' + ' ' * len(tmp)))
-        return fmt_str
+    def extra_repr(self):
+        return "Split: {split}".format(**self.__dict__)

--- a/torchvision/datasets/svhn.py
+++ b/torchvision/datasets/svhn.py
@@ -41,7 +41,7 @@ class SVHN(VisionDataset):
 
     def __init__(self, root, split='train',
                  transform=None, target_transform=None, download=False):
-        super().__init__(root, transform, target_transform)
+        super(VisionDataset, self).__init__(root, transform, target_transform)
         self.split = split  # training set or test set or extra set
 
         if self.split not in self.split_list:

--- a/torchvision/datasets/svhn.py
+++ b/torchvision/datasets/svhn.py
@@ -41,7 +41,9 @@ class SVHN(VisionDataset):
 
     def __init__(self, root, split='train',
                  transform=None, target_transform=None, download=False):
-        super(SVHN, self).__init__(root, transform, target_transform)
+        super(SVHN, self).__init__(root)
+        self.transform = transform
+        self.target_transform = target_transform
         self.split = split  # training set or test set or extra set
 
         if self.split not in self.split_list:

--- a/torchvision/datasets/vision.py
+++ b/torchvision/datasets/vision.py
@@ -10,8 +10,6 @@ class VisionDataset(data.Dataset):
         if isinstance(root, torch._six.string_classes):
             root = os.path.expanduser(root)
         self.root = root
-        self.transform = None
-        self.target_transform = None
 
     def __getitem__(self, index):
         raise NotImplementedError
@@ -25,10 +23,10 @@ class VisionDataset(data.Dataset):
         if self.root is not None:
             body.append("Root location: {}".format(self.root))
         body += self.extra_repr().splitlines()
-        if self.transform is not None:
+        if hasattr(self, 'transform') and self.transform is not None:
             body += self._format_transform_repr(self.transform,
                                                 "Transforms: ")
-        if self.target_transform is not None:
+        if hasattr(self, 'target_transform') and self.target_transform is not None:
             body += self._format_transform_repr(self.target_transform,
                                                 "Target transforms: ")
         lines = [head] + [" " * self._repr_indent + line for line in body]

--- a/torchvision/datasets/vision.py
+++ b/torchvision/datasets/vision.py
@@ -20,8 +20,9 @@ class VisionDataset(data.Dataset):
 
     def __repr__(self):
         head = "Dataset " + self.__class__.__name__
-        body = ["Root location: {}".format(self.root),
-                "Number of datapoints: {}".format(self.__len__())]
+        body = ["Number of datapoints: {}".format(self.__len__())]
+        if self.root is not None:
+            body.append("Root location: {}".format(self.root))
         body += self.extra_repr().splitlines()
         if self.transform is not None:
             body += self._format_transform_repr(self.transform,

--- a/torchvision/datasets/vision.py
+++ b/torchvision/datasets/vision.py
@@ -6,12 +6,12 @@ import torch.utils.data as data
 class VisionDataset(data.Dataset):
     _repr_indent = 4
 
-    def __init__(self, root, transform, target_transform):
+    def __init__(self, root):
         if isinstance(root, torch._six.string_classes):
             root = os.path.expanduser(root)
         self.root = root
-        self.transform = transform
-        self.target_transform = target_transform
+        self.transform = None
+        self.target_transform = None
 
     def __getitem__(self, index):
         raise NotImplementedError

--- a/torchvision/datasets/vision.py
+++ b/torchvision/datasets/vision.py
@@ -1,0 +1,41 @@
+import os
+import torch.utils.data as data
+
+
+class VisionDataset(data.Dataset):
+    _repr_indent = 4
+
+    def __init__(self, root, transform, target_transform):
+        if isinstance(root, str):
+            root = os.path.expanduser(root)
+        self.root = root
+        self.transform = transform
+        self.target_transform = target_transform
+
+    def __getitem__(self, index):
+        raise NotImplementedError
+
+    def __len__(self):
+        raise NotImplementedError
+
+    def __repr__(self):
+        head = "Dataset " + self.__class__.__name__
+        body = ["Root location: {}".format(self.root),
+                "Number of datapoints: {}".format(self.__len__())]
+        body += self.extra_repr().splitlines()
+        if self.transform is not None:
+            body += self._format_transform_repr(self.transform,
+                                                "Transforms: ")
+        if self.target_transform is not None:
+            body += self._format_transform_repr(self.target_transform,
+                                                "Target transforms: ")
+        lines = [head] + [" " * self._repr_indent + line for line in body]
+        return '\n'.join(lines)
+
+    def _format_transform_repr(self, transform, head):
+        lines = transform.__repr__().splitlines()
+        return (["{}{}".format(head, lines[0])] +
+                ["{}{}".format(" " * len(head), line) for line in lines[1:]])
+
+    def extra_repr(self):
+        return ""

--- a/torchvision/datasets/vision.py
+++ b/torchvision/datasets/vision.py
@@ -1,4 +1,5 @@
 import os
+import torch
 import torch.utils.data as data
 
 
@@ -6,7 +7,7 @@ class VisionDataset(data.Dataset):
     _repr_indent = 4
 
     def __init__(self, root, transform, target_transform):
-        if isinstance(root, str):
+        if isinstance(root, torch._six.string_classes):
             root = os.path.expanduser(root)
         self.root = root
         self.transform = transform

--- a/torchvision/datasets/voc.py
+++ b/torchvision/datasets/voc.py
@@ -189,8 +189,7 @@ class VOCDetection(VisionDataset):
             file_names = [x.strip() for x in f.readlines()]
 
         self.images = [os.path.join(image_dir, x + ".jpg") for x in file_names]
-        self.annotations = [os.path.join(annotation_dir, x + ".xml") for x in
-                            file_names]
+        self.annotations = [os.path.join(annotation_dir, x + ".xml") for x in file_names]
         assert (len(self.images) == len(self.annotations))
 
     def __getitem__(self, index):

--- a/torchvision/datasets/voc.py
+++ b/torchvision/datasets/voc.py
@@ -2,7 +2,8 @@ import os
 import sys
 import tarfile
 import collections
-import torch.utils.data as data
+from .vision import VisionDataset
+
 if sys.version_info[0] == 2:
     import xml.etree.cElementTree as ET
 else:
@@ -51,7 +52,7 @@ DATASET_YEAR_DICT = {
 }
 
 
-class VOCSegmentation(data.Dataset):
+class VOCSegmentation(VisionDataset):
     """`Pascal VOC <http://host.robots.ox.ac.uk/pascal/VOC/>`_ Segmentation Dataset.
 
     Args:
@@ -74,13 +75,11 @@ class VOCSegmentation(data.Dataset):
                  download=False,
                  transform=None,
                  target_transform=None):
-        self.root = os.path.expanduser(root)
+        super().__init__(root, transform, target_transform)
         self.year = year
         self.url = DATASET_YEAR_DICT[year]['url']
         self.filename = DATASET_YEAR_DICT[year]['filename']
         self.md5 = DATASET_YEAR_DICT[year]['md5']
-        self.transform = transform
-        self.target_transform = target_transform
         self.image_set = image_set
         base_dir = DATASET_YEAR_DICT[year]['base_dir']
         voc_root = os.path.join(self.root, base_dir)
@@ -133,7 +132,7 @@ class VOCSegmentation(data.Dataset):
         return len(self.images)
 
 
-class VOCDetection(data.Dataset):
+class VOCDetection(VisionDataset):
     """`Pascal VOC <http://host.robots.ox.ac.uk/pascal/VOC/>`_ Detection Dataset.
 
     Args:
@@ -157,13 +156,11 @@ class VOCDetection(data.Dataset):
                  download=False,
                  transform=None,
                  target_transform=None):
-        self.root = os.path.expanduser(root)
+        super().__init__(root, transform, target_transform)
         self.year = year
         self.url = DATASET_YEAR_DICT[year]['url']
         self.filename = DATASET_YEAR_DICT[year]['filename']
         self.md5 = DATASET_YEAR_DICT[year]['md5']
-        self.transform = transform
-        self.target_transform = target_transform
         self.image_set = image_set
 
         base_dir = DATASET_YEAR_DICT[year]['base_dir']
@@ -192,7 +189,8 @@ class VOCDetection(data.Dataset):
             file_names = [x.strip() for x in f.readlines()]
 
         self.images = [os.path.join(image_dir, x + ".jpg") for x in file_names]
-        self.annotations = [os.path.join(annotation_dir, x + ".xml") for x in file_names]
+        self.annotations = [os.path.join(annotation_dir, x + ".xml") for x in
+                            file_names]
         assert (len(self.images) == len(self.annotations))
 
     def __getitem__(self, index):
@@ -228,8 +226,8 @@ class VOCDetection(data.Dataset):
                     def_dic[ind].append(v)
             voc_dict = {
                 node.tag:
-                {ind: v[0] if len(v) == 1 else v
-                 for ind, v in def_dic.items()}
+                    {ind: v[0] if len(v) == 1 else v
+                     for ind, v in def_dic.items()}
             }
         if node.text:
             text = node.text.strip()

--- a/torchvision/datasets/voc.py
+++ b/torchvision/datasets/voc.py
@@ -75,7 +75,7 @@ class VOCSegmentation(VisionDataset):
                  download=False,
                  transform=None,
                  target_transform=None):
-        super(VisionDataset, self).__init__(root, transform, target_transform)
+        super(VOCSegmentation, self).__init__(root, transform, target_transform)
         self.year = year
         self.url = DATASET_YEAR_DICT[year]['url']
         self.filename = DATASET_YEAR_DICT[year]['filename']
@@ -156,7 +156,7 @@ class VOCDetection(VisionDataset):
                  download=False,
                  transform=None,
                  target_transform=None):
-        super(VisionDataset, self).__init__(root, transform, target_transform)
+        super(VOCDetection, self).__init__(root, transform, target_transform)
         self.year = year
         self.url = DATASET_YEAR_DICT[year]['url']
         self.filename = DATASET_YEAR_DICT[year]['filename']

--- a/torchvision/datasets/voc.py
+++ b/torchvision/datasets/voc.py
@@ -75,7 +75,9 @@ class VOCSegmentation(VisionDataset):
                  download=False,
                  transform=None,
                  target_transform=None):
-        super(VOCSegmentation, self).__init__(root, transform, target_transform)
+        super(VOCSegmentation, self).__init__(root)
+        self.transform = transform
+        self.target_transform = target_transform
         self.year = year
         self.url = DATASET_YEAR_DICT[year]['url']
         self.filename = DATASET_YEAR_DICT[year]['filename']
@@ -156,7 +158,9 @@ class VOCDetection(VisionDataset):
                  download=False,
                  transform=None,
                  target_transform=None):
-        super(VOCDetection, self).__init__(root, transform, target_transform)
+        super(VOCDetection, self).__init__(root)
+        self.transform = transform
+        self.target_transform = target_transform
         self.year = year
         self.url = DATASET_YEAR_DICT[year]['url']
         self.filename = DATASET_YEAR_DICT[year]['filename']

--- a/torchvision/datasets/voc.py
+++ b/torchvision/datasets/voc.py
@@ -75,7 +75,7 @@ class VOCSegmentation(VisionDataset):
                  download=False,
                  transform=None,
                  target_transform=None):
-        super().__init__(root, transform, target_transform)
+        super(VisionDataset, self).__init__(root, transform, target_transform)
         self.year = year
         self.url = DATASET_YEAR_DICT[year]['url']
         self.filename = DATASET_YEAR_DICT[year]['filename']
@@ -156,7 +156,7 @@ class VOCDetection(VisionDataset):
                  download=False,
                  transform=None,
                  target_transform=None):
-        super().__init__(root, transform, target_transform)
+        super(VisionDataset, self).__init__(root, transform, target_transform)
         self.year = year
         self.url = DATASET_YEAR_DICT[year]['url']
         self.filename = DATASET_YEAR_DICT[year]['filename']


### PR DESCRIPTION
I'm not sure if there is a practical reason for almost all datasets to individually define the attributes `root`, `transform`, and `target_transform` as well as the `__repr__` method. Since I think there is no reason I've introduced a superclass `VisionDataset` to streamline the process. This achieves two things:

1. Since almost all classes have a `root` and `target_transform` attribute and all of them have a `transform` attribute, I think it is a good idea to move them to `VisionDataset`. The only two exceptions are: `FakeData` without `root` and `PhotoTour` without `target_transform`. Both cases are handled by `VisionDataset` if `None` is passed for these arguments.
2. I've implemted the `__repr__` similar to `torch.nn.Module`. Thus, `__repr__` always returns the name of the dataset as well as the number of samples within it. If the attributes `root`, `transform`, and `target_transform` are not `None` they are added. Additionally, the subclasses can override the `extra_repr` method to include information specific for that dataset.

Next to the refactoring with these changes the datasets `CocoCaptions`, `Flickr*`, `Omniglot`, `SBU`, and `VOC*` now also have a human-readable representation.

