### PR TITLE
Fix:to_tensor's error message

### DIFF
--- a/torchvision/transforms/functional.py
+++ b/torchvision/transforms/functional.py
@@ -34,6 +34,11 @@ def _is_tensor_image(img):
 def _is_numpy_image(img):
     return isinstance(img, np.ndarray) and (img.ndim in {2, 3})
 
+def _is_numpy(img):
+    return isinstance(img, np.ndarray)
+
+def _is_numpy_image_dim(img):
+    return img.ndim not in {2, 3}
 
 def to_tensor(pic):
     """Convert a ``PIL Image`` or ``numpy.ndarray`` to tensor.
@@ -46,8 +51,11 @@ def to_tensor(pic):
     Returns:
         Tensor: Converted image.
     """
-    if not(_is_pil_image(pic) or _is_numpy_image(pic)):
+    if not(_is_pil_image(pic) or _is_numpy(pic)):
         raise TypeError('pic should be PIL Image or ndarray. Got {}'.format(type(pic)))
+        
+    if _is_numpy(pic) and not _is_numpy_image_dim(pic):
+        raise ValueError('pic should be 2/3 dimensional. Got {} dimensions.'.format(pic.ndim))
 
     if isinstance(pic, np.ndarray):
         # handle numpy array


### PR DESCRIPTION
It makes us confused when accepting an error "pic should be PIL Image or ndarray. Got '<numpy.ndarray>'".