### PR TITLE
Sampling aspect ratio from a logarithmic distribution

### DIFF
--- a/torchvision/transforms/transforms.py
+++ b/torchvision/transforms/transforms.py
@@ -572,24 +572,31 @@ class RandomResizedCrop(object):
 
         for attempt in range(10):
             target_area = random.uniform(*scale) * area
-            aspect_ratio = random.uniform(*ratio)
+            log_ratio = (math.log(ratio[0]), math.log(ratio[1]))
+            aspect_ratio = math.exp(random.uniform(*log_ratio))
 
             w = int(round(math.sqrt(target_area * aspect_ratio)))
             h = int(round(math.sqrt(target_area / aspect_ratio)))
-
-            if random.random() < 0.5 and min(ratio) <= (h / w) <= max(ratio):
-                w, h = h, w
 
             if w <= img.size[0] and h <= img.size[1]:
                 i = random.randint(0, img.size[1] - h)
                 j = random.randint(0, img.size[0] - w)
                 return i, j, h, w
 
-        # Fallback
-        w = min(img.size[0], img.size[1])
-        i = (img.size[1] - w) // 2
+        # Fallback to central crop
+        in_ratio = img.size[0] / img.size[1]
+        if (in_ratio < min(ratio)):
+            w = img.size[0]
+            h = w / min(ratio)
+        elif (in_ratio > max(ratio)):
+            h = img.size[1]
+            w = h * max(ratio)
+        else:  # whole image
+            w = img.size[0]
+            h = img.size[1]
+        i = (img.size[1] - h) // 2
         j = (img.size[0] - w) // 2
-        return i, j, w, w
+        return i, j, h, w
 
     def __call__(self, img):
         """


### PR DESCRIPTION
Previous way of preventing out-of-bounds aspect ration caused the distribution to be skewed*. Also, the default case, when the number of attempts was exceeded, always generated a square crop, which too might fall out of user-defined range.

* An example: if user specified ratio from 0.1 to 1, then the mean aspect ratio would be around 0.55; on the other hand, for the range 1 to 10, the mean ratio would be 5.5 - a dramatically different result. When using logarithmic distribution, the first range will produce a mean of 0.60653065971 and the second 1.6487212707 - the reciprocal of the first one.

Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>
