### PR TITLE
Fixed video labelling after `subset` call for HMDB51 dataset (hmdb51.py) (EDIT: UCF101 as well)

### DIFF
--- a/torchvision/datasets/hmdb51.py
+++ b/torchvision/datasets/hmdb51.py
@@ -65,8 +65,8 @@ class HMDB51(VisionDataset):
         self.classes = classes
         video_list = [x[0] for x in self.samples]
         video_clips = VideoClips(video_list, frames_per_clip, step_between_clips)
-        indices = self._select_fold(video_list, annotation_path, fold, train)
-        self.video_clips = video_clips.subset(indices)
+        self.indices = self._select_fold(video_list, annotation_path, fold, train)
+        self.video_clips = video_clips.subset(self.indices)
         self.transform = transform
 
     def _select_fold(self, video_list, annotation_path, fold, train):
@@ -89,7 +89,7 @@ class HMDB51(VisionDataset):
 
     def __getitem__(self, idx):
         video, audio, info, video_idx = self.video_clips.get_clip(idx)
-        label = self.samples[video_idx][1]
+        label = self.samples[self.indices[video_idx]][1]
 
         if self.transform is not None:
             video = self.transform(video)

--- a/torchvision/datasets/ucf101.py
+++ b/torchvision/datasets/ucf101.py
@@ -58,8 +58,8 @@ class UCF101(VisionDataset):
         self.classes = classes
         video_list = [x[0] for x in self.samples]
         video_clips = VideoClips(video_list, frames_per_clip, step_between_clips)
-        indices = self._select_fold(video_list, annotation_path, fold, train)
-        self.video_clips = video_clips.subset(indices)
+        self.indices = self._select_fold(video_list, annotation_path, fold, train)
+        self.video_clips = video_clips.subset(self.indices)
         self.transform = transform
 
     def _select_fold(self, video_list, annotation_path, fold, train):
@@ -81,7 +81,7 @@ class UCF101(VisionDataset):
 
     def __getitem__(self, idx):
         video, audio, info, video_idx = self.video_clips.get_clip(idx)
-        label = self.samples[video_idx][1]
+        label = self.samples[self.indices[video_idx]][1]
 
         if self.transform is not None:
             video = self.transform(video)


### PR DESCRIPTION
In the current `torchvision` release, when we take a subset of a given `VideoClips` object `X` (by calling `X.subset(indices)`), as we would when creating Val and Train splits in HMDB51, a new `VideoClips` instance `Y` is returned, where `Y.video_paths` is a subset of `X.video_paths`. 

As a result, after a non-trivial subset is selected from the `HMDB51` dataset, the i-th video in `self.samples` does not correspond to the i-th video in `self.video_clips.video_paths`.

Because of that, the label retrieved from `self.samples[video_idx][1]` in the `__getitem__()` method of `HMDB51` is not the correct label for the video at `self.video_clips.video_paths[video_idx]`. This leads to mislabeling in the dataset.

Our fix stores `self.indices` to allow `__getitem__()` to invoke `self.samples[self.indices[video_idx]][1]`, which retrieves the label of the correct video.