### PR TITLE
Ignore utf-8 decode errors

### DIFF
--- a/torchvision/io/video.py
+++ b/torchvision/io/video.py
@@ -4,6 +4,7 @@ import numpy as np
 
 try:
     import av
+    av.logging.set_level(av.logging.ERROR)
 except ImportError:
     av = None
 
@@ -118,7 +119,7 @@ def read_video(filename, start_pts=0, end_pts=None):
         raise ValueError("end_pts should be larger than start_pts, got "
                          "start_pts={} and end_pts={}".format(start_pts, end_pts))
 
-    container = av.open(filename)
+    container = av.open(filename, metadata_errors='ignore')
     info = {}
 
     video_frames = []
@@ -162,7 +163,7 @@ def read_video_timestamps(filename):
         video_fps (int): the frame rate for the video
     """
     _check_av_available()
-    container = av.open(filename)
+    container = av.open(filename, metadata_errors='ignore')
 
     video_frames = []
     video_fps = None


### PR DESCRIPTION
Some videos have metadata which is not encoded in utf-8 format. This PR ignore decoding errors of metadata by [setting it to "ignore" instead](https://docs.python.org/3/library/codecs.html#error-handlers)

Also make logging less verbose by only printing errors, and not warning information.

This is necessary for properly decoding some videos in HMDB51 dataset

@bjuncek