### PR TITLE
Change usage of "view" to "reshape" in resnet to enable running with mkldnn

### DIFF
--- a/torchvision/models/resnet.py
+++ b/torchvision/models/resnet.py
@@ -198,7 +198,7 @@ class ResNet(nn.Module):
         x = self.layer4(x)
 
         x = self.avgpool(x)
-        x = x.view(x.size(0), -1)
+        x = x.reshape(x.size(0), -1)
         x = self.fc(x)
 
         return x


### PR DESCRIPTION
Recently we have added Mkldnn tensor in PyTorch, which can be used to gain big perf gain when doing resnet style models inference. 
However, in PyTorch currently Mkldnn tensor couldn't support the storage sharing semantics in `view`, so instead we support `reshape`. https://github.com/pytorch/pytorch/pull/19209