### PR TITLE
Update usps.py

### DIFF
--- a/torchvision/datasets/usps.py
+++ b/torchvision/datasets/usps.py
@@ -9,7 +9,7 @@ from .vision import VisionDataset
 
 class USPS(VisionDataset):
     """`USPS <https://www.csie.ntu.edu.tw/~cjlin/libsvmtools/datasets/multiclass.html#usps>`_ Dataset.
-    The data-format is : [label [index:value ]*256 \n] * num_lines, where ``label`` lies in ``[1, 10]``.
+    The data-format is : [label [index:value ]*256 \\n] * num_lines, where ``label`` lies in ``[1, 10]``.
     The value for each pixel lies in ``[-1, 1]``. Here we transform the ``label`` into ``[0, 9]``
     and make pixel values in ``[0, 255]``.
 


### PR DESCRIPTION
The backslash should be escaped. Currently, [it](https://pytorch.org/docs/master/torchvision/datasets.html#usps) looks bad: