### PR TITLE
Add ssTEM dataset

### DIFF
--- a/docs/source/datasets.rst
+++ b/docs/source/datasets.rst
@@ -188,3 +188,9 @@ SBD
 .. autoclass:: SBDataset
   :members: __getitem__
   :special-members:
+
+ssTEM
+~~~~~
+
+.. note ::
+    This requires `skimage` to be installed

--- a/docs/source/datasets.rst
+++ b/docs/source/datasets.rst
@@ -194,3 +194,7 @@ ssTEM
 
 .. note ::
     This requires `skimage` to be installed
+
+.. autoclass:: ssTEM
+   :members: __getitem__
+   :special-members:

--- a/torchvision/datasets/__init__.py
+++ b/torchvision/datasets/__init__.py
@@ -18,6 +18,7 @@ from .caltech import Caltech101, Caltech256
 from .celeba import CelebA
 from .sbd import SBDataset
 from .vision import VisionDataset
+from .sstem import ssTEM
 
 __all__ = ('LSUN', 'LSUNClass',
            'ImageFolder', 'DatasetFolder', 'FakeData',

--- a/torchvision/datasets/sstem.py
+++ b/torchvision/datasets/sstem.py
@@ -49,6 +49,8 @@ class ssTEM(VisionDataset):
         # Lazy import
         import skimage.io
 
+        super(ssTEM, self).__init__(root, transforms)
+
         self.root = os.path.expanduser(root)
         self.train = train
         self.transforms = transforms

--- a/torchvision/datasets/sstem.py
+++ b/torchvision/datasets/sstem.py
@@ -51,9 +51,7 @@ class ssTEM(VisionDataset):
 
         super(ssTEM, self).__init__(root, transforms)
 
-        self.root = os.path.expanduser(root)
         self.train = train
-        self.transforms = transforms
 
         if download:
             self.download()

--- a/torchvision/datasets/sstem.py
+++ b/torchvision/datasets/sstem.py
@@ -1,0 +1,134 @@
+from __future__ import print_function
+
+import os
+
+from PIL import Image
+import skimage
+import torch.utils.data as data
+
+from .utils import download_url, check_integrity
+
+
+class ssTEM(data.Dataset):
+    """Dataset for `ISBI Challenge: Segmentation of neuronal structures
+    in EM stacks <http://brainiac2.mit.edu/isbi_challenge/>`_.
+
+    Args:
+        root (string): Root directory where dataset exists or will be saved
+            to if download is set to True.
+        train (bool, optional): If True, creates dataset from training set,
+            otherwise creates from test set.
+        transform (callable, optional): A function/transform that takes in a
+            PIL image and returns a transformed version.
+        target_transform (callable, optional): A function/transform that takes
+            in the target and transforms it.
+        download (bool, optional): If true, downloads the dataset from the
+            internet and puts it in root directory. If dataset is already
+            downloaded, it is not downloaded again.
+    """
+    base_url = 'http://brainiac2.mit.edu/isbi_challenge/sites/default/files/'
+
+    meta = {
+        'train': {
+            'data': {
+                'filename': 'train-volume.tif',
+                'md5': '465461edbe0254630c4ec5577f1e7764'
+            },
+            'labels': {
+                'filename': 'train-labels.tif',
+                'md5': '657fe6b728c6dd0152e295c6d800001d'
+            }
+        },
+        'test': {
+            'data': {
+                'filename': 'test-volume.tif',
+                'md5': '9767660d7abe4e0ecbdd0061a16058ad'
+            }
+        }
+    }
+
+    def __init__(self, root, train=True, transform=None, target_transform=None,
+                 download=False):
+        self.root = os.path.expanduser(root)
+        self.train = train
+        self.transform = transform
+        self.target_transform = target_transform
+
+        if download:
+            self.download()
+
+        if not self._check_integrity():
+            raise RuntimeError('Dataset not found or corrupted.' +
+                               ' You can use download=True to download it')
+
+        if train:
+            self.data = skimage.io.imread(os.path.join(
+                self.root, self.meta['train']['data']['filename']))
+            self.labels = skimage.io.imread(os.path.join(
+                self.root, self.meta['train']['labels']['filename']))
+        else:
+            self.data = skimage.io.imread(os.path.join(
+                self.root, self.meta['test']['data']['filename']))
+
+    def __getitem__(self, index):
+        """
+        Args:
+            index (int): Index
+        Returns:
+            tuple: (image, target) where target is index of the target class.
+        """
+        img = self.data[index]
+        img = Image.fromarray(img)
+
+        if self.transform is not None:
+            img = self.transform(img)
+
+        if not self.train:
+            return img
+
+        target = self.labels[index]
+        target = Image.fromarray(img)
+
+        if self.target_transform is not None:
+            target = self.target_transform(target)
+
+        return img, target
+
+    def __len__(self):
+        return len(self.data)
+
+    def _check_integrity(self):
+        if self.train:
+            dataset = 'train'
+            records = ['data', 'labels']
+        else:
+            dataset = 'test'
+            records = ['data']
+
+        for record in records:
+            filename = self.meta[dataset][record]['filename']
+            fpath = os.path.join(self.root, filename)
+            md5 = self.meta[dataset][record]['md5']
+
+            if not check_integrity(fpath, md5):
+                return False
+
+        return True
+
+    def download(self):
+        if self._check_integrity():
+            print('Files already downloaded and verified')
+            return
+
+        if self.train:
+            dataset = 'train'
+            records = ['data', 'labels']
+        else:
+            dataset = 'test'
+            records = ['data']
+
+        for record in records:
+            filename = self.meta[dataset][record]['filename']
+            md5 = self.meta[dataset][record]['md5']
+
+            download_url(self.base_url + filename, self.root, filename, md5)


### PR DESCRIPTION
This PR adds a dataset for [ISBI Challenge: Segmentation of neuronal structures in EM stacks](http://brainiac2.mit.edu/isbi_challenge/), which involves imagery from an ssTEM microscope.

Questions:

- I wasn't sure what to call the dataset, as there are several different ISBI challenges per year
- ~This dataset requires `skimage` to load, as it includes multi-channel TIF images that PIL does not support. How should we handle this? Should I make the `skimage` import lazy so that it isn't required to import `torchvision`?~
- ~This is a segmentation dataset. As such, most transforms like RandomHorizontalFlip and RandomAffine must be applied to both img and target. Is their any precedence for how to handle this? Or should I have a separate `transform` and `target_transform` like other datasets?~
- The train dataset comes with both data and labels, but the test dataset only comes with data. Users are expected to upload their predictions to the challenge website and have them graded for them. Hopefully this is okay.