### PR TITLE
Auto calculating return dimension of squeezenet forward method

### DIFF
--- a/torchvision/models/squeezenet.py
+++ b/torchvision/models/squeezenet.py
@@ -99,7 +99,7 @@ class SqueezeNet(nn.Module):
     def forward(self, x):
         x = self.features(x)
         x = self.classifier(x)
-        return x.view(x.size(0), self.num_classes)
+        return x.view(x.size(0), -1)
 
 
 def _squeezenet(version, pretrained, progress, **kwargs):


### PR DESCRIPTION
The return argument of the forward method on squeezenet currently is calculating its dimensions based on the number of classes. Letting it be inferred based on the input dimension makes the network more flexible. The approach is already used on some of the other architectures, such as vgg:

https://github.com/pytorch/vision/blob/0c575ace48dee00791377eedd19f1507ccc2314a/torchvision/models/vgg.py#L41-L46