### PR TITLE
Make test_save_image more robust

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 import torch
 import torchvision.utils as utils
 import unittest
@@ -37,11 +38,10 @@ class Tester(unittest.TestCase):
         assert torch.equal(norm_min, rounded_grid_min), 'Normalized min is not equal to 0'
 
     def test_save_image(self):
-        t = torch.rand(2, 3, 64, 64)
-        file_name = 'test_image.png'
-        utils.save_image(t, file_name)
-        assert os.path.exists(file_name), 'The image is not present after save'
-        os.remove(file_name)
+        with tempfile.NamedTemporaryFile(suffix='.png') as f:
+            t = torch.rand(2, 3, 64, 64)
+            utils.save_image(t, f.name)
+            assert os.path.exists(f.name), 'The image is not present after save'
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This makes the test more robust, as if the tests are run many times in parallel, deleting the file might make it fail sometimes