### PR TITLE
Remove shebang in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 import os
 import io
 import re


### PR DESCRIPTION
Hi,

Related to PEP 394, some Linux distributions (at the very least Ubuntu) use 'python' interpreter name for Python 2, and 'python3' for Python 3.

As in setup.py there's a check for pillow vs pillow-simd, keeping an explicit '/usr/bin/env python' leads to search for Python 2 package, even if the install is targeted for Python 3.

So keeping the shebang, seems not only useless, but become an issue, and forbid to install torchvision with pillow-simd in Python3 env.

Thanks in advance to considering applying this PR.