### PR TITLE
Update travis to use more recent GCC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 
+dist: xenial
 matrix:
   include:
     - env: LINT_CHECK
@@ -31,6 +32,7 @@ before_install:
     if [[ "$IMAGE_BACKEND" == "Pillow-SIMD" ]]; then
       pip uninstall -y pillow && CC="cc -march=native" pip install --force-reinstall pillow-simd
     fi
+  - pip install future
   - pip install pytest pytest-cov codecov
 
 


### PR DESCRIPTION
This should enable using newer GCC, which is required for the C++ extensions to work.

This has been factored out from https://github.com/pytorch/vision/pull/826 , without installing `pytorch-nightly`, because now PyTorch 1.1 has been released.

cc @soumith 