### PR TITLE
torchvision/models support load pretrained model from local system

### DIFF
--- a/torchvision/models/alexnet.py
+++ b/torchvision/models/alexnet.py
@@ -1,3 +1,4 @@
+import torch
 import torch.nn as nn
 from .utils import load_state_dict_from_url
 
@@ -48,17 +49,21 @@ class AlexNet(nn.Module):
         return x
 
 
-def alexnet(pretrained=False, progress=True, **kwargs):
+def alexnet(pretrained=False, progress=True, pretrained_model_path=None, **kwargs):
     r"""AlexNet model architecture from the
     `"One weird trick..." <https://arxiv.org/abs/1404.5997>`_ paper.
 
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
         progress (bool): If True, displays a progress bar of the download to stderr
+        pretrained_model_path (string): If provided, loads a pre-trained model from it rather than download it
     """
     model = AlexNet(**kwargs)
     if pretrained:
-        state_dict = load_state_dict_from_url(model_urls['alexnet'],
-                                              progress=progress)
-        model.load_state_dict(state_dict)
+        if pretrained_model_path is None:
+            state_dict = load_state_dict_from_url(model_urls['alexnet'],
+                                                  progress=progress)
+            model.load_state_dict(state_dict)
+        else:
+            model.load_state_dict(torch.load(pretrained_model_path))
     return model

--- a/torchvision/models/densenet.py
+++ b/torchvision/models/densenet.py
@@ -159,7 +159,7 @@ class DenseNet(nn.Module):
         return out
 
 
-def _load_state_dict(model, model_url, progress):
+def _load_state_dict(model, model_url, progress, pretrained_model_path):
     # '.'s are no longer allowed in module names, but previous _DenseLayer
     # has keys 'norm.1', 'relu.1', 'conv.1', 'norm.2', 'relu.2', 'conv.2'.
     # They are also in the checkpoints in model_urls. This pattern is used
@@ -167,7 +167,10 @@ def _load_state_dict(model, model_url, progress):
     pattern = re.compile(
         r'^(.*denselayer\d+\.(?:norm|relu|conv))\.((?:[12])\.(?:weight|bias|running_mean|running_var))$')
 
-    state_dict = load_state_dict_from_url(model_url, progress=progress)
+    if pretrained_model_path is None:
+        state_dict = load_state_dict_from_url(model_url, progress=progress)
+    else:
+        state_dict = torch.load(pretrained_model_path)
     for key in list(state_dict.keys()):
         res = pattern.match(key)
         if res:
@@ -177,57 +180,61 @@ def _load_state_dict(model, model_url, progress):
     model.load_state_dict(state_dict)
 
 
-def _densenet(arch, growth_rate, block_config, num_init_features, pretrained, progress,
+def _densenet(arch, growth_rate, block_config, num_init_features, pretrained, progress, pretrained_model_path,
               **kwargs):
     model = DenseNet(growth_rate, block_config, num_init_features, **kwargs)
     if pretrained:
-        _load_state_dict(model, model_urls[arch], progress)
+        _load_state_dict(model, model_urls[arch], progress, pretrained_model_path)
     return model
 
 
-def densenet121(pretrained=False, progress=True, **kwargs):
+def densenet121(pretrained=False, progress=True, pretrained_model_path=None, **kwargs):
     r"""Densenet-121 model from
     `"Densely Connected Convolutional Networks" <https://arxiv.org/pdf/1608.06993.pdf>`_
 
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
         progress (bool): If True, displays a progress bar of the download to stderr
+        pretrained_model_path (string): If provided, loads a pre-trained model from it rather than download it
     """
-    return _densenet('densenet121', 32, (6, 12, 24, 16), 64, pretrained, progress,
+    return _densenet('densenet121', 32, (6, 12, 24, 16), 64, pretrained, progress, pretrained_model_path,
                      **kwargs)
 
 
-def densenet161(pretrained=False, progress=True, **kwargs):
+def densenet161(pretrained=False, progress=True, pretrained_model_path=None, **kwargs):
     r"""Densenet-161 model from
     `"Densely Connected Convolutional Networks" <https://arxiv.org/pdf/1608.06993.pdf>`_
 
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
         progress (bool): If True, displays a progress bar of the download to stderr
+        pretrained_model_path (string): If provided, loads a pre-trained model from it rather than download it
     """
-    return _densenet('densenet161', 48, (6, 12, 36, 24), 96, pretrained, progress,
+    return _densenet('densenet161', 48, (6, 12, 36, 24), 96, pretrained, progress, pretrained_model_path,
                      **kwargs)
 
 
-def densenet169(pretrained=False, progress=True, **kwargs):
+def densenet169(pretrained=False, progress=True, pretrained_model_path=None, **kwargs):
     r"""Densenet-169 model from
     `"Densely Connected Convolutional Networks" <https://arxiv.org/pdf/1608.06993.pdf>`_
 
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
         progress (bool): If True, displays a progress bar of the download to stderr
+        pretrained_model_path (string): If provided, loads a pre-trained model from it rather than download it
     """
-    return _densenet('densenet169', 32, (6, 12, 32, 32), 64, pretrained, progress,
+    return _densenet('densenet169', 32, (6, 12, 32, 32), 64, pretrained, progress, pretrained_model_path,
                      **kwargs)
 
 
-def densenet201(pretrained=False, progress=True, **kwargs):
+def densenet201(pretrained=False, progress=True, pretrained_model_path=None, **kwargs):
     r"""Densenet-201 model from
     `"Densely Connected Convolutional Networks" <https://arxiv.org/pdf/1608.06993.pdf>`_
 
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
         progress (bool): If True, displays a progress bar of the download to stderr
+        pretrained_model_path (string): If provided, loads a pre-trained model from it rather than download it
     """
-    return _densenet('densenet201', 32, (6, 12, 48, 32), 64, pretrained, progress,
+    return _densenet('densenet201', 32, (6, 12, 48, 32), 64, pretrained, progress, pretrained_model_path,
                      **kwargs)

--- a/torchvision/models/detection/faster_rcnn.py
+++ b/torchvision/models/detection/faster_rcnn.py
@@ -288,7 +288,7 @@ model_urls = {
 }
 
 
-def fasterrcnn_resnet50_fpn(pretrained=False, progress=True,
+def fasterrcnn_resnet50_fpn(pretrained=False, progress=True, pretrained_model_path=None,
                             num_classes=91, pretrained_backbone=True, **kwargs):
     """
     Constructs a Faster R-CNN model with a ResNet-50-FPN backbone.
@@ -325,6 +325,7 @@ def fasterrcnn_resnet50_fpn(pretrained=False, progress=True,
     Arguments:
         pretrained (bool): If True, returns a model pre-trained on COCO train2017
         progress (bool): If True, displays a progress bar of the download to stderr
+        pretrained_model_path (string): If provided, loads a pre-trained model from it rather than download it
     """
     if pretrained:
         # no need to download the backbone if pretrained is set
@@ -332,7 +333,10 @@ def fasterrcnn_resnet50_fpn(pretrained=False, progress=True,
     backbone = resnet_fpn_backbone('resnet50', pretrained_backbone)
     model = FasterRCNN(backbone, num_classes, **kwargs)
     if pretrained:
-        state_dict = load_state_dict_from_url(model_urls['fasterrcnn_resnet50_fpn_coco'],
-                                              progress=progress)
-        model.load_state_dict(state_dict)
+        if pretrained_model_path is None:
+            state_dict = load_state_dict_from_url(model_urls['fasterrcnn_resnet50_fpn_coco'],
+                                                  progress=progress)
+            model.load_state_dict(state_dict)
+        else:
+            model.load_state_dict(torch.load(pretrained_model_path))
     return model

--- a/torchvision/models/detection/keypoint_rcnn.py
+++ b/torchvision/models/detection/keypoint_rcnn.py
@@ -263,7 +263,7 @@ model_urls = {
 }
 
 
-def keypointrcnn_resnet50_fpn(pretrained=False, progress=True,
+def keypointrcnn_resnet50_fpn(pretrained=False, progress=True, pretrained_model_path=None,
                               num_classes=2, num_keypoints=17,
                               pretrained_backbone=True, **kwargs):
     """
@@ -304,6 +304,7 @@ def keypointrcnn_resnet50_fpn(pretrained=False, progress=True,
     Arguments:
         pretrained (bool): If True, returns a model pre-trained on COCO train2017
         progress (bool): If True, displays a progress bar of the download to stderr
+        pretrained_model_path (string): If provided, loads a pre-trained model from it rather than download it
     """
     if pretrained:
         # no need to download the backbone if pretrained is set
@@ -311,7 +312,10 @@ def keypointrcnn_resnet50_fpn(pretrained=False, progress=True,
     backbone = resnet_fpn_backbone('resnet50', pretrained_backbone)
     model = KeypointRCNN(backbone, num_classes, num_keypoints=num_keypoints, **kwargs)
     if pretrained:
-        state_dict = load_state_dict_from_url(model_urls['keypointrcnn_resnet50_fpn_coco'],
-                                              progress=progress)
-        model.load_state_dict(state_dict)
+        if pretrained_model_path is None:
+            state_dict = load_state_dict_from_url(model_urls['keypointrcnn_resnet50_fpn_coco'],
+                                                  progress=progress)
+            model.load_state_dict(state_dict)
+        else:
+            model.load_state_dict(torch.load(pretrained_model_path))
     return model

--- a/torchvision/models/detection/mask_rcnn.py
+++ b/torchvision/models/detection/mask_rcnn.py
@@ -263,7 +263,7 @@ model_urls = {
 }
 
 
-def maskrcnn_resnet50_fpn(pretrained=False, progress=True,
+def maskrcnn_resnet50_fpn(pretrained=False, progress=True, pretrained_model_path=None,
                           num_classes=91, pretrained_backbone=True, **kwargs):
     """
     Constructs a Mask R-CNN model with a ResNet-50-FPN backbone.
@@ -304,6 +304,7 @@ def maskrcnn_resnet50_fpn(pretrained=False, progress=True,
     Arguments:
         pretrained (bool): If True, returns a model pre-trained on COCO train2017
         progress (bool): If True, displays a progress bar of the download to stderr
+        pretrained_model_path (string): If provided, loads a pre-trained model from it rather than download it
     """
     if pretrained:
         # no need to download the backbone if pretrained is set
@@ -311,7 +312,10 @@ def maskrcnn_resnet50_fpn(pretrained=False, progress=True,
     backbone = resnet_fpn_backbone('resnet50', pretrained_backbone)
     model = MaskRCNN(backbone, num_classes, **kwargs)
     if pretrained:
-        state_dict = load_state_dict_from_url(model_urls['maskrcnn_resnet50_fpn_coco'],
-                                              progress=progress)
-        model.load_state_dict(state_dict)
+        if pretrained_model_path is None:
+            state_dict = load_state_dict_from_url(model_urls['maskrcnn_resnet50_fpn_coco'],
+                                                  progress=progress)
+            model.load_state_dict(state_dict)
+        else:
+            model.load_state_dict(torch.load(pretrained_model_path))
     return model

--- a/torchvision/models/googlenet.py
+++ b/torchvision/models/googlenet.py
@@ -15,13 +15,14 @@ model_urls = {
 _GoogLeNetOutputs = namedtuple('GoogLeNetOutputs', ['logits', 'aux_logits2', 'aux_logits1'])
 
 
-def googlenet(pretrained=False, progress=True, **kwargs):
+def googlenet(pretrained=False, progress=True, pretrained_model_path=None, **kwargs):
     r"""GoogLeNet (Inception v1) model architecture from
     `"Going Deeper with Convolutions" <http://arxiv.org/abs/1409.4842>`_.
 
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
         progress (bool): If True, displays a progress bar of the download to stderr
+        pretrained_model_path (string): If provided, loads a pre-trained model from it rather than download it
         aux_logits (bool): If True, adds two auxiliary branches that can improve training.
             Default: *False* when pretrained is True otherwise *True*
         transform_input (bool): If True, preprocesses the input according to the method with which it
@@ -39,9 +40,12 @@ def googlenet(pretrained=False, progress=True, **kwargs):
         kwargs['aux_logits'] = True
         kwargs['init_weights'] = False
         model = GoogLeNet(**kwargs)
-        state_dict = load_state_dict_from_url(model_urls['googlenet'],
-                                              progress=progress)
-        model.load_state_dict(state_dict)
+        if pretrained_model_path is None:
+            state_dict = load_state_dict_from_url(model_urls['googlenet'],
+                                                  progress=progress)
+            model.load_state_dict(state_dict)
+        else:
+            model.load_state_dict(torch.load(pretrained_model_path))
         if not original_aux_logits:
             model.aux_logits = False
             del model.aux1, model.aux2

--- a/torchvision/models/inception.py
+++ b/torchvision/models/inception.py
@@ -16,7 +16,7 @@ model_urls = {
 _InceptionOutputs = namedtuple('InceptionOutputs', ['logits', 'aux_logits'])
 
 
-def inception_v3(pretrained=False, progress=True, **kwargs):
+def inception_v3(pretrained=False, progress=True, pretrained_model_path=None, **kwargs):
     r"""Inception v3 model architecture from
     `"Rethinking the Inception Architecture for Computer Vision" <http://arxiv.org/abs/1512.00567>`_.
 
@@ -27,6 +27,7 @@ def inception_v3(pretrained=False, progress=True, **kwargs):
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
         progress (bool): If True, displays a progress bar of the download to stderr
+        pretrained_model_path (string): If provided, loads a pre-trained model from it rather than download it
         aux_logits (bool): If True, add an auxiliary branch that can improve training.
             Default: *True*
         transform_input (bool): If True, preprocesses the input according to the method with which it
@@ -41,9 +42,12 @@ def inception_v3(pretrained=False, progress=True, **kwargs):
         else:
             original_aux_logits = True
         model = Inception3(**kwargs)
-        state_dict = load_state_dict_from_url(model_urls['inception_v3_google'],
-                                              progress=progress)
-        model.load_state_dict(state_dict)
+        if pretrained_model_path is None:
+            state_dict = load_state_dict_from_url(model_urls['inception_v3_google'],
+                                                  progress=progress)
+            model.load_state_dict(state_dict)
+        else:
+            model.load_state_dict(torch.load(pretrained_model_path))
         if not original_aux_logits:
             model.aux_logits = False
             del model.AuxLogits

--- a/torchvision/models/mnasnet.py
+++ b/torchvision/models/mnasnet.py
@@ -143,41 +143,44 @@ class MNASNet(torch.nn.Module):
                 nn.init.zeros_(m.bias)
 
 
-def _load_pretrained(model_name, model, progress):
+def _load_pretrained(model_name, model, progress, pretrained_model_path):
     if model_name not in _MODEL_URLS or _MODEL_URLS[model_name] is None:
         raise ValueError(
             "No checkpoint is available for model type {}".format(model_name))
     checkpoint_url = _MODEL_URLS[model_name]
-    model.load_state_dict(load_state_dict_from_url(checkpoint_url, progress=progress))
+    if pretrained_model_path is None:
+        model.load_state_dict(load_state_dict_from_url(checkpoint_url, progress=progress))
+    else:
+        model.load_state_dict(torch.load(pretrained_model_path))
 
 
-def mnasnet0_5(pretrained=False, progress=True, **kwargs):
+def mnasnet0_5(pretrained=False, progress=True, pretrained_model_path=None, **kwargs):
     """ MNASNet with depth multiplier of 0.5. """
     model = MNASNet(0.5, **kwargs)
     if pretrained:
-        _load_pretrained("mnasnet0_5", model, progress)
+        _load_pretrained("mnasnet0_5", model, progress, pretrained_model_path)
     return model
 
 
-def mnasnet0_75(pretrained=False, progress=True, **kwargs):
+def mnasnet0_75(pretrained=False, progress=True, pretrained_model_path=None, **kwargs):
     """ MNASNet with depth multiplier of 0.75. """
     model = MNASNet(0.75, **kwargs)
     if pretrained:
-        _load_pretrained("mnasnet0_75", model, progress)
+        _load_pretrained("mnasnet0_75", model, progress, pretrained_model_path)
     return model
 
 
-def mnasnet1_0(pretrained=False, progress=True, **kwargs):
+def mnasnet1_0(pretrained=False, progress=True, pretrained_model_path=None, **kwargs):
     """ MNASNet with depth multiplier of 1.0. """
     model = MNASNet(1.0, **kwargs)
     if pretrained:
-        _load_pretrained("mnasnet1_0", model, progress)
+        _load_pretrained("mnasnet1_0", model, progress, pretrained_model_path)
     return model
 
 
-def mnasnet1_3(pretrained=False, progress=True, **kwargs):
+def mnasnet1_3(pretrained=False, progress=True, pretrained_model_path=None, **kwargs):
     """ MNASNet with depth multiplier of 1.3. """
     model = MNASNet(1.3, **kwargs)
     if pretrained:
-        _load_pretrained("mnasnet1_3", model, progress)
+        _load_pretrained("mnasnet1_3", model, progress, pretrained_model_path)
     return model

--- a/torchvision/models/mobilenet.py
+++ b/torchvision/models/mobilenet.py
@@ -1,3 +1,4 @@
+import torch
 from torch import nn
 from .utils import load_state_dict_from_url
 
@@ -115,7 +116,7 @@ class MobileNetV2(nn.Module):
         return x
 
 
-def mobilenet_v2(pretrained=False, progress=True, **kwargs):
+def mobilenet_v2(pretrained=False, progress=True, pretrained_model_path=None, **kwargs):
     """
     Constructs a MobileNetV2 architecture from
     `"MobileNetV2: Inverted Residuals and Linear Bottlenecks" <https://arxiv.org/abs/1801.04381>`_.
@@ -123,10 +124,14 @@ def mobilenet_v2(pretrained=False, progress=True, **kwargs):
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
         progress (bool): If True, displays a progress bar of the download to stderr
+        pretrained_model_path (string): If provided, loads a pre-trained model from it rather than download it
     """
     model = MobileNetV2(**kwargs)
     if pretrained:
-        state_dict = load_state_dict_from_url(model_urls['mobilenet_v2'],
-                                              progress=progress)
-        model.load_state_dict(state_dict)
+        if pretrained_model_path is None:
+            state_dict = load_state_dict_from_url(model_urls['mobilenet_v2'],
+                                                  progress=progress)
+            model.load_state_dict(state_dict)
+        else:
+            model.load_state_dict(torch.load(pretrained_model_path))
     return model

--- a/torchvision/models/resnet.py
+++ b/torchvision/models/resnet.py
@@ -1,3 +1,4 @@
+import torch
 import torch.nn as nn
 from .utils import load_state_dict_from_url
 
@@ -206,91 +207,101 @@ class ResNet(nn.Module):
         return x
 
 
-def _resnet(arch, block, layers, pretrained, progress, **kwargs):
+def _resnet(arch, block, layers, pretrained, progress, pretrained_model_path, **kwargs):
     model = ResNet(block, layers, **kwargs)
     if pretrained:
-        state_dict = load_state_dict_from_url(model_urls[arch],
-                                              progress=progress)
-        model.load_state_dict(state_dict)
+        if pretrained_model_path is None:
+            state_dict = load_state_dict_from_url(model_urls[arch],
+                                                  progress=progress)
+            model.load_state_dict(state_dict)
+        else:
+            model.load_state_dict(torch.load(pretrained_model_path))
     return model
 
 
-def resnet18(pretrained=False, progress=True, **kwargs):
+def resnet18(pretrained=False, progress=True, pretrained_model_path=None, **kwargs):
     """Constructs a ResNet-18 model.
 
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
         progress (bool): If True, displays a progress bar of the download to stderr
+        pretrained_model_path (string): If provided, loads a pre-trained model from it rather than download it
     """
-    return _resnet('resnet18', BasicBlock, [2, 2, 2, 2], pretrained, progress,
+    return _resnet('resnet18', BasicBlock, [2, 2, 2, 2], pretrained, progress, pretrained_model_path,
                    **kwargs)
 
 
-def resnet34(pretrained=False, progress=True, **kwargs):
+def resnet34(pretrained=False, progress=True, pretrained_model_path=None, **kwargs):
     """Constructs a ResNet-34 model.
 
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
         progress (bool): If True, displays a progress bar of the download to stderr
+        pretrained_model_path (string): If provided, loads a pre-trained model from it rather than download it
     """
-    return _resnet('resnet34', BasicBlock, [3, 4, 6, 3], pretrained, progress,
+    return _resnet('resnet34', BasicBlock, [3, 4, 6, 3], pretrained, progress, pretrained_model_path,
                    **kwargs)
 
 
-def resnet50(pretrained=False, progress=True, **kwargs):
+def resnet50(pretrained=False, progress=True, pretrained_model_path=None, **kwargs):
     """Constructs a ResNet-50 model.
 
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
         progress (bool): If True, displays a progress bar of the download to stderr
+        pretrained_model_path (string): If provided, loads a pre-trained model from it rather than download it
     """
-    return _resnet('resnet50', Bottleneck, [3, 4, 6, 3], pretrained, progress,
+    return _resnet('resnet50', Bottleneck, [3, 4, 6, 3], pretrained, progress, pretrained_model_path,
                    **kwargs)
 
 
-def resnet101(pretrained=False, progress=True, **kwargs):
+def resnet101(pretrained=False, progress=True, pretrained_model_path=None, **kwargs):
     """Constructs a ResNet-101 model.
 
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
         progress (bool): If True, displays a progress bar of the download to stderr
+        pretrained_model_path (string): If provided, loads a pre-trained model from it rather than download it
     """
-    return _resnet('resnet101', Bottleneck, [3, 4, 23, 3], pretrained, progress,
+    return _resnet('resnet101', Bottleneck, [3, 4, 23, 3], pretrained, progress, pretrained_model_path,
                    **kwargs)
 
 
-def resnet152(pretrained=False, progress=True, **kwargs):
+def resnet152(pretrained=False, progress=True, pretrained_model_path=None, **kwargs):
     """Constructs a ResNet-152 model.
 
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
         progress (bool): If True, displays a progress bar of the download to stderr
+        pretrained_model_path (string): If provided, loads a pre-trained model from it rather than download it
     """
-    return _resnet('resnet152', Bottleneck, [3, 8, 36, 3], pretrained, progress,
+    return _resnet('resnet152', Bottleneck, [3, 8, 36, 3], pretrained, progress, pretrained_model_path,
                    **kwargs)
 
 
-def resnext50_32x4d(pretrained=False, progress=True, **kwargs):
+def resnext50_32x4d(pretrained=False, progress=True, pretrained_model_path=None, **kwargs):
     """Constructs a ResNeXt-50 32x4d model.
 
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
         progress (bool): If True, displays a progress bar of the download to stderr
+        pretrained_model_path (string): If provided, loads a pre-trained model from it rather than download it
     """
     kwargs['groups'] = 32
     kwargs['width_per_group'] = 4
     return _resnet('resnext50_32x4d', Bottleneck, [3, 4, 6, 3],
-                   pretrained, progress, **kwargs)
+                   pretrained, progress, pretrained_model_path, **kwargs)
 
 
-def resnext101_32x8d(pretrained=False, progress=True, **kwargs):
+def resnext101_32x8d(pretrained=False, progress=True, pretrained_model_path=None, **kwargs):
     """Constructs a ResNeXt-101 32x8d model.
 
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
         progress (bool): If True, displays a progress bar of the download to stderr
+        pretrained_model_path (string): If provided, loads a pre-trained model from it rather than download it
     """
     kwargs['groups'] = 32
     kwargs['width_per_group'] = 8
     return _resnet('resnext101_32x8d', Bottleneck, [3, 4, 23, 3],
-                   pretrained, progress, **kwargs)
+                   pretrained, progress, pretrained_model_path, **kwargs)

--- a/torchvision/models/segmentation/segmentation.py
+++ b/torchvision/models/segmentation/segmentation.py
@@ -1,3 +1,4 @@
+import torch
 from .._utils import IntermediateLayerGetter
 from ..utils import load_state_dict_from_url
 from .. import resnet
@@ -43,7 +44,7 @@ def _segm_resnet(name, backbone_name, num_classes, aux, pretrained_backbone=True
     return model
 
 
-def _load_model(arch_type, backbone, pretrained, progress, num_classes, aux_loss, **kwargs):
+def _load_model(arch_type, backbone, pretrained, progress, pretrained_model_path, num_classes, aux_loss, **kwargs):
     if pretrained:
         aux_loss = True
     model = _segm_resnet(arch_type, backbone, num_classes, aux_loss, **kwargs)
@@ -53,12 +54,15 @@ def _load_model(arch_type, backbone, pretrained, progress, num_classes, aux_loss
         if model_url is None:
             raise NotImplementedError('pretrained {} is not supported as of now'.format(arch))
         else:
-            state_dict = load_state_dict_from_url(model_url, progress=progress)
-            model.load_state_dict(state_dict)
+            if pretrained_model_path is None:
+                state_dict = load_state_dict_from_url(model_url, progress=progress)
+                model.load_state_dict(state_dict)
+            else:
+                model.load_state_dict(torch.load(pretrained_model_path))
     return model
 
 
-def fcn_resnet50(pretrained=False, progress=True,
+def fcn_resnet50(pretrained=False, progress=True, pretrained_model_path=None,
                  num_classes=21, aux_loss=None, **kwargs):
     """Constructs a Fully-Convolutional Network model with a ResNet-50 backbone.
 
@@ -66,11 +70,12 @@ def fcn_resnet50(pretrained=False, progress=True,
         pretrained (bool): If True, returns a model pre-trained on COCO train2017 which
             contains the same classes as Pascal VOC
         progress (bool): If True, displays a progress bar of the download to stderr
+        pretrained_model_path (string): If provided, loads a pre-trained model from it rather than download it
     """
-    return _load_model('fcn', 'resnet50', pretrained, progress, num_classes, aux_loss, **kwargs)
+    return _load_model('fcn', 'resnet50', pretrained, progress, pretrained_model_path, num_classes, aux_loss, **kwargs)
 
 
-def fcn_resnet101(pretrained=False, progress=True,
+def fcn_resnet101(pretrained=False, progress=True, pretrained_model_path=None,
                   num_classes=21, aux_loss=None, **kwargs):
     """Constructs a Fully-Convolutional Network model with a ResNet-101 backbone.
 
@@ -78,11 +83,12 @@ def fcn_resnet101(pretrained=False, progress=True,
         pretrained (bool): If True, returns a model pre-trained on COCO train2017 which
             contains the same classes as Pascal VOC
         progress (bool): If True, displays a progress bar of the download to stderr
+        pretrained_model_path (string): If provided, loads a pre-trained model from it rather than download it
     """
-    return _load_model('fcn', 'resnet101', pretrained, progress, num_classes, aux_loss, **kwargs)
+    return _load_model('fcn', 'resnet101', pretrained, progress, pretrained_model_path, num_classes, aux_loss, **kwargs)
 
 
-def deeplabv3_resnet50(pretrained=False, progress=True,
+def deeplabv3_resnet50(pretrained=False, progress=True, pretrained_model_path=None,
                        num_classes=21, aux_loss=None, **kwargs):
     """Constructs a DeepLabV3 model with a ResNet-50 backbone.
 
@@ -90,11 +96,12 @@ def deeplabv3_resnet50(pretrained=False, progress=True,
         pretrained (bool): If True, returns a model pre-trained on COCO train2017 which
             contains the same classes as Pascal VOC
         progress (bool): If True, displays a progress bar of the download to stderr
+        pretrained_model_path (string): If provided, loads a pre-trained model from it rather than download it
     """
-    return _load_model('deeplabv3', 'resnet50', pretrained, progress, num_classes, aux_loss, **kwargs)
+    return _load_model('deeplabv3', 'resnet50', pretrained, progress, pretrained_model_path, num_classes, aux_loss, **kwargs)
 
 
-def deeplabv3_resnet101(pretrained=False, progress=True,
+def deeplabv3_resnet101(pretrained=False, progress=True, pretrained_model_path=None,
                         num_classes=21, aux_loss=None, **kwargs):
     """Constructs a DeepLabV3 model with a ResNet-101 backbone.
 
@@ -102,5 +109,6 @@ def deeplabv3_resnet101(pretrained=False, progress=True,
         pretrained (bool): If True, returns a model pre-trained on COCO train2017 which
             contains the same classes as Pascal VOC
         progress (bool): If True, displays a progress bar of the download to stderr
+        pretrained_model_path (string): If provided, loads a pre-trained model from it rather than download it
     """
-    return _load_model('deeplabv3', 'resnet101', pretrained, progress, num_classes, aux_loss, **kwargs)
+    return _load_model('deeplabv3', 'resnet101', pretrained, progress, pretrained_model_path, num_classes, aux_loss, **kwargs)

--- a/torchvision/models/segmentation/segmentation.py
+++ b/torchvision/models/segmentation/segmentation.py
@@ -72,7 +72,8 @@ def fcn_resnet50(pretrained=False, progress=True, pretrained_model_path=None,
         progress (bool): If True, displays a progress bar of the download to stderr
         pretrained_model_path (string): If provided, loads a pre-trained model from it rather than download it
     """
-    return _load_model('fcn', 'resnet50', pretrained, progress, pretrained_model_path, num_classes, aux_loss, **kwargs)
+    return _load_model('fcn', 'resnet50', pretrained, progress, pretrained_model_path,
+                       num_classes, aux_loss, **kwargs)
 
 
 def fcn_resnet101(pretrained=False, progress=True, pretrained_model_path=None,
@@ -85,7 +86,8 @@ def fcn_resnet101(pretrained=False, progress=True, pretrained_model_path=None,
         progress (bool): If True, displays a progress bar of the download to stderr
         pretrained_model_path (string): If provided, loads a pre-trained model from it rather than download it
     """
-    return _load_model('fcn', 'resnet101', pretrained, progress, pretrained_model_path, num_classes, aux_loss, **kwargs)
+    return _load_model('fcn', 'resnet101', pretrained, progress, pretrained_model_path,
+                       num_classes, aux_loss, **kwargs)
 
 
 def deeplabv3_resnet50(pretrained=False, progress=True, pretrained_model_path=None,
@@ -98,7 +100,8 @@ def deeplabv3_resnet50(pretrained=False, progress=True, pretrained_model_path=No
         progress (bool): If True, displays a progress bar of the download to stderr
         pretrained_model_path (string): If provided, loads a pre-trained model from it rather than download it
     """
-    return _load_model('deeplabv3', 'resnet50', pretrained, progress, pretrained_model_path, num_classes, aux_loss, **kwargs)
+    return _load_model('deeplabv3', 'resnet50', pretrained, progress, pretrained_model_path,
+                       num_classes, aux_loss, **kwargs)
 
 
 def deeplabv3_resnet101(pretrained=False, progress=True, pretrained_model_path=None,
@@ -111,4 +114,5 @@ def deeplabv3_resnet101(pretrained=False, progress=True, pretrained_model_path=N
         progress (bool): If True, displays a progress bar of the download to stderr
         pretrained_model_path (string): If provided, loads a pre-trained model from it rather than download it
     """
-    return _load_model('deeplabv3', 'resnet101', pretrained, progress, pretrained_model_path, num_classes, aux_loss, **kwargs)
+    return _load_model('deeplabv3', 'resnet101', pretrained, progress, pretrained_model_path,
+                       num_classes, aux_loss, **kwargs)

--- a/torchvision/models/shufflenetv2.py
+++ b/torchvision/models/shufflenetv2.py
@@ -131,7 +131,7 @@ class ShuffleNetV2(nn.Module):
         return x
 
 
-def _shufflenetv2(arch, pretrained, progress, *args, **kwargs):
+def _shufflenetv2(arch, pretrained, progress, pretrained_model_path, *args, **kwargs):
     model = ShuffleNetV2(*args, **kwargs)
 
     if pretrained:
@@ -139,13 +139,16 @@ def _shufflenetv2(arch, pretrained, progress, *args, **kwargs):
         if model_url is None:
             raise NotImplementedError('pretrained {} is not supported as of now'.format(arch))
         else:
-            state_dict = load_state_dict_from_url(model_url, progress=progress)
-            model.load_state_dict(state_dict)
+            if pretrained_model_path is None:
+                state_dict = load_state_dict_from_url(model_url, progress=progress)
+                model.load_state_dict(state_dict)
+            else:
+                model.load_state_dict(torch.load(pretrained_model_path))
 
     return model
 
 
-def shufflenet_v2_x0_5(pretrained=False, progress=True, **kwargs):
+def shufflenet_v2_x0_5(pretrained=False, progress=True, pretrained_model_path=None, **kwargs):
     """
     Constructs a ShuffleNetV2 with 0.5x output channels, as described in
     `"ShuffleNet V2: Practical Guidelines for Efficient CNN Architecture Design"
@@ -154,12 +157,13 @@ def shufflenet_v2_x0_5(pretrained=False, progress=True, **kwargs):
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
         progress (bool): If True, displays a progress bar of the download to stderr
+        pretrained_model_path (string): If provided, loads a pre-trained model from it rather than download it
     """
-    return _shufflenetv2('shufflenetv2_x0.5', pretrained, progress,
+    return _shufflenetv2('shufflenetv2_x0.5', pretrained, progress, pretrained_model_path,
                          [4, 8, 4], [24, 48, 96, 192, 1024], **kwargs)
 
 
-def shufflenet_v2_x1_0(pretrained=False, progress=True, **kwargs):
+def shufflenet_v2_x1_0(pretrained=False, progress=True, pretrained_model_path=None, **kwargs):
     """
     Constructs a ShuffleNetV2 with 1.0x output channels, as described in
     `"ShuffleNet V2: Practical Guidelines for Efficient CNN Architecture Design"
@@ -168,12 +172,13 @@ def shufflenet_v2_x1_0(pretrained=False, progress=True, **kwargs):
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
         progress (bool): If True, displays a progress bar of the download to stderr
+        pretrained_model_path (string): If provided, loads a pre-trained model from it rather than download it
     """
-    return _shufflenetv2('shufflenetv2_x1.0', pretrained, progress,
+    return _shufflenetv2('shufflenetv2_x1.0', pretrained, progress, pretrained_model_path,
                          [4, 8, 4], [24, 116, 232, 464, 1024], **kwargs)
 
 
-def shufflenet_v2_x1_5(pretrained=False, progress=True, **kwargs):
+def shufflenet_v2_x1_5(pretrained=False, progress=True, pretrained_model_path=None, **kwargs):
     """
     Constructs a ShuffleNetV2 with 1.5x output channels, as described in
     `"ShuffleNet V2: Practical Guidelines for Efficient CNN Architecture Design"
@@ -182,12 +187,13 @@ def shufflenet_v2_x1_5(pretrained=False, progress=True, **kwargs):
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
         progress (bool): If True, displays a progress bar of the download to stderr
+        pretrained_model_path (string): If provided, loads a pre-trained model from it rather than download it
     """
-    return _shufflenetv2('shufflenetv2_x1.5', pretrained, progress,
+    return _shufflenetv2('shufflenetv2_x1.5', pretrained, progress, pretrained_model_path,
                          [4, 8, 4], [24, 176, 352, 704, 1024], **kwargs)
 
 
-def shufflenet_v2_x2_0(pretrained=False, progress=True, **kwargs):
+def shufflenet_v2_x2_0(pretrained=False, progress=True, pretrained_model_path=None, **kwargs):
     """
     Constructs a ShuffleNetV2 with 2.0x output channels, as described in
     `"ShuffleNet V2: Practical Guidelines for Efficient CNN Architecture Design"
@@ -196,6 +202,7 @@ def shufflenet_v2_x2_0(pretrained=False, progress=True, **kwargs):
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
         progress (bool): If True, displays a progress bar of the download to stderr
+        pretrained_model_path (string): If provided, loads a pre-trained model from it rather than download it
     """
-    return _shufflenetv2('shufflenetv2_x2.0', pretrained, progress,
+    return _shufflenetv2('shufflenetv2_x2.0', pretrained, progress, pretrained_model_path,
                          [4, 8, 4], [24, 244, 488, 976, 2048], **kwargs)

--- a/torchvision/models/squeezenet.py
+++ b/torchvision/models/squeezenet.py
@@ -102,17 +102,20 @@ class SqueezeNet(nn.Module):
         return x.view(x.size(0), -1)
 
 
-def _squeezenet(version, pretrained, progress, **kwargs):
+def _squeezenet(version, pretrained, progress, pretrained_model_path, **kwargs):
     model = SqueezeNet(version, **kwargs)
     if pretrained:
         arch = 'squeezenet' + version
-        state_dict = load_state_dict_from_url(model_urls[arch],
-                                              progress=progress)
-        model.load_state_dict(state_dict)
+        if pretrained_model_path is None:
+            state_dict = load_state_dict_from_url(model_urls[arch],
+                                                  progress=progress)
+            model.load_state_dict(state_dict)
+        else:
+            model.load_state_dict(torch.load(pretrained_model_path))
     return model
 
 
-def squeezenet1_0(pretrained=False, progress=True, **kwargs):
+def squeezenet1_0(pretrained=False, progress=True, pretrained_model_path=None, **kwargs):
     r"""SqueezeNet model architecture from the `"SqueezeNet: AlexNet-level
     accuracy with 50x fewer parameters and <0.5MB model size"
     <https://arxiv.org/abs/1602.07360>`_ paper.
@@ -120,11 +123,12 @@ def squeezenet1_0(pretrained=False, progress=True, **kwargs):
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
         progress (bool): If True, displays a progress bar of the download to stderr
+        pretrained_model_path (string): If provided, loads a pre-trained model from it rather than download it
     """
-    return _squeezenet('1_0', pretrained, progress, **kwargs)
+    return _squeezenet('1_0', pretrained, progress, pretrained_model_path, **kwargs)
 
 
-def squeezenet1_1(pretrained=False, progress=True, **kwargs):
+def squeezenet1_1(pretrained=False, progress=True, pretrained_model_path=None, **kwargs):
     r"""SqueezeNet 1.1 model from the `official SqueezeNet repo
     <https://github.com/DeepScale/SqueezeNet/tree/master/SqueezeNet_v1.1>`_.
     SqueezeNet 1.1 has 2.4x less computation and slightly fewer parameters
@@ -133,5 +137,6 @@ def squeezenet1_1(pretrained=False, progress=True, **kwargs):
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
         progress (bool): If True, displays a progress bar of the download to stderr
+        pretrained_model_path (string): If provided, loads a pre-trained model from it rather than download it
     """
-    return _squeezenet('1_1', pretrained, progress, **kwargs)
+    return _squeezenet('1_1', pretrained, progress, pretrained_model_path, **kwargs)

--- a/torchvision/models/vgg.py
+++ b/torchvision/models/vgg.py
@@ -1,3 +1,4 @@
+import torch
 import torch.nn as nn
 from .utils import load_state_dict_from_url
 
@@ -83,92 +84,103 @@ cfgs = {
 }
 
 
-def _vgg(arch, cfg, batch_norm, pretrained, progress, **kwargs):
+def _vgg(arch, cfg, batch_norm, pretrained, progress, pretrained_model_path, **kwargs):
     if pretrained:
         kwargs['init_weights'] = False
     model = VGG(make_layers(cfgs[cfg], batch_norm=batch_norm), **kwargs)
     if pretrained:
-        state_dict = load_state_dict_from_url(model_urls[arch],
-                                              progress=progress)
-        model.load_state_dict(state_dict)
+        if pretrained_model_path is None:
+            state_dict = load_state_dict_from_url(model_urls[arch],
+                                                  progress=progress)
+            model.load_state_dict(state_dict)
+        else:
+            model.load_state_dict(torch.load(pretrained_model_path))
     return model
 
 
-def vgg11(pretrained=False, progress=True, **kwargs):
+def vgg11(pretrained=False, progress=True, pretrained_model_path=None, **kwargs):
     """VGG 11-layer model (configuration "A")
 
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
         progress (bool): If True, displays a progress bar of the download to stderr
+        pretrained_model_path (string): If provided, loads a pre-trained model from it rather than download it
     """
-    return _vgg('vgg11', 'A', False, pretrained, progress, **kwargs)
+    return _vgg('vgg11', 'A', False, pretrained, progress, pretrained_model_path, **kwargs)
 
 
-def vgg11_bn(pretrained=False, progress=True, **kwargs):
+def vgg11_bn(pretrained=False, progress=True, pretrained_model_path=None, **kwargs):
     """VGG 11-layer model (configuration "A") with batch normalization
 
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
         progress (bool): If True, displays a progress bar of the download to stderr
+        pretrained_model_path (string): If provided, loads a pre-trained model from it rather than download it
     """
-    return _vgg('vgg11_bn', 'A', True, pretrained, progress, **kwargs)
+    return _vgg('vgg11_bn', 'A', True, pretrained, progress, pretrained_model_path, **kwargs)
 
 
-def vgg13(pretrained=False, progress=True, **kwargs):
+def vgg13(pretrained=False, progress=True, pretrained_model_path=None, **kwargs):
     """VGG 13-layer model (configuration "B")
 
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
         progress (bool): If True, displays a progress bar of the download to stderr
+        pretrained_model_path (string): If provided, loads a pre-trained model from it rather than download it
     """
-    return _vgg('vgg13', 'B', False, pretrained, progress, **kwargs)
+    return _vgg('vgg13', 'B', False, pretrained, progress, pretrained_model_path, **kwargs)
 
 
-def vgg13_bn(pretrained=False, progress=True, **kwargs):
+def vgg13_bn(pretrained=False, progress=True, pretrained_model_path=None, **kwargs):
     """VGG 13-layer model (configuration "B") with batch normalization
 
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
         progress (bool): If True, displays a progress bar of the download to stderr
+        pretrained_model_path (string): If provided, loads a pre-trained model from it rather than download it
     """
-    return _vgg('vgg13_bn', 'B', True, pretrained, progress, **kwargs)
+    return _vgg('vgg13_bn', 'B', True, pretrained, progress, pretrained_model_path, **kwargs)
 
 
-def vgg16(pretrained=False, progress=True, **kwargs):
+def vgg16(pretrained=False, progress=True, pretrained_model_path=None, **kwargs):
     """VGG 16-layer model (configuration "D")
 
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
         progress (bool): If True, displays a progress bar of the download to stderr
+        pretrained_model_path (string): If provided, loads a pre-trained model from it rather than download it
     """
-    return _vgg('vgg16', 'D', False, pretrained, progress, **kwargs)
+    return _vgg('vgg16', 'D', False, pretrained, progress, pretrained_model_path, **kwargs)
 
 
-def vgg16_bn(pretrained=False, progress=True, **kwargs):
+def vgg16_bn(pretrained=False, progress=True, pretrained_model_path=None, **kwargs):
     """VGG 16-layer model (configuration "D") with batch normalization
 
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
         progress (bool): If True, displays a progress bar of the download to stderr
+        pretrained_model_path (string): If provided, loads a pre-trained model from it rather than download it
     """
-    return _vgg('vgg16_bn', 'D', True, pretrained, progress, **kwargs)
+    return _vgg('vgg16_bn', 'D', True, pretrained, progress, pretrained_model_path, **kwargs)
 
 
-def vgg19(pretrained=False, progress=True, **kwargs):
+def vgg19(pretrained=False, progress=True, pretrained_model_path=None, **kwargs):
     """VGG 19-layer model (configuration "E")
 
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
         progress (bool): If True, displays a progress bar of the download to stderr
+        pretrained_model_path (string): If provided, loads a pre-trained model from it rather than download it
     """
-    return _vgg('vgg19', 'E', False, pretrained, progress, **kwargs)
+    return _vgg('vgg19', 'E', False, pretrained, progress, pretrained_model_path, **kwargs)
 
 
-def vgg19_bn(pretrained=False, progress=True, **kwargs):
+def vgg19_bn(pretrained=False, progress=True, pretrained_model_path=None, **kwargs):
     """VGG 19-layer model (configuration 'E') with batch normalization
 
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
         progress (bool): If True, displays a progress bar of the download to stderr
+        pretrained_model_path (string): If provided, loads a pre-trained model from it rather than download it
     """
-    return _vgg('vgg19_bn', 'E', True, pretrained, progress, **kwargs)
+    return _vgg('vgg19_bn', 'E', True, pretrained, progress, pretrained_model_path, **kwargs)


### PR DESCRIPTION
Sometimes we already have a pretrained model and we don't wish to download it again or put it in the default path where the download code will download a model into, I add some codes in the way keras does, so users can provide a local model path and load the pretrained model from it.