### PR TITLE
Add test for loading pretrained weights

### DIFF
--- a/test/test_models.py
+++ b/test/test_models.py
@@ -10,7 +10,8 @@ def get_available_models():
 
 class Tester(unittest.TestCase):
     def _test_model(self, name, input_shape):
-        model = models.__dict__[name]()
+        # test whether model can successfully load the pretrained weights
+        model = models.__dict__[name](pretrained=True)
         model.eval()
         x = torch.rand(input_shape)
         out = model(x)


### PR DESCRIPTION
Adds the test for checking whether the model can successfully load the pretrained weights besides outputting 1000 classes. Will raise an error if the model parameters are not properly defined or named according to the saved weights.