### PR TITLE
update detection transformation to allow tensor input

### DIFF
--- a/torchvision/models/detection/transform.py
+++ b/torchvision/models/detection/transform.py
@@ -30,7 +30,7 @@ class GeneralizedRCNNTransform(nn.Module):
         self.image_std = image_std
 
     def forward(self, images, targets=None):
-        images = images[:]
+        images = [img for img in images]
         for i in range(len(images)):
             image = images[i]
             target = targets[i] if targets is not None else targets


### PR DESCRIPTION
Though official document says the rcnns accepts a list of images. But it also makes sense to accept a batched tensor directly. The change eliminates bugs triggered when passing in tensor