### PR TITLE
Refactor mkdir function

### DIFF
--- a/references/classification/utils.py
+++ b/references/classification/utils.py
@@ -5,7 +5,6 @@ import time
 import torch
 import torch.distributed as dist
 
-import errno
 import os
 
 

--- a/references/classification/utils.py
+++ b/references/classification/utils.py
@@ -162,11 +162,7 @@ def accuracy(output, target, topk=(1,)):
 
 
 def mkdir(path):
-    try:
-        os.makedirs(path)
-    except OSError as e:
-        if e.errno != errno.EEXIST:
-            raise
+    os.makedirs(path, exist_ok=True)
 
 
 def setup_for_distributed(is_master):


### PR DESCRIPTION
What I understood is the purpose of the `mkdir` function is to create the directories and not raise an error if the directories are already there, but raise other exceptions.

I think this simple refactoring does the same thing.