### PR TITLE
Fixed vision.h installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,21 +4,17 @@ set(CMAKE_CXX_STANDARD 11)
 
 find_package(Torch REQUIRED)
 
-file(GLOB_RECURSE HEADERS torchvision/csrc/vision.h)
-file(GLOB_RECURSE MODELS_HEADERS torchvision/csrc/models/*.h)
-file(GLOB_RECURSE MODELS_SOURCES torchvision/csrc/models/*.h torchvision/csrc/models/*.cpp)
+file(GLOB VISION_HEADERS torchvision/csrc/vision.h)
+file(GLOB MODELS_HEADERS torchvision/csrc/models/*.h)
+file(GLOB MODELS_SOURCES torchvision/csrc/models/*.h torchvision/csrc/models/*.cpp)
 
 add_library (${PROJECT_NAME} SHARED ${MODELS_SOURCES})
-target_link_libraries(${PROJECT_NAME} "${TORCH_LIBRARIES}")
+target_link_libraries(${PROJECT_NAME} PUBLIC "${TORCH_LIBRARIES}")
 
 add_executable(convertmodels torchvision/csrc/convert_models/convert_models.cpp)
-target_link_libraries(convertmodels "${PROJECT_NAME}")
+target_link_libraries(convertmodels ${PROJECT_NAME})
 target_link_libraries(convertmodels "${TORCH_LIBRARIES}")
 
-#add_executable(testmodels test/test_models.cpp)
-#target_link_libraries(testmodels "${PROJECT_NAME}")
-#target_link_libraries(testmodels "${TORCH_LIBRARIES}")
-
-install(TARGETS ${PROJECT_NAME} DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
-install(FILES ${HEADERS} DESTINATION ${CMAKE_INSTALL_PREFIX}/include/${PROJECT_NAME})
-install(FILES ${MODELS_HEADERS} DESTINATION ${CMAKE_INSTALL_PREFIX}/include/${PROJECT_NAME}/models)
+install(TARGETS ${PROJECT_NAME} DESTINATION "${CMAKE_INSTALL_PREFIX}/lib")
+install(FILES ${VISION_HEADERS} DESTINATION "${CMAKE_INSTALL_PREFIX}/include/${PROJECT_NAME}")
+install(FILES ${MODELS_HEADERS} DESTINATION "${CMAKE_INSTALL_PREFIX}/include/${PROJECT_NAME}/models")


### PR DESCRIPTION
Hi. This is a PR fixing an issue in cmake file. I ran cmake and make and make install but the file ```vision.h``` was copied to install path from ```torchvision/csrc/cpu/vision.h``` and not ```torchvision/csrc/vision.h```. I fixed this issue.

@fmassa having three ```vision.h``` files in project is a bit unorthodox. What do you think?
