### PR TITLE
Added Semantic Boundaries Dataset

### DIFF
--- a/docs/source/datasets.rst
+++ b/docs/source/datasets.rst
@@ -181,3 +181,11 @@ Cityscapes
 .. autoclass:: Cityscapes
   :members: __getitem__
   :special-members:
+
+SBD
+~~~~~~
+
+
+.. autoclass:: SBDataset
+  :members: __getitem__
+  :special-members:

--- a/torchvision/datasets/__init__.py
+++ b/torchvision/datasets/__init__.py
@@ -16,6 +16,7 @@ from .cityscapes import Cityscapes
 from .imagenet import ImageNet
 from .caltech import Caltech101, Caltech256
 from .celeba import CelebA
+from .sbd import SBDataset
 
 __all__ = ('LSUN', 'LSUNClass',
            'ImageFolder', 'DatasetFolder', 'FakeData',
@@ -24,4 +25,4 @@ __all__ = ('LSUN', 'LSUNClass',
            'MNIST', 'KMNIST', 'STL10', 'SVHN', 'PhotoTour', 'SEMEION',
            'Omniglot', 'SBU', 'Flickr8k', 'Flickr30k',
            'VOCSegmentation', 'VOCDetection', 'Cityscapes', 'ImageNet',
-           'Caltech101', 'Caltech256', 'CelebA')
+           'Caltech101', 'Caltech256', 'CelebA', 'SBDataset')

--- a/torchvision/datasets/sbd.py
+++ b/torchvision/datasets/sbd.py
@@ -10,9 +10,10 @@ from .voc import download_extract
 
 class SBDataset(data.Dataset):
     """`Semantic Boundaries Dataset <http://home.bharathh.info/pubs/codes/SBD/download.html>`_
+
     The SBD currently contains annotations from 11355 images taken from the PASCAL VOC 2011 dataset.
 
-    Notes:
+    .. note ::
 
         Please note that the train and val splits included with this dataset are different from
         the splits in the PASCAL VOC dataset. In particular some "train" images might be part of
@@ -22,7 +23,7 @@ class SBDataset(data.Dataset):
 
     .. warning::
 
-        This classes needs `scipy` to load target files from `.mat` format.
+        This class needs `scipy <https://docs.scipy.org/doc/>`_ to load target files from `.mat` format.
 
     Args:
         root (string): Root directory of the Semantic Boundaries Dataset

--- a/torchvision/datasets/sbd.py
+++ b/torchvision/datasets/sbd.py
@@ -1,0 +1,122 @@
+import os
+import torch.utils.data as data
+
+import numpy as np
+
+from PIL import Image
+from .utils import download_url
+from .voc import download_extract
+
+
+class SBDataset(data.Dataset):
+    """`Semantic Boundaries Dataset <http://home.bharathh.info/pubs/codes/SBD/download.html>`_
+    The SBD currently contains annotations from 11355 images taken from the PASCAL VOC 2011 dataset.
+
+    Notes:
+
+        Please note that the train and val splits included with this dataset are different from
+        the splits in the PASCAL VOC dataset. In particular some "train" images might be part of
+        VOC2012 val.
+        If you are interested in testing on VOC 2012 val, then use `image_set='train_noval'`,
+        which excludes all val images.
+
+    .. warning::
+
+        This classes needs `scipy` to load target files from `.mat` format.
+
+    Args:
+        root (string): Root directory of the Semantic Boundaries Dataset
+        image_set (string, optional): Select the image_set to use, ``train``, ``val`` or ``train_noval``.
+            Image set ``train_noval`` excludes VOC 2012 val images.
+        mode (string, optional): Select target type. Possible values 'boundaries' or 'segmentation'.
+            In case of 'boundaries', the target is an array of shape `[num_classes, H, W]`,
+            where `num_classes=20`.
+        download (bool, optional): If true, downloads the dataset from the internet and
+            puts it in root directory. If dataset is already downloaded, it is not
+            downloaded again.
+        xy_transform (callable, optional): A function/transform that takes input sample and its target as entry
+            and returns a transformed version. Input sample is PIL image and target is a numpy array
+            if `mode='boundaries'` or PIL image if `mode='segmentation'`.
+    """
+
+    url = "http://www.eecs.berkeley.edu/Research/Projects/CS/vision/grouping/semantic_contours/benchmark.tgz"
+    md5 = "82b4d87ceb2ed10f6038a1cba92111cb"
+    filename = "benchmark.tgz"
+
+    voc_train_url = "http://home.bharathh.info/pubs/codes/SBD/train_noval.txt"
+    voc_split_filename = "train_noval.txt"
+    voc_split_md5 = "79bff800c5f0b1ec6b21080a3c066722"
+
+    def __init__(self,
+                 root,
+                 image_set='train',
+                 mode='boundaries',
+                 download=False,
+                 xy_transform=None):
+
+        try:
+            from scipy.io import loadmat
+            self._loadmat = loadmat
+        except ImportError:
+            raise RuntimeError("Scipy is not found. This dataset needs to have scipy installed: "
+                               "pip install scipy")
+
+        if mode not in ("segmentation", "boundaries"):
+            raise ValueError("Argument mode should be 'segmentation' or 'boundaries'")
+
+        self.root = os.path.expanduser(root)
+        self.xy_transform = xy_transform
+        self.image_set = image_set
+        self.mode = mode
+        self.num_classes = 20
+
+        sbd_root = os.path.join(self.root, "benchmark_RELEASE", "dataset")
+        image_dir = os.path.join(sbd_root, 'img')
+        mask_dir = os.path.join(sbd_root, 'cls')
+
+        if download:
+            download_extract(self.url, self.root, self.filename, self.md5)
+            download_url(self.voc_train_url, sbd_root, self.voc_split_filename,
+                         self.voc_split_md5)
+
+        if not os.path.isdir(sbd_root):
+            raise RuntimeError('Dataset not found or corrupted.' +
+                               ' You can use download=True to download it')
+
+        split_f = os.path.join(sbd_root, image_set.rstrip('\n') + '.txt')
+
+        if not os.path.exists(split_f):
+            raise ValueError(
+                'Wrong image_set entered! Please use image_set="train" '
+                'or image_set="val" or image_set="train_noval"')
+
+        with open(os.path.join(split_f), "r") as f:
+            file_names = [x.strip() for x in f.readlines()]
+
+        self.images = [os.path.join(image_dir, x + ".jpg") for x in file_names]
+        self.masks = [os.path.join(mask_dir, x + ".mat") for x in file_names]
+        assert (len(self.images) == len(self.masks))
+
+        self._get_target = self._get_segmentation_target \
+            if self.mode == "segmentation" else self._get_boundaries_target
+
+    def _get_segmentation_target(self, filepath):
+        mat = self._loadmat(filepath)
+        return Image.fromarray(mat['GTcls'][0]['Segmentation'][0])
+
+    def _get_boundaries_target(self, filepath):
+        mat = self._loadmat(filepath)
+        return np.concatenate([np.expand_dims(mat['GTcls'][0]['Boundaries'][0][i][0].toarray(), axis=0)
+                               for i in range(self.num_classes)], axis=0)
+
+    def __getitem__(self, index):
+        img = Image.open(self.images[index]).convert('RGB')
+        target = self._get_target(self.masks[index])
+
+        if self.xy_transform is not None:
+            img, target = self.xy_transform(img, target)
+
+        return img, target
+
+    def __len__(self):
+        return len(self.images)

--- a/torchvision/datasets/sbd.py
+++ b/torchvision/datasets/sbd.py
@@ -52,7 +52,7 @@ class SBDataset(data.Dataset):
                  image_set='train',
                  mode='boundaries',
                  download=False,
-                 xy_transform=None):
+                 xy_transform=None, **kwargs):
 
         try:
             from scipy.io import loadmat


### PR DESCRIPTION
In several papers like [deeplab](https://arxiv.org/abs/1706.05587) authors use Pascal VOC in addition with Semantic Boundaries Dataset (its segmentation part). Here it is added as torch dataset.

Options:
- Image sets: train, val or train_noval (without intersection with Pascal VOC)
- mode: boundaries, segmentation
- target types:
  - PIL.Image, pil mode="L" if mode is segmentation
  - ndarray of shape (20, H, W) if mode is boundaries
- Replaced `transform/transform_target` by `xy_transform` to apply a transformation on both: `img, target = xy_transform(img, target)` 

Drawbacks:
- Depends on `scipy` to load target files in `.mat` format. Scipy module importing is done at initialization level of the dataset.


Usage:
```python
sbds = SBDataset("/path/to/dataset", image_set='train_noval', mode='segmentation')
type(sbds[1123][0]), type(sbds[1123][1])
> (PIL.Image.Image, PIL.Image.Image)
```
```python
sbds = SBDataset("/path/to/dataset", image_set='train_noval', mode='boundaries')
type(sbds[1123][0]), type(sbds[1123][1]), sbds[1234][1].shape
> (PIL.Image.Image, numpy.ndarray, (20, 375, 500))
```