### PR TITLE
Fix calls to 'download_and_extract_archive()'

### DIFF
--- a/torchvision/datasets/caltech.py
+++ b/torchvision/datasets/caltech.py
@@ -116,13 +116,13 @@ class Caltech101(VisionDataset):
         download_and_extract_archive(
             "http://www.vision.caltech.edu/Image_Datasets/Caltech101/101_ObjectCategories.tar.gz",
             self.root,
-            "101_ObjectCategories.tar.gz",
-            "b224c7392d521a49829488ab0f1120d9")
+            filename="101_ObjectCategories.tar.gz",
+            md5="b224c7392d521a49829488ab0f1120d9")
         download_and_extract_archive(
             "http://www.vision.caltech.edu/Image_Datasets/Caltech101/Annotations.tar",
             self.root,
-            "101_Annotations.tar",
-            "6f83eeb1f24d99cab4eb377263132c91")
+            filename="101_Annotations.tar",
+            md5="6f83eeb1f24d99cab4eb377263132c91")
 
     def extra_repr(self):
         return "Target type: {target_type}".format(**self.__dict__)
@@ -204,5 +204,5 @@ class Caltech256(VisionDataset):
         download_and_extract_archive(
             "http://www.vision.caltech.edu/Image_Datasets/Caltech256/256_ObjectCategories.tar",
             self.root,
-            "256_ObjectCategories.tar",
-            "67b4f42ca05d46448c6bb8ecd2220f6d")
+            filename="256_ObjectCategories.tar",
+            md5="67b4f42ca05d46448c6bb8ecd2220f6d")

--- a/torchvision/datasets/cifar.py
+++ b/torchvision/datasets/cifar.py
@@ -147,7 +147,7 @@ class CIFAR10(VisionDataset):
         if self._check_integrity():
             print('Files already downloaded and verified')
             return
-        download_and_extract_archive(self.url, self.root, self.filename, self.tgz_md5)
+        download_and_extract_archive(self.url, self.root, filename=self.filename, md5=self.tgz_md5)
 
     def extra_repr(self):
         return "Split: {}".format("Train" if self.train is True else "Test")

--- a/torchvision/datasets/omniglot.py
+++ b/torchvision/datasets/omniglot.py
@@ -88,7 +88,7 @@ class Omniglot(VisionDataset):
         filename = self._get_target_folder()
         zip_filename = filename + '.zip'
         url = self.download_url_prefix + '/' + zip_filename
-        download_and_extract_archive(url, self.root, zip_filename, self.zips_md5[filename])
+        download_and_extract_archive(url, self.root, filename=zip_filename, md5=self.zips_md5[filename])
 
     def _get_target_folder(self):
         return 'images_background' if self.background else 'images_evaluation'

--- a/torchvision/datasets/stl10.py
+++ b/torchvision/datasets/stl10.py
@@ -152,7 +152,7 @@ class STL10(VisionDataset):
         if self._check_integrity():
             print('Files already downloaded and verified')
             return
-        download_and_extract_archive(self.url, self.root, self.filename, self.tgz_md5)
+        download_and_extract_archive(self.url, self.root, filename=self.filename, md5=self.tgz_md5)
 
     def extra_repr(self):
         return "Split: {split}".format(**self.__dict__)


### PR DESCRIPTION
Changes made in 7716aba broke calls to this method. Extraction of Caltech, CIFAR10, Omniglot and STL10 were failing as a result.