### PR TITLE
Fix ResNeXt model defs with backwards compat for ResNet.

### DIFF
--- a/torchvision/models/resnet.py
+++ b/torchvision/models/resnet.py
@@ -72,7 +72,7 @@ class Bottleneck(nn.Module):
         super(Bottleneck, self).__init__()
         if norm_layer is None:
             norm_layer = nn.BatchNorm2d
-        width = int(planes * (base_width / 64)) * groups
+        width = int(planes * (base_width / 64.)) * groups
         # Both self.conv2 and self.downsample layers downsample the input when stride != 1
         self.conv1 = conv1x1(inplanes, width)
         self.bn1 = norm_layer(width)


### PR DESCRIPTION
I believe this is the correct impl of the intended ResNeXt additions as per the Torch impl and paper.

I have a set of decent weights that I trained which will work with the resnext50_32x4d model that I can contribute. 
w/ bilinear scaling - Acc@1 78.246 Acc@5 93.902
w/ bicubic scaling - Acc@1 78.512 Acc@5 94.042

I tried the resnet34/50 models with pytorch/examples imagenet eval to verify I didn't break things.