### PR TITLE
Fix building C++ ops with GPU support in docker

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ def get_extensions():
 
     define_macros = []
 
-    if torch.cuda.is_available() and CUDA_HOME is not None:
+    if CUDA_HOME is not None:
         extension = CUDAExtension
         sources += source_cuda
         define_macros += [('WITH_CUDA', None)]


### PR DESCRIPTION
Build GPU extensions whenever CUDA_HOME is available.
This is the same logic and motivation as in https://github.com/pytorch/pytorch/pull/8244/ - that is to build a docker image (which has no GPU available at build time), and then use it with nvidia-docker.

I checked that this fixes the build with GPU available, and that the build still works without CUDA (on OS X).