### PR TITLE
Rename `_resnet` arguments

### DIFF
--- a/torchvision/models/resnet.py
+++ b/torchvision/models/resnet.py
@@ -204,8 +204,8 @@ class ResNet(nn.Module):
         return x
 
 
-def _resnet(arch, inplanes, planes, pretrained, progress, **kwargs):
-    model = ResNet(inplanes, planes, **kwargs)
+def _resnet(arch, block, layers, pretrained, progress, **kwargs):
+    model = ResNet(block, layers, **kwargs)
     if pretrained:
         state_dict = load_state_dict_from_url(model_urls[arch],
                                               progress=progress)


### PR DESCRIPTION
`inplanes, planes` are confusing names for what actually are block type and layers per block