### PR TITLE
Miscellaneous fixes and improvements for video reading

### DIFF
--- a/test/test_io.py
+++ b/test/test_io.py
@@ -6,6 +6,7 @@ import torchvision.datasets.utils as utils
 import torchvision.io as io
 import unittest
 import sys
+import warnings
 
 from common_utils import get_tmp_dir
 

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -2,9 +2,17 @@ import os
 import contextlib
 import tempfile
 import torch
+import torchvision.datasets.utils as utils
 import torchvision.io as io
 import unittest
+import sys
 
+from common_utils import get_tmp_dir
+
+if sys.version_info < (3,):
+    from urllib2 import URLError
+else:
+    from urllib.error import URLError
 
 try:
     import av
@@ -103,6 +111,22 @@ class Tester(unittest.TestCase):
             lv, _, _ = io.read_video(f_name, pts[4] + 1, pts[7])
             self.assertEqual(len(lv), 4)
             self.assertTrue((data[4:8].float() - lv.float()).abs().max() < self.TOLERANCE)
+
+    @unittest.skipIf(av is None, "PyAV unavailable")
+    def test_read_packed_b_frames_divx_file(self):
+        with get_tmp_dir() as temp_dir:
+            name = "hmdb51_Turnk_r_Pippi_Michel_cartwheel_f_cm_np2_le_med_6.avi"
+            f_name = os.path.join(temp_dir, name)
+            url = "https://download.pytorch.org/vision_tests/io/" + name
+            try:
+                utils.download_url(url, temp_dir)
+                pts, fps = io.read_video_timestamps(f_name)
+                self.assertEqual(pts, sorted(pts))
+                self.assertEqual(fps, 30)
+            except URLError:
+                msg = "could not download test file '{}'".format(url)
+                warnings.warn(msg, RuntimeWarning)
+                raise unittest.SkipTest(msg)
 
     # TODO add tests for audio
 

--- a/torchvision/datasets/video_utils.py
+++ b/torchvision/datasets/video_utils.py
@@ -84,6 +84,10 @@ class VideoClips(object):
 
     @staticmethod
     def compute_clips_for_video(video_pts, num_frames, step, fps, frame_rate):
+        if fps is None:
+            # if for some reason the video doesn't have fps (because doesn't have a video stream)
+            # set the fps to 1. The value doesn't matter, because video_pts is empty anyway
+            fps = 1
         if frame_rate is None:
             frame_rate = fps
         total_frames = len(video_pts) * (float(frame_rate) / fps)

--- a/torchvision/io/video.py
+++ b/torchvision/io/video.py
@@ -79,9 +79,9 @@ def _read_from_stream(container, start_offset, end_offset, stream, stream_name):
             # can't use regex directly because of some weird characters sometimes...
             pos = extradata.find(b"DivX")
             d = extradata[pos:]
-            o = re.search(b"DivX(\d+)Build(\d+)(\w)", d)
+            o = re.search(br"DivX(\d+)Build(\d+)(\w)", d)
             if o is None:
-                o = re.search(b"DivX(\d+)b(\d+)(\w)", d)
+                o = re.search(br"DivX(\d+)b(\d+)(\w)", d)
             if o is not None:
                 should_buffer = o.group(3) == b"p"
     seek_offset = start_offset


### PR DESCRIPTION
There are a few different fixes in this PR:
- improve `should_buffer` detection to only happen when `divx_packed` is set
- fix offset for seek for some files. for some reason they don't seek to the requested position
- add guard for corrupted files
- add guard in VideoClips for videos without stream (fps was `None` in this case)

The added test uses a file from HMDB51 `cartwheel/Turnk_r_Pippi_Michel_cartwheel_f_cm_np2_le_med_6.avi`, which is [licensed under a Creative Commons Attribution 4.0 International License](http://serre-lab.clps.brown.edu/resource/hmdb-a-large-human-motion-database/).

![image](https://user-images.githubusercontent.com/9110200/61877699-d7a76780-aeef-11e9-8a37-41035631b9eb.png)

cc @stephenyan1231