### PR TITLE
Fix wrong comments

### DIFF
--- a/torchvision/models/googlenet.py
+++ b/torchvision/models/googlenet.py
@@ -211,11 +211,11 @@ class InceptionAux(nn.Module):
         x = torch.flatten(x, 1)
         # N x 2048
         x = F.relu(self.fc1(x), inplace=True)
-        # N x 2048
-        x = F.dropout(x, 0.7, training=self.training)
-        # N x 2048
-        x = self.fc2(x)
         # N x 1024
+        x = F.dropout(x, 0.7, training=self.training)
+        # N x 1024
+        x = self.fc2(x)
+        # N x 1000 (num_classes)
 
         return x
 


### PR DESCRIPTION
`self.fc1(x)` converts the shape of `x` into "N x 1024", and `self.fc2(x)` converts it into "N x num_classes".

By adding `print(x.shape)` under each comment line, the console displays as follows (batch_size is 1):

```text
torch.Size([1, 2048])
torch.Size([1, 1024])
torch.Size([1, 1024])
torch.Size([1, 1000])
```

It shows that my modifications are correct.