### PR TITLE
Remove empty proposals from the RPN

### DIFF
--- a/torchvision/models/detection/rpn.py
+++ b/torchvision/models/detection/rpn.py
@@ -252,7 +252,7 @@ class RegionProposalNetwork(torch.nn.Module):
         self._pre_nms_top_n = pre_nms_top_n
         self._post_nms_top_n = post_nms_top_n
         self.nms_thresh = nms_thresh
-        self.min_size = 0
+        self.min_size = 1e-3
 
     @property
     def pre_nms_top_n(self):


### PR DESCRIPTION
This is a harmless change, but avoid boxes with size 0 being fed to nms.