### PR TITLE
add more hub models

### DIFF
--- a/hubconf.py
+++ b/hubconf.py
@@ -4,6 +4,10 @@ dependencies = ['torch']
 from torchvision.models.alexnet import alexnet
 from torchvision.models.densenet import densenet121, densenet169, densenet201, densenet161
 from torchvision.models.inception import inception_v3
-from torchvision.models.resnet import resnet18, resnet34, resnet50, resnet101, resnet152
+from torchvision.models.resnet import resnet18, resnet34, resnet50, resnet101, resnet152, resnext50_32x4d, resnext101_32x8d
 from torchvision.models.squeezenet import squeezenet1_0, squeezenet1_1
 from torchvision.models.vgg import vgg11, vgg13, vgg16, vgg19, vgg11_bn, vgg13_bn, vgg16_bn, vgg19_bn
+from torchvision.models.segmentation import fcn_resnet101, deeplabv3_resnet101
+from torchvision.models.googlenet import googlenet
+from torchvision.models.shufflenetv2 import shufflenet_v2_x0_5, shufflenet_v2_x1_0
+from torchvision.models.mobilenet import mobilenet_v2

--- a/hubconf.py
+++ b/hubconf.py
@@ -4,7 +4,8 @@ dependencies = ['torch']
 from torchvision.models.alexnet import alexnet
 from torchvision.models.densenet import densenet121, densenet169, densenet201, densenet161
 from torchvision.models.inception import inception_v3
-from torchvision.models.resnet import resnet18, resnet34, resnet50, resnet101, resnet152, resnext50_32x4d, resnext101_32x8d
+from torchvision.models.resnet import resnet18, resnet34, resnet50, resnet101, resnet152,\
+    resnext50_32x4d, resnext101_32x8d
 from torchvision.models.squeezenet import squeezenet1_0, squeezenet1_1
 from torchvision.models.vgg import vgg11, vgg13, vgg16, vgg19, vgg11_bn, vgg13_bn, vgg16_bn, vgg19_bn
 from torchvision.models.segmentation import fcn_resnet101, deeplabv3_resnet101


### PR DESCRIPTION
This PR add a few resnext, segmentation models, shufflenext, googlenet, mobilenet in hubconf. 
Here is a few quick experiments:
```
In [3]: torch.hub.list('ailzhang/vision:add_segmentation_hubconf', force_reload=True)
Downloading: "https://github.com/ailzhang/vision/archive/add_segmentation_hubconf.zip" to /private/home/ailzhang/.cache/torch/hub/add_segmentation_hubconf.zip
Out[3]:
['alexnet',
 'deeplabv3_resnet101',
 'densenet121',
 'densenet161',
 'densenet169',
 'densenet201',
 'fcn_resnet101',
 'googlenet',
 'inception_v3',
 'mobilenet_v2',
 'resnet101',
 'resnet152',
 'resnet18',
 'resnet34',
 'resnet50',
 'resnext101_32x8d',
 'resnext50_32x4d',
 'shufflenet_v2_x0_5',
 'shufflenet_v2_x1_0',
 'squeezenet1_0',
 'squeezenet1_1',
 'vgg11',
 'vgg11_bn',
 'vgg13',
 'vgg13_bn',
 'vgg16',
 'vgg16_bn',
 'vgg19',
 'vgg19_bn']


In [4]: model = torch.hub.load('ailzhang/vision:add_segmentation_hubconf', 'mobilenet_v2', pretrained=True)
Using cache found in /private/home/ailzhang/.cache/torch/hub/ailzhang_vision_add_segmentation_hubconf
Downloading: "https://download.pytorch.org/models/mobilenet_v2-b0353104.pth" to /private/home/ailzhang/.cache/torch/checkpoints/mobilenet_v2-b0353104.pth
100%|██████████████████████████████████████████████████████████████████████████████████████████████| 13.6M/13.6M [00:00<00:00, 19.3MB/s]

In [5]: model = torch.hub.load('ailzhang/vision:add_segmentation_hubconf', 'googlenet', pretrained=True)
Using cache found in /private/home/ailzhang/.cache/torch/hub/ailzhang_vision_add_segmentation_hubconf
Downloading: "https://download.pytorch.org/models/googlenet-1378be20.pth" to /private/home/ailzhang/.cache/torch/checkpoints/googlenet-1378be20.pth
100%|██████████████████████████████████████████████████████████████████████████████████████████████| 49.7M/49.7M [00:01<00:00, 35.4MB/s]

In [6]: model = torch.hub.load('ailzhang/vision:add_segmentation_hubconf', 'resnext101_32x8d', pretrained=True)
Using cache found in /private/home/ailzhang/.cache/torch/hub/ailzhang_vision_add_segmentation_hubconf
Downloading: "https://download.pytorch.org/models/resnext101_32x8d-8ba56ff5.pth" to /private/home/ailzhang/.cache/torch/checkpoints/resnext101_32x8d-8ba56ff5.pth
100%|████████████████████████████████████████████████████████████████████████████████████████████████| 340M/340M [00:08<00:00, 40.7MB/s]

In [7]: model = torch.hub.load('ailzhang/vision:add_segmentation_hubconf', 'resnext50_32x4d', pretrained=True)
Using cache found in /private/home/ailzhang/.cache/torch/hub/ailzhang_vision_add_segmentation_hubconf
Downloading: "https://download.pytorch.org/models/resnext50_32x4d-7cdf4587.pth" to /private/home/ailzhang/.cache/torch/checkpoints/resnext50_32x4d-7cdf4587.pth
100%|██████████████████████████████████████████████████████████████████████████████████████████████| 95.8M/95.8M [00:03<00:00, 29.8MB/s]

In [8]: model = torch.hub.load('ailzhang/vision:add_segmentation_hubconf', 'shufflenet_v2_x0_5', pretrained=True)
Using cache found in /private/home/ailzhang/.cache/torch/hub/ailzhang_vision_add_segmentation_hubconf
Downloading: "https://download.pytorch.org/models/shufflenetv2_x0.5-f707e7126e.pth" to /private/home/ailzhang/.cache/torch/checkpoints/shufflenetv2_x0.5-f707e7126e.pth
100%|██████████████████████████████████████████████████████████████████████████████████████████████| 5.28M/5.28M [00:00<00:00, 9.80MB/s]

In [9]: model = torch.hub.load('ailzhang/vision:add_segmentation_hubconf', 'shufflenet_v2_x1_0', pretrained=True)
Using cache found in /private/home/ailzhang/.cache/torch/hub/ailzhang_vision_add_segmentation_hubconf
Downloading: "https://download.pytorch.org/models/shufflenetv2_x1-5666bf0f80.pth" to /private/home/ailzhang/.cache/torch/checkpoints/shufflenetv2_x1-5666bf0f80.pth
100%|██████████████████████████████████████████████████████████████████████████████████████████████| 8.79M/8.79M [00:00<00:00, 15.7MB/s]

In [2]: model = torch.hub.load('ailzhang/vision:add_segmentation_hubconf', 'deeplabv3_resnet101', pretrained=True)
Using cache found in /private/home/ailzhang/.cache/torch/hub/ailzhang_vision_add_segmentation_hubconf

In [3]: model = torch.hub.load('ailzhang/vision:add_segmentation_hubconf', 'fcn_resnet101', pretrained=True)
Using cache found in /private/home/ailzhang/.cache/torch/hub/ailzhang_vision_add_segmentation_hubconf
```