### PR TITLE
Replacing PIL and OpenCV

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,15 +2,23 @@ cmake_minimum_required(VERSION 2.8)
 project(torchvision)
 set(CMAKE_CXX_STANDARD 11)
 
+find_package(PNG REQUIRED)
 find_package(Torch REQUIRED)
+include_directories(${PNG_INCLUDE_DIR})
 
 file(GLOB HEADERS torchvision/csrc/vision.h)
+
 file(GLOB MODELS_HEADERS torchvision/csrc/models/*.h)
 file(GLOB MODELS_SOURCES torchvision/csrc/models/*.h torchvision/csrc/models/*.cpp)
 
-add_library (${PROJECT_NAME} SHARED ${MODELS_SOURCES})
+file(GLOB IMAGE_HEADERS torchvision/csrc/image/*.h)
+file(GLOB IMAGE_SOURCES torchvision/csrc/image/*.h torchvision/csrc/image/*.cpp)
+
+add_library(${PROJECT_NAME} SHARED ${MODELS_SOURCES} ${IMAGE_SOURCES})
+target_link_libraries(${PROJECT_NAME} PUBLIC "${PNG_LIBRARY}")
 target_link_libraries(${PROJECT_NAME} PUBLIC "${TORCH_LIBRARIES}")
 
 install(TARGETS ${PROJECT_NAME} DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
 install(FILES ${HEADERS} DESTINATION ${CMAKE_INSTALL_PREFIX}/include/${PROJECT_NAME})
 install(FILES ${MODELS_HEADERS} DESTINATION ${CMAKE_INSTALL_PREFIX}/include/${PROJECT_NAME}/models)
+install(FILES ${IMAGE_HEADERS} DESTINATION ${CMAKE_INSTALL_PREFIX}/include/${PROJECT_NAME}/image)

--- a/torchvision/csrc/image/image.h
+++ b/torchvision/csrc/image/image.h
@@ -1,0 +1,6 @@
+#ifndef IMAGE_H
+#define IMAGE_H
+
+#include "readpng.h"
+
+#endif // IMAGE_H

--- a/torchvision/csrc/image/readpng.cpp
+++ b/torchvision/csrc/image/readpng.cpp
@@ -1,0 +1,83 @@
+#include "readpng.h"
+
+#include <sxx/sxx.h>
+
+#include <png.h>
+
+namespace torch {
+namespace vision {
+namespace image {
+namespace impl {
+bool is_png(const void* data) {
+  return png_sig_cmp(png_const_bytep(data), 0, 8) == 0;
+}
+
+torch::Tensor readpng(const void* data) {
+  struct Reader {
+    png_const_bytep ptr;
+  } reader;
+
+  reader.ptr = png_const_bytep(data) + 8;
+  auto read_callback =
+      [](png_structp png_ptr, png_bytep output, png_size_t bytes) {
+        auto reader = static_cast<Reader*>(png_get_io_ptr(png_ptr));
+        std::copy(reader->ptr, reader->ptr + bytes, output);
+        reader->ptr += bytes;
+      };
+
+  auto png_ptr =
+      png_create_read_struct(PNG_LIBPNG_VER_STRING, nullptr, nullptr, nullptr);
+  if (!png_ptr)
+    return torch::tensor({0});
+
+  auto info_ptr = png_create_info_struct(png_ptr);
+  if (!info_ptr) {
+    png_destroy_read_struct(&png_ptr, nullptr, nullptr);
+    return torch::tensor({0});
+  }
+
+  if (setjmp(png_jmpbuf(png_ptr)) != 0) {
+    png_destroy_read_struct(&png_ptr, &info_ptr, nullptr);
+    return torch::tensor({0});
+  }
+
+  png_set_read_fn(png_ptr, &reader, read_callback);
+  png_set_sig_bytes(png_ptr, 8);
+  png_read_info(png_ptr, info_ptr);
+
+  png_uint_32 width, height;
+  int bit_depth, color_type;
+  auto retval = png_get_IHDR(
+      png_ptr,
+      info_ptr,
+      &width,
+      &height,
+      &bit_depth,
+      &color_type,
+      nullptr,
+      nullptr,
+      nullptr);
+
+  if (retval != 1 || color_type != PNG_COLOR_TYPE_RGB) {
+    png_destroy_read_struct(&png_ptr, &info_ptr, nullptr);
+    return torch::tensor({0});
+  }
+
+  auto tensor =
+      torch::empty({int64_t(height), int64_t(width), int64_t(3)}, torch::kU8);
+  auto ptr = tensor.data<uint8_t>();
+  auto bytes = png_get_rowbytes(png_ptr, info_ptr);
+
+  for (decltype(height) i = 0; i < height; ++i) {
+    png_read_row(png_ptr, ptr, nullptr);
+    ptr += bytes;
+  }
+
+  png_destroy_read_struct(&png_ptr, &info_ptr, nullptr);
+  return tensor;
+}
+
+} // namespace impl
+} // namespace image
+} // namespace vision
+} // namespace torch

--- a/torchvision/csrc/image/readpng.h
+++ b/torchvision/csrc/image/readpng.h
@@ -1,0 +1,19 @@
+#ifndef READPNG_H
+#define READPNG_H
+
+#include <torch/torch.h>
+
+namespace torch {
+namespace vision {
+namespace image {
+namespace impl {
+
+bool is_png(const void* data);
+torch::Tensor readpng(const void* data);
+
+} // namespace impl
+} // namespace image
+} // namespace vision
+} // namespace torch
+
+#endif // READPNG_H


### PR DESCRIPTION
This is the first part of our own image reading functions. This PR adds PNG reading functions using libpng. @fmassa what are your thoughts on these?
+ Right now the code is only reading ```RGB```(and not ```RGBA```). Should it stay this way?
+ We have two functions. ```is_png``` tells us weather the data is a PNG image or not. ```read_png``` reads the image and returns a ```torch::Tensor```.
+ In case of failure the code returns an empty ```torch::Tensor```.
+ How should the tests be? we can write the tests in ```C++``` and compare the read image with ```OpenCV``` (or some other library) output (which is not good because it has ```OpenCV``` as a dependency). Or we can expose to ```Python``` and compare with ```PIL``` output.