### PR TITLE
fix inconsistent behavior for ~ expression

### DIFF
--- a/torchvision/datasets/folder.py
+++ b/torchvision/datasets/folder.py
@@ -82,10 +82,10 @@ class DatasetFolder(VisionDataset):
         super(DatasetFolder, self).__init__(root)
         self.transform = transform
         self.target_transform = target_transform
-        classes, class_to_idx = self._find_classes(root)
-        samples = make_dataset(root, class_to_idx, extensions)
+        classes, class_to_idx = self._find_classes(self.root)
+        samples = make_dataset(self.root, class_to_idx, extensions)
         if len(samples) == 0:
-            raise (RuntimeError("Found 0 files in subfolders of: " + root + "\n"
+            raise (RuntimeError("Found 0 files in subfolders of: " + self.root + "\n"
                                 "Supported extensions are: " + ",".join(extensions)))
 
         self.loader = loader

--- a/torchvision/datasets/omniglot.py
+++ b/torchvision/datasets/omniglot.py
@@ -31,7 +31,7 @@ class Omniglot(VisionDataset):
     def __init__(self, root, background=True,
                  transform=None, target_transform=None,
                  download=False):
-        super(Omniglot, self).__init__(join(os.path.expanduser(root), self.folder))
+        super(Omniglot, self).__init__(join(root, self.folder))
         self.transform = transform
         self.target_transform = target_transform
         self.background = background

--- a/torchvision/datasets/semeion.py
+++ b/torchvision/datasets/semeion.py
@@ -39,7 +39,7 @@ class SEMEION(VisionDataset):
 
         self.data = []
         self.labels = []
-        fp = os.path.join(root, self.filename)
+        fp = os.path.join(self.root, self.filename)
         data = np.loadtxt(fp)
         # convert value to 8 bit unsigned integer
         # color (white #255) the pixels


### PR DESCRIPTION
- Fixed DatasetFolder and SEMEION to work for ~ path expression.
- Removed `os.path.expanduser` from Omniglot constructor  in accordance with other datasets (the behavior does not change).