### PR TITLE
added test set to VOC

### DIFF
--- a/torchvision/datasets/voc.py
+++ b/torchvision/datasets/voc.py
@@ -84,7 +84,7 @@ class VOCSegmentation(VisionDataset):
         self.filename = DATASET_YEAR_DICT[year]['filename']
         self.md5 = DATASET_YEAR_DICT[year]['md5']
         self.image_set = verify_str_arg(image_set, "image_set",
-                                        ("train", "trainval", "val"))
+                                        ("train", "trainval", "val", "test"))
         base_dir = DATASET_YEAR_DICT[year]['base_dir']
         voc_root = os.path.join(self.root, base_dir)
         image_dir = os.path.join(voc_root, 'JPEGImages')
@@ -161,7 +161,7 @@ class VOCDetection(VisionDataset):
         self.filename = DATASET_YEAR_DICT[year]['filename']
         self.md5 = DATASET_YEAR_DICT[year]['md5']
         self.image_set = verify_str_arg(image_set, "image_set",
-                                        ("train", "trainval", "val"))
+                                        ("train", "trainval", "val", "test"))
 
         base_dir = DATASET_YEAR_DICT[year]['base_dir']
         voc_root = os.path.join(self.root, base_dir)


### PR DESCRIPTION
`test` labels are provided alongside VOC dataset, no reason to exclude it from the class