### PR TITLE
Replace endswith calls in a loop with a single endswith call

### DIFF
--- a/torchvision/datasets/folder.py
+++ b/torchvision/datasets/folder.py
@@ -12,13 +12,12 @@ def has_file_allowed_extension(filename, extensions):
 
     Args:
         filename (string): path to a file
-        extensions (iterable of strings): extensions to consider (lowercase)
+        extensions (tuple of strings): extensions to consider (lowercase)
 
     Returns:
         bool: True if the filename ends with one of given extensions
     """
-    filename_lower = filename.lower()
-    return any(filename_lower.endswith(ext) for ext in extensions)
+    return filename.lower().endswith(extensions)
 
 
 def is_image_file(filename):
@@ -65,7 +64,7 @@ class DatasetFolder(data.Dataset):
     Args:
         root (string): Root directory path.
         loader (callable): A function to load a sample given its path.
-        extensions (list[string]): A list of allowed extensions.
+        extensions (tuple[string]): A list of allowed extensions.
         transform (callable, optional): A function/transform that takes in
             a sample and returns a transformed version.
             E.g, ``transforms.RandomCrop`` for images.
@@ -151,7 +150,7 @@ class DatasetFolder(data.Dataset):
         return fmt_str
 
 
-IMG_EXTENSIONS = ['.jpg', '.jpeg', '.png', '.ppm', '.bmp', '.pgm', '.tif', '.tiff', 'webp']
+IMG_EXTENSIONS = ('.jpg', '.jpeg', '.png', '.ppm', '.bmp', '.pgm', '.tif', '.tiff', 'webp')
 
 
 def pil_loader(path):


### PR DESCRIPTION
str.endswith can take a single string, or a tuple of strings. This replaces a loop over each extension and a call to endswith with a single call to endswith passing in all the allowed extensions. This has the advantage that the loop over each extension is done in c rather than python, and the code is a little less verbose.

This restricts the type of IMG_EXTENSIONS and DatasetFolder.extensions to a tuple of strings instead of a list of strings. A grep of the codebase shows these objects are not referenced anywhere outside of folder.py. Sifting through the first few pages of results for "DatasetFolder" in python on github, I didn't find anywhere that is affected by this change.

As an aside, on my machine this change brings a small performance improvement when tested under a micro-benchmark.

<details>
<summary>Benchmarking code</summary>

```
def original(filename, extensions): 
    filename_lower = filename.lower() 
    return any(filename_lower.endswith(ext) for ext in extensions)

def endswith_on_tuple(filename, extensions): 
    return filename.lower().endswith(extensions)

IMG_EXTENSIONS = ('.jpg', '.jpeg', '.png', '.ppm', '.bmp', '.pgm', '.tif', '.tiff', 'webp')
short_filename_t = "a.png"
short_filename_f = "a.png2"
medium_filename_t = "abc" * 10 + ".pgm"
medium_filename_f = "abc" * 10 + ".agm"
long_filename_t = "abcde" * 1000 + ".webp"
long_filename_f = "abcde" * 1000 + ".weqp"
```

```
Python 3.7.3, IPython 7.4.0
In [15]: %timeit original(short_filename_t, IMG_EXTENSIONS)                                               
776 ns ± 4.88 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
In [16]: %timeit original(short_filename_f, IMG_EXTENSIONS)                                               
1.31 µs ± 4.66 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)

In [17]: %timeit endswith_on_tuple(short_filename_t, IMG_EXTENSIONS)                                      
204 ns ± 1.37 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
In [18]: %timeit endswith_on_tuple(short_filename_f, IMG_EXTENSIONS)                                      
234 ns ± 1.39 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)

In [19]: %timeit original(medium_filename_t, IMG_EXTENSIONS)                                              
1.11 µs ± 2.98 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
In [20]: %timeit original(medium_filename_f, IMG_EXTENSIONS)                                              
1.39 µs ± 3.99 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)

In [21]: %timeit endswith_on_tuple(medium_filename_t, IMG_EXTENSIONS)                                     
244 ns ± 1.1 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
In [22]: %timeit endswith_on_tuple(medium_filename_f, IMG_EXTENSIONS)                                     
266 ns ± 0.506 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)

In [23]: %timeit original(long_filename_t, IMG_EXTENSIONS)                                                
3.59 µs ± 21.3 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
In [24]: %timeit original(long_filename_f, IMG_EXTENSIONS)                                                
3.56 µs ± 7.62 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

In [25]: %timeit endswith_on_tuple(long_filename_t, IMG_EXTENSIONS)                                       
2.44 µs ± 2.8 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
In [26]: %timeit endswith_on_tuple(long_filename_f, IMG_EXTENSIONS)                                       
2.43 µs ± 7.06 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
```
</details>