### PR TITLE
ImageNet dataset

### DIFF
--- a/torchvision/datasets/__init__.py
+++ b/torchvision/datasets/__init__.py
@@ -13,7 +13,7 @@ from .sbu import SBU
 from .flickr import Flickr8k, Flickr30k
 from .voc import VOCSegmentation, VOCDetection
 from .cityscapes import Cityscapes
-from .imagenet import ImageNetClassification, ImageNetDetection
+from .imagenet import ImageNet
 
 __all__ = ('LSUN', 'LSUNClass',
            'ImageFolder', 'DatasetFolder', 'FakeData',
@@ -21,5 +21,4 @@ __all__ = ('LSUN', 'LSUNClass',
            'CIFAR10', 'CIFAR100', 'EMNIST', 'FashionMNIST',
            'MNIST', 'KMNIST', 'STL10', 'SVHN', 'PhotoTour', 'SEMEION',
            'Omniglot', 'SBU', 'Flickr8k', 'Flickr30k',
-           'VOCSegmentation', 'VOCDetection', 'Cityscapes', 'ImageNetClassification',
-           'ImageNetDetection')
+           'VOCSegmentation', 'VOCDetection', 'Cityscapes', 'ImageNet')

--- a/torchvision/datasets/__init__.py
+++ b/torchvision/datasets/__init__.py
@@ -13,7 +13,7 @@ from .sbu import SBU
 from .flickr import Flickr8k, Flickr30k
 from .voc import VOCSegmentation, VOCDetection
 from .cityscapes import Cityscapes
-from .imagenet import ImageNetDetection, ImageNetSegmentation
+from .imagenet import ImageNetClassification, ImageNetDetection
 
 __all__ = ('LSUN', 'LSUNClass',
            'ImageFolder', 'DatasetFolder', 'FakeData',
@@ -21,5 +21,5 @@ __all__ = ('LSUN', 'LSUNClass',
            'CIFAR10', 'CIFAR100', 'EMNIST', 'FashionMNIST',
            'MNIST', 'KMNIST', 'STL10', 'SVHN', 'PhotoTour', 'SEMEION',
            'Omniglot', 'SBU', 'Flickr8k', 'Flickr30k',
-           'VOCSegmentation', 'VOCDetection', 'Cityscapes', 'ImageNetDetection',
-           'ImageNetSegmentation')
+           'VOCSegmentation', 'VOCDetection', 'Cityscapes', 'ImageNetClassification',
+           'ImageNetDetection')

--- a/torchvision/datasets/__init__.py
+++ b/torchvision/datasets/__init__.py
@@ -13,6 +13,7 @@ from .sbu import SBU
 from .flickr import Flickr8k, Flickr30k
 from .voc import VOCSegmentation, VOCDetection
 from .cityscapes import Cityscapes
+from .imagenet import ImageNetDetection, ImageNetSegmentation
 
 __all__ = ('LSUN', 'LSUNClass',
            'ImageFolder', 'DatasetFolder', 'FakeData',
@@ -20,4 +21,5 @@ __all__ = ('LSUN', 'LSUNClass',
            'CIFAR10', 'CIFAR100', 'EMNIST', 'FashionMNIST',
            'MNIST', 'KMNIST', 'STL10', 'SVHN', 'PhotoTour', 'SEMEION',
            'Omniglot', 'SBU', 'Flickr8k', 'Flickr30k',
-           'VOCSegmentation', 'VOCDetection', 'Cityscapes')
+           'VOCSegmentation', 'VOCDetection', 'Cityscapes', 'ImageNetDetection',
+           'ImageNetSegmentation')

--- a/torchvision/datasets/imagenet.py
+++ b/torchvision/datasets/imagenet.py
@@ -1,0 +1,192 @@
+import os
+import shutil
+import scipy.io as sio
+import torch
+from .folder import ImageFolder
+from .utils import check_integrity, download_url
+
+ARCHIVE_DICT = {
+    ('2012', 'train'): {
+        'url': 'http://www.image-net.org/challenges/LSVRC/2012/nnoupb/ILSVRC2012_img_train.tar',
+        'md5': '1d675b47d978889d74fa0da5fadfb00e',
+    },
+    ('2012', 'val'): {
+        'url': 'http://www.image-net.org/challenges/LSVRC/2012/nnoupb/ILSVRC2012_img_val.tar',
+        'md5': '29b22e2961454d5413ddabcf34fc5622',
+    },
+    ('2012', 'devkit'): {
+        'url': 'http://www.image-net.org/challenges/LSVRC/2012/nnoupb/ILSVRC2012_devkit_t12.tar.gz',
+        'md5': 'fa75699e90414af021442c21a62c3abf',
+    }
+}
+
+META_DICT = {
+    '2012': '5c2648af14b2ff44540504b860a81a79',
+}
+
+META_FILE = 'meta.bin'
+
+
+class ImageNetDetection(ImageFolder):
+    def __init__(self, root, split='val', year='2012', download=False, **kwargs):
+
+        root = self.root = os.path.expanduser(root)
+        self.split = self._verify_split(split)
+        self.year = self._verify_year(year)
+
+        if download:
+            self.download()
+
+        self.wnids, self.wnid_to_idx, classes, class_to_idx = self._load_meta()
+        super(ImageNetDetection, self).__init__(self.split_folder, **kwargs)
+        self.root = root
+        self.classes = classes
+        self.class_to_idx = class_to_idx
+
+    def download(self):
+        self._prepare_tree()
+
+        meta_file = os.path.join(self.year_folder, META_FILE)
+        if not check_integrity(meta_file, META_DICT[self.year]):
+            tmpdir = os.path.join(self.root, 'tmp')
+
+            archive_dict = ARCHIVE_DICT[(self.year, 'devkit')]
+            download_and_extract_tar(archive_dict['url'], self.root,
+                                     extract_root=tmpdir,
+                                     md5=archive_dict['md5'], gzip=True)
+            devkit_folder = _splitexts(os.path.basename(archive_dict['url']))[0]
+            meta, val_wnids = parse_devkit(os.path.join(tmpdir, devkit_folder))
+            torch.save((meta, val_wnids), meta_file)
+
+            shutil.rmtree(tmpdir)
+
+        archive_dict = ARCHIVE_DICT[(self.year, self.split)]
+        download_and_extract_tar(archive_dict['url'], self.root,
+                                 extract_root=self.split_folder,
+                                 md5=archive_dict['md5'], gzip=False)
+
+        if self.split == 'val':
+            val_wnids = torch.load(meta_file)[1]
+            prepare_val_folder(self.split_folder, val_wnids)
+
+    def _load_meta(self):
+        # TODO: verify meta file
+        return torch.load(os.path.join(self.year_folder, META_FILE))[0]
+
+    def _prepare_tree(self):
+        try:
+            os.makedirs(self.split_folder)
+        except FileExistsError:
+            shutil.rmtree(self.split_folder)
+
+    def _verify_split(self, split):
+        if split not in self.valid_splits:
+            msg = "Unknown split {} .".format(split)
+            msg += "Valid splits are {{}}.".format(", ".join(self.valid_splits))
+            raise ValueError(msg)
+        return split
+
+    @property
+    def valid_splits(self):
+        return 'train', 'val'
+
+    def _verify_year(self, year):
+        if year not in self.valid_years:
+            msg = "Unknown year {} .".format(year)
+            msg += "Valid splits are {{}}.".format(", ".join(self.valid_years))
+            raise ValueError(msg)
+        return year
+
+    @property
+    def valid_years(self):
+        return '2012',
+
+    @property
+    def base_folder(self):
+        return os.path.join(self.root, 'ILSVRC')
+
+    @property
+    def year_folder(self):
+        return os.path.join(self.base_folder, self.year)
+
+    @property
+    def split_folder(self):
+        return os.path.join(self.year_folder, self.split)
+
+    @property
+    def archive_dict(self):
+        return ARCHIVE_DICT[(self.year, self.split)]
+
+
+class ImageNetSegmentation():
+    # TODO: implement
+    pass
+
+
+def download_and_extract_tar(url, download_root, extract_root=None, filename=None,
+                             md5=None, gzip=False):
+    import tarfile
+
+    download_root = os.path.expanduser(download_root)
+    if not extract_root:
+        extract_root = download_root
+    if not filename:
+        filename = os.path.basename(url)
+
+    archive = os.path.join(download_root, filename)
+    if not check_integrity(archive, md5):
+        download_url(url, download_root, filename=filename, md5=md5)
+
+    mode = 'r:gz' if gzip else 'r'
+    with tarfile.open(archive, mode) as tgzfh:
+        tgzfh.extractall(path=extract_root)
+
+
+def parse_devkit(root):
+    # FIXME: generalize this for all years
+    meta = parse_meta(root)
+    val_idcs = parse_val_groundtruth(root)
+
+    wnid_to_idx = meta[1]
+    idx_to_wnid = {val: key for key, val in wnid_to_idx.items()}
+    val_wnids = [idx_to_wnid[val_idx] for val_idx in val_idcs]
+
+    return meta, val_wnids
+
+
+def parse_meta(devkit_root, path='data', filename='meta.mat'):
+    # FIXME: generalize this for all years
+    metafile = os.path.join(devkit_root, path, filename)
+    meta = sio.loadmat(metafile, squeeze_me=True)['synsets']
+    idcs, wnids, classes = list(zip(*meta))[:3]
+    classes = [tuple(cls.split(', ')) for cls in classes]
+    wnid_to_idx = {wnid: idx for wnid, idx in zip(wnids, idcs)}
+    class_to_idx = {cls: idx for cls, idx in zip(classes, idcs)}
+    return wnids, wnid_to_idx, classes, class_to_idx
+
+
+def parse_val_groundtruth(devkit_root, path='data',
+                          filename='ILSVRC2012_validation_ground_truth.txt'):
+    # FIXME: generalize this for all years
+    with open(os.path.join(devkit_root, path, filename), 'r') as fh:
+        val_idcs = fh.readlines()
+    return [int(val_idx) for val_idx in val_idcs]
+
+
+def prepare_val_folder(folder, wnids):
+    img_files = sorted([os.path.join(folder, file) for file in os.listdir(folder)])
+
+    for wnid in set(wnids):
+        os.mkdir(os.path.join(folder, wnid))
+
+    for wnid, img_file in zip(wnids, img_files):
+        shutil.move(img_file, os.path.join(folder, wnid, os.path.basename(img_file)))
+
+
+def _splitexts(root):
+    exts = []
+    ext = '.'
+    while ext:
+        root, ext = os.path.splitext(root)
+        exts.append(ext)
+    return root, ''.join(reversed(exts))

--- a/torchvision/datasets/imagenet.py
+++ b/torchvision/datasets/imagenet.py
@@ -1,4 +1,9 @@
 import os
+import sys
+if sys.version_info[0] == 2:
+    # FIXME: I don't know if this is good pratice / robust
+    FileExistsError = OSError
+
 import shutil
 import scipy.io as sio
 import torch
@@ -27,7 +32,7 @@ META_DICT = {
 META_FILE = 'meta.bin'
 
 
-class ImageNetDetection(ImageFolder):
+class ImageNetClassification(ImageFolder):
     def __init__(self, root, split='val', year='2012', download=False, **kwargs):
 
         root = self.root = os.path.expanduser(root)
@@ -38,7 +43,7 @@ class ImageNetDetection(ImageFolder):
             self.download()
 
         self.wnids, self.wnid_to_idx, classes, class_to_idx = self._load_meta()
-        super(ImageNetDetection, self).__init__(self.split_folder, **kwargs)
+        super(ImageNetClassification, self).__init__(self.split_folder, **kwargs)
         self.root = root
         self.classes = classes
         self.class_to_idx = class_to_idx
@@ -76,7 +81,7 @@ class ImageNetDetection(ImageFolder):
     def _prepare_tree(self):
         try:
             os.makedirs(self.split_folder)
-        except (OSError, FileExistsError):
+        except FileExistsError:
             shutil.rmtree(self.split_folder)
 
     def _verify_split(self, split):
@@ -118,7 +123,7 @@ class ImageNetDetection(ImageFolder):
         return ARCHIVE_DICT[(self.year, self.split)]
 
 
-class ImageNetSegmentation():
+class ImageNetDetection():
     # TODO: implement
     pass
 

--- a/torchvision/datasets/imagenet.py
+++ b/torchvision/datasets/imagenet.py
@@ -69,8 +69,6 @@ class ImageNet(ImageFolder):
         self.class_to_idx = class_to_idx
 
     def download(self):
-        self._empty_split_folder()
-
         meta_file = os.path.join(self.root, META_DICT['filename'])
         if not check_integrity(meta_file, META_DICT['md5']):
             tmpdir = os.path.join(self.root, 'tmp')
@@ -99,13 +97,6 @@ class ImageNet(ImageFolder):
     def _load_meta(self):
         # TODO: verify meta file
         return torch.load(os.path.join(self.root, META_DICT['filename']))[0]
-
-    def _empty_split_folder(self):
-        try:
-            shutil.rmtree(self.split_folder)
-        except FileNotFoundError:
-            pass
-        os.makedirs(self.split_folder)
 
     def _verify_split(self, split):
         if split not in self.valid_splits:
@@ -170,6 +161,7 @@ def download_and_extract_tar(url, download_root, extract_root=None, filename=Non
     if not check_integrity(os.path.join(download_root, filename), md5):
         download_url(url, download_root, filename=filename, md5=md5)
 
+    _empty_folder(extract_root)
     extract_tar(os.path.join(download_root, filename), extract_root, **kwargs)
 
 
@@ -218,6 +210,14 @@ def prepare_val_folder(folder, wnids):
 
     for wnid, img_file in zip(wnids, img_files):
         shutil.move(img_file, os.path.join(folder, wnid, os.path.basename(img_file)))
+
+
+def _empty_folder(folder):
+    try:
+        shutil.rmtree(folder)
+    except FileNotFoundError:
+        pass
+    os.makedirs(folder)
 
 
 def _splitexts(root):

--- a/torchvision/datasets/imagenet.py
+++ b/torchvision/datasets/imagenet.py
@@ -1,15 +1,14 @@
 import os
 import sys
-
-if sys.version_info[0] == 2:
-    # FIXME: I don't know if this is good pratice / robust
-    FileExistsError = OSError
-
 import shutil
 import scipy.io as sio
 import torch
 from .folder import ImageFolder
 from .utils import check_integrity, download_url
+
+if sys.version_info[0] == 2:
+    # FIXME: I don't know if this is good pratice / robust
+    FileExistsError = OSError
 
 ARCHIVE_DICT = {
     ('2012', 'train'): {
@@ -33,7 +32,7 @@ META_DICT = {
 META_FILE = 'meta.bin'
 
 
-class ImageNetClassification(ImageFolder):
+class ImageNet(ImageFolder):
     def __init__(self, root, split='train', year='2012', download=False, **kwargs):
 
         root = self.root = os.path.expanduser(root)
@@ -44,7 +43,7 @@ class ImageNetClassification(ImageFolder):
             self.download()
 
         self.wnids, self.wnid_to_idx, classes, class_to_idx = self._load_meta()
-        super(ImageNetClassification, self).__init__(self.split_folder, **kwargs)
+        super(ImageNet, self).__init__(self.split_folder, **kwargs)
         self.root = root
         self.classes = classes
         self.class_to_idx = class_to_idx
@@ -120,11 +119,6 @@ class ImageNetClassification(ImageFolder):
     @property
     def split_folder(self):
         return os.path.join(self.year_folder, self.split)
-
-
-class ImageNetDetection():
-    # TODO: implement
-    pass
 
 
 def extract_tar(src, dest=None, gzip=None, delete=False):

--- a/torchvision/datasets/imagenet.py
+++ b/torchvision/datasets/imagenet.py
@@ -214,9 +214,11 @@ def parse_meta(devkit_root, path='data', filename='meta.mat'):
     metafile = os.path.join(devkit_root, path, filename)
     meta = sio.loadmat(metafile, squeeze_me=True)['synsets']
     idcs, wnids, classes = list(zip(*meta))[:3]
-    classes = [tuple(cls.split(', ')) for cls in classes]
     wnid_to_idx = {wnid: idx for wnid, idx in zip(wnids, idcs)}
-    class_to_idx = {cls: idx for cls, idx in zip(classes, idcs)}
+    classes = [tuple(cls.split(', ')) for cls in classes]
+    class_to_idx = {cls: idx
+                    for clss, idx in zip(classes, idcs)
+                    for cls in clss}
     return wnids, wnid_to_idx, classes, class_to_idx
 
 

--- a/torchvision/datasets/imagenet.py
+++ b/torchvision/datasets/imagenet.py
@@ -1,7 +1,6 @@
 import os
 import sys
 import shutil
-import scipy.io as sio
 import torch
 from .folder import ImageFolder
 from .utils import check_integrity, download_url
@@ -210,6 +209,8 @@ def parse_devkit(root):
 
 def parse_meta(devkit_root, path='data', filename='meta.mat'):
     # FIXME: generalize this for all years
+    import scipy.io as sio
+
     metafile = os.path.join(devkit_root, path, filename)
     meta = sio.loadmat(metafile, squeeze_me=True)['synsets']
     idcs, wnids, classes = list(zip(*meta))[:3]

--- a/torchvision/datasets/imagenet.py
+++ b/torchvision/datasets/imagenet.py
@@ -33,6 +33,30 @@ META_FILE = 'meta.bin'
 
 
 class ImageNet(ImageFolder):
+    """`ImageNet <http://image-net.org/>`_ Classification Dataset.
+
+    Args:
+        root (string): Root directory of the ImageNet Dataset.
+        year (string, optional): The dataset year, supports years 2012 to 2012.
+        split (string, optional): The dataset split, supports ``train``, or ``val``.
+        download (bool, optional): If true, downloads the dataset from the internet and
+            puts it in root directory. If dataset is already downloaded, it is not
+            downloaded again.
+        transform (callable, optional): A function/transform that  takes in an PIL image
+            and returns a transformed version. E.g, ``transforms.RandomCrop``
+        target_transform (callable, optional): A function/transform that takes in the
+            target and transforms it.
+        loader (callable, optional): A function to load an image given its path.
+
+     Attributes:
+        classes (list): List of the class names.
+        class_to_idx (dict): Dict with items (class_name, class_index).
+        wnids (list): List of the WordNet IDs.
+        class_to_idx (dict): Dict with items (wordnet_id, wordnet_id_index).
+        imgs (list): List of (image path, class_index) tuples
+        targets (list): The class_index value for each image in the dataset
+    """
+
     def __init__(self, root, split='train', year='2012', download=False, **kwargs):
 
         root = self.root = os.path.expanduser(root)
@@ -119,6 +143,27 @@ class ImageNet(ImageFolder):
     @property
     def split_folder(self):
         return os.path.join(self.year_folder, self.split)
+
+    def __repr__(self):
+        head = "Dataset " + self.__class__.__name__
+        body = ["Number of datapoints: {}".format(self.__len__())]
+        if self.root is not None:
+            body.append("Root location: {}".format(self.root))
+        body += ["Year: {}".format(self.year),
+                 "Split: {}".format(self.split)]
+        if hasattr(self, 'transform') and self.transform is not None:
+            body += self._format_transform_repr(self.transform,
+                                                "Transforms: ")
+        if hasattr(self, 'target_transform') and self.target_transform is not None:
+            body += self._format_transform_repr(self.target_transform,
+                                                "Target transforms: ")
+        lines = [head] + [" " * 4 + line for line in body]
+        return '\n'.join(lines)
+
+    def _format_transform_repr(self, transform, head):
+        lines = transform.__repr__().splitlines()
+        return (["{}{}".format(head, lines[0])] +
+                ["{}{}".format(" " * len(head), line) for line in lines[1:]])
 
 
 def extract_tar(src, dest=None, gzip=None, delete=False):

--- a/torchvision/datasets/imagenet.py
+++ b/torchvision/datasets/imagenet.py
@@ -76,7 +76,7 @@ class ImageNetDetection(ImageFolder):
     def _prepare_tree(self):
         try:
             os.makedirs(self.split_folder)
-        except FileExistsError:
+        except (OSError, FileExistsError):
             shutil.rmtree(self.split_folder)
 
     def _verify_split(self, split):

--- a/torchvision/datasets/imagenet.py
+++ b/torchvision/datasets/imagenet.py
@@ -1,14 +1,10 @@
 from __future__ import print_function
 import os
-import sys
 import shutil
 import torch
 from .folder import ImageFolder
 from .utils import check_integrity, download_url
 
-if sys.version_info[0] == 2:
-    # FIXME: I don't know if this is good pratice / robust
-    FileNotFoundError = OSError
 
 ARCHIVE_DICT = {
     'train': {
@@ -149,7 +145,6 @@ def extract_tar(src, dest=None, gzip=None, delete=False):
         gzip = src.lower().endswith('.gz')
 
     mode = 'r:gz' if gzip else 'r'
-
     with tarfile.open(src, mode) as tarfh:
         tarfh.extractall(path=dest)
 

--- a/torchvision/tmp.py
+++ b/torchvision/tmp.py
@@ -1,3 +1,0 @@
-from torchvision.datasets import ImageNet
-
-a = ImageNet('~/Downloads/ImageNet', download=True)

--- a/torchvision/tmp.py
+++ b/torchvision/tmp.py
@@ -1,0 +1,3 @@
+from torchvision.datasets import ImageNet
+
+a = ImageNet('~/Downloads/ImageNet', download=True)


### PR DESCRIPTION
This is my first attempt to implement the `ImageNet` dataset as discussed in #713. I only used the official files, which can be downloaded [here](https://simon32.github.io/2018/01/09/image-net/).

Since the training and validation set as well as the meta information have to be downloaded separately I see no downside to structure the dataset properly. In anticipation of multiple years of the ILSVRC I've created the following dataset structure:
```
ILSVRC
└── 2012
    ├── meta.bin
    ├── train
        ├── n012345678
        ...
    └── val
        ├── n012345678
        ...
└── 2013
    ...
```
The sysnet identifier and the corresponding converter are accessible via the attributes `wnids` and `wnid_to_idx` while `classes` and `class_to_idx` now refer to the human-readable classes.

# Major Edits

- Within 616492e the attribute `year` was removed as requested. Thus, the tree now looks like this:
```
ILSVRC
├── meta.bin
├── train
    ├── n012345678
     ...
├── train.tar
├── val
    ├── n012345678
     ...
└── val.tar
```

# To Do

- ~~For now only the classification challenge is supported.~~
- ~~For now only the ILSVRC2012 is supported. The parsing of the development kit, which contains the meta information, is (probably) not yet applicable to other years.~~
- ~~I don't know, if the meta information is changing between the years. If not, I think it would be preferrable to have only one meta file in the `ILSVRC` folder.~~
- ~~The `class_to_idx` converter is not a good solution in its current state, since one requires the tuple of all correct class names to convert it to an index~~.
- In its current state, the meta file also contains the ground truth data of the validation set. I save this, since it is needed to prepare the validation folder. Afterwards this information is not needed anymore.
- ~~For now this is only tested on the validation set, since the download of the training set is still ongoing.~~

Let me know what you think.