### PR TITLE
Refactoring of ShuffleNetV2

### DIFF
--- a/torchvision/models/shufflenetv2.py
+++ b/torchvision/models/shufflenetv2.py
@@ -2,6 +2,7 @@ import functools
 
 import torch
 import torch.nn as nn
+from .utils import load_state_dict_from_url
 
 __all__ = ['ShuffleNetV2', 'shufflenetv2',
            'shufflenetv2_x0_5', 'shufflenetv2_x1_0',
@@ -89,7 +90,7 @@ class ShuffleNetV2(nn.Module):
         super(ShuffleNetV2, self).__init__()
 
         try:
-            self.stage_out_channels = self._getStages(float(width_mult))
+            self.stage_out_channels = self._getStages(width_mult)
         except KeyError:
             raise ValueError('width_mult {} is not supported'.format(width_mult))
 
@@ -145,36 +146,34 @@ class ShuffleNetV2(nn.Module):
         return stages[str(mult)]
 
 
-def shufflenetv2(pretrained=False, num_classes=1000, width_mult=1, **kwargs):
-    model = ShuffleNetV2(num_classes=num_classes, width_mult=width_mult)
+def _shufflenetv2(version, pretrained=False, progress, width_mult=1.0):
+    model = ShuffleNetV2(width_mult=width_mult)
 
     if pretrained:
-        # change width_mult to float
-        if isinstance(width_mult, int):
-            width_mult = float(width_mult)
-        model_type = ('_'.join([ShuffleNetV2.__name__, 'x' + str(width_mult)]))
+        arch = 'shufflenetv2_x' + version
         try:
-            model_url = model_urls[model_type.lower()]
+            model_url = model_urls[arch]
         except KeyError:
             raise ValueError('model {} is not support'.format(model_type))
         if model_url is None:
             raise NotImplementedError('pretrained {} is not supported'.format(model_type))
-        model.load_state_dict(torch.utils.model_zoo.load_url(model_url))
+        state_dict = load_state_dict_from_url(model_urls, progress=progress)
+        model.load_state_dict(state_dict)
 
     return model
 
 
-def shufflenetv2_x0_5(pretrained=False, num_classes=1000, **kwargs):
-    return shufflenetv2(pretrained, num_classes, 0.5)
+def shufflenetv2_x0_5(pretrained=False, progress=True):
+    return _shufflenetv2('0.5', pretrained, progress, 0.5)
 
 
-def shufflenetv2_x1_0(pretrained=False, num_classes=1000, **kwargs):
-    return shufflenetv2(pretrained, num_classes, 1)
+def shufflenetv2_x1_0(pretrained=False, progress=True):
+    return _shufflenetv2('1.0', pretrained, progress, 1.0)
 
 
-def shufflenetv2_x1_5(pretrained=False, num_classes=1000, **kwargs):
-    return shufflenetv2(pretrained, num_classes, 1.5)
+def shufflenetv2_x1_5(pretrained=False, progress=True):
+    return _shufflenetv2('1.5', pretrained, progress, 1.5)
 
 
-def shufflenetv2_x2_0(pretrained=False, num_classes=1000, **kwargs):
-    return shufflenetv2(pretrained, num_classes, 2)
+def shufflenetv2_x2_0(pretrained=False, progress=True):
+    return _shufflenetv2('2.0', pretrained, progress, 2.0)

--- a/torchvision/models/shufflenetv2.py
+++ b/torchvision/models/shufflenetv2.py
@@ -146,11 +146,11 @@ class ShuffleNetV2(nn.Module):
         return stages[str(mult)]
 
 
-def _shufflenetv2(version, pretrained=False, progress, width_mult=1.0):
+def _shufflenetv2(width_mult=1.0, pretrained, progress):
     model = ShuffleNetV2(width_mult=width_mult)
 
     if pretrained:
-        arch = 'shufflenetv2_x' + version
+        arch = 'shufflenetv2_x' + str(width_mult)
         try:
             model_url = model_urls[arch]
         except KeyError:
@@ -164,16 +164,16 @@ def _shufflenetv2(version, pretrained=False, progress, width_mult=1.0):
 
 
 def shufflenetv2_x0_5(pretrained=False, progress=True):
-    return _shufflenetv2('0.5', pretrained, progress, 0.5)
+    return _shufflenetv2(0.5, pretrained, progress)
 
 
 def shufflenetv2_x1_0(pretrained=False, progress=True):
-    return _shufflenetv2('1.0', pretrained, progress, 1.0)
+    return _shufflenetv2(1.0, pretrained, progress)
 
 
 def shufflenetv2_x1_5(pretrained=False, progress=True):
-    return _shufflenetv2('1.5', pretrained, progress, 1.5)
+    return _shufflenetv2(1.5, pretrained, progress)
 
 
 def shufflenetv2_x2_0(pretrained=False, progress=True):
-    return _shufflenetv2('2.0', pretrained, progress, 2.0)
+    return _shufflenetv2(2.0, pretrained, progress)

--- a/torchvision/models/shufflenetv2.py
+++ b/torchvision/models/shufflenetv2.py
@@ -84,16 +84,13 @@ class InvertedResidual(nn.Module):
 
 
 class ShuffleNetV2(nn.Module):
-    def __init__(self, num_classes=1000, width_mult=1):
+    def __init__(self, num_classes=1000, width_mult='1.0'):
         super(ShuffleNetV2, self).__init__()
 
-        try:
-            self.stage_out_channels = self._getStages(width_mult)
-        except KeyError:
-            raise ValueError('width_mult {} is not supported'.format(width_mult))
-
+        self.stage_out_channels = self._getStages(width_mult)
         input_channels = 3
         output_channels = self.stage_out_channels[0]
+
         self.conv1 = nn.Sequential(
             nn.Conv2d(input_channels, output_channels, 3, 2, 1, bias=False),
             nn.BatchNorm2d(output_channels),
@@ -141,14 +138,14 @@ class ShuffleNetV2(nn.Module):
             '1.5': [24, 176, 352, 704, 1024],
             '2.0': [24, 244, 488, 976, 2048],
         }
-        return stages[str(mult)]
+        return stages[mult]
 
 
 def _shufflenetv2(pretrained, progress, width_mult, **kwargs):
     model = ShuffleNetV2(width_mult=width_mult, **kwargs)
 
     if pretrained:
-        arch = 'shufflenetv2_x' + str(width_mult)
+        arch = 'shufflenetv2_x' + width_mult
         model_url = model_urls[arch]
         if model_url is None:
             raise NotImplementedError('pretrained {} is not supported as of now'.format(arch))
@@ -160,16 +157,16 @@ def _shufflenetv2(pretrained, progress, width_mult, **kwargs):
 
 
 def shufflenetv2_x0_5(pretrained=False, progress=True, **kwargs):
-    return _shufflenetv2(pretrained, progress, 0.5, **kwargs)
+    return _shufflenetv2(pretrained, progress, '0.5', **kwargs)
 
 
 def shufflenetv2_x1_0(pretrained=False, progress=True, **kwargs):
-    return _shufflenetv2(pretrained, progress, 1.0, **kwargs)
+    return _shufflenetv2(pretrained, progress, '1.0', **kwargs)
 
 
 def shufflenetv2_x1_5(pretrained=False, progress=True, **kwargs):
-    return _shufflenetv2(pretrained, progress, 1.5, **kwargs)
+    return _shufflenetv2(pretrained, progress, '1.5', **kwargs)
 
 
 def shufflenetv2_x2_0(pretrained=False, progress=True, **kwargs):
-    return _shufflenetv2(pretrained, progress, 2.0, **kwargs)
+    return _shufflenetv2(pretrained, progress, '2.0', **kwargs)

--- a/torchvision/models/shufflenetv2.py
+++ b/torchvision/models/shufflenetv2.py
@@ -4,9 +4,7 @@ import torch
 import torch.nn as nn
 from .utils import load_state_dict_from_url
 
-__all__ = ['ShuffleNetV2', 'shufflenetv2',
-           'shufflenetv2_x0_5', 'shufflenetv2_x1_0',
-           'shufflenetv2_x1_5', 'shufflenetv2_x2_0']
+__all__ = ['ShuffleNetV2', 'shufflenetv2_x0_5', 'shufflenetv2_x1_0', 'shufflenetv2_x1_5', 'shufflenetv2_x2_0']
 
 model_urls = {
     'shufflenetv2_x0.5':
@@ -151,14 +149,12 @@ def _shufflenetv2(pretrained, progress, width_mult=1.0):
 
     if pretrained:
         arch = 'shufflenetv2_x' + str(width_mult)
-        try:
-            model_url = model_urls[arch]
-        except KeyError:
-            raise ValueError('model {} is not support'.format(model_type))
+        model_url = model_urls[arch]
         if model_url is None:
-            raise NotImplementedError('pretrained {} is not supported'.format(model_type))
-        state_dict = load_state_dict_from_url(model_urls, progress=progress)
-        model.load_state_dict(state_dict)
+            raise NotImplementedError('pretrained {} is not supported as of now'.format(arch))
+        else:
+            state_dict = load_state_dict_from_url(model_urls, progress=progress)
+            model.load_state_dict(state_dict)
 
     return model
 

--- a/torchvision/models/shufflenetv2.py
+++ b/torchvision/models/shufflenetv2.py
@@ -146,7 +146,7 @@ class ShuffleNetV2(nn.Module):
         return stages[str(mult)]
 
 
-def _shufflenetv2(width_mult=1.0, pretrained, progress):
+def _shufflenetv2(pretrained, progress, width_mult=1.0):
     model = ShuffleNetV2(width_mult=width_mult)
 
     if pretrained:
@@ -164,16 +164,16 @@ def _shufflenetv2(width_mult=1.0, pretrained, progress):
 
 
 def shufflenetv2_x0_5(pretrained=False, progress=True):
-    return _shufflenetv2(0.5, pretrained, progress)
+    return _shufflenetv2(pretrained, progress, 0.5)
 
 
 def shufflenetv2_x1_0(pretrained=False, progress=True):
-    return _shufflenetv2(1.0, pretrained, progress)
+    return _shufflenetv2(pretrained, progress, 1.0)
 
 
 def shufflenetv2_x1_5(pretrained=False, progress=True):
-    return _shufflenetv2(1.5, pretrained, progress)
+    return _shufflenetv2(pretrained, progress, 1.5)
 
 
 def shufflenetv2_x2_0(pretrained=False, progress=True):
-    return _shufflenetv2(2.0, pretrained, progress)
+    return _shufflenetv2(pretrained, progress, 2.0)

--- a/torchvision/models/shufflenetv2.py
+++ b/torchvision/models/shufflenetv2.py
@@ -144,8 +144,8 @@ class ShuffleNetV2(nn.Module):
         return stages[str(mult)]
 
 
-def _shufflenetv2(pretrained, progress, width_mult=1.0):
-    model = ShuffleNetV2(width_mult=width_mult)
+def _shufflenetv2(pretrained, progress, width_mult, **kwargs):
+    model = ShuffleNetV2(width_mult=width_mult, **kwargs)
 
     if pretrained:
         arch = 'shufflenetv2_x' + str(width_mult)
@@ -159,17 +159,17 @@ def _shufflenetv2(pretrained, progress, width_mult=1.0):
     return model
 
 
-def shufflenetv2_x0_5(pretrained=False, progress=True):
-    return _shufflenetv2(pretrained, progress, 0.5)
+def shufflenetv2_x0_5(pretrained=False, progress=True, **kwargs):
+    return _shufflenetv2(pretrained, progress, 0.5, **kwargs)
 
 
-def shufflenetv2_x1_0(pretrained=False, progress=True):
-    return _shufflenetv2(pretrained, progress, 1.0)
+def shufflenetv2_x1_0(pretrained=False, progress=True, **kwargs):
+    return _shufflenetv2(pretrained, progress, 1.0, **kwargs)
 
 
-def shufflenetv2_x1_5(pretrained=False, progress=True):
-    return _shufflenetv2(pretrained, progress, 1.5)
+def shufflenetv2_x1_5(pretrained=False, progress=True, **kwargs):
+    return _shufflenetv2(pretrained, progress, 1.5, **kwargs)
 
 
-def shufflenetv2_x2_0(pretrained=False, progress=True):
-    return _shufflenetv2(pretrained, progress, 2.0)
+def shufflenetv2_x2_0(pretrained=False, progress=True, **kwargs):
+    return _shufflenetv2(pretrained, progress, 2.0, **kwargs)

--- a/torchvision/models/shufflenetv2.py
+++ b/torchvision/models/shufflenetv2.py
@@ -84,10 +84,10 @@ class InvertedResidual(nn.Module):
 
 
 class ShuffleNetV2(nn.Module):
-    def __init__(self, num_classes=1000, width_mult='1.0'):
+    def __init__(self, stage_out_channels, num_classes=1000):
         super(ShuffleNetV2, self).__init__()
 
-        self.stage_out_channels = self._getStages(width_mult)
+        self.stage_out_channels = stage_out_channels
         input_channels = 3
         output_channels = self.stage_out_channels[0]
 
@@ -130,22 +130,11 @@ class ShuffleNetV2(nn.Module):
         x = self.fc(x)
         return x
 
-    @staticmethod
-    def _getStages(mult):
-        stages = {
-            '0.5': [24, 48, 96, 192, 1024],
-            '1.0': [24, 116, 232, 464, 1024],
-            '1.5': [24, 176, 352, 704, 1024],
-            '2.0': [24, 244, 488, 976, 2048],
-        }
-        return stages[mult]
 
-
-def _shufflenetv2(pretrained, progress, width_mult, **kwargs):
-    model = ShuffleNetV2(width_mult=width_mult, **kwargs)
+def _shufflenetv2(arch, pretrained, progress, stage_out_channels, **kwargs):
+    model = ShuffleNetV2(stage_out_channels=stage_out_channels, **kwargs)
 
     if pretrained:
-        arch = 'shufflenetv2_x' + width_mult
         model_url = model_urls[arch]
         if model_url is None:
             raise NotImplementedError('pretrained {} is not supported as of now'.format(arch))
@@ -157,16 +146,16 @@ def _shufflenetv2(pretrained, progress, width_mult, **kwargs):
 
 
 def shufflenetv2_x0_5(pretrained=False, progress=True, **kwargs):
-    return _shufflenetv2(pretrained, progress, '0.5', **kwargs)
+    return _shufflenetv2('shufflenetv2_x0.5', pretrained, progress, [24, 48, 96, 192, 1024], **kwargs)
 
 
 def shufflenetv2_x1_0(pretrained=False, progress=True, **kwargs):
-    return _shufflenetv2(pretrained, progress, '1.0', **kwargs)
+    return _shufflenetv2('shufflenetv2_x1.0', pretrained, progress, [24, 116, 232, 464, 1024], **kwargs)
 
 
 def shufflenetv2_x1_5(pretrained=False, progress=True, **kwargs):
-    return _shufflenetv2(pretrained, progress, '1.5', **kwargs)
+    return _shufflenetv2('shufflenetv2_x1.5', pretrained, progress, [24, 176, 352, 704, 1024], **kwargs)
 
 
 def shufflenetv2_x2_0(pretrained=False, progress=True, **kwargs):
-    return _shufflenetv2(pretrained, progress, '2.0', **kwargs)
+    return _shufflenetv2('shufflenetv2_x2.0', pretrained, progress, [24, 244, 488, 976, 2048], **kwargs)


### PR DESCRIPTION
Added progress flag following #875. Further the following refactoring were also done:

1) removed the operations for converting the `width_mult` arg to float.
2) removed `num_classes` argument from functions except `ShuffleNetV2`
3) removed `try expect` block for handling errors for absent pretrained weights and `width_mult`
4) replace `mult_width` with `stages_out_channels`.