### PR TITLE
transforms: add Random Erasing for image augmentation

### DIFF
--- a/docs/source/transforms.rst
+++ b/docs/source/transforms.rst
@@ -63,6 +63,8 @@ Transforms on torch.\*Tensor
 	:members: __call__
 	:special-members:
 
+.. autoclass:: RandomErasing
+
 Conversion Transforms
 ---------------------
 

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -1326,6 +1326,14 @@ class Tester(unittest.TestCase):
         img_re = transforms.RandomErasing(value=0)(img)
         assert img_re.size(0) == 3
 
+        # Test Set 2: Erasing with random value
+        img_re = transforms.RandomErasing(value='random')(img)
+        assert img_re.size(0) == 3
+
+        # Test Set 3: Erasing with tuple value
+        img_re = transforms.RandomErasing(value=(0.2, 0.2, 0.2))(img)
+        assert img_re.size(0) == 3
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -1320,16 +1320,15 @@ class Tester(unittest.TestCase):
     def test_random_erasing(self):
         """Unit tests for random erasing transform"""
 
-        img = torch.rand([3, 20, 20])
+        img = torch.rand([3, 224, 224])
 
         # Test Set 1: Erasing with int value
         img_re = transforms.RandomErasing(value=0)(img)
+        assert img_re.size(0) == 3
 
         # Test Set 2: Erasing with random value
         img_re = transforms.RandomErasing(value='random')(img)
-
-        # Test Set 3: Erasing with tuple value
-        img_re = transforms.RandomErasing(value=(0.2, 0.2, 0.2))(img)
+        assert img_re.size(0) == 3
 
 
 if __name__ == '__main__':

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -1316,6 +1316,20 @@ class Tester(unittest.TestCase):
 
         # Checking if RandomGrayscale can be printed as string
         trans3.__repr__()
+        
+    def test_random_erasing(self):
+        """Unit tests for random erasing transform"""
+
+        img = torch.rand([3, 20, 20])
+
+        # Test Set 1: Erasing with int value
+        img_re = transforms.RandomErasing(value=0)(img)
+
+        # Test Set 2: Erasing with random value
+        img_re = transforms.RandomErasing(value='random')(img)
+
+        # Test Set 3: Erasing with tuple value
+        img_re = transforms.RandomErasing(value=(0.2, 0.2, 0.2))(img)
 
 
 if __name__ == '__main__':

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -1326,10 +1326,6 @@ class Tester(unittest.TestCase):
         img_re = transforms.RandomErasing(value=0)(img)
         assert img_re.size(0) == 3
 
-        # Test Set 2: Erasing with random value
-        img_re = transforms.RandomErasing(value='random')(img)
-        assert img_re.size(0) == 3
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -1316,7 +1316,7 @@ class Tester(unittest.TestCase):
 
         # Checking if RandomGrayscale can be printed as string
         trans3.__repr__()
-        
+
     def test_random_erasing(self):
         """Unit tests for random erasing transform"""
 

--- a/torchvision/transforms/functional.py
+++ b/torchvision/transforms/functional.py
@@ -798,18 +798,22 @@ def to_grayscale(img, num_output_channels=1):
     return img
 
 
-def erase(img, x, y, h, w, value=0):
-    """ Erase the given Image with given value.
-        'Random Erasing Data Augmentation' by Zhong et al.
-        See https://arxiv.org/pdf/1708.04896.pdf
-     Args:
-        img (Tensor): Image to be erased.
-        x, y: Upper left pixel coordinate.
-        w: Width of the erased image.
-        h: Height of the erased image.
-        value: Erasing value.
-     Returns:
-        Erased Image.
+def erase(img, i, j, h, w, v):
+    """ Erase the input Tensor Image with given value.
+
+    Args:
+        img (Tensor Image): Tensor image of size (C, H, W) to be erased
+        i (int): i in (i,j) i.e coordinates of the upper left corner.
+        j (int): j in (i,j) i.e coordinates of the upper left corner.
+        h (int): Height of the erased region.
+        w (int): Width of the erased region.
+        v: Erasing value.
+
+    Returns:
+        Tensor Image: Erased image.
     """
-    img[:, x:x + h, y:y + w] = value
+    if not isinstance(img, torch.Tensor):
+        raise TypeError('img should be Tensor Image. Got {}'.format(type(img)))
+
+    img[:, i:i + h, j:j + w] = v
     return img

--- a/torchvision/transforms/functional.py
+++ b/torchvision/transforms/functional.py
@@ -804,8 +804,7 @@ def erase(img, x, y, h, w, value=0):
         See https://arxiv.org/pdf/1708.04896.pdf
      Args:
         img (Tensor): Image to be erased.
-        x: Upper pixel coordinate.
-        y: Left pixel coordinate.
+        x, y: Upper left pixel coordinate.
         w: Width of the erased image.
         h: Height of the erased image.
         value: Erasing value.

--- a/torchvision/transforms/functional.py
+++ b/torchvision/transforms/functional.py
@@ -798,7 +798,7 @@ def to_grayscale(img, num_output_channels=1):
     return img
 
 
-def erase(img, x, y, w, h, value=0):
+def erase(img, x, y, h, w, value=0):
     """ Erase the given Image with given value.
         'Random Erasing Data Augmentation' by Zhong et al.
         See https://arxiv.org/pdf/1708.04896.pdf
@@ -812,5 +812,5 @@ def erase(img, x, y, w, h, value=0):
      Returns:
         Erased Image.
     """
-    img[:, y:y + h, x:x + w] = value
+    img[:, x:x + h, y:y + w] = value
     return img

--- a/torchvision/transforms/functional.py
+++ b/torchvision/transforms/functional.py
@@ -796,3 +796,21 @@ def to_grayscale(img, num_output_channels=1):
         raise ValueError('num_output_channels should be either 1 or 3')
 
     return img
+
+
+def erase(img, x, y, w, h, value=0):
+    """ Erase the given Image with given value.
+        'Random Erasing Data Augmentation' by Zhong et al.
+        See https://arxiv.org/pdf/1708.04896.pdf
+     Args:
+        img (Tensor): Image to be erased.
+        x: Upper pixel coordinate.
+        y: Left pixel coordinate.
+        w: Width of the erased image.
+        h: Height of the erased image.
+        value: Erasing value.
+     Returns:
+        Erased Image.
+    """
+    img[:, y:y + h, x:x + w] = value
+    return img

--- a/torchvision/transforms/transforms.py
+++ b/torchvision/transforms/transforms.py
@@ -1186,8 +1186,6 @@ class RandomErasing(object):
     """ Randomly selects a rectangle region in an image and erases its pixels.
         'Random Erasing Data Augmentation' by Zhong et al. Arxiv 2017.
         See https://arxiv.org/pdf/1708.04896.pdf
-        'Improved Regularization of Convolutional Neural Networks with Cutout' by DeVries. Arxiv 2017.
-        See https://arxiv.org/pdf/1708.04552.pdf
     Args:
          probability: The probability that the Random Erasing operation will be performed.
          sl: Minimum proportion of erased area against input image.

--- a/torchvision/transforms/transforms.py
+++ b/torchvision/transforms/transforms.py
@@ -1255,4 +1255,3 @@ class RandomErasing(object):
             x, y, h, w, v = self.get_params(img, sl=self.sl, sh=self.sh, r1=self.r1, value=self.value)
             return F.erase(img, x, y, h, w, v)
         return img
-

--- a/torchvision/transforms/transforms.py
+++ b/torchvision/transforms/transforms.py
@@ -1239,7 +1239,7 @@ class RandomErasing(object):
                 if isinstance(value, numbers.Number):
                     v = value
                 elif isinstance(value, str):
-                    v = torch.rand(img.size()[0], h, w)
+                    v = torch.empty([img.size()[0], h, w], dtype=torch.float32).normal_()
                 elif isinstance(value, tuple):
                     v = torch.FloatTensor(value).view(-1, 1, 1).expand(-1, h, w)
                 return x, y, h, w, v

--- a/torchvision/transforms/transforms.py
+++ b/torchvision/transforms/transforms.py
@@ -1186,6 +1186,8 @@ class RandomErasing(object):
     """ Randomly selects a rectangle region in an image and erases its pixels.
         'Random Erasing Data Augmentation' by Zhong et al. Arxiv 2017.
         See https://arxiv.org/pdf/1708.04896.pdf
+        'Improved Regularization of Convolutional Neural Networks with Cutout' by DeVries. Arxiv 2017.
+        See https://arxiv.org/pdf/1708.04552.pdf
     Args:
          probability: The probability that the Random Erasing operation will be performed.
          sl: Minimum proportion of erased area against input image.


### PR DESCRIPTION
Random Erasing randomly selects a rectangle region in an image and erases its pixels with random values. It can reduce the risk of overfitting, and improves CNN baselines in image classification, object detection and person reidentification.

I found that this augmentation method has been widely used in image classification (CIFA-10, CIFAR-100) and person re-identification. 

Also, it could achieve improvements on ImageNet: +0.7% in Prec@1 for ResNet-50, +0.33% in Prec@1 for ResNet-34.

Therefore, I think it would be valuable to users.

'Random Erasing Data Augmentation' by Zhong et.al. https://arxiv.org/pdf/1708.04896.pdf

A parallel work is "Improved Regularization of Convolutional Neural Networks with Cutout" proposed by  DeVries. https://arxiv.org/pdf/1708.04552.pdf

Previous pull request and issues #335 #226 #420 