### PR TITLE
Remove empty boxes before NMS in detection models

### DIFF
--- a/torchvision/models/detection/roi_heads.py
+++ b/torchvision/models/detection/roi_heads.py
@@ -501,6 +501,10 @@ class RoIHeads(torch.nn.Module):
             inds = torch.nonzero(scores > self.score_thresh).squeeze(1)
             boxes, scores, labels = boxes[inds], scores[inds], labels[inds]
 
+            # remove empty boxes
+            keep = box_ops.remove_small_boxes(boxes, min_size=1e-2)
+            boxes, scores, labels = boxes[keep], scores[keep], labels[keep]
+
             # non-maximum suppression, independently done per class
             keep = box_ops.batched_nms(boxes, scores, labels, self.nms_thresh)
             # keep only topk scoring predictions


### PR DESCRIPTION
Prior to this PR, we would pass (and return) empty boxes to the NMS.
This means that those boxes could be returned by the model (even though they might have very low scores and get filtered afterwards).
This is more of a safety check, and additionally avoid potential divisions by zero in the NMS.