### PR TITLE
fix transform for rcnns so original images list is unchanged

### DIFF
--- a/torchvision/models/detection/transform.py
+++ b/torchvision/models/detection/transform.py
@@ -39,7 +39,6 @@ class GeneralizedRCNNTransform(nn.Module):
                                  "of shape [C, H, W], got {}".format(image.shape))
             image = self.normalize(image)
             image, target = self.resize(image, target)
-            transformed_images.append(image)
             if targets is not None:
                 targets[i] = target
 

--- a/torchvision/models/detection/transform.py
+++ b/torchvision/models/detection/transform.py
@@ -30,9 +30,9 @@ class GeneralizedRCNNTransform(nn.Module):
         self.image_std = image_std
 
     def forward(self, images, targets=None):
-        transformed_images = []
+        images = images[:]
         for i in range(len(images)):
-            image = images[i].clone()
+            image = images[i]
             target = targets[i] if targets is not None else targets
             if image.dim() != 3:
                 raise ValueError("images is expected to be a list of 3d tensors "
@@ -42,7 +42,7 @@ class GeneralizedRCNNTransform(nn.Module):
             transformed_images.append(image)
             if targets is not None:
                 targets[i] = target
-        images = transformed_images
+
         image_sizes = [img.shape[-2:] for img in images]
         images = self.batch_images(images)
         image_list = ImageList(images, image_sizes)

--- a/torchvision/models/detection/transform.py
+++ b/torchvision/models/detection/transform.py
@@ -39,6 +39,7 @@ class GeneralizedRCNNTransform(nn.Module):
                                  "of shape [C, H, W], got {}".format(image.shape))
             image = self.normalize(image)
             image, target = self.resize(image, target)
+            images[i] = image
             if targets is not None:
                 targets[i] = target
 

--- a/torchvision/models/detection/transform.py
+++ b/torchvision/models/detection/transform.py
@@ -30,17 +30,19 @@ class GeneralizedRCNNTransform(nn.Module):
         self.image_std = image_std
 
     def forward(self, images, targets=None):
+        transformed_images = []
         for i in range(len(images)):
-            image = images[i]
+            image = images[i].clone()
             target = targets[i] if targets is not None else targets
             if image.dim() != 3:
                 raise ValueError("images is expected to be a list of 3d tensors "
                                  "of shape [C, H, W], got {}".format(image.shape))
             image = self.normalize(image)
             image, target = self.resize(image, target)
-            images[i] = image
+            transformed_images.append(image)
             if targets is not None:
                 targets[i] = target
+        images = transformed_images
         image_sizes = [img.shape[-2:] for img in images]
         images = self.batch_images(images)
         image_list = ImageList(images, image_sizes)


### PR DESCRIPTION
Maskrcnn or fastrcnn pass input image list into the transform module in torchvision/models/detection/transform.py. However, the method modifies content in the list where transformed images are pasted back to corresponding entries of the input list.  

As a result, user may meet unintended behavior when they hold reference to the original input list outside the maskrcnn call. The proposed change leave user input image list to the maskrcnn call unchanged.