### PR TITLE
Add VideoClips and Kinetics dataset

### DIFF
--- a/test/test_datasets_video_utils.py
+++ b/test/test_datasets_video_utils.py
@@ -119,6 +119,31 @@ class Tester(unittest.TestCase):
                     self.assertEqual(info["video_fps"], fps)
                     # TODO add tests checking that the content is right
 
+    def test_compute_clips_for_video(self):
+        video_pts = torch.arange(30)
+        # case 1: single clip
+        num_frames = 13
+        orig_fps = 30
+        duration = float(len(video_pts)) / orig_fps
+        new_fps = 13
+        clips, idxs = VideoClips.compute_clips_for_video(video_pts, num_frames, num_frames,
+                                                         orig_fps, new_fps)
+        resampled_idxs = VideoClips._resample_video_idx(int(duration * new_fps), orig_fps, new_fps)
+        self.assertEqual(len(clips), 1)
+        self.assertTrue(clips.equal(idxs))
+        self.assertTrue(idxs[0].equal(resampled_idxs))
+
+        # case 2: all frames appear only once
+        num_frames = 4
+        orig_fps = 30
+        duration = float(len(video_pts)) / orig_fps
+        new_fps = 12
+        clips, idxs = VideoClips.compute_clips_for_video(video_pts, num_frames, num_frames,
+                                                         orig_fps, new_fps)
+        resampled_idxs = VideoClips._resample_video_idx(int(duration * new_fps), orig_fps, new_fps)
+        self.assertEqual(len(clips), 3)
+        self.assertTrue(clips.equal(idxs))
+        self.assertTrue(idxs.flatten().equal(resampled_idxs))
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_datasets_video_utils.py
+++ b/test/test_datasets_video_utils.py
@@ -4,17 +4,21 @@ import torch
 import unittest
 
 from torchvision import io
-from torchvision.datasets.video_utils import VideoClips, unfold
+from torchvision.datasets.video_utils import VideoClips, unfold, RandomMaxVideoClipSampler
 
 from common_utils import get_tmp_dir
 
 
 @contextlib.contextmanager
-def get_list_of_videos(num_videos=5):
+def get_list_of_videos(num_videos=5, sizes=None):
     with get_tmp_dir() as tmp_dir:
         names = []
         for i in range(num_videos):
-            data = torch.randint(0, 255, (5 * (i + 1), 300, 400, 3), dtype=torch.uint8)
+            if sizes is None:
+                size = 5 * (i + 1)
+            else:
+                size = sizes[i]
+            data = torch.randint(0, 255, (size, 300, 400, 3), dtype=torch.uint8)
             name = os.path.join(tmp_dir, "{}.mp4".format(i))
             names.append(name)
             io.write_video(name, data, fps=5)
@@ -71,6 +75,34 @@ class Tester(unittest.TestCase):
                 video_idx, clip_idx = video_clips.get_clip_location(i)
                 self.assertEqual(video_idx, v_idx)
                 self.assertEqual(clip_idx, c_idx)
+
+    def test_video_sampler(self):
+        with get_list_of_videos(num_videos=3, sizes=[25, 25, 25]) as video_list:
+            video_clips = VideoClips(video_list, 5, 5)
+            sampler = RandomMaxVideoClipSampler(video_clips, 3)
+            self.assertEqual(len(sampler), 3 * 3)
+            indices = torch.tensor(list(iter(sampler)))
+            videos = indices // 5
+            v_idxs, count = torch.unique(videos, return_counts=True)
+            self.assertTrue(v_idxs.equal(torch.tensor([0, 1, 2])))
+            self.assertTrue(count.equal(torch.tensor([3, 3, 3])))
+
+    def test_video_sampler_unequal(self):
+        with get_list_of_videos(num_videos=3, sizes=[10, 25, 25]) as video_list:
+            video_clips = VideoClips(video_list, 5, 5)
+            sampler = RandomMaxVideoClipSampler(video_clips, 3)
+            self.assertEqual(len(sampler), 2 + 3 + 3)
+            indices = list(iter(sampler))
+            self.assertIn(0, indices)
+            self.assertIn(1, indices)
+            # remove elements of the first video, to simplify testing
+            indices.remove(0)
+            indices.remove(1)
+            indices = torch.tensor(indices) - 2
+            videos = indices // 5
+            v_idxs, count = torch.unique(videos, return_counts=True)
+            self.assertTrue(v_idxs.equal(torch.tensor([0, 1])))
+            self.assertTrue(count.equal(torch.tensor([3, 3])))
 
 
 if __name__ == '__main__':

--- a/test/test_datasets_video_utils.py
+++ b/test/test_datasets_video_utils.py
@@ -49,7 +49,6 @@ class Tester(unittest.TestCase):
         ])
         self.assertTrue(r.equal(expected))
 
-
     def test_video_clips(self):
         with get_list_of_videos(num_videos=3) as video_list:
             video_clips = VideoClips(video_list, 5, 5)

--- a/test/test_datasets_video_utils.py
+++ b/test/test_datasets_video_utils.py
@@ -4,7 +4,7 @@ import torch
 import unittest
 
 from torchvision import io
-from torchvision.datasets.video_utils import VideoClips, unfold, RandomMaxVideoClipSampler
+from torchvision.datasets.video_utils import VideoClips, unfold, RandomClipSampler
 
 from common_utils import get_tmp_dir
 
@@ -79,7 +79,7 @@ class Tester(unittest.TestCase):
     def test_video_sampler(self):
         with get_list_of_videos(num_videos=3, sizes=[25, 25, 25]) as video_list:
             video_clips = VideoClips(video_list, 5, 5)
-            sampler = RandomMaxVideoClipSampler(video_clips, 3)
+            sampler = RandomClipSampler(video_clips, 3)
             self.assertEqual(len(sampler), 3 * 3)
             indices = torch.tensor(list(iter(sampler)))
             videos = indices // 5
@@ -90,7 +90,7 @@ class Tester(unittest.TestCase):
     def test_video_sampler_unequal(self):
         with get_list_of_videos(num_videos=3, sizes=[10, 25, 25]) as video_list:
             video_clips = VideoClips(video_list, 5, 5)
-            sampler = RandomMaxVideoClipSampler(video_clips, 3)
+            sampler = RandomClipSampler(video_clips, 3)
             self.assertEqual(len(sampler), 2 + 3 + 3)
             indices = list(iter(sampler))
             self.assertIn(0, indices)

--- a/test/test_datasets_video_utils.py
+++ b/test/test_datasets_video_utils.py
@@ -1,0 +1,78 @@
+import contextlib
+import os
+import torch
+import unittest
+
+from torchvision import io
+from torchvision.datasets.video_utils import VideoClips, unfold
+
+from common_utils import get_tmp_dir
+
+
+@contextlib.contextmanager
+def get_list_of_videos(num_videos=5):
+    with get_tmp_dir() as tmp_dir:
+        names = []
+        for i in range(num_videos):
+            data = torch.randint(0, 255, (5 * (i + 1), 300, 400, 3), dtype=torch.uint8)
+            name = os.path.join(tmp_dir, "{}.mp4".format(i))
+            names.append(name)
+            io.write_video(name, data, fps=5)
+
+        yield names
+
+
+class Tester(unittest.TestCase):
+
+    def test_unfold(self):
+        a = torch.arange(7)
+
+        r = unfold(a, 3, 3, 1)
+        expected = torch.tensor([
+            [0, 1, 2],
+            [3, 4, 5],
+        ])
+        self.assertTrue(r.equal(expected))
+
+        r = unfold(a, 3, 2, 1)
+        expected = torch.tensor([
+            [0, 1, 2],
+            [2, 3, 4],
+            [4, 5, 6]
+        ])
+        self.assertTrue(r.equal(expected))
+
+        r = unfold(a, 3, 2, 2)
+        expected = torch.tensor([
+            [0, 2, 4],
+            [2, 4, 6],
+        ])
+        self.assertTrue(r.equal(expected))
+
+
+    def test_video_clips(self):
+        with get_list_of_videos(num_videos=3) as video_list:
+            video_clips = VideoClips(video_list, 5, 5)
+            self.assertEqual(video_clips.num_clips(), 1 + 2 + 3)
+            for i, (v_idx, c_idx) in enumerate([(0, 0), (1, 0), (1, 1), (2, 0), (2, 1), (2, 2)]):
+                video_idx, clip_idx = video_clips.get_clip_location(i)
+                self.assertEqual(video_idx, v_idx)
+                self.assertEqual(clip_idx, c_idx)
+
+            video_clips = VideoClips(video_list, 6, 6)
+            self.assertEqual(video_clips.num_clips(), 0 + 1 + 2)
+            for i, (v_idx, c_idx) in enumerate([(1, 0), (2, 0), (2, 1)]):
+                video_idx, clip_idx = video_clips.get_clip_location(i)
+                self.assertEqual(video_idx, v_idx)
+                self.assertEqual(clip_idx, c_idx)
+
+            video_clips = VideoClips(video_list, 6, 1)
+            self.assertEqual(video_clips.num_clips(), 0 + (10 - 6 + 1) + (15 - 6 + 1))
+            for i, v_idx, c_idx in [(0, 1, 0), (4, 1, 4), (5, 2, 0), (6, 2, 1)]:
+                video_idx, clip_idx = video_clips.get_clip_location(i)
+                self.assertEqual(video_idx, v_idx)
+                self.assertEqual(clip_idx, c_idx)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_datasets_video_utils.py
+++ b/test/test_datasets_video_utils.py
@@ -145,5 +145,6 @@ class Tester(unittest.TestCase):
         self.assertTrue(clips.equal(idxs))
         self.assertTrue(idxs.flatten().equal(resampled_idxs))
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -44,7 +44,7 @@ class Tester(unittest.TestCase):
             data = self._create_video_frames(10, 300, 300)
             io.write_video(f.name, data, fps=5)
 
-            pts = io.read_video_timestamps(f.name)
+            pts, _ = io.read_video_timestamps(f.name)
 
             # note: not all formats/codecs provide accurate information for computing the
             # timestamps. For the format that we use here, this information is available,
@@ -63,7 +63,7 @@ class Tester(unittest.TestCase):
             data = self._create_video_frames(10, 300, 300)
             io.write_video(f.name, data, fps=5)
 
-            pts = io.read_video_timestamps(f.name)
+            pts, _ = io.read_video_timestamps(f.name)
 
             for start in range(5):
                 for l in range(1, 4):

--- a/torchvision/datasets/__init__.py
+++ b/torchvision/datasets/__init__.py
@@ -19,6 +19,7 @@ from .celeba import CelebA
 from .sbd import SBDataset
 from .vision import VisionDataset
 from .usps import USPS
+from .kinetics import KineticsVideo
 
 __all__ = ('LSUN', 'LSUNClass',
            'ImageFolder', 'DatasetFolder', 'FakeData',
@@ -28,4 +29,4 @@ __all__ = ('LSUN', 'LSUNClass',
            'Omniglot', 'SBU', 'Flickr8k', 'Flickr30k',
            'VOCSegmentation', 'VOCDetection', 'Cityscapes', 'ImageNet',
            'Caltech101', 'Caltech256', 'CelebA', 'SBDataset', 'VisionDataset',
-           'USPS')
+           'USPS', 'KineticsVideo')

--- a/torchvision/datasets/kinetics.py
+++ b/torchvision/datasets/kinetics.py
@@ -13,7 +13,7 @@ class KineticsVideo(VisionDataset):
         class_to_idx = {classes[i]: i for i in range(len(classes))}
         self.samples = make_dataset(self.root, class_to_idx, extensions, is_valid_file=None)
         self.classes = classes
-        self.class_to_idx = class_to_idx
+        video_list = [x[0] for x in self.samples]
         self.video_clips = VideoClips(video_list, frames_per_clip, step_between_clips)
 
     def __len__(self):

--- a/torchvision/datasets/kinetics.py
+++ b/torchvision/datasets/kinetics.py
@@ -1,0 +1,26 @@
+from .video_utils import VideoClips
+from .utils import list_dir
+from .folder import make_dataset
+from .vision import VisionDataset
+
+
+class KineticsVideo(VisionDataset):
+    def __init__(self, root, frames_per_clip, step_between_clips=1):
+        super(KineticsVideo, self).__init__(root)
+        extensions = ('avi',)
+
+        classes = list(sorted(list_dir(root)))
+        class_to_idx = {classes[i]: i for i in range(len(classes))}
+        self.samples = make_dataset(self.root, class_to_idx, extensions, is_valid_file=None)
+        self.classes = classes
+        self.class_to_idx = class_to_idx
+        self.video_clips = VideoClips(video_list, frames_per_clip, step_between_clips)
+
+    def __len__(self):
+        return self.video_clips.num_clips()
+
+    def __getitem__(self, idx):
+        video, audio, info, video_idx = self.video_clips.get_clip(idx)
+        label = self.samples[video_idx][1]
+
+        return video, audio, label

--- a/torchvision/datasets/video_utils.py
+++ b/torchvision/datasets/video_utils.py
@@ -60,8 +60,8 @@ class VideoClips(object):
         for video_pts in self.video_pts:
             clips = unfold(video_pts, num_frames, step, dilation)
             self.clips.append(clips)
-        l = torch.as_tensor([len(v) for v in self.clips])
-        self.cumulative_sizes = l.cumsum(0).tolist()
+        clip_lengths = torch.as_tensor([len(v) for v in self.clips])
+        self.cumulative_sizes = clip_lengths.cumsum(0).tolist()
 
     def __len__(self):
         return self.num_clips()

--- a/torchvision/datasets/video_utils.py
+++ b/torchvision/datasets/video_utils.py
@@ -118,7 +118,7 @@ class VideoClips(object):
         return video, audio, info, video_idx
 
 
-class RandomMaxVideoClipSampler(torch.utils.data.Sampler):
+class RandomClipSampler(torch.utils.data.Sampler):
     """
     Samples at most `max_video_clips_per_video` clips for each video randomly
 

--- a/torchvision/datasets/video_utils.py
+++ b/torchvision/datasets/video_utils.py
@@ -1,0 +1,110 @@
+import bisect
+import torch
+from torchvision.io import read_video_timestamps, read_video
+
+
+def unfold(tensor, size, step, dilation):
+    """
+    similar to tensor.unfold, but with the dilation
+    and specialized for 1d tensors
+    """
+    assert tensor.dim() == 1
+    o_stride = tensor.stride(0)
+    numel = tensor.numel()
+    new_stride = (step * o_stride, dilation * o_stride)
+    new_size = ((numel - (dilation * (size - 1) + 1)) // step + 1, size)
+    if new_size[0] < 1:
+        new_size = (0, size)
+    return torch.as_strided(tensor, new_size, new_stride)
+
+
+class VideoClips(object):
+    """
+    Given a list of video files, computes all consecutive subvideos of size
+    `clip_length_in_frames`, where the distance between each subvideo in the
+    same video is defined by `frames_between_clips`.
+
+    Creating this instance the first time is time-consuming, as it needs to
+    decode all the videos in `video_paths`. It is recommended that you
+    cache the results after instantiation of the class.
+
+    Recreating the clips for different clip lengths is fast, and can be done
+    with the `compute_clips` method.
+    """
+    def __init__(self, video_paths, clip_length_in_frames=16, frames_between_clips=1):
+        self.video_paths = video_paths
+        self._compute_frame_pts()
+        self.compute_clips(clip_length_in_frames, frames_between_clips)
+
+    def _compute_frame_pts(self):
+        self.video_pts = []
+        # TODO maybe paralellize this
+        for video_file in self.video_paths:
+            clips = read_video_timestamps(video_file)
+            self.video_pts.append(torch.as_tensor(clips))
+
+    def compute_clips(self, num_frames, step, dilation=1):
+        """
+        Compute all consecutive sequences of clips from video_pts.
+
+        Arguments:
+            num_frames (int): number of frames for the clip
+            step (int): distance between two clips
+            dilation (int): distance between two consecutive frames
+                in a clip
+        """
+        self.num_frames = num_frames
+        self.step = step
+        self.dilation = dilation
+        self.clips = []
+        for video_pts in self.video_pts:
+            clips = unfold(video_pts, num_frames, step, dilation)
+            self.clips.append(clips)
+        l = torch.as_tensor([len(v) for v in self.clips])
+        self.cumulative_sizes = l.cumsum(0).tolist()
+
+    def __len__(self):
+        return self.num_clips()
+
+    def num_videos(self):
+        return len(self.video_paths)
+
+    def num_clips(self):
+        """
+        Number of subclips that are available in the video list.
+        """
+        return self.cumulative_sizes[-1]
+
+    def get_clip_location(self, idx):
+        """
+        Converts a flattened representation of the indices into a video_idx, clip_idx
+        representation.
+        """
+        video_idx = bisect.bisect_right(self.cumulative_sizes, idx)
+        if video_idx == 0:
+            clip_idx = idx
+        else:
+            clip_idx = idx - self.cumulative_sizes[video_idx - 1]
+        return video_idx, clip_idx
+
+    def get_clip(self, idx):
+        """
+        Gets a subclip from a list of videos.
+
+        Arguments:
+            idx (int): index of the subclip. Must be between 0 and num_clips().
+
+        Returns:
+            video (Tensor)
+            audio (Tensor)
+            info (Dict)
+            video_idx (int): index of the video in `video_paths`
+        """
+        video_idx, clip_idx = self.get_clip_location(idx)
+        video_path = self.video_paths[video_idx]
+        clip_pts = self.clips[video_idx][clip_idx]
+        video, audio, info = read_video(video_path, clip_pts[0].item(), clip_pts[-1].item())
+        video = video[::self.dilation]
+        # TODO change video_fps in info?
+        assert len(video) == self.num_frames
+        return video, audio, info, video_idx

--- a/torchvision/datasets/video_utils.py
+++ b/torchvision/datasets/video_utils.py
@@ -126,7 +126,7 @@ class VideoClips(object):
 
     @staticmethod
     def _resample_video_idx(num_frames, original_fps, new_fps):
-        step = original_fps / new_fps
+        step = float(original_fps) / new_fps
         if step.is_integer():
             # optimization: if step is integer, don't need to perform
             # advanced indexing

--- a/torchvision/datasets/video_utils.py
+++ b/torchvision/datasets/video_utils.py
@@ -64,6 +64,8 @@ class VideoClips(object):
     def compute_clips(self, num_frames, step, frame_rate=None):
         """
         Compute all consecutive sequences of clips from video_pts.
+        Always returns clips of size `num_frames`, meaning that the
+        last few frames in a video can potentially be dropped.
 
         Arguments:
             num_frames (int): number of frames for the clip

--- a/torchvision/io/video.py
+++ b/torchvision/io/video.py
@@ -159,13 +159,16 @@ def read_video_timestamps(filename):
     Returns:
         pts (List[int]): presentation timestamps for each one of the frames
             in the video.
+        video_fps (int): the frame rate for the video
     """
     _check_av_available()
     container = av.open(filename)
 
     video_frames = []
+    video_fps = None
     if container.streams.video:
         video_frames = _read_from_stream(container, 0, float("inf"),
                                          container.streams.video[0], {'video': 0})
+        video_fps = float(container.streams.video[0].average_rate)
     container.close()
-    return [x.pts for x in video_frames]
+    return [x.pts for x in video_frames], video_fps


### PR DESCRIPTION
This PR adds functionalities to simplify build video datasets.

The main addition is the `VideoClips` class.
From a list of videos, `VideoClips` computes all the possible sub-videos (or clips) which are consecutive and contiguous, and enables to select from a particular clip easily.
This is made possible via `unfold`, which do some stride tricks on a tensor so that we can have all possible subsequences of a list without duplicating memory, and is very efficient.

As an example on how it should be used, I've written a basic `KineticsVideo` (better names welcome) illustrating how `VideoClips` can be used.

I need to add tests for `KineticsVideo` and improve the documentation overall, but this is a first version to get some feedback.

cc @bjuncek @stephenyan1231 for review