### PR TITLE
Refactor transforms

### DIFF
--- a/torchvision/transforms/__init__.py
+++ b/torchvision/transforms/__init__.py
@@ -1,1 +1,2 @@
+from .container import *
 from .transforms import *

--- a/torchvision/transforms/container.py
+++ b/torchvision/transforms/container.py
@@ -1,0 +1,92 @@
+import random
+
+__all__ = ['Compose', 'RandomTransforms', 'RandomApply', 'RandomOrder',
+           'RandomChoice']
+
+
+class Compose(object):
+    """Composes several transforms together.
+
+    Args:
+        transforms (list of ``Transform`` objects): list of transforms to compose.
+
+    Example:
+        >>> transforms.Compose([
+        >>>     transforms.CenterCrop(10),
+        >>>     transforms.ToTensor(),
+        >>> ])
+    """
+    _repr_indent = 4
+
+    def __init__(self, transforms):
+        assert isinstance(transforms, (list, tuple))
+        self.transforms = transforms
+
+    def __call__(self, img):
+        for t in self.transforms:
+            img = t(img)
+        return img
+
+    def __repr__(self):
+        head = ["{0}({1}".format(self.__class__.__name__, self.extra_repr())]
+        body = [' ' * self._repr_indent + str(t)
+                for t in self.transforms]
+        tail = [')']
+        return '\n'.join(head + body + tail)
+
+    def extra_repr(self):
+        return ""
+
+
+class RandomTransforms(Compose):
+    """Base class for a list of transformations with randomness
+
+    Args:
+        transforms (list or tuple): list of transformations
+    """
+    def __call__(self, *args, **kwargs):
+        raise NotImplementedError()
+
+
+class RandomApply(RandomTransforms):
+    """Apply randomly a list of transformations with a given probability
+
+    Args:
+        transforms (list or tuple): list of transformations
+        p (float): probability
+    """
+
+    def __init__(self, transforms, p=0.5):
+        super(RandomApply, self).__init__(transforms)
+        self.p = p
+
+    def __call__(self, img):
+        if self.p < random.random():
+            return img
+        for t in self.transforms:
+            img = t(img)
+        return img
+
+    def extra_repr(self):
+        return "p={p}".format(**self.__dict__)
+
+
+class RandomOrder(RandomTransforms):
+    """Apply a list of transformations in a random order
+    """
+
+    def __call__(self, img):
+        order = list(range(len(self.transforms)))
+        random.shuffle(order)
+        for i in order:
+            img = self.transforms[i](img)
+        return img
+
+
+class RandomChoice(RandomTransforms):
+    """Apply single transformation randomly picked from a list
+    """
+
+    def __call__(self, img):
+        t = random.choice(self.transforms)
+        return t(img)

--- a/torchvision/transforms/transforms.py
+++ b/torchvision/transforms/transforms.py
@@ -15,7 +15,7 @@ import warnings
 from copy import copy
 
 from . import functional as F
-from .container import  Compose
+from .container import Compose
 
 if sys.version_info < (3, 3):
     Sequence = collections.Sequence

--- a/torchvision/transforms/transforms.py
+++ b/torchvision/transforms/transforms.py
@@ -74,7 +74,7 @@ class ToTensor(Transform):
         return F.to_tensor(pic)
 
 
-class ToPILImage(object):
+class ToPILImage(Transform):
     """Convert a tensor or an ndarray to PIL Image.
 
     Converts a torch.*Tensor of shape C x H x W or a numpy ndarray of shape
@@ -109,7 +109,7 @@ class ToPILImage(object):
         return "mode={mode}".format(**self.__dict__) if self.mode is not None else ""
 
 
-class Normalize(object):
+class Normalize(Transform):
     """Normalize a tensor image with mean and standard deviation.
     Given mean: ``(M1,...,Mn)`` and std: ``(S1,..,Sn)`` for ``n`` channels, this transform
     will normalize each channel of the input ``torch.*Tensor`` i.e.
@@ -142,7 +142,7 @@ class Normalize(object):
         return "mean={mean}, std={std}".format(**self.__dict__)
 
 
-class Resize(object):
+class Resize(Transform):
     """Resize the input PIL Image to the given size.
 
     Args:
@@ -186,7 +186,7 @@ class Scale(Resize):
         super(Scale, self).__init__(*args, **kwargs)
 
 
-class CenterCrop(object):
+class CenterCrop(Transform):
     """Crops the given PIL Image at the center.
 
     Args:
@@ -215,7 +215,7 @@ class CenterCrop(object):
         return "size={size}".format(**self.__dict__)
 
 
-class Pad(object):
+class Pad(Transform):
     """Pad the given PIL Image on all sides with the given "pad" value.
 
     Args:
@@ -272,7 +272,7 @@ class Pad(object):
                 "padding_mode={padding_mode}").format(**self.__dict__)
 
 
-class Lambda(object):
+class Lambda(Transform):
     """Apply a user-defined lambda as a transform.
 
     Args:
@@ -280,14 +280,14 @@ class Lambda(object):
     """
 
     def __init__(self, lambd):
-        assert callable(lambd), repr(type(lambd).__name__) + " object is not callable"
+        assert callable(lambd), repr(type(lambd).__name__) + " Transform is not callable"
         self.lambd = lambd
 
     def __call__(self, img):
         return self.lambd(img)
 
 
-class RandomCrop(object):
+class RandomCrop(Transform):
     """Crop the given PIL Image at a random location.
 
     Args:
@@ -379,7 +379,7 @@ class RandomCrop(object):
         return "size={size}, padding={padding}".format(**self.__dict__)
 
 
-class RandomHorizontalFlip(object):
+class RandomHorizontalFlip(Transform):
     """Horizontally flip the given PIL Image randomly with a given probability.
 
     Args:
@@ -405,7 +405,7 @@ class RandomHorizontalFlip(object):
         return "p={p}".format(**self.__dict__)
 
 
-class RandomVerticalFlip(object):
+class RandomVerticalFlip(Transform):
     """Vertically flip the given PIL Image randomly with a given probability.
 
     Args:
@@ -431,7 +431,7 @@ class RandomVerticalFlip(object):
         return "p={p}".format(**self.__dict__)
 
 
-class RandomResizedCrop(object):
+class RandomResizedCrop(Transform):
     """Crop the given PIL Image to random size and aspect ratio.
 
     A crop of random size (default: of 0.08 to 1.0) of the original size and a random
@@ -531,7 +531,7 @@ class RandomSizedCrop(RandomResizedCrop):
         super(RandomSizedCrop, self).__init__(*args, **kwargs)
 
 
-class FiveCrop(object):
+class FiveCrop(Transform):
     """Crop the given PIL Image into four corners and the central crop
 
     .. Note::
@@ -570,7 +570,7 @@ class FiveCrop(object):
         return "size={size}".format(**self.__dict__)
 
 
-class TenCrop(object):
+class TenCrop(Transform):
     """Crop the given PIL Image into four corners and the central crop plus the flipped version of
     these (horizontal flipping is used by default)
 
@@ -613,7 +613,7 @@ class TenCrop(object):
         return "size={size}, vertical_flip={vertical_flip}".format(**self.__dict__)
 
 
-class LinearTransformation(object):
+class LinearTransformation(Transform):
     """Transform a tensor image with a square transformation matrix and a mean_vector computed
     offline.
     Given transformation_matrix and mean_vector, will flatten the torch.*Tensor and
@@ -667,7 +667,7 @@ class LinearTransformation(object):
                 "mean_vector={mean_vector}").format(**dct)
 
 
-class ColorJitter(object):
+class ColorJitter(Transform):
     """Randomly change the brightness, contrast and saturation of an image.
 
     Args:
@@ -760,7 +760,7 @@ class ColorJitter(object):
                 "saturation={saturation}, hue={hue}").format(**self.__dict__)
 
 
-class RandomRotation(object):
+class RandomRotation(Transform):
     """Rotate the image by angle.
 
     Args:
@@ -826,7 +826,7 @@ class RandomRotation(object):
         return s.format(**self.__dict__)
 
 
-class RandomAffine(object):
+class RandomAffine(Transform):
     """Random affine transformation of the image keeping center invariant
 
     Args:
@@ -947,7 +947,7 @@ class RandomAffine(object):
         return s.format(**dct)
 
 
-class Grayscale(object):
+class Grayscale(Transform):
     """Convert image to grayscale.
 
     Args:
@@ -977,7 +977,7 @@ class Grayscale(object):
         return "num_output_channels={num_output_channels}".format(**self.__dict__)
 
 
-class RandomGrayscale(object):
+class RandomGrayscale(Transform):
     """Randomly convert image to grayscale with a probability of p (default 0.1).
 
     Args:


### PR DESCRIPTION
Edit: I only now became aware of #855 and especially [a comment](https://github.com/pytorch/vision/issues/855#issuecomment-483573388) from @fmassa about the future of the `torchvision.transform`: if  this PR does not fit into the grand scheme of the upcoming release, feel free to close it.

### TL,DR

This PR does not add any new functionality, but streamlines the `__repr__` methods. In order to do so it introduces the superclasses `Transform` and `TransformContainer`.

### Details

- The `__repr__` methods of the `Transform` and `TransformContainer` objects are based the idea of `torch.nn.Module`: each subclass has the possibility to add information by overriding the `extra_repr` method.
- `Compose`, `RandomTransforms`, `RandomApply`, `RandomOrder`, `RandomChoice` are moved to `container.py`
- `RandomTransforms` is superseded by `TransformContainer`, since its only tasks were to handle the `__repr__` method and make sure the subclasses implement the `__call__` method.
- Some tests in `test_transforms.py` fail, but the same tests also fail on the `master` branch