### PR TITLE
Update CI to Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ matrix:
     - python: "2.7"
       env: IMAGE_BACKEND=Pillow-SIMD
     - python: "2.7"
-    - python: "3.5"
+    - python: "3.6"
       env: IMAGE_BACKEND=Pillow-SIMD
-    - python: "3.5"
+    - python: "3.6"
 
 before_install:
   - sudo apt-get update


### PR DESCRIPTION
Python 3.6 (and 3.7) are by far the most downloaded distributions in anaconda.

Let's update the CI to test on Python 3.6.

This will simplify some other tasks down the road, like https://github.com/pytorch/vision/pull/1039, as PyAV version in conda is very old for Python 3.5

Another option is to add another build environment keeping Python 3.5, but I'm not sure it's necessary.