### PR TITLE
Fix for no tqdm

### DIFF
--- a/test/preprocess-bench.py
+++ b/test/preprocess-bench.py
@@ -46,8 +46,10 @@ if __name__ == "__main__":
 
     start_time = timer()
     batch_count = 20 * args.nThreads
-    for _ in tqdm(range(batch_count)):
-        batch = next(train_iter)
+    with tqdm(total=batch_count) as pbar:
+        for _ in tqdm(range(batch_count)):
+            pbar.update(1)
+            batch = next(train_iter)
     end_time = timer()
     print("Performance: {dataset:.0f} minutes/dataset, {batch:.1f} ms/batch,"
           " {image:.2f} ms/image {rate:.0f} images/sec"

--- a/test/test_datasets_utils.py
+++ b/test/test_datasets_utils.py
@@ -1,0 +1,25 @@
+import shutil
+import tempfile
+import torch
+import torchvision.datasets.utils as utils
+import unittest
+
+
+class Tester(unittest.TestCase):
+
+    def test_download_url(self):
+        temp_dir = tempfile.mkdtemp()
+        url = "http://github.com/pytorch/vision/archive/master.zip"
+        utils.download_url(url, temp_dir)
+        shutil.rmtree(temp_dir)
+
+    def test_download_url_retry_http(self):
+        temp_dir = tempfile.mkdtemp()
+        url = "https://github.com/pytorch/vision/archive/master.zip"
+        utils.download_url(url, temp_dir)
+        shutil.rmtree(temp_dir)
+
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_datasets_utils.py
+++ b/test/test_datasets_utils.py
@@ -20,6 +20,5 @@ class Tester(unittest.TestCase):
         shutil.rmtree(temp_dir)
 
 
-
 if __name__ == '__main__':
     unittest.main()

--- a/torchvision/datasets/utils.py
+++ b/torchvision/datasets/utils.py
@@ -7,6 +7,7 @@ from torch.utils.model_zoo import tqdm
 
 def gen_bar_updater():
     pbar = tqdm(total=None)
+
     def bar_update(count, block_size, total_size):
         if pbar.total is None and total_size:
             pbar.total = total_size

--- a/torchvision/datasets/utils.py
+++ b/torchvision/datasets/utils.py
@@ -5,7 +5,8 @@ import errno
 from torch.utils.model_zoo import tqdm
 
 
-def gen_bar_updater(pbar):
+def gen_bar_updater():
+    pbar = tqdm(total=None)
     def bar_update(count, block_size, total_size):
         if pbar.total is None and total_size:
             pbar.total = total_size
@@ -70,7 +71,7 @@ def download_url(url, root, filename=None, md5=None):
             print('Downloading ' + url + ' to ' + fpath)
             urllib.request.urlretrieve(
                 url, fpath,
-                reporthook=gen_bar_updater(tqdm())
+                reporthook=gen_bar_updater()
             )
         except OSError:
             if url[:5] == 'https':
@@ -79,7 +80,7 @@ def download_url(url, root, filename=None, md5=None):
                       ' Downloading ' + url + ' to ' + fpath)
                 urllib.request.urlretrieve(
                     url, fpath,
-                    reporthook=gen_bar_updater(tqdm())
+                    reporthook=gen_bar_updater()
                 )
 
 


### PR DESCRIPTION
Fixes https://github.com/pytorch/vision/issues/769

The interface for PyTorch's tqdm doesn't support not passing the `total` argument, but it does support `None`.

Also adds tests, which should run in the "no-tqdm" configuration.