### PR TITLE
fixed Python PIL “IOError: image file truncated” with big images

### DIFF
--- a/torchvision/datasets/folder.py
+++ b/torchvision/datasets/folder.py
@@ -1,6 +1,8 @@
 from .vision import VisionDataset
 
 from PIL import Image
+from PIL import ImageFile
+ImageFile.LOAD_TRUNCATED_IMAGES = True
 
 import os
 import os.path


### PR DESCRIPTION
fix IOError: image file truncated” with big image

If the image size is too large, then such error will occur:
OSError: image file is truncated

The solution I found from stackoverflow: https://stackoverflow.com/questions/12984426/python-pil-ioerror-image-file-truncated-with-big-images.

I tested it and it actually works.