### PR TITLE
Rename "Imagenet-12" to ImageNet for consistency in docs

### DIFF
--- a/docs/source/datasets.rst
+++ b/docs/source/datasets.rst
@@ -97,7 +97,7 @@ DatasetFolder
 
 
 
-Imagenet-12
+ImageNet
 ~~~~~~~~~~~
 
 .. autoclass:: ImageNet


### PR DESCRIPTION
"Imagenet-12" is an odd name, it is better to keep the class name. The year is in python doc string.