### PR TITLE
fix save_image when height or width == 1

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -43,6 +43,12 @@ class Tester(unittest.TestCase):
             utils.save_image(t, f.name)
             assert os.path.exists(f.name), 'The image is not present after save'
 
+    def test_save_image_single_pixel(self):
+        with tempfile.NamedTemporaryFile(suffix='.png') as f:
+            t = torch.rand(1, 3, 1, 1)
+            utils.save_image(t, f.name)
+            assert os.path.exists(f.name), 'The pixel image is not present after save'
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/torchvision/utils.py
+++ b/torchvision/utils.py
@@ -67,7 +67,7 @@ def make_grid(tensor, nrow=8, padding=2,
             norm_range(tensor, range)
 
     if tensor.size(0) == 1:
-        return tensor.squeeze()
+        return tensor.squeeze(0)
 
     # make the mini-batch of images into a grid
     nmaps = tensor.size(0)


### PR DESCRIPTION
This fixes the save_image function when one of the dimensions is one.

Otherwise error is as follow:

```
Traceback (most recent call last):
  File "run_nn.py", line 250, in <module>
    torchvision.utils.save_image(batch_x.detach().unsqueeze(2).cpu(), "dbg/%s-x.png"%(dbgtitle))
  File "/home/trougnouf/.local/lib/python3.6/site-packages/torchvision/utils.py", line 103, in save_image
    ndarr = grid.mul_(255).add_(0.5).clamp_(0, 255).permute(1, 2, 0).to('cpu', torch.uint8).numpy()
RuntimeError: number of dims don't match in permute

```