### PR TITLE
Revert "Fix building C++ ops with GPU support in docker"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ def get_extensions():
 
     define_macros = []
 
-    if CUDA_HOME is not None:
+    if torch.cuda.is_available() and CUDA_HOME is not None:
         extension = CUDAExtension
         sources += source_cuda
         define_macros += [('WITH_CUDA', None)]


### PR DESCRIPTION
Reverts pytorch/vision#911

This breaks compilation for me and @szagoruyko on our laptops (OSX).

I get error messages like
```
/Users/fmassa/anaconda3/lib/python3.6/site-packages/torch/include/c10/cuda/CUDAMacros.h:4:10: fatal error: 'c10/cuda/impl/cuda_cmake_macros.h' file not found
#include <c10/cuda/impl/cuda_cmake_macros.h>
```

Indeed, `CUDA_HOME` is not `None` in my case, but I get a default string setup.
```python
In [1]: from torch.utils.cpp_extension import CUDA_HOME
No CUDA runtime is found, using CUDA_HOME='/usr/local/cuda'

In [2]: CUDA_HOME
Out[2]: '/usr/local/cuda'
```

Given that this fails even on my laptop, I'm reverting this. If we want to properly support Docker we will need a better workaround.

cc @soumith 