### PR TITLE
Making references/classification/train.py and references/classification/utils.py  compatible with python2 

### DIFF
--- a/references/classification/train.py
+++ b/references/classification/train.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import datetime
 import os
 import time

--- a/references/classification/utils.py
+++ b/references/classification/utils.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from collections import defaultdict, deque
 import datetime
 import time

--- a/torchvision/models/mobilenet.py
+++ b/torchvision/models/mobilenet.py
@@ -33,7 +33,6 @@ class InvertedResidual(nn.Module):
         ])
         self.conv = nn.Sequential(*layers)
 
-
     def forward(self, x):
         if self.use_res_connect:
             return x + self.conv(x)


### PR DESCRIPTION
This PR solves recent lint errors caused by incompatibility of print statements in the above programs for python2.

cc : @soumith 