### PR TITLE
Removing uneccesary sys comparison for collections objects

### DIFF
--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -6,6 +6,7 @@ from torch._utils_internal import get_file_path_2
 import unittest
 import math
 import sys
+import collections
 import random
 import numpy as np
 from PIL import Image

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -25,7 +25,7 @@ GRACE_HOPPER = get_file_path_2('assets/grace_hopper_517x606.jpg')
 class Tester(unittest.TestCase):
 
     def test_sys_collections(self):
-        if sys.version_info >= (3,3):
+        if sys.version_info >= (3, 3):
             assert collections.abc.Sequence == collections.Sequence
             assert collections.abc.Iterable == collections.Iterable
 

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -5,6 +5,7 @@ import torchvision.transforms.functional as F
 from torch._utils_internal import get_file_path_2
 import unittest
 import math
+import sys
 import random
 import numpy as np
 from PIL import Image
@@ -22,6 +23,11 @@ GRACE_HOPPER = get_file_path_2('assets/grace_hopper_517x606.jpg')
 
 
 class Tester(unittest.TestCase):
+
+    def test_sys_collections(self):
+        if sys.version_info >= (3,3):
+            assert collections.abc.Sequence == collections.Sequence
+            assert collections.abc.Iterable == collections.Iterable
 
     def test_crop(self):
         height = random.randint(10, 32) * 2

--- a/torchvision/transforms/functional.py
+++ b/torchvision/transforms/functional.py
@@ -12,13 +12,8 @@ import numbers
 import collections
 import warnings
 
-if sys.version_info < (3, 3):
-    Sequence = collections.Sequence
-    Iterable = collections.Iterable
-else:
-    Sequence = collections.abc.Sequence
-    Iterable = collections.abc.Iterable
-
+Sequence = collections.abc.Sequence
+Iterable = collections.abc.Iterable
 
 def _is_pil_image(img):
     if accimage is not None:

--- a/torchvision/transforms/functional.py
+++ b/torchvision/transforms/functional.py
@@ -12,8 +12,9 @@ import numbers
 import collections
 import warnings
 
-Sequence = collections.abc.Sequence
-Iterable = collections.abc.Iterable
+Sequence = collections.Sequence
+Iterable = collections.Iterable
+
 
 def _is_pil_image(img):
     if accimage is not None:

--- a/torchvision/transforms/transforms.py
+++ b/torchvision/transforms/transforms.py
@@ -16,13 +16,8 @@ import warnings
 
 from . import functional as F
 
-if sys.version_info < (3, 3):
-    Sequence = collections.Sequence
-    Iterable = collections.Iterable
-else:
-    Sequence = collections.abc.Sequence
-    Iterable = collections.abc.Iterable
-
+Sequence = collections.Sequence
+Iterable = collections.Iterable
 
 __all__ = ["Compose", "ToTensor", "ToPILImage", "Normalize", "Resize", "Scale", "CenterCrop", "Pad",
            "Lambda", "RandomApply", "RandomChoice", "RandomOrder", "RandomCrop", "RandomHorizontalFlip",


### PR DESCRIPTION
currently we use :

` Sequence = collections.abc.Sequence`
`Iterable = collections.abc.Iterable `
For python versions >= 3.3 

But i noticed that 
`Sequence = collections.Sequence`
`Iterable = collections.Iterable `
works for python >=3.3 as well

Also added tests if this behaviour changes in the future.

cc: @fmassa 

