### PR TITLE
Removing forcing of tqdm version for python2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,14 +39,12 @@ requirements = [
     'numpy',
     'six',
     'torch',
+    'tqdm',
 ]
 
 pillow_ver = ' >= 4.1.1'
 pillow_req = 'pillow-simd' if get_dist('pillow-simd') is not None else 'pillow'
 requirements.append(pillow_req + pillow_ver)
-
-tqdm_ver = ' == 4.19.9' if sys.version_info[0] < 3 else ''
-requirements.append('tqdm' + tqdm_ver)
 
 setup(
     # Metadata


### PR DESCRIPTION
Relates to  #766 which mentions problems with installing newer versions of the package due to tqdm==4.19.9.

This forcing was done in #542 due to error mentioned in #541.

The new release tqdm==4.31.1 handles the problem mentioned in #541 and no error appears on downloading.
I hope in the versions following 4.31.1 , tqdm wont regress to the same problem mentioned  in #541 .

cc : @vishwakftw @fmassa 
