### PR TITLE
Changed an initialization of avg_pool2d Functional to use lambda

### DIFF
--- a/torchvision/csrc/models/densenet.cpp
+++ b/torchvision/csrc/models/densenet.cpp
@@ -77,7 +77,7 @@ struct _TransitionImpl : torch::nn::SequentialImpl {
                               .stride(1)
                               .with_bias(false)));
     push_back(
-        "pool", torch::nn::Functional(torch::avg_pool2d, 2, 2, 0, false, true));
+        "pool", torch::nn::Functional([](torch::Tensor input) { return torch::avg_pool2d(input, 2, 2, 0, false, true); }));
   }
 
   torch::Tensor forward(torch::Tensor x) {


### PR DESCRIPTION
We plan to change avg_pool2d and add extra optional parameter to the signature of the method.
Currently torch::nn::Functional does not support this, if you will initialize it in regular way. Instead of torch::nn::Functional(func, arg1, arg2, ...), we should write torch::nn::Functional([](torch::Tensor input){return func(input, arg1, arg2, ...); }

In the future, regular initialization will be deprecated and instead lambda will be used. This will be a separate PR.