### PR TITLE
Corrected typo: 5 to 0.5

### DIFF
--- a/docs/source/transforms.rst
+++ b/docs/source/transforms.rst
@@ -95,7 +95,7 @@ For example, you can apply a functional transform to multiple images like this:
     import random
 
     def my_segmentation_transforms(image, segmentation):
-        if random.random() > 5:
+        if random.random() > 0.5:
             angle = random.randint(-30, 30)
             image = TF.rotate(image, angle)
             segmentation = TF.rotate(segmentation, angle)


### PR DESCRIPTION
Values from random.random() are always in the range [0.0, 1.0), so the statement `random.random() > 5` will never be true.