### PR TITLE
Use Tensor.clamp_() instead of torch::clamp_().

### DIFF
--- a/torchvision/csrc/models/modelsimpl.h
+++ b/torchvision/csrc/models/modelsimpl.h
@@ -15,7 +15,7 @@ inline torch::Tensor& relu_(torch::Tensor x) {
 }
 
 inline torch::Tensor relu6_(torch::Tensor x) {
-  return torch::clamp_(x, 0, 6);
+  return x.clamp_(0, 6);
 }
 
 inline torch::Tensor adaptive_avg_pool2d(


### PR DESCRIPTION
In-place operators should only have method variant. Update here in
preparation of future PyTorch change. For example see
https://github.com/pytorch/pytorch/issues/22707