### PR TITLE
GPU efficient Densenets

### DIFF
--- a/test/test_models.py
+++ b/test/test_models.py
@@ -1,0 +1,120 @@
+from collections import OrderedDict
+from itertools import product
+import torch
+from torchvision import models
+import unittest
+
+
+def get_available_classification_models():
+    # TODO add a registration mechanism to torchvision.models
+    return [k for k, v in models.__dict__.items() if callable(v) and k[0].lower() == k[0] and k[0] != "_"]
+
+
+def get_available_segmentation_models():
+    # TODO add a registration mechanism to torchvision.models
+    return [k for k, v in models.segmentation.__dict__.items() if callable(v) and k[0].lower() == k[0] and k[0] != "_"]
+
+
+def get_available_detection_models():
+    # TODO add a registration mechanism to torchvision.models
+    return [k for k, v in models.detection.__dict__.items() if callable(v) and k[0].lower() == k[0] and k[0] != "_"]
+
+
+class Tester(unittest.TestCase):
+    def _test_classification_model(self, name, input_shape):
+        if name[:8] == 'densenet':
+            model1 = models.__dict__[name](num_classes=50, efficient=True)
+            model1.eval()
+            x = torch.rand(input_shape)
+            out = model1(x)
+            
+            model2 = models.__dict__[name](num_classes=50, efficient=False)
+            mode2.eval()
+            out2 = model2(x)
+            
+            ans = (out==out2).sum().item()
+            
+            assert ans==out1.view(-1, 1).shape[0], "efficient not equal"
+        else:
+            # passing num_class equal to a number other than 1000 helps in making the test
+            # more enforcing in nature
+            model = models.__dict__[name](num_classes=50)
+            model.eval()
+            x = torch.rand(input_shape)
+            out = model(x)
+        self.assertEqual(out.shape[-1], 50)
+
+    def _test_segmentation_model(self, name):
+        # passing num_class equal to a number other than 1000 helps in making the test
+        # more enforcing in nature
+        model = models.segmentation.__dict__[name](num_classes=50, pretrained_backbone=False)
+        model.eval()
+        input_shape = (1, 3, 300, 300)
+        x = torch.rand(input_shape)
+        out = model(x)
+        self.assertEqual(tuple(out["out"].shape), (1, 50, 300, 300))
+
+    def _test_detection_model(self, name):
+        model = models.detection.__dict__[name](num_classes=50, pretrained_backbone=False)
+        model.eval()
+        input_shape = (3, 300, 300)
+        x = torch.rand(input_shape)
+        out = model([x])
+        self.assertEqual(len(out), 1)
+        self.assertTrue("boxes" in out[0])
+        self.assertTrue("scores" in out[0])
+        self.assertTrue("labels" in out[0])
+
+    def _make_sliced_model(self, model, stop_layer):
+        layers = OrderedDict()
+        for name, layer in model.named_children():
+            layers[name] = layer
+            if name == stop_layer:
+                break
+        new_model = torch.nn.Sequential(layers)
+        return new_model
+
+    def test_resnet_dilation(self):
+        # TODO improve tests to also check that each layer has the right dimensionality
+        for i in product([False, True], [False, True], [False, True]):
+            model = models.__dict__["resnet50"](replace_stride_with_dilation=i)
+            model = self._make_sliced_model(model, stop_layer="layer4")
+            model.eval()
+            x = torch.rand(1, 3, 224, 224)
+            out = model(x)
+            f = 2 ** sum(i)
+            self.assertEqual(out.shape, (1, 2048, 7 * f, 7 * f))
+
+
+for model_name in get_available_classification_models():
+    # for-loop bodies don't define scopes, so we have to save the variables
+    # we want to close over in some way
+    def do_test(self, model_name=model_name):
+        input_shape = (1, 3, 224, 224)
+        if model_name in ['inception_v3']:
+            input_shape = (1, 3, 299, 299)
+        self._test_classification_model(model_name, input_shape)
+
+    setattr(Tester, "test_" + model_name, do_test)
+
+
+for model_name in get_available_segmentation_models():
+    # for-loop bodies don't define scopes, so we have to save the variables
+    # we want to close over in some way
+    def do_test(self, model_name=model_name):
+        self._test_segmentation_model(model_name)
+
+    setattr(Tester, "test_" + model_name, do_test)
+
+
+for model_name in get_available_detection_models():
+    # for-loop bodies don't define scopes, so we have to save the variables
+    # we want to close over in some way
+    def do_test(self, model_name=model_name):
+        self._test_detection_model(model_name)
+
+    setattr(Tester, "test_" + model_name, do_test)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/torchvision/models/densenet.py
+++ b/torchvision/models/densenet.py
@@ -1,8 +1,10 @@
 import re
+import math
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
 import torch.utils.model_zoo as model_zoo
+import torch.utils.checkpoint as cp
 from collections import OrderedDict
 
 __all__ = ['DenseNet', 'densenet121', 'densenet169', 'densenet201', 'densenet161']
@@ -16,8 +18,17 @@ model_urls = {
 }
 
 
+def _bn_function_factory(norm, relu, conv):
+    def bn_function(*inputs):
+        concated_features = torch.cat(inputs, 1)
+        bottleneck_output = conv(relu(norm(concated_features)))
+        return bottleneck_output
+
+    return bn_function
+
+
 class _DenseLayer(nn.Sequential):
-    def __init__(self, num_input_features, growth_rate, bn_size, drop_rate):
+    def __init__(self, num_input_features, growth_rate, bn_size, drop_rate, efficient=False):
         super(_DenseLayer, self).__init__()
         self.add_module('norm1', nn.BatchNorm2d(num_input_features)),
         self.add_module('relu1', nn.ReLU(inplace=True)),
@@ -28,20 +39,39 @@ class _DenseLayer(nn.Sequential):
         self.add_module('conv2', nn.Conv2d(bn_size * growth_rate, growth_rate,
                         kernel_size=3, stride=1, padding=1, bias=False)),
         self.drop_rate = drop_rate
+        self.efficient = efficient
 
-    def forward(self, x):
-        new_features = super(_DenseLayer, self).forward(x)
+    def forward(self, *prev_features):
+        bn_function = _bn_function_factory(self.norm1, self.relu1, self.conv1)
+        if self.efficient and any(prev_feature.requires_grad for prev_feature in prev_features):
+            bottleneck_output = cp.checkpoint(bn_function, *prev_features)
+        else:
+            bottleneck_output = bn_function(*prev_features)
+        new_features = self.conv2(self.relu2(self.norm2(bottleneck_output)))
         if self.drop_rate > 0:
             new_features = F.dropout(new_features, p=self.drop_rate, training=self.training)
-        return torch.cat([x, new_features], 1)
+        return new_features
 
 
-class _DenseBlock(nn.Sequential):
-    def __init__(self, num_layers, num_input_features, bn_size, growth_rate, drop_rate):
+class _DenseBlock(nn.Module):
+    def __init__(self, num_layers, num_input_features, bn_size, growth_rate, drop_rate, efficient=False):
         super(_DenseBlock, self).__init__()
         for i in range(num_layers):
-            layer = _DenseLayer(num_input_features + i * growth_rate, growth_rate, bn_size, drop_rate)
+            layer = _DenseLayer(
+                num_input_features + i * growth_rate,
+                growth_rate=growth_rate,
+                bn_size=bn_size,
+                drop_rate=drop_rate,
+                efficient=efficient,
+            )
             self.add_module('denselayer%d' % (i + 1), layer)
+
+    def forward(self, init_features):
+        features = [init_features]
+        for name, layer in self.named_children():
+            new_features = layer(*features)
+            features.append(new_features)
+        return torch.cat(features, 1)
 
 
 class _Transition(nn.Sequential):
@@ -66,10 +96,11 @@ class DenseNet(nn.Module):
           (i.e. bn_size * k features in the bottleneck layer)
         drop_rate (float) - dropout rate after each dense layer
         num_classes (int) - number of classification classes
+        efficient (bool) - set to True to use checkpointing. Much more memory efficient, but slower. Default: *False*
     """
 
     def __init__(self, growth_rate=32, block_config=(6, 12, 24, 16),
-                 num_init_features=64, bn_size=4, drop_rate=0, num_classes=1000):
+                 num_init_features=64, bn_size=4, drop_rate=0, num_classes=1000, efficient=False):
 
         super(DenseNet, self).__init__()
 
@@ -84,8 +115,14 @@ class DenseNet(nn.Module):
         # Each denseblock
         num_features = num_init_features
         for i, num_layers in enumerate(block_config):
-            block = _DenseBlock(num_layers=num_layers, num_input_features=num_features,
-                                bn_size=bn_size, growth_rate=growth_rate, drop_rate=drop_rate)
+            block = _DenseBlock(
+                num_layers=num_layers,
+                num_input_features=num_features,
+                bn_size=bn_size,
+                growth_rate=growth_rate,
+                drop_rate=drop_rate,
+                efficient=efficient
+            )
             self.features.add_module('denseblock%d' % (i + 1), block)
             num_features = num_features + num_layers * growth_rate
             if i != len(block_config) - 1:
@@ -120,7 +157,6 @@ class DenseNet(nn.Module):
 def densenet121(pretrained=False, **kwargs):
     r"""Densenet-121 model from
     `"Densely Connected Convolutional Networks" <https://arxiv.org/pdf/1608.06993.pdf>`_
-
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
     """
@@ -147,7 +183,6 @@ def densenet121(pretrained=False, **kwargs):
 def densenet169(pretrained=False, **kwargs):
     r"""Densenet-169 model from
     `"Densely Connected Convolutional Networks" <https://arxiv.org/pdf/1608.06993.pdf>`_
-
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
     """
@@ -174,7 +209,6 @@ def densenet169(pretrained=False, **kwargs):
 def densenet201(pretrained=False, **kwargs):
     r"""Densenet-201 model from
     `"Densely Connected Convolutional Networks" <https://arxiv.org/pdf/1608.06993.pdf>`_
-
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
     """
@@ -201,7 +235,6 @@ def densenet201(pretrained=False, **kwargs):
 def densenet161(pretrained=False, **kwargs):
     r"""Densenet-161 model from
     `"Densely Connected Convolutional Networks" <https://arxiv.org/pdf/1608.06993.pdf>`_
-
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
     """

--- a/torchvision/models/densenet.py
+++ b/torchvision/models/densenet.py
@@ -27,7 +27,7 @@ def _bn_function_factory(norm, relu, conv):
 
 
 class _DenseLayer(nn.Sequential):
-    def __init__(self, num_input_features, growth_rate, bn_size, drop_rate, efficient=False):
+    def __init__(self, num_input_features, growth_rate, bn_size, drop_rate, memory_efficient=False):
         super(_DenseLayer, self).__init__()
         self.add_module('norm1', nn.BatchNorm2d(num_input_features)),
         self.add_module('relu1', nn.ReLU(inplace=True)),
@@ -38,11 +38,11 @@ class _DenseLayer(nn.Sequential):
         self.add_module('conv2', nn.Conv2d(bn_size * growth_rate, growth_rate,
                         kernel_size=3, stride=1, padding=1, bias=False)),
         self.drop_rate = drop_rate
-        self.efficient = efficient
+        self.memory_efficient = memory_efficient
 
     def forward(self, *prev_features):
         bn_function = _bn_function_factory(self.norm1, self.relu1, self.conv1)
-        if self.efficient and any(prev_feature.requires_grad for prev_feature in prev_features):
+        if self.memory_efficient and any(prev_feature.requires_grad for prev_feature in prev_features):
             bottleneck_output = cp.checkpoint(bn_function, *prev_features)
         else:
             bottleneck_output = bn_function(*prev_features)
@@ -53,7 +53,7 @@ class _DenseLayer(nn.Sequential):
 
 
 class _DenseBlock(nn.Module):
-    def __init__(self, num_layers, num_input_features, bn_size, growth_rate, drop_rate, efficient=False):
+    def __init__(self, num_layers, num_input_features, bn_size, growth_rate, drop_rate, memory_efficient=False):
         super(_DenseBlock, self).__init__()
         for i in range(num_layers):
             layer = _DenseLayer(
@@ -61,7 +61,7 @@ class _DenseBlock(nn.Module):
                 growth_rate=growth_rate,
                 bn_size=bn_size,
                 drop_rate=drop_rate,
-                efficient=efficient,
+                memory_efficient=memory_efficient,
             )
             self.add_module('denselayer%d' % (i + 1), layer)
 
@@ -95,11 +95,11 @@ class DenseNet(nn.Module):
           (i.e. bn_size * k features in the bottleneck layer)
         drop_rate (float) - dropout rate after each dense layer
         num_classes (int) - number of classification classes
-        efficient (bool) - set to True to use checkpointing. Much more memory efficient, but slower. Default: *False*
+        memory_efficient (bool) - set to True to use checkpointing. Much more memory efficient, but slower. Default: *False*
     """
 
     def __init__(self, growth_rate=32, block_config=(6, 12, 24, 16),
-                 num_init_features=64, bn_size=4, drop_rate=0, num_classes=1000, efficient=False):
+                 num_init_features=64, bn_size=4, drop_rate=0, num_classes=1000, memory_efficient=False):
 
         super(DenseNet, self).__init__()
 
@@ -120,7 +120,7 @@ class DenseNet(nn.Module):
                 bn_size=bn_size,
                 growth_rate=growth_rate,
                 drop_rate=drop_rate,
-                efficient=efficient
+                memory_efficient=memory_efficient
             )
             self.features.add_module('denseblock%d' % (i + 1), block)
             num_features = num_features + num_layers * growth_rate

--- a/torchvision/models/densenet.py
+++ b/torchvision/models/densenet.py
@@ -1,5 +1,4 @@
 import re
-import math
 import torch
 import torch.nn as nn
 import torch.nn.functional as F


### PR DESCRIPTION
In reference to #691, this PR provides the option for memory efficient implement of densenet models. 

I tested the models (original implementation and the new implementation with `efficient=False` as well as with `efficient=True`) on [hymenoptera dataset](https://download.pytorch.org/tutorial/hymenoptera_data.zip) which gave the follow results

Benchmark results (Batch size = 8, image size = 224x224):
 ```

                                                  Time taken         GPU Memory Consumption
Original                                          2m 55s                    1668mb
New (`efficient=False`)                           2m 58s                    1667mb
New (`efficient=True`)                            4m 6s                     1115mb

```
There was no significant change in the accuracy of the trained models. The implementation does not change the performance in terms of accuracy.

The new implementation with `efficient=True` seems to comsume ~1.5 times lesser GPU memory at the cost of ~1.4 times increased compute time. 

cc: @soumith 