### PR TITLE
Allow forcing GPU build with FORCE_CUDA=1

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,6 +37,9 @@ From source:
 
     python setup.py install
 
+By default, GPU support is built if CUDA is found and ``torch.cuda.is_available()`` is true.
+It's possible to force building GPU support by setting ``FORCE_CUDA=1`` environment variable,
+which is useful when building a docker image.
 
 Image Backend
 =============

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ def get_extensions():
 
     define_macros = []
 
-    if torch.cuda.is_available() and CUDA_HOME is not None:
+    if (torch.cuda.is_available() and CUDA_HOME is not None) or os.getenv('FORCE_CUDA', '0') == '1':
         extension = CUDAExtension
         sources += source_cuda
         define_macros += [('WITH_CUDA', None)]


### PR DESCRIPTION
This is convenient to e.g. build with GPU support inside a docker image, because GPU is often not available during the docker build, but the image is intended to be used with nvidia-docker. Related previous attempt - https://github.com/pytorch/vision/pull/911, reverted in https://github.com/pytorch/vision/pull/924 because it breaks the build in some cases.
This PR is similar to https://github.com/facebookresearch/maskrcnn-benchmark/pull/612

I wonder if we should mention anything in the docs about this flag, e.g. at the end of installation section here https://github.com/pytorch/vision#installation ?