### PR TITLE
Remove dependency from functool in ShuffleNetsV2

### DIFF
--- a/torchvision/models/shufflenetv2.py
+++ b/torchvision/models/shufflenetv2.py
@@ -41,7 +41,6 @@ class InvertedResidual(nn.Module):
         branch_features = oup // 2
         assert (self.stride != 1) or (inp == branch_features << 1)
 
-
         if self.stride > 1:
             self.branch1 = nn.Sequential(
                 self.depthwise_conv(inp, inp, kernel_size=3, stride=self.stride, padding=1),
@@ -52,7 +51,8 @@ class InvertedResidual(nn.Module):
             )
 
         self.branch2 = nn.Sequential(
-            nn.Conv2d(inp if (self.stride > 1) else branch_features, branch_features, kernel_size=1, stride=1, padding=0, bias=False),
+            nn.Conv2d(inp if (self.stride > 1) else branch_features,
+                      branch_features, kernel_size=1, stride=1, padding=0, bias=False),
             nn.BatchNorm2d(branch_features),
             nn.ReLU(inplace=True),
             self.depthwise_conv(branch_features, branch_features, kernel_size=3, stride=self.stride, padding=1),


### PR DESCRIPTION
This PR removes the dependence of the ShuffleNetV2 code from `functool`.