### PR TITLE
Fix bug of changing input tensor in utils.save_image

### DIFF
--- a/torchvision/utils.py
+++ b/torchvision/utils.py
@@ -97,6 +97,7 @@ def save_image(tensor, filename, nrow=8, padding=2,
         **kwargs: Other arguments are documented in ``make_grid``.
     """
     from PIL import Image
+    tensor = tensor.clone()
     grid = make_grid(tensor, nrow=nrow, padding=padding, pad_value=pad_value,
                      normalize=normalize, range=range, scale_each=scale_each)
     # Add 0.5 after unnormalizing to [0, 255] to round to nearest integer

--- a/torchvision/utils.py
+++ b/torchvision/utils.py
@@ -97,10 +97,9 @@ def save_image(tensor, filename, nrow=8, padding=2,
         **kwargs: Other arguments are documented in ``make_grid``.
     """
     from PIL import Image
-    tensor = tensor.clone()
     grid = make_grid(tensor, nrow=nrow, padding=padding, pad_value=pad_value,
                      normalize=normalize, range=range, scale_each=scale_each)
     # Add 0.5 after unnormalizing to [0, 255] to round to nearest integer
-    ndarr = grid.mul_(255).add_(0.5).clamp_(0, 255).permute(1, 2, 0).to('cpu', torch.uint8).numpy()
+    ndarr = grid.mul(255).add_(0.5).clamp_(0, 255).permute(1, 2, 0).to('cpu', torch.uint8).numpy()
     im = Image.fromarray(ndarr)
     im.save(filename)


### PR DESCRIPTION
The original code of torchvision.utils.save_image will change the image tensor passed in by multiplying it by 255. The PR fixes that.

Sample code to reproduce the bug:

import torch
from torchvision.utils import save_image

img = torch.ones((5, 3, 64, 64))
save_image(img[0], 'dummy.jpg')
print(torch.max(img))