### PR TITLE
Fix TypeError in RandomResizedCrop.get_params

### DIFF
--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -147,10 +147,14 @@ class Tester(unittest.TestCase):
             aspect_min = max(round(random.random(), 2), epsilon)
             aspect_ratio_range = (aspect_min, aspect_min + round(random.random(), 2))
             randresizecrop = transforms.RandomResizedCrop(size, scale_range, aspect_ratio_range)
-            _, _, h, w = randresizecrop.get_params(img, scale_range, aspect_ratio_range)
+            i, j, h, w = randresizecrop.get_params(img, scale_range, aspect_ratio_range)
             aspect_ratio_obtained = w / h
             assert (min(aspect_ratio_range) - epsilon <= aspect_ratio_obtained <= max(aspect_ratio_range) + epsilon or
                     aspect_ratio_obtained == 1.0)
+            assert isinstance(i, int)
+            assert isinstance(j, int)
+            assert isinstance(h, int)
+            assert isinstance(w, int)
 
     def test_randomperspective(self):
         for _ in range(10):

--- a/torchvision/transforms/transforms.py
+++ b/torchvision/transforms/transforms.py
@@ -652,10 +652,10 @@ class RandomResizedCrop(object):
         in_ratio = img.size[0] / img.size[1]
         if (in_ratio < min(ratio)):
             w = img.size[0]
-            h = w / min(ratio)
+            h = int(round(w / min(ratio)))
         elif (in_ratio > max(ratio)):
             h = img.size[1]
-            w = h * max(ratio)
+            w = int(round(h * max(ratio)))
         else:  # whole image
             w = img.size[0]
             h = img.size[1]


### PR DESCRIPTION
We started seeing internal errors in `RandomResizedCrop`.
```python
TypeError: integer argument expected, got float
```

This fixes it