### PR TITLE
Minor fix to evaluation formula of PILLOW_VERSION

### DIFF
--- a/torchvision/transforms/functional.py
+++ b/torchvision/transforms/functional.py
@@ -766,7 +766,7 @@ def affine(img, angle, translate, scale, shear, resample=0, fillcolor=None):
     output_size = img.size
     center = (img.size[0] * 0.5 + 0.5, img.size[1] * 0.5 + 0.5)
     matrix = _get_inverse_affine_matrix(center, angle, translate, scale, shear)
-    kwargs = {"fillcolor": fillcolor} if PILLOW_VERSION[0] == '5' else {}
+    kwargs = {"fillcolor": fillcolor} if PILLOW_VERSION[0] >= '5' else {}
     return img.transform(output_size, Image.AFFINE, matrix, resample, **kwargs)
 
 


### PR DESCRIPTION
Enable fillcolor option for affine transformation for Pillow >= 5.0.0 as described