### PR TITLE
Change SBDataset to make it support already-downloaded datasets

### DIFF
--- a/torchvision/datasets/sbd.py
+++ b/torchvision/datasets/sbd.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 from .vision import VisionDataset
 
 import numpy as np
@@ -72,12 +73,16 @@ class SBDataset(VisionDataset):
         self.mode = mode
         self.num_classes = 20
 
-        sbd_root = os.path.join(self.root, "benchmark_RELEASE", "dataset")
+        sbd_root = self.root
         image_dir = os.path.join(sbd_root, 'img')
         mask_dir = os.path.join(sbd_root, 'cls')
 
         if download:
             download_extract(self.url, self.root, self.filename, self.md5)
+            extracted_ds_root = os.path.join(self.root, "benchmark_RELEASE", "dataset")
+            for f in ["cls", "img", "inst", "train.txt", "val.txt"]:
+                old_path = os.path.join(extracted_ds_root, f)
+                shutil.move(old_path, sbd_root)
             download_url(self.voc_train_url, sbd_root, self.voc_split_filename,
                          self.voc_split_md5)
 


### PR DESCRIPTION
Prior to this PR, if the user already had downloaded SBD and copied the relevant files somewhere, it wouldn't be possible to use the already-downloaded files, because the structure of the folder was fixed.

This is a breaking change in the sense that the files will need to be downloaded again (or manually moved), but given that this dataset hasn't been in any release yet, I think this is fine.

cc @vfdev-5 who originally added this dataset.