### PR TITLE
Update max size to ensure divisible by 64 after rescaling

### DIFF
--- a/torchvision/models/detection/mask_rcnn.py
+++ b/torchvision/models/detection/mask_rcnn.py
@@ -150,7 +150,7 @@ class MaskRCNN(FasterRCNN):
     """
     def __init__(self, backbone, num_classes=None,
                  # transform parameters
-                 min_size=800, max_size=1333,
+                 min_size=800, max_size=1312,
                  image_mean=None, image_std=None,
                  # RPN parameters
                  rpn_anchor_generator=None, rpn_head=None,

--- a/torchvision/models/detection/mask_rcnn.py
+++ b/torchvision/models/detection/mask_rcnn.py
@@ -150,7 +150,7 @@ class MaskRCNN(FasterRCNN):
     """
     def __init__(self, backbone, num_classes=None,
                  # transform parameters
-                 min_size=800, max_size=1312,
+                 min_size=800, max_size=1344,
                  image_mean=None, image_std=None,
                  # RPN parameters
                  rpn_anchor_generator=None, rpn_head=None,


### PR DESCRIPTION
In maskrcnn with fpn, image size must be divisible by 64 to be consistent for FPN. The proposed change will use rescaling to 1344 instead of original 1333 so we can achieve best performance. Should we also add a warning message to remind users the divisible rule? 