### PR TITLE
Always pass transform and target_transform to abstract dataset

### DIFF
--- a/torchvision/datasets/caltech.py
+++ b/torchvision/datasets/caltech.py
@@ -28,9 +28,8 @@ class Caltech101(VisionDataset):
 
     def __init__(self, root, target_type="category", transforms=None, transform=None,
                  target_transform=None, download=False):
-        super(Caltech101, self).__init__(os.path.join(root, 'caltech101'),
-                                         transforms=transforms, transform=transform,
-                                         target_transform=target_transform)
+        super(Caltech101, self).__init__(os.path.join(root, 'caltech101'), transforms,
+                                         transform, target_transform)
         makedir_exist_ok(self.root)
         if isinstance(target_type, list):
             self.target_type = target_type
@@ -142,13 +141,11 @@ class Caltech256(VisionDataset):
             downloaded again.
     """
 
-    def __init__(self, root,
-                 transform=None, target_transform=None,
+    def __init__(self, root, transforms=None, transform=None, target_transform=None,
                  download=False):
-        super(Caltech256, self).__init__(os.path.join(root, 'caltech256'))
+        super(Caltech256, self).__init__(os.path.join(root, 'caltech256'), transforms,
+                                         transform, target_transform)
         makedir_exist_ok(self.root)
-        self.transform = transform
-        self.target_transform = target_transform
 
         if download:
             self.download()

--- a/torchvision/datasets/caltech.py
+++ b/torchvision/datasets/caltech.py
@@ -28,8 +28,9 @@ class Caltech101(VisionDataset):
 
     def __init__(self, root, target_type="category", transform=None,
                  target_transform=None, download=False):
-        super(Caltech101, self).__init__(os.path.join(root, 'caltech101'), transforms,
-                                         transform, target_transform)
+        super(Caltech101, self).__init__(os.path.join(root, 'caltech101'),
+                                         transform=transform,
+                                         target_transform=target_transform)
         makedir_exist_ok(self.root)
         if isinstance(target_type, list):
             self.target_type = target_type

--- a/torchvision/datasets/caltech.py
+++ b/torchvision/datasets/caltech.py
@@ -26,17 +26,16 @@ class Caltech101(VisionDataset):
             downloaded again.
     """
 
-    def __init__(self, root, target_type="category",
-                 transform=None, target_transform=None,
-                 download=False):
-        super(Caltech101, self).__init__(os.path.join(root, 'caltech101'))
+    def __init__(self, root, target_type="category", transforms=None, transform=None,
+                 target_transform=None, download=False):
+        super(Caltech101, self).__init__(os.path.join(root, 'caltech101'),
+                                         transforms=transforms, transform=transform,
+                                         target_transform=target_transform)
         makedir_exist_ok(self.root)
         if isinstance(target_type, list):
             self.target_type = target_type
         else:
             self.target_type = [target_type]
-        self.transform = transform
-        self.target_transform = target_transform
 
         if download:
             self.download()

--- a/torchvision/datasets/caltech.py
+++ b/torchvision/datasets/caltech.py
@@ -27,7 +27,7 @@ class Caltech101(VisionDataset):
     """
 
     def __init__(self, root, target_type="category", transform=None,
-                 target_transform=None, transforms=None, download=False):
+                 target_transform=None, download=False):
         super(Caltech101, self).__init__(os.path.join(root, 'caltech101'), transforms,
                                          transform, target_transform)
         makedir_exist_ok(self.root)

--- a/torchvision/datasets/caltech.py
+++ b/torchvision/datasets/caltech.py
@@ -26,8 +26,8 @@ class Caltech101(VisionDataset):
             downloaded again.
     """
 
-    def __init__(self, root, target_type="category", transforms=None, transform=None,
-                 target_transform=None, download=False):
+    def __init__(self, root, target_type="category", transform=None,
+                 target_transform=None, transforms=None, download=False):
         super(Caltech101, self).__init__(os.path.join(root, 'caltech101'), transforms,
                                          transform, target_transform)
         makedir_exist_ok(self.root)
@@ -141,7 +141,7 @@ class Caltech256(VisionDataset):
             downloaded again.
     """
 
-    def __init__(self, root, transforms=None, transform=None, target_transform=None,
+    def __init__(self, root, transform=None, target_transform=None, transforms=None,
                  download=False):
         super(Caltech256, self).__init__(os.path.join(root, 'caltech256'), transforms,
                                          transform, target_transform)

--- a/torchvision/datasets/caltech.py
+++ b/torchvision/datasets/caltech.py
@@ -142,10 +142,10 @@ class Caltech256(VisionDataset):
             downloaded again.
     """
 
-    def __init__(self, root, transform=None, target_transform=None, transforms=None,
-                 download=False):
-        super(Caltech256, self).__init__(os.path.join(root, 'caltech256'), transforms,
-                                         transform, target_transform)
+    def __init__(self, root, transform=None, target_transform=None, download=False):
+        super(Caltech256, self).__init__(os.path.join(root, 'caltech256'),
+                                         transform=transform,
+                                         target_transform=target_transform)
         makedir_exist_ok(self.root)
 
         if download:

--- a/torchvision/datasets/celeba.py
+++ b/torchvision/datasets/celeba.py
@@ -49,7 +49,7 @@ class CelebA(VisionDataset):
     ]
 
     def __init__(self, root, split="train", target_type="attr", transform=None,
-                 target_transform=None, transforms=None, download=False):
+                 target_transform=None, download=False):
         import pandas
         super(CelebA, self).__init__(root, transforms, transform, target_transform)
         self.split = split

--- a/torchvision/datasets/celeba.py
+++ b/torchvision/datasets/celeba.py
@@ -48,20 +48,16 @@ class CelebA(VisionDataset):
         ("0B7EVK8r0v71pY0NSMzRuSXJEVkk", "d32c9cbf5e040fd4025c592c306e6668", "list_eval_partition.txt"),
     ]
 
-    def __init__(self, root,
-                 split="train",
-                 target_type="attr",
-                 transform=None, target_transform=None,
-                 download=False):
+    def __init__(self, root, split="train", target_type="attr", transforms=None,
+                 transform=None, target_transform=None, download=False):
         import pandas
-        super(CelebA, self).__init__(root)
+        super(CelebA, self).__init__(root, transforms=transforms, transform=transform,
+                                     target_transform=target_transform)
         self.split = split
         if isinstance(target_type, list):
             self.target_type = target_type
         else:
             self.target_type = [target_type]
-        self.transform = transform
-        self.target_transform = target_transform
 
         if download:
             self.download()
@@ -69,9 +65,6 @@ class CelebA(VisionDataset):
         if not self._check_integrity():
             raise RuntimeError('Dataset not found or corrupted.' +
                                ' You can use download=True to download it')
-
-        self.transform = transform
-        self.target_transform = target_transform
 
         if split.lower() == "train":
             split = 0

--- a/torchvision/datasets/celeba.py
+++ b/torchvision/datasets/celeba.py
@@ -51,8 +51,7 @@ class CelebA(VisionDataset):
     def __init__(self, root, split="train", target_type="attr", transforms=None,
                  transform=None, target_transform=None, download=False):
         import pandas
-        super(CelebA, self).__init__(root, transforms=transforms, transform=transform,
-                                     target_transform=target_transform)
+        super(CelebA, self).__init__(root, transforms, transform, target_transform)
         self.split = split
         if isinstance(target_type, list):
             self.target_type = target_type

--- a/torchvision/datasets/celeba.py
+++ b/torchvision/datasets/celeba.py
@@ -51,7 +51,8 @@ class CelebA(VisionDataset):
     def __init__(self, root, split="train", target_type="attr", transform=None,
                  target_transform=None, download=False):
         import pandas
-        super(CelebA, self).__init__(root, transforms, transform, target_transform)
+        super(CelebA, self).__init__(root, transform=transform,
+                                     target_transform=target_transform)
         self.split = split
         if isinstance(target_type, list):
             self.target_type = target_type

--- a/torchvision/datasets/celeba.py
+++ b/torchvision/datasets/celeba.py
@@ -48,8 +48,8 @@ class CelebA(VisionDataset):
         ("0B7EVK8r0v71pY0NSMzRuSXJEVkk", "d32c9cbf5e040fd4025c592c306e6668", "list_eval_partition.txt"),
     ]
 
-    def __init__(self, root, split="train", target_type="attr", transforms=None,
-                 transform=None, target_transform=None, download=False):
+    def __init__(self, root, split="train", target_type="attr", transform=None,
+                 target_transform=None, transforms=None, download=False):
         import pandas
         super(CelebA, self).__init__(root, transforms, transform, target_transform)
         self.split = split

--- a/torchvision/datasets/cifar.py
+++ b/torchvision/datasets/cifar.py
@@ -52,8 +52,8 @@ class CIFAR10(VisionDataset):
         'md5': '5ff9c542aee3614f3951f8cda6e48888',
     }
 
-    def __init__(self, root, train=True, transforms=None, transform=None,
-                 target_transform=None, download=False):
+    def __init__(self, root, train=True, transform=None, target_transform=None,
+                 transforms=None, download=False):
 
         super(CIFAR10, self).__init__(root, transforms, transform, target_transform)
 

--- a/torchvision/datasets/cifar.py
+++ b/torchvision/datasets/cifar.py
@@ -52,13 +52,11 @@ class CIFAR10(VisionDataset):
         'md5': '5ff9c542aee3614f3951f8cda6e48888',
     }
 
-    def __init__(self, root, train=True,
-                 transform=None, target_transform=None,
-                 download=False):
+    def __init__(self, root, train=True, transforms=None, transform=None,
+                 target_transform=None, download=False):
 
-        super(CIFAR10, self).__init__(root)
-        self.transform = transform
-        self.target_transform = target_transform
+        super(CIFAR10, self).__init__(root, transforms=transforms, transform=transform,
+                                      target_transform=target_transform)
 
         self.train = train  # training set or test set
 

--- a/torchvision/datasets/cifar.py
+++ b/torchvision/datasets/cifar.py
@@ -55,8 +55,7 @@ class CIFAR10(VisionDataset):
     def __init__(self, root, train=True, transforms=None, transform=None,
                  target_transform=None, download=False):
 
-        super(CIFAR10, self).__init__(root, transforms=transforms, transform=transform,
-                                      target_transform=target_transform)
+        super(CIFAR10, self).__init__(root, transforms, transform, target_transform)
 
         self.train = train  # training set or test set
 

--- a/torchvision/datasets/cifar.py
+++ b/torchvision/datasets/cifar.py
@@ -53,7 +53,7 @@ class CIFAR10(VisionDataset):
     }
 
     def __init__(self, root, train=True, transform=None, target_transform=None,
-                 transforms=None, download=False):
+                 download=False):
 
         super(CIFAR10, self).__init__(root, transforms, transform, target_transform)
 

--- a/torchvision/datasets/cifar.py
+++ b/torchvision/datasets/cifar.py
@@ -55,7 +55,8 @@ class CIFAR10(VisionDataset):
     def __init__(self, root, train=True, transform=None, target_transform=None,
                  download=False):
 
-        super(CIFAR10, self).__init__(root, transforms, transform, target_transform)
+        super(CIFAR10, self).__init__(root, transform=transform,
+                                      target_transform=target_transform)
 
         self.train = train  # training set or test set
 

--- a/torchvision/datasets/fakedata.py
+++ b/torchvision/datasets/fakedata.py
@@ -20,8 +20,7 @@ class FakeData(VisionDataset):
     """
 
     def __init__(self, size=1000, image_size=(3, 224, 224), num_classes=10,
-                 transform=None, target_transform=None, transforms=None,
-                 random_offset=0):
+                 transform=None, target_transform=None, random_offset=0):
         super(FakeData, self).__init__(None, transforms, transform, target_transform)
         self.size = size
         self.num_classes = num_classes

--- a/torchvision/datasets/fakedata.py
+++ b/torchvision/datasets/fakedata.py
@@ -20,8 +20,9 @@ class FakeData(VisionDataset):
     """
 
     def __init__(self, size=1000, image_size=(3, 224, 224), num_classes=10,
-                 transform=None, target_transform=None, random_offset=0):
-        super(FakeData, self).__init__(None, transform=transform,
+                 transforms=None, transform=None, target_transform=None,
+                 random_offset=0):
+        super(FakeData, self).__init__(None, transforms=transforms, transform=transform,
                                        target_transform=target_transform)
         self.size = size
         self.num_classes = num_classes

--- a/torchvision/datasets/fakedata.py
+++ b/torchvision/datasets/fakedata.py
@@ -22,8 +22,7 @@ class FakeData(VisionDataset):
     def __init__(self, size=1000, image_size=(3, 224, 224), num_classes=10,
                  transforms=None, transform=None, target_transform=None,
                  random_offset=0):
-        super(FakeData, self).__init__(None, transforms=transforms, transform=transform,
-                                       target_transform=target_transform)
+        super(FakeData, self).__init__(None, transforms, transform, target_transform)
         self.size = size
         self.num_classes = num_classes
         self.image_size = image_size

--- a/torchvision/datasets/fakedata.py
+++ b/torchvision/datasets/fakedata.py
@@ -20,7 +20,7 @@ class FakeData(VisionDataset):
     """
 
     def __init__(self, size=1000, image_size=(3, 224, 224), num_classes=10,
-                 transforms=None, transform=None, target_transform=None,
+                 transform=None, target_transform=None, transforms=None,
                  random_offset=0):
         super(FakeData, self).__init__(None, transforms, transform, target_transform)
         self.size = size

--- a/torchvision/datasets/fakedata.py
+++ b/torchvision/datasets/fakedata.py
@@ -21,7 +21,8 @@ class FakeData(VisionDataset):
 
     def __init__(self, size=1000, image_size=(3, 224, 224), num_classes=10,
                  transform=None, target_transform=None, random_offset=0):
-        super(FakeData, self).__init__(None, transforms, transform, target_transform)
+        super(FakeData, self).__init__(None, transform=transform,
+                                       target_transform=target_transform)
         self.size = size
         self.num_classes = num_classes
         self.image_size = image_size

--- a/torchvision/datasets/flickr.py
+++ b/torchvision/datasets/flickr.py
@@ -63,7 +63,8 @@ class Flickr8k(VisionDataset):
     """
 
     def __init__(self, root, ann_file, transform=None, target_transform=None):
-        super(Flickr8k, self).__init__(root, transforms, transform, target_transform)
+        super(Flickr8k, self).__init__(root, transform=transform,
+                                       target_transform=target_transform)
         self.ann_file = os.path.expanduser(ann_file)
 
         # Read annotations and store in a dict
@@ -113,7 +114,8 @@ class Flickr30k(VisionDataset):
     """
 
     def __init__(self, root, ann_file, transform=None, target_transform=None):
-        super(Flickr30k, self).__init__(root, transforms, transform, target_transform)
+        super(Flickr30k, self).__init__(root, transform=transform,
+                                        target_transform=target_transform)
         self.ann_file = os.path.expanduser(ann_file)
 
         # Read annotations and store in a dict

--- a/torchvision/datasets/flickr.py
+++ b/torchvision/datasets/flickr.py
@@ -62,10 +62,10 @@ class Flickr8k(VisionDataset):
             target and transforms it.
     """
 
-    def __init__(self, root, ann_file, transform=None, target_transform=None):
-        super(Flickr8k, self).__init__(root)
-        self.transform = transform
-        self.target_transform = target_transform
+    def __init__(self, root, ann_file, transforms=None, transform=None,
+                 target_transform=None):
+        super(Flickr8k, self).__init__(root, transforms=transforms, transform=transform,
+                                       target_transform=target_transform)
         self.ann_file = os.path.expanduser(ann_file)
 
         # Read annotations and store in a dict
@@ -114,10 +114,11 @@ class Flickr30k(VisionDataset):
             target and transforms it.
     """
 
-    def __init__(self, root, ann_file, transform=None, target_transform=None):
-        super(Flickr30k, self).__init__(root)
-        self.transform = transform
-        self.target_transform = target_transform
+    def __init__(self, root, ann_file, transforms=None, transform=None,
+                 target_transform=None):
+        super(Flickr30k, self).__init__(root, transforms=transforms,
+                                        transform=transform,
+                                        target_transform=target_transform)
         self.ann_file = os.path.expanduser(ann_file)
 
         # Read annotations and store in a dict

--- a/torchvision/datasets/flickr.py
+++ b/torchvision/datasets/flickr.py
@@ -62,8 +62,7 @@ class Flickr8k(VisionDataset):
             target and transforms it.
     """
 
-    def __init__(self, root, ann_file, transform=None, target_transform=None,
-                 transforms=None):
+    def __init__(self, root, ann_file, transform=None, target_transform=None):
         super(Flickr8k, self).__init__(root, transforms, transform, target_transform)
         self.ann_file = os.path.expanduser(ann_file)
 
@@ -113,8 +112,7 @@ class Flickr30k(VisionDataset):
             target and transforms it.
     """
 
-    def __init__(self, root, ann_file, transforms=None, transform=None,
-                 target_transform=None):
+    def __init__(self, root, ann_file, transform=None, target_transform=None):
         super(Flickr30k, self).__init__(root, transforms, transform, target_transform)
         self.ann_file = os.path.expanduser(ann_file)
 

--- a/torchvision/datasets/flickr.py
+++ b/torchvision/datasets/flickr.py
@@ -64,8 +64,7 @@ class Flickr8k(VisionDataset):
 
     def __init__(self, root, ann_file, transforms=None, transform=None,
                  target_transform=None):
-        super(Flickr8k, self).__init__(root, transforms=transforms, transform=transform,
-                                       target_transform=target_transform)
+        super(Flickr8k, self).__init__(root, transforms, transform, target_transform)
         self.ann_file = os.path.expanduser(ann_file)
 
         # Read annotations and store in a dict
@@ -116,9 +115,7 @@ class Flickr30k(VisionDataset):
 
     def __init__(self, root, ann_file, transforms=None, transform=None,
                  target_transform=None):
-        super(Flickr30k, self).__init__(root, transforms=transforms,
-                                        transform=transform,
-                                        target_transform=target_transform)
+        super(Flickr30k, self).__init__(root, transforms, transform, target_transform)
         self.ann_file = os.path.expanduser(ann_file)
 
         # Read annotations and store in a dict

--- a/torchvision/datasets/flickr.py
+++ b/torchvision/datasets/flickr.py
@@ -62,8 +62,8 @@ class Flickr8k(VisionDataset):
             target and transforms it.
     """
 
-    def __init__(self, root, ann_file, transforms=None, transform=None,
-                 target_transform=None):
+    def __init__(self, root, ann_file, transform=None, target_transform=None,
+                 transforms=None):
         super(Flickr8k, self).__init__(root, transforms, transform, target_transform)
         self.ann_file = os.path.expanduser(ann_file)
 

--- a/torchvision/datasets/folder.py
+++ b/torchvision/datasets/folder.py
@@ -87,7 +87,7 @@ class DatasetFolder(VisionDataset):
     """
 
     def __init__(self, root, loader, extensions=None, transform=None,
-                 target_transform=None, transforms=None, is_valid_file=None):
+                 target_transform=None, is_valid_file=None):
         super(DatasetFolder, self).__init__(root, transforms, transform,
                                             target_transform)
         classes, class_to_idx = self._find_classes(self.root)
@@ -201,10 +201,9 @@ class ImageFolder(DatasetFolder):
         imgs (list): List of (image path, class_index) tuples
     """
 
-    def __init__(self, root, transform=None, target_transform=None, transforms=None,
+    def __init__(self, root, transform=None, target_transform=None,
                  loader=default_loader, is_valid_file=None):
         super(ImageFolder, self).__init__(root, loader, IMG_EXTENSIONS if is_valid_file is None else None,
-                                          transforms=transforms,
                                           transform=transform,
                                           target_transform=target_transform,
                                           is_valid_file=is_valid_file)

--- a/torchvision/datasets/folder.py
+++ b/torchvision/datasets/folder.py
@@ -88,9 +88,8 @@ class DatasetFolder(VisionDataset):
 
     def __init__(self, root, loader, extensions=None, transforms=None,
                  transform=None, target_transform=None, is_valid_file=None):
-        super(DatasetFolder, self).__init__(root, transforms=transforms,
-                                            transform=transform,
-                                            target_transform=target_transform)
+        super(DatasetFolder, self).__init__(root, transforms, transform,
+                                            target_transform)
         classes, class_to_idx = self._find_classes(self.root)
         samples = make_dataset(self.root, class_to_idx, extensions, is_valid_file)
         if len(samples) == 0:

--- a/torchvision/datasets/folder.py
+++ b/torchvision/datasets/folder.py
@@ -88,8 +88,8 @@ class DatasetFolder(VisionDataset):
 
     def __init__(self, root, loader, extensions=None, transform=None,
                  target_transform=None, is_valid_file=None):
-        super(DatasetFolder, self).__init__(root, transforms, transform,
-                                            target_transform)
+        super(DatasetFolder, self).__init__(root, transform=transform,
+                                            target_transform=target_transform)
         classes, class_to_idx = self._find_classes(self.root)
         samples = make_dataset(self.root, class_to_idx, extensions, is_valid_file)
         if len(samples) == 0:

--- a/torchvision/datasets/folder.py
+++ b/torchvision/datasets/folder.py
@@ -86,8 +86,8 @@ class DatasetFolder(VisionDataset):
         targets (list): The class_index value for each image in the dataset
     """
 
-    def __init__(self, root, loader, extensions=None, transforms=None,
-                 transform=None, target_transform=None, is_valid_file=None):
+    def __init__(self, root, loader, extensions=None, transform=None,
+                 target_transform=None, transforms=None, is_valid_file=None):
         super(DatasetFolder, self).__init__(root, transforms, transform,
                                             target_transform)
         classes, class_to_idx = self._find_classes(self.root)
@@ -201,7 +201,7 @@ class ImageFolder(DatasetFolder):
         imgs (list): List of (image path, class_index) tuples
     """
 
-    def __init__(self, root, transforms=None, transform=None, target_transform=None,
+    def __init__(self, root, transform=None, target_transform=None, transforms=None,
                  loader=default_loader, is_valid_file=None):
         super(ImageFolder, self).__init__(root, loader, IMG_EXTENSIONS if is_valid_file is None else None,
                                           transforms=transforms,

--- a/torchvision/datasets/folder.py
+++ b/torchvision/datasets/folder.py
@@ -86,10 +86,11 @@ class DatasetFolder(VisionDataset):
         targets (list): The class_index value for each image in the dataset
     """
 
-    def __init__(self, root, loader, extensions=None, transform=None, target_transform=None, is_valid_file=None):
-        super(DatasetFolder, self).__init__(root)
-        self.transform = transform
-        self.target_transform = target_transform
+    def __init__(self, root, loader, extensions=None, transforms=None,
+                 transform=None, target_transform=None, is_valid_file=None):
+        super(DatasetFolder, self).__init__(root, transforms=transforms,
+                                            transform=transform,
+                                            target_transform=target_transform)
         classes, class_to_idx = self._find_classes(self.root)
         samples = make_dataset(self.root, class_to_idx, extensions, is_valid_file)
         if len(samples) == 0:
@@ -201,9 +202,10 @@ class ImageFolder(DatasetFolder):
         imgs (list): List of (image path, class_index) tuples
     """
 
-    def __init__(self, root, transform=None, target_transform=None,
+    def __init__(self, root, transforms=None, transform=None, target_transform=None,
                  loader=default_loader, is_valid_file=None):
         super(ImageFolder, self).__init__(root, loader, IMG_EXTENSIONS if is_valid_file is None else None,
+                                          transforms=transforms,
                                           transform=transform,
                                           target_transform=target_transform,
                                           is_valid_file=is_valid_file)

--- a/torchvision/datasets/lsun.py
+++ b/torchvision/datasets/lsun.py
@@ -69,7 +69,8 @@ class LSUN(VisionDataset):
     """
 
     def __init__(self, root, classes='train', transform=None, target_transform=None):
-        super(LSUN, self).__init__(root, transforms, transform, target_transform)
+        super(LSUN, self).__init__(root, transform=transform,
+                                   target_transform=target_transform)
         categories = ['bedroom', 'bridge', 'church_outdoor', 'classroom',
                       'conference_room', 'dining_room', 'kitchen',
                       'living_room', 'restaurant', 'tower']

--- a/torchvision/datasets/lsun.py
+++ b/torchvision/datasets/lsun.py
@@ -15,8 +15,7 @@ else:
 class LSUNClass(VisionDataset):
     def __init__(self, root, transform=None, target_transform=None):
         import lmdb
-        super(LSUNClass, self).__init__(root, transforms=transforms,
-                                        transform=transform,
+        super(LSUNClass, self).__init__(root, transform=transform,
                                         target_transform=target_transform)
 
         self.env = lmdb.open(root, max_readers=1, readonly=True, lock=False,

--- a/torchvision/datasets/lsun.py
+++ b/torchvision/datasets/lsun.py
@@ -68,8 +68,8 @@ class LSUN(VisionDataset):
             target and transforms it.
     """
 
-    def __init__(self, root, classes='train', transforms=None, transform=None,
-                 target_transform=None):
+    def __init__(self, root, classes='train', transform=None, target_transform=None,
+                 transforms=None):
         super(LSUN, self).__init__(root, transforms, transform, target_transform)
         categories = ['bedroom', 'bridge', 'church_outdoor', 'classroom',
                       'conference_room', 'dining_room', 'kitchen',

--- a/torchvision/datasets/lsun.py
+++ b/torchvision/datasets/lsun.py
@@ -70,8 +70,7 @@ class LSUN(VisionDataset):
 
     def __init__(self, root, classes='train', transforms=None, transform=None,
                  target_transform=None):
-        super(LSUN, self).__init__(root, transforms=transforms, transform=transform,
-                                   target_transform=target_transform)
+        super(LSUN, self).__init__(root, transforms, transform, target_transform)
         categories = ['bedroom', 'bridge', 'church_outdoor', 'classroom',
                       'conference_room', 'dining_room', 'kitchen',
                       'living_room', 'restaurant', 'tower']

--- a/torchvision/datasets/lsun.py
+++ b/torchvision/datasets/lsun.py
@@ -13,7 +13,7 @@ else:
 
 
 class LSUNClass(VisionDataset):
-    def __init__(self, root, transforms=None, transform=None, target_transform=None):
+    def __init__(self, root, transform=None, target_transform=None):
         import lmdb
         super(LSUNClass, self).__init__(root, transforms=transforms,
                                         transform=transform,
@@ -68,8 +68,7 @@ class LSUN(VisionDataset):
             target and transforms it.
     """
 
-    def __init__(self, root, classes='train', transform=None, target_transform=None,
-                 transforms=None):
+    def __init__(self, root, classes='train', transform=None, target_transform=None):
         super(LSUN, self).__init__(root, transforms, transform, target_transform)
         categories = ['bedroom', 'bridge', 'church_outdoor', 'classroom',
                       'conference_room', 'dining_room', 'kitchen',

--- a/torchvision/datasets/lsun.py
+++ b/torchvision/datasets/lsun.py
@@ -13,11 +13,11 @@ else:
 
 
 class LSUNClass(VisionDataset):
-    def __init__(self, root, transform=None, target_transform=None):
+    def __init__(self, root, transforms=None, transform=None, target_transform=None):
         import lmdb
-        super(LSUNClass, self).__init__(root)
-        self.transform = transform
-        self.target_transform = target_transform
+        super(LSUNClass, self).__init__(root, transforms=transforms,
+                                        transform=transform,
+                                        target_transform=target_transform)
 
         self.env = lmdb.open(root, max_readers=1, readonly=True, lock=False,
                              readahead=False, meminit=False)
@@ -68,11 +68,10 @@ class LSUN(VisionDataset):
             target and transforms it.
     """
 
-    def __init__(self, root, classes='train',
-                 transform=None, target_transform=None):
-        super(LSUN, self).__init__(root)
-        self.transform = transform
-        self.target_transform = target_transform
+    def __init__(self, root, classes='train', transforms=None, transform=None,
+                 target_transform=None):
+        super(LSUN, self).__init__(root, transforms=transforms, transform=transform,
+                                   target_transform=target_transform)
         categories = ['bedroom', 'bridge', 'church_outdoor', 'classroom',
                       'conference_room', 'dining_room', 'kitchen',
                       'living_room', 'restaurant', 'tower']

--- a/torchvision/datasets/mnist.py
+++ b/torchvision/datasets/mnist.py
@@ -59,7 +59,8 @@ class MNIST(VisionDataset):
 
     def __init__(self, root, train=True, transform=None, target_transform=None,
                  download=False):
-        super(MNIST, self).__init__(root, transforms, transform, target_transform)
+        super(MNIST, self).__init__(root, transform=transform,
+                                    target_transform=target_transform)
         self.train = train  # training set or test set
 
         if download:

--- a/torchvision/datasets/mnist.py
+++ b/torchvision/datasets/mnist.py
@@ -58,7 +58,7 @@ class MNIST(VisionDataset):
         return self.data
 
     def __init__(self, root, train=True, transform=None, target_transform=None,
-                 transforms=None, download=False):
+                 download=False):
         super(MNIST, self).__init__(root, transforms, transform, target_transform)
         self.train = train  # training set or test set
 

--- a/torchvision/datasets/mnist.py
+++ b/torchvision/datasets/mnist.py
@@ -57,10 +57,10 @@ class MNIST(VisionDataset):
         warnings.warn("test_data has been renamed data")
         return self.data
 
-    def __init__(self, root, train=True, transform=None, target_transform=None, download=False):
-        super(MNIST, self).__init__(root)
-        self.transform = transform
-        self.target_transform = target_transform
+    def __init__(self, root, train=True, transforms=None, transform=None,
+                 target_transform=None, download=False):
+        super(MNIST, self).__init__(root, transforms=transforms, transform=transform,
+                                    target_transform=target_transform)
         self.train = train  # training set or test set
 
         if download:

--- a/torchvision/datasets/mnist.py
+++ b/torchvision/datasets/mnist.py
@@ -59,8 +59,7 @@ class MNIST(VisionDataset):
 
     def __init__(self, root, train=True, transforms=None, transform=None,
                  target_transform=None, download=False):
-        super(MNIST, self).__init__(root, transforms=transforms, transform=transform,
-                                    target_transform=target_transform)
+        super(MNIST, self).__init__(root, transforms, transform, target_transform)
         self.train = train  # training set or test set
 
         if download:

--- a/torchvision/datasets/mnist.py
+++ b/torchvision/datasets/mnist.py
@@ -57,8 +57,8 @@ class MNIST(VisionDataset):
         warnings.warn("test_data has been renamed data")
         return self.data
 
-    def __init__(self, root, train=True, transforms=None, transform=None,
-                 target_transform=None, download=False):
+    def __init__(self, root, train=True, transform=None, target_transform=None,
+                 transforms=None, download=False):
         super(MNIST, self).__init__(root, transforms, transform, target_transform)
         self.train = train  # training set or test set
 

--- a/torchvision/datasets/omniglot.py
+++ b/torchvision/datasets/omniglot.py
@@ -28,8 +28,8 @@ class Omniglot(VisionDataset):
         'images_evaluation': '6b91aef0f799c5bb55b94e3f2daec811'
     }
 
-    def __init__(self, root, background=True, transforms=None, transform=None,
-                 target_transform=None, download=False):
+    def __init__(self, root, background=True, transform=None, target_transform=None,
+                 transforms=None, download=False):
         super(Omniglot, self).__init__(join(root, self.folder), transforms, transform,
                                        target_transform)
         self.background = background

--- a/torchvision/datasets/omniglot.py
+++ b/torchvision/datasets/omniglot.py
@@ -30,9 +30,8 @@ class Omniglot(VisionDataset):
 
     def __init__(self, root, background=True, transforms=None, transform=None,
                  target_transform=None, download=False):
-        super(Omniglot, self).__init__(join(root, self.folder), transforms=transforms,
-                                       transform=transform,
-                                       target_transform=target_transform)
+        super(Omniglot, self).__init__(join(root, self.folder), transforms, transform,
+                                       target_transform)
         self.background = background
 
         if download:

--- a/torchvision/datasets/omniglot.py
+++ b/torchvision/datasets/omniglot.py
@@ -30,8 +30,8 @@ class Omniglot(VisionDataset):
 
     def __init__(self, root, background=True, transform=None, target_transform=None,
                  download=False):
-        super(Omniglot, self).__init__(join(root, self.folder), transforms, transform,
-                                       target_transform)
+        super(Omniglot, self).__init__(join(root, self.folder), transform=transform,
+                                       target_transform=target_transform)
         self.background = background
 
         if download:

--- a/torchvision/datasets/omniglot.py
+++ b/torchvision/datasets/omniglot.py
@@ -28,12 +28,11 @@ class Omniglot(VisionDataset):
         'images_evaluation': '6b91aef0f799c5bb55b94e3f2daec811'
     }
 
-    def __init__(self, root, background=True,
-                 transform=None, target_transform=None,
-                 download=False):
-        super(Omniglot, self).__init__(join(root, self.folder))
-        self.transform = transform
-        self.target_transform = target_transform
+    def __init__(self, root, background=True, transforms=None, transform=None,
+                 target_transform=None, download=False):
+        super(Omniglot, self).__init__(join(root, self.folder), transforms=transforms,
+                                       transform=transform,
+                                       target_transform=target_transform)
         self.background = background
 
         if download:

--- a/torchvision/datasets/omniglot.py
+++ b/torchvision/datasets/omniglot.py
@@ -29,7 +29,7 @@ class Omniglot(VisionDataset):
     }
 
     def __init__(self, root, background=True, transform=None, target_transform=None,
-                 transforms=None, download=False):
+                 download=False):
         super(Omniglot, self).__init__(join(root, self.folder), transforms, transform,
                                        target_transform)
         self.background = background

--- a/torchvision/datasets/phototour.py
+++ b/torchvision/datasets/phototour.py
@@ -65,8 +65,7 @@ class PhotoTour(VisionDataset):
     matches_files = 'm50_100000_100000_0.txt'
 
     def __init__(self, root, name, train=True, transform=None, download=False):
-        super(PhotoTour, self).__init__(root)
-        self.transform = transform
+        super(PhotoTour, self).__init__(root, transform=transform)
         self.name = name
         self.data_dir = os.path.join(self.root, name)
         self.data_down = os.path.join(self.root, '{}.zip'.format(name))

--- a/torchvision/datasets/sbu.py
+++ b/torchvision/datasets/sbu.py
@@ -24,8 +24,7 @@ class SBU(VisionDataset):
     filename = "SBUCaptionedPhotoDataset.tar.gz"
     md5_checksum = '9aec147b3488753cf758b4d493422285'
 
-    def __init__(self, root, transform=None, target_transform=None, transforms=None,
-                 download=True):
+    def __init__(self, root, transform=None, target_transform=None, download=True):
         super(SBU, self).__init__(root, transforms, transform, target_transform)
 
         if download:

--- a/torchvision/datasets/sbu.py
+++ b/torchvision/datasets/sbu.py
@@ -24,11 +24,10 @@ class SBU(VisionDataset):
     filename = "SBUCaptionedPhotoDataset.tar.gz"
     md5_checksum = '9aec147b3488753cf758b4d493422285'
 
-    def __init__(self, root, transform=None, target_transform=None,
+    def __init__(self, root, transforms=None, transform=None, target_transform=None,
                  download=True):
-        super(SBU, self).__init__(root)
-        self.transform = transform
-        self.target_transform = target_transform
+        super(SBU, self).__init__(root, transforms=transforms, transform=transform,
+                                  target_transform=target_transform)
 
         if download:
             self.download()

--- a/torchvision/datasets/sbu.py
+++ b/torchvision/datasets/sbu.py
@@ -24,7 +24,7 @@ class SBU(VisionDataset):
     filename = "SBUCaptionedPhotoDataset.tar.gz"
     md5_checksum = '9aec147b3488753cf758b4d493422285'
 
-    def __init__(self, root, transforms=None, transform=None, target_transform=None,
+    def __init__(self, root, transform=None, target_transform=None, transforms=None,
                  download=True):
         super(SBU, self).__init__(root, transforms, transform, target_transform)
 

--- a/torchvision/datasets/sbu.py
+++ b/torchvision/datasets/sbu.py
@@ -25,7 +25,8 @@ class SBU(VisionDataset):
     md5_checksum = '9aec147b3488753cf758b4d493422285'
 
     def __init__(self, root, transform=None, target_transform=None, download=True):
-        super(SBU, self).__init__(root, transforms, transform, target_transform)
+        super(SBU, self).__init__(root, transform=transform,
+                                  target_transform=target_transform)
 
         if download:
             self.download()

--- a/torchvision/datasets/sbu.py
+++ b/torchvision/datasets/sbu.py
@@ -26,8 +26,7 @@ class SBU(VisionDataset):
 
     def __init__(self, root, transforms=None, transform=None, target_transform=None,
                  download=True):
-        super(SBU, self).__init__(root, transforms=transforms, transform=transform,
-                                  target_transform=target_transform)
+        super(SBU, self).__init__(root, transforms, transform, target_transform)
 
         if download:
             self.download()

--- a/torchvision/datasets/semeion.py
+++ b/torchvision/datasets/semeion.py
@@ -24,7 +24,7 @@ class SEMEION(VisionDataset):
     filename = "semeion.data"
     md5_checksum = 'cb545d371d2ce14ec121470795a77432'
 
-    def __init__(self, root, transforms=None, transform=None, target_transform=None,
+    def __init__(self, root, transform=None, target_transform=None, transforms=None,
                  download=True):
         super(SEMEION, self).__init__(root, transforms, transform, target_transform)
 

--- a/torchvision/datasets/semeion.py
+++ b/torchvision/datasets/semeion.py
@@ -26,8 +26,7 @@ class SEMEION(VisionDataset):
 
     def __init__(self, root, transforms=None, transform=None, target_transform=None,
                  download=True):
-        super(SEMEION, self).__init__(root, transforms=transforms, transform=transform,
-                                      target_transform=target_transform)
+        super(SEMEION, self).__init__(root, transforms, transform, target_transform)
 
         if download:
             self.download()

--- a/torchvision/datasets/semeion.py
+++ b/torchvision/datasets/semeion.py
@@ -24,11 +24,10 @@ class SEMEION(VisionDataset):
     filename = "semeion.data"
     md5_checksum = 'cb545d371d2ce14ec121470795a77432'
 
-    def __init__(self, root, transform=None, target_transform=None,
+    def __init__(self, root, transforms=None, transform=None, target_transform=None,
                  download=True):
-        super(SEMEION, self).__init__(root)
-        self.transform = transform
-        self.target_transform = target_transform
+        super(SEMEION, self).__init__(root, transforms=transforms, transform=transform,
+                                      target_transform=target_transform)
 
         if download:
             self.download()

--- a/torchvision/datasets/semeion.py
+++ b/torchvision/datasets/semeion.py
@@ -25,7 +25,8 @@ class SEMEION(VisionDataset):
     md5_checksum = 'cb545d371d2ce14ec121470795a77432'
 
     def __init__(self, root, transform=None, target_transform=None, download=True):
-        super(SEMEION, self).__init__(root, transforms, transform, target_transform)
+        super(SEMEION, self).__init__(root, transform=transform,
+                                      target_transform=target_transform)
 
         if download:
             self.download()

--- a/torchvision/datasets/semeion.py
+++ b/torchvision/datasets/semeion.py
@@ -24,8 +24,7 @@ class SEMEION(VisionDataset):
     filename = "semeion.data"
     md5_checksum = 'cb545d371d2ce14ec121470795a77432'
 
-    def __init__(self, root, transform=None, target_transform=None, transforms=None,
-                 download=True):
+    def __init__(self, root, transform=None, target_transform=None, download=True):
         super(SEMEION, self).__init__(root, transforms, transform, target_transform)
 
         if download:

--- a/torchvision/datasets/stl10.py
+++ b/torchvision/datasets/stl10.py
@@ -47,7 +47,7 @@ class STL10(VisionDataset):
     splits = ('train', 'train+unlabeled', 'unlabeled', 'test')
 
     def __init__(self, root, split='train', folds=None, transform=None,
-                 target_transform=None, transforms=None, download=False):
+                 target_transform=None, download=False):
         if split not in self.splits:
             raise ValueError('Split "{}" not found. Valid splits are: {}'.format(
                 split, ', '.join(self.splits),

--- a/torchvision/datasets/stl10.py
+++ b/torchvision/datasets/stl10.py
@@ -46,15 +46,14 @@ class STL10(VisionDataset):
     ]
     splits = ('train', 'train+unlabeled', 'unlabeled', 'test')
 
-    def __init__(self, root, split='train', folds=None,
+    def __init__(self, root, split='train', folds=None, transforms=None,
                  transform=None, target_transform=None, download=False):
         if split not in self.splits:
             raise ValueError('Split "{}" not found. Valid splits are: {}'.format(
                 split, ', '.join(self.splits),
             ))
-        super(STL10, self).__init__(root)
-        self.transform = transform
-        self.target_transform = target_transform
+        super(STL10, self).__init__(root, transforms=transforms, transform=transform,
+                                    target_transform=target_transform)
         self.split = split  # train/test/unlabeled set
         self.folds = folds  # one of the 10 pre-defined folds or the full dataset
 

--- a/torchvision/datasets/stl10.py
+++ b/torchvision/datasets/stl10.py
@@ -46,8 +46,8 @@ class STL10(VisionDataset):
     ]
     splits = ('train', 'train+unlabeled', 'unlabeled', 'test')
 
-    def __init__(self, root, split='train', folds=None, transforms=None,
-                 transform=None, target_transform=None, download=False):
+    def __init__(self, root, split='train', folds=None, transform=None,
+                 target_transform=None, transforms=None, download=False):
         if split not in self.splits:
             raise ValueError('Split "{}" not found. Valid splits are: {}'.format(
                 split, ', '.join(self.splits),

--- a/torchvision/datasets/stl10.py
+++ b/torchvision/datasets/stl10.py
@@ -52,7 +52,8 @@ class STL10(VisionDataset):
             raise ValueError('Split "{}" not found. Valid splits are: {}'.format(
                 split, ', '.join(self.splits),
             ))
-        super(STL10, self).__init__(root, transforms, transform, target_transform)
+        super(STL10, self).__init__(root, transform=transform,
+                                    target_transform=target_transform)
         self.split = split  # train/test/unlabeled set
         self.folds = folds  # one of the 10 pre-defined folds or the full dataset
 

--- a/torchvision/datasets/stl10.py
+++ b/torchvision/datasets/stl10.py
@@ -52,8 +52,7 @@ class STL10(VisionDataset):
             raise ValueError('Split "{}" not found. Valid splits are: {}'.format(
                 split, ', '.join(self.splits),
             ))
-        super(STL10, self).__init__(root, transforms=transforms, transform=transform,
-                                    target_transform=target_transform)
+        super(STL10, self).__init__(root, transforms, transform, target_transform)
         self.split = split  # train/test/unlabeled set
         self.folds = folds  # one of the 10 pre-defined folds or the full dataset
 

--- a/torchvision/datasets/svhn.py
+++ b/torchvision/datasets/svhn.py
@@ -39,8 +39,8 @@ class SVHN(VisionDataset):
         'extra': ["http://ufldl.stanford.edu/housenumbers/extra_32x32.mat",
                   "extra_32x32.mat", "a93ce644f1a588dc4d68dda5feec44a7"]}
 
-    def __init__(self, root, split='train', transforms=None,
-                 transform=None, target_transform=None, download=False):
+    def __init__(self, root, split='train', transform=None, target_transform=None,
+                 transforms=None, download=False):
         super(SVHN, self).__init__(root, transforms, transform, target_transform)
         self.split = split  # training set or test set or extra set
 

--- a/torchvision/datasets/svhn.py
+++ b/torchvision/datasets/svhn.py
@@ -41,7 +41,8 @@ class SVHN(VisionDataset):
 
     def __init__(self, root, split='train', transform=None, target_transform=None,
                  download=False):
-        super(SVHN, self).__init__(root, transforms, transform, target_transform)
+        super(SVHN, self).__init__(root, transform=transform,
+                                   target_transform=target_transform)
         self.split = split  # training set or test set or extra set
 
         if self.split not in self.split_list:

--- a/torchvision/datasets/svhn.py
+++ b/torchvision/datasets/svhn.py
@@ -39,11 +39,10 @@ class SVHN(VisionDataset):
         'extra': ["http://ufldl.stanford.edu/housenumbers/extra_32x32.mat",
                   "extra_32x32.mat", "a93ce644f1a588dc4d68dda5feec44a7"]}
 
-    def __init__(self, root, split='train',
+    def __init__(self, root, split='train', transforms=None,
                  transform=None, target_transform=None, download=False):
-        super(SVHN, self).__init__(root)
-        self.transform = transform
-        self.target_transform = target_transform
+        super(SVHN, self).__init__(root, transforms=transforms, transform=transform,
+                                   target_transform=target_transform)
         self.split = split  # training set or test set or extra set
 
         if self.split not in self.split_list:

--- a/torchvision/datasets/svhn.py
+++ b/torchvision/datasets/svhn.py
@@ -40,7 +40,7 @@ class SVHN(VisionDataset):
                   "extra_32x32.mat", "a93ce644f1a588dc4d68dda5feec44a7"]}
 
     def __init__(self, root, split='train', transform=None, target_transform=None,
-                 transforms=None, download=False):
+                 download=False):
         super(SVHN, self).__init__(root, transforms, transform, target_transform)
         self.split = split  # training set or test set or extra set
 

--- a/torchvision/datasets/svhn.py
+++ b/torchvision/datasets/svhn.py
@@ -41,8 +41,7 @@ class SVHN(VisionDataset):
 
     def __init__(self, root, split='train', transforms=None,
                  transform=None, target_transform=None, download=False):
-        super(SVHN, self).__init__(root, transforms=transforms, transform=transform,
-                                   target_transform=target_transform)
+        super(SVHN, self).__init__(root, transforms, transform, target_transform)
         self.split = split  # training set or test set or extra set
 
         if self.split not in self.split_list:

--- a/torchvision/datasets/usps.py
+++ b/torchvision/datasets/usps.py
@@ -37,8 +37,10 @@ class USPS(VisionDataset):
         ],
     }
 
-    def __init__(self, root, train=True, transform=None, target_transform=None, download=False):
-        super(USPS, self).__init__(root, transform=transform, target_transform=target_transform)
+    def __init__(self, root, train=True, transforms=None, transform=None,
+                 target_transform=None, download=False):
+        super(USPS, self).__init__(root, transforms=None, transform=transform,
+                                   target_transform=target_transform)
         split = 'train' if train else 'test'
         url, filename, checksum = self.split_list[split]
         full_path = os.path.join(self.root, filename)

--- a/torchvision/datasets/usps.py
+++ b/torchvision/datasets/usps.py
@@ -37,8 +37,8 @@ class USPS(VisionDataset):
         ],
     }
 
-    def __init__(self, root, train=True, transforms=None, transform=None,
-                 target_transform=None, download=False):
+    def __init__(self, root, train=True, transform=None, target_transform=None,
+                 transforms=None, download=False):
         super(USPS, self).__init__(root, transforms, transform, target_transform)
         split = 'train' if train else 'test'
         url, filename, checksum = self.split_list[split]

--- a/torchvision/datasets/usps.py
+++ b/torchvision/datasets/usps.py
@@ -39,7 +39,8 @@ class USPS(VisionDataset):
 
     def __init__(self, root, train=True, transform=None, target_transform=None,
                  download=False):
-        super(USPS, self).__init__(root, transforms, transform, target_transform)
+        super(USPS, self).__init__(root, transform=transform,
+                                   target_transform=target_transform)
         split = 'train' if train else 'test'
         url, filename, checksum = self.split_list[split]
         full_path = os.path.join(self.root, filename)

--- a/torchvision/datasets/usps.py
+++ b/torchvision/datasets/usps.py
@@ -39,8 +39,7 @@ class USPS(VisionDataset):
 
     def __init__(self, root, train=True, transforms=None, transform=None,
                  target_transform=None, download=False):
-        super(USPS, self).__init__(root, transforms=None, transform=transform,
-                                   target_transform=target_transform)
+        super(USPS, self).__init__(root, transforms, transform, target_transform)
         split = 'train' if train else 'test'
         url, filename, checksum = self.split_list[split]
         full_path = os.path.join(self.root, filename)

--- a/torchvision/datasets/usps.py
+++ b/torchvision/datasets/usps.py
@@ -38,7 +38,7 @@ class USPS(VisionDataset):
     }
 
     def __init__(self, root, train=True, transform=None, target_transform=None,
-                 transforms=None, download=False):
+                 download=False):
         super(USPS, self).__init__(root, transforms, transform, target_transform)
         split = 'train' if train else 'test'
         url, filename, checksum = self.split_list[split]


### PR DESCRIPTION
Kicked of by [@zhiqwang (comment)](https://github.com/pytorch/vision/pull/1125#discussion_r303761080). Now, `transforms`, `transform`, and `target_transform` are passed to `VisionDataset.__init__()` for all datasets as intended.

@fmassa Should the usage of separate transforms deprecated? I'm asking since `SBDataset` only has joint transform:

https://github.com/pytorch/vision/blob/8837e0efbe16dc07ccdd4f1d06460643c7b41c50/torchvision/datasets/sbd.py#L52-L57 

I'll fix the docstrings afterwards.