### PR TITLE
Add dilation option to ResNet

### DIFF
--- a/test/test_models.py
+++ b/test/test_models.py
@@ -1,3 +1,5 @@
+from collections import OrderedDict
+from itertools import product
 import torch
 from torchvision import models
 import unittest
@@ -10,12 +12,33 @@ def get_available_models():
 
 class Tester(unittest.TestCase):
     def _test_model(self, name, input_shape):
-        # passing num_class equal to a number other than 1000 helps in making the test more enforcing in nature
+        # passing num_class equal to a number other than 1000 helps in making the test
+        # more enforcing in nature
         model = models.__dict__[name](num_classes=50)
         model.eval()
         x = torch.rand(input_shape)
         out = model(x)
         self.assertEqual(out.shape[-1], 50)
+
+    def _make_sliced_model(self, model, stop_layer):
+        layers = OrderedDict()
+        for name, layer in model.named_children():
+            layers[name] = layer
+            if name == stop_layer:
+                break
+        new_model = torch.nn.Sequential(layers)
+        return new_model
+
+    def test_resnet_dilation(self):
+        # TODO improve tests to also check that each layer has the right dimensionality
+        for i in product([False, True], [False, True], [False, True]):
+            model = models.__dict__["resnet50"](replace_stride_with_dilation=i)
+            model = self._make_sliced_model(model, stop_layer="layer4")
+            model.eval()
+            x = torch.rand(1, 3, 224, 224)
+            out = model(x)
+            f = 2 ** sum(i)
+            self.assertEqual(out.shape, (1, 2048, 7 * f, 7 * f))
 
 
 for model_name in get_available_models():

--- a/torchvision/models/resnet.py
+++ b/torchvision/models/resnet.py
@@ -125,6 +125,9 @@ class ResNet(nn.Module):
             # each element in the tuple indicates if we should replace
             # the 2x2 stride with a dilated convolution instead
             replace_stride_with_dilation = [False, False, False]
+        if len(replace_stride_with_dilation) != 3:
+            raise ValueError("replace_stride_with_dilation should be None "
+                             "or a 3-element tuple, got {}".format(replace_stride_with_dilation))
         self.groups = groups
         self.base_width = width_per_group
         self.conv1 = nn.Conv2d(3, self.inplanes, kernel_size=7, stride=2, padding=3,


### PR DESCRIPTION
This PR adds support for replacing 2x2 strides in ResNet with dilation.

This functionality is useful for segmentation models, where high-resolution feature maps are desirable.

Instead of hard-coding the resolution of the feature map, we let the user specify explicitly which blocks they want the 2x2 stride to be replaced by a dilated convolution.
Given that there are only 3 blocks with 2x2 strides (if we don't consider the initial convolution, which also performs downsampling), the user needs to specify a 3-element list of booleans.

Suggestions for a better naming (instead of `replace_stride_with_dilation`) are welcome.

cc @aadcock