### PR TITLE
Register Torchvision Ops as Cutom Ops

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,10 @@ before_install:
   - pip install future
   - pip install pytest pytest-cov codecov
   - pip install mock
-  - pip install onnx
-  - pip install onnxruntime
+  - |
+    if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then
+      pip install onnxruntime
+    fi
   - conda install av -c conda-forge
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,8 @@ before_install:
   - pip install future
   - pip install pytest pytest-cov codecov
   - pip install mock
+  - pip install onnx
+  - pip install onnxruntime
   - conda install av -c conda-forge
 
 

--- a/setup.py
+++ b/setup.py
@@ -171,9 +171,10 @@ class build_ext(torch.utils.cpp_extension.BuildExtension):
         os.rename(os.path.join(build_dir, 'custom_ops.' + suffix),
                   os.path.join(build_dir, 'custom_ops.' + extension))
 
-        # rename custom_ops.<lib_suffix>.<ext> in torchvision_dir to custom_ops.<ext>
-        shutil.copy(os.path.join(torchvision_dir, 'custom_ops.' + suffix),
+        # copy custom_ops.<ext> to torchvision_dir
+        shutil.copy(os.path.join(build_dir, 'custom_ops.' + extension),
                     os.path.join(torchvision_dir, 'custom_ops.' + extension))
+
 
 class clean(distutils.command.clean.clean):
     def run(self):

--- a/setup.py
+++ b/setup.py
@@ -164,15 +164,17 @@ class build_ext(torch.utils.cpp_extension.BuildExtension):
         build_dir = os.path.join(self.build_lib, 'torchvision')
         torchvision_dir = os.path.join('torchvision')
 
-        suffix = os.path.basename(torch._C.__file__).split('.', 1)[1]
-        extension = suffix.rsplit('.', 1)[1]
+        extension = os.path.basename(torch._C.__file__).rsplit('.', 1)[1]
 
-        # rename custom_ops.<lib_suffix>.<ext> in build_dir to custom_ops.<ext>
-        os.rename(os.path.join(build_dir, 'custom_ops.' + suffix),
-                  os.path.join(build_dir, 'custom_ops.' + extension))
+        # find lib with pattern custom_ops*.<extension>
+        custom_op_lib_path = os.path.join(build_dir, 'custom_ops*.' + extension)
+        custom_op_lib = glob.glob(custom_op_lib_path)
+        assert len(custom_op_lib) == 1, \
+            "Expecting to find one library matching custom_ops*." + \
+            extension + " but " + str(len(custom_op_lib)) + " were found."
 
-        # copy custom_ops.<ext> to torchvision_dir
-        shutil.copy(os.path.join(build_dir, 'custom_ops.' + extension),
+        # copy custom_ops*.<ext> to torchvision_dir as custom_ops.<ext>
+        shutil.copy(custom_op_lib[0],
                     os.path.join(torchvision_dir, 'custom_ops.' + extension))
 
 

--- a/setup.py
+++ b/setup.py
@@ -146,7 +146,7 @@ def get_extensions():
             extra_compile_args=extra_compile_args,
         ),
         extension(
-            "torchvision.custom_ops",
+            "torchvision._custom_ops",
             sources=custom_ops_sources,
             include_dirs=include_dirs,
             define_macros=define_macros,
@@ -155,27 +155,6 @@ def get_extensions():
     ]
 
     return ext_modules
-
-
-class build_ext(torch.utils.cpp_extension.BuildExtension):
-    def run(self):
-        torch.utils.cpp_extension.BuildExtension.run(self)
-
-        build_dir = os.path.join(self.build_lib, 'torchvision')
-        torchvision_dir = os.path.join('torchvision')
-
-        extension = os.path.basename(torch._C.__file__).rsplit('.', 1)[1]
-
-        # find lib with pattern custom_ops*.<extension>
-        custom_op_lib_path = os.path.join(build_dir, 'custom_ops*.' + extension)
-        custom_op_lib = glob.glob(custom_op_lib_path)
-        assert len(custom_op_lib) == 1, \
-            "Expecting to find one library matching custom_ops*." + \
-            extension + " but " + str(len(custom_op_lib)) + " were found."
-
-        # copy custom_ops*.<ext> to torchvision_dir as custom_ops.<ext>
-        shutil.copy(custom_op_lib[0],
-                    os.path.join(torchvision_dir, 'custom_ops.' + extension))
 
 
 class clean(distutils.command.clean.clean):
@@ -213,6 +192,6 @@ setup(
         "scipy": ["scipy"],
     },
     ext_modules=get_extensions(),
-    cmdclass={'build_ext': build_ext,
+    cmdclass={'build_ext': torch.utils.cpp_extension.BuildExtension,
               'clean': clean}
 )

--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ def get_extensions():
                           os.path.join(extensions_dir, "cpu", "nms_cpu.cpp"),
                           os.path.join(extensions_dir, "cpu", "ROIAlign_cpu.cpp"),
                           os.path.join(extensions_dir, "cpu", "ROIPool_cpu.cpp")]
-    custom_ops_sources_cuda = [os.path.join(extensions_dir, "cuda", "nms.cu"),
+    custom_ops_sources_cuda = [os.path.join(extensions_dir, "cuda", "nms_cuda.cu"),
                                os.path.join(extensions_dir, "cuda", "ROIAlign_cuda.cu"),
                                os.path.join(extensions_dir, "cuda", "ROIPool_cuda.cu")]
 

--- a/setup.py
+++ b/setup.py
@@ -157,6 +157,25 @@ def get_extensions():
     return ext_modules
 
 
+class build_ext(torch.utils.cpp_extension.BuildExtension):
+    def run(self):
+        torch.utils.cpp_extension.BuildExtension.run(self)
+
+        build_dir = os.path.join(self.build_lib, 'torchvision')
+        torchvision_dir = os.path.join('torchvision')
+
+        suffix = os.path.basename(torch._C.__file__).split('.', 1)[1]
+        extension = suffix.rsplit('.', 1)[1]
+
+        # rename custom_ops.<lib_suffix>.<ext> in build_dir to custom_ops.<ext>
+        os.rename(os.path.join(build_dir, 'custom_ops.' + suffix),
+                  os.path.join(build_dir, 'custom_ops.' + extension))
+
+        # rename custom_ops.<lib_suffix>.<ext> in torchvision_dir to custom_ops.<ext>
+        os.rename(os.path.join(torchvision_dir, 'custom_ops.' + suffix),
+                  os.path.join(torchvision_dir, 'custom_ops.' + extension))
+
+
 class clean(distutils.command.clean.clean):
     def run(self):
         with open('.gitignore', 'r') as f:
@@ -192,5 +211,6 @@ setup(
         "scipy": ["scipy"],
     },
     ext_modules=get_extensions(),
-    cmdclass={'build_ext': torch.utils.cpp_extension.BuildExtension, 'clean': clean}
+    cmdclass={'build_ext': build_ext,
+              'clean': clean}
 )

--- a/setup.py
+++ b/setup.py
@@ -172,9 +172,8 @@ class build_ext(torch.utils.cpp_extension.BuildExtension):
                   os.path.join(build_dir, 'custom_ops.' + extension))
 
         # rename custom_ops.<lib_suffix>.<ext> in torchvision_dir to custom_ops.<ext>
-        os.rename(os.path.join(torchvision_dir, 'custom_ops.' + suffix),
-                  os.path.join(torchvision_dir, 'custom_ops.' + extension))
-
+        shutil.copy(os.path.join(torchvision_dir, 'custom_ops.' + suffix),
+                    os.path.join(torchvision_dir, 'custom_ops.' + extension))
 
 class clean(distutils.command.clean.clean):
     def run(self):

--- a/setup.py
+++ b/setup.py
@@ -96,12 +96,21 @@ def get_extensions():
     source_models = [os.path.join(models_dir, s) for s in source_models]
     tests = test_file + source_models
 
+    custom_ops_sources = [os.path.join(extensions_dir, "custom_ops", "custom_ops.cpp"),
+                          os.path.join(extensions_dir, "cpu", "nms_cpu.cpp"),
+                          os.path.join(extensions_dir, "cpu", "ROIAlign_cpu.cpp"),
+                          os.path.join(extensions_dir, "cpu", "ROIPool_cpu.cpp")]
+    custom_ops_sources_cuda = [os.path.join(extensions_dir, "cuda", "nms.cu"),
+                               os.path.join(extensions_dir, "cuda", "ROIAlign_cuda.cu"),
+                               os.path.join(extensions_dir, "cuda", "ROIPool_cuda.cu")]
+
     define_macros = []
 
     extra_compile_args = {}
     if (torch.cuda.is_available() and CUDA_HOME is not None) or os.getenv('FORCE_CUDA', '0') == '1':
         extension = CUDAExtension
         sources += source_cuda
+        custom_ops_sources += custom_ops_sources_cuda
         define_macros += [('WITH_CUDA', None)]
         nvcc_flags = os.getenv('NVCC_FLAGS', '')
         if nvcc_flags == '':
@@ -135,7 +144,14 @@ def get_extensions():
             include_dirs=tests_include_dirs,
             define_macros=define_macros,
             extra_compile_args=extra_compile_args,
-        )
+        ),
+        extension(
+            "torchvision.custom_ops",
+            sources=custom_ops_sources,
+            include_dirs=include_dirs,
+            define_macros=define_macros,
+            extra_compile_args=extra_compile_args,
+        ),
     ]
 
     return ext_modules

--- a/test/test_onnx.py
+++ b/test/test_onnx.py
@@ -2,6 +2,11 @@ import numpy
 import io
 import torch
 from torchvision import ops
+
+# onnxruntime requires python 3.5 or above
+import sys
+if sys.version_info[0] < 3 or (sys.version_info[0] == 3 and sys.version_info[1] < 5):
+    sys.exit()
 import onnxruntime
 
 import unittest

--- a/test/test_onnx.py
+++ b/test/test_onnx.py
@@ -1,0 +1,79 @@
+import numpy
+import io
+import torch
+from torchvision import ops
+import onnxruntime
+
+import unittest
+
+
+class ONNXExporterTester(unittest.TestCase):
+
+    def run_model(self, model, inputs):
+        model.eval()
+
+        # run pytorch model
+        with torch.no_grad():
+            if isinstance(inputs, torch.Tensor):
+                inputs = (inputs,)
+            outputs = model(*inputs)
+            if isinstance(outputs, torch.Tensor):
+                outputs = (outputs,)
+
+        onnx_io = io.BytesIO()
+        # export to onnx
+        torch.onnx.export(model, inputs, onnx_io, do_constant_folding=True, opset_version=10)
+
+        # validate the exported model with onnx runtime
+        self.ort_validate(onnx_io, inputs, outputs)
+
+    def ort_validate(self, onnx_io, inputs, outputs):
+
+        inputs, _ = torch.jit._flatten(inputs)
+        outputs, _ = torch.jit._flatten(outputs)
+
+        def to_numpy(tensor):
+            if tensor.requires_grad:
+                return tensor.detach().cpu().numpy()
+            else:
+                return tensor.cpu().numpy()
+
+        inputs = list(map(to_numpy, inputs))
+        outputs = list(map(to_numpy, outputs))
+
+        ort_session = onnxruntime.InferenceSession(onnx_io.getvalue())
+        # compute onnxruntime output prediction
+        ort_inputs = dict((ort_session.get_inputs()[i].name, inpt) for i, inpt in enumerate(inputs))
+        ort_outs = ort_session.run(None, ort_inputs)
+
+        for i in range(0, len(outputs)):
+            numpy.testing.assert_allclose(outputs[i], ort_outs[i], rtol=1e-03, atol=1e-05)
+
+    def test_nms(self):
+        boxes = torch.randn(5, 4)
+        scores = torch.randn(5)
+
+        class Module(torch.nn.Module):
+            def forward(self, boxes, scores):
+                return ops.nms(boxes, scores, 0.5)
+
+        self.run_model(Module(), (boxes, scores))
+
+    def test_roi_pool(self):
+        x = torch.rand(1, 1, 10, 10, dtype=torch.float32)
+        single_roi = torch.tensor([[0, 0, 0, 4, 4]], dtype=torch.float32)
+        model = ops.RoIAlign((5, 5), 1, 2)
+        self.run_model(model, (x, single_roi))
+
+    def test_roi_align(self):
+        x = torch.rand(1, 1, 10, 10, dtype=torch.float32)
+        rois = torch.tensor([[0, 0, 0, 4, 4]], dtype=torch.float32)
+        pool_h = 5
+        pool_w = 5
+        model = ops.RoIPool((pool_h, pool_w), 2)
+        model.eval()
+        self.run_model(model, (x, rois))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/torchvision/csrc/ROIAlign.h
+++ b/torchvision/csrc/ROIAlign.h
@@ -10,11 +10,11 @@
 at::Tensor ROIAlign_forward(
     const at::Tensor& input, // Input feature map.
     const at::Tensor& rois, // List of ROIs to pool over.
-    const float spatial_scale, // The scale of the image features. ROIs will be
+    const double spatial_scale, // The scale of the image features. ROIs will be
     // scaled to this.
-    const int pooled_height, // The height of the pooled feature map.
-    const int pooled_width, // The width of the pooled feature
-    const int sampling_ratio) // The number of points to sample in each bin
+    const int64_t pooled_height, // The height of the pooled feature map.
+    const int64_t pooled_width, // The width of the pooled feature
+    const int64_t sampling_ratio) // The number of points to sample in each bin
 // along each axis.
 {
   if (input.type().is_cuda()) {

--- a/torchvision/csrc/ROIPool.h
+++ b/torchvision/csrc/ROIPool.h
@@ -9,9 +9,9 @@
 std::tuple<at::Tensor, at::Tensor> ROIPool_forward(
     const at::Tensor& input,
     const at::Tensor& rois,
-    const float spatial_scale,
-    const int pooled_height,
-    const int pooled_width) {
+    const double spatial_scale,
+    const int64_t pooled_height,
+    const int64_t pooled_width) {
   if (input.type().is_cuda()) {
 #ifdef WITH_CUDA
     return ROIPool_forward_cuda(

--- a/torchvision/csrc/custom_ops/custom_ops.cpp
+++ b/torchvision/csrc/custom_ops/custom_ops.cpp
@@ -1,8 +1,8 @@
 #include <torch/script.h>
 
-#include "nms.h"
 #include "ROIAlign.h"
 #include "ROIPool.h"
+#include "nms.h"
 
 using namespace at;
 

--- a/torchvision/csrc/custom_ops/custom_ops.cpp
+++ b/torchvision/csrc/custom_ops/custom_ops.cpp
@@ -1,13 +1,13 @@
 #include <torch/script.h>
 
-#include "nms.h"
 #include "ROIAlign.h"
 #include "ROIPool.h"
+#include "nms.h"
 
 using namespace at;
 
 static auto registry =
-  torch::jit::RegisterOperators()
-    .op("torchvision::nms", &nms)
-    .op("torchvision::roi_align(Tensor input, Tensor rois, float spatial_scale, int pooled_height, int pooled_width, int sampling_ratio) -> Tensor", &ROIAlign_forward)
-    .op("torchvision::roi_pool", &ROIPool_forward);
+    torch::jit::RegisterOperators()
+        .op("torchvision::nms", &nms)
+        .op("torchvision::roi_align(Tensor input, Tensor rois, float spatial_scale, int pooled_height, int pooled_width, int sampling_ratio) -> Tensor", &ROIAlign_forward)
+        .op("torchvision::roi_pool", &ROIPool_forward);

--- a/torchvision/csrc/custom_ops/custom_ops.cpp
+++ b/torchvision/csrc/custom_ops/custom_ops.cpp
@@ -1,13 +1,14 @@
 #include <torch/script.h>
 
+#include "nms.h"
 #include "ROIAlign.h"
 #include "ROIPool.h"
-#include "nms.h"
 
 using namespace at;
 
 static auto registry =
-    torch::jit::RegisterOperators()
+    torch::RegisterOperators()
         .op("torchvision::nms", &nms)
-        .op("torchvision::roi_align(Tensor input, Tensor rois, float spatial_scale, int pooled_height, int pooled_width, int sampling_ratio) -> Tensor", &ROIAlign_forward)
+        .op("torchvision::roi_align(Tensor input, Tensor rois, float spatial_scale, int pooled_height, int pooled_width, int sampling_ratio) -> Tensor",
+            &ROIAlign_forward)
         .op("torchvision::roi_pool", &ROIPool_forward);

--- a/torchvision/csrc/custom_ops/custom_ops.cpp
+++ b/torchvision/csrc/custom_ops/custom_ops.cpp
@@ -1,0 +1,13 @@
+#include <torch/script.h>
+
+#include "nms.h"
+#include "ROIAlign.h"
+#include "ROIPool.h"
+
+using namespace at;
+
+static auto registry =
+  torch::jit::RegisterOperators()
+    .op("torchvision::nms", &nms)
+    .op("torchvision::roi_align_forward(Tensor input, Tensor rois, float spatial_scale, int pooled_height, int pooled_width, int sampling_ratio) -> Tensor", &ROIAlign_forward)
+    .op("torchvision::roi_pool_forward", &ROIPool_forward);

--- a/torchvision/csrc/custom_ops/custom_ops.cpp
+++ b/torchvision/csrc/custom_ops/custom_ops.cpp
@@ -9,5 +9,5 @@ using namespace at;
 static auto registry =
   torch::jit::RegisterOperators()
     .op("torchvision::nms", &nms)
-    .op("torchvision::roi_align_forward(Tensor input, Tensor rois, float spatial_scale, int pooled_height, int pooled_width, int sampling_ratio) -> Tensor", &ROIAlign_forward)
-    .op("torchvision::roi_pool_forward", &ROIPool_forward);
+    .op("torchvision::roi_align(Tensor input, Tensor rois, float spatial_scale, int pooled_height, int pooled_width, int sampling_ratio) -> Tensor", &ROIAlign_forward)
+    .op("torchvision::roi_pool", &ROIPool_forward);

--- a/torchvision/csrc/nms.h
+++ b/torchvision/csrc/nms.h
@@ -8,7 +8,7 @@
 at::Tensor nms(
     const at::Tensor& dets,
     const at::Tensor& scores,
-    const float iou_threshold) {
+    const double iou_threshold) {
   if (dets.device().is_cuda()) {
 #ifdef WITH_CUDA
     if (dets.numel() == 0) {

--- a/torchvision/csrc/vision.cpp
+++ b/torchvision/csrc/vision.cpp
@@ -7,7 +7,7 @@
 #endif
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
-  m.def("nms", &nms, "non-maximum suppression");
+  // no need to define nms here since it is registered and used as a PyTorch custom op
   m.def("roi_align_forward", &ROIAlign_forward, "ROIAlign_forward");
   m.def("roi_align_backward", &ROIAlign_backward, "ROIAlign_backward");
   m.def("roi_pool_forward", &ROIPool_forward, "ROIPool_forward");

--- a/torchvision/csrc/vision.cpp
+++ b/torchvision/csrc/vision.cpp
@@ -7,7 +7,9 @@
 #endif
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
-  // no need to define nms here since it is registered and used as a PyTorch custom op
+  // TODO: remove nms from here since it is now registered
+  //       and used as a PyTorch custom op
+  m.def("nms", &nms, "non-maximum suppression");
   m.def("roi_align_forward", &ROIAlign_forward, "ROIAlign_forward");
   m.def("roi_align_backward", &ROIAlign_backward, "ROIAlign_backward");
   m.def("roi_pool_forward", &ROIPool_forward, "ROIPool_forward");

--- a/torchvision/ops/_custom_ops.py
+++ b/torchvision/ops/_custom_ops.py
@@ -1,13 +1,13 @@
 import os
 import sys
+import imp
 import torch
 
 
 # load the custom_op_library and register the custom ops
 lib_dir = os.path.join(os.path.dirname(__file__), '..')
-extension = os.path.basename(torch._C.__file__).rsplit('.', 1)[1]
-custom_op_lib = os.path.join(lib_dir, 'custom_ops.' + extension)
-torch.ops.load_library(custom_op_lib)
+file, path, description = imp.find_module("_custom_ops", [lib_dir])
+torch.ops.load_library(path)
 
 
 def register_custom_op():

--- a/torchvision/ops/_custom_ops.py
+++ b/torchvision/ops/_custom_ops.py
@@ -1,0 +1,44 @@
+import os
+import torch
+import glob
+
+# load the custom_op_library and register the custom ops
+custom_op_lib_path = os.path.join(os.path.dirname(__file__), '..', 'custom_ops.*.so')
+custom_op_lib = glob.glob(custom_op_lib_path)
+torch.ops.load_library(custom_op_lib[0])
+
+
+def register_custom_op():
+    from torch.onnx.symbolic_helper import parse_args, scalar_type_to_onnx
+    from torch.onnx.symbolic_opset9 import select, unsqueeze, squeeze, _cast_Long, reshape
+
+    @parse_args('v', 'v', 'f')
+    def symbolic_multi_label_nms(g, boxes, scores, iou_threshold):
+        boxes = unsqueeze(g, boxes, 0)
+        scores = unsqueeze(g, unsqueeze(g, scores, 0), 0)
+        max_output_per_class = g.op('Constant', value_t=torch.tensor([2000], dtype=torch.long))
+        iou_threshold = g.op('Constant', value_t=torch.tensor([iou_threshold], dtype=torch.float))
+        nms_out = g.op('NonMaxSuppression', boxes, scores, max_output_per_class, iou_threshold)
+        return squeeze(g, select(g, nms_out, 1, g.op('Constant', value_t=torch.tensor([2], dtype=torch.long))), 1)
+
+    @parse_args('v', 'v', 'f', 'i', 'i', 'i')
+    def roi_align(g, input, rois, spatial_scale, pooled_height, pooled_width, sampling_ratio):
+        batch_indices = _cast_Long(g, squeeze(g, select(g, rois, 1, g.op('Constant',
+                                   value_t=torch.tensor([0], dtype=torch.long))), 1), False)
+        rois = select(g, rois, 1, g.op('Constant', value_t=torch.tensor([1, 2, 3, 4], dtype=torch.long)))
+        return g.op('RoiAlign', input, rois, batch_indices, spatial_scale_f=spatial_scale,
+                    output_height_i=pooled_height, output_width_i=pooled_width, sampling_ratio_i=sampling_ratio)
+
+    @parse_args('v', 'v', 'f', 'i', 'i')
+    def roi_pool(g, input, rois, spatial_scale, pooled_height, pooled_width):
+        roi_pool = g.op('MaxRoiPool', input, rois,
+                        pooled_shape_i=(pooled_height, pooled_width), spatial_scale_f=spatial_scale)
+        return roi_pool, None
+
+    from torch.onnx import register_custom_op_symbolic
+    register_custom_op_symbolic('torchvision::nms', symbolic_multi_label_nms, 10)
+    register_custom_op_symbolic('torchvision::roi_align_forward', roi_align, 10)
+    register_custom_op_symbolic('torchvision::roi_pool_forward', roi_pool, 10)
+
+
+register_custom_op()

--- a/torchvision/ops/_custom_ops.py
+++ b/torchvision/ops/_custom_ops.py
@@ -4,7 +4,7 @@ import torch
 
 
 # load the custom_op_library and register the custom ops
-lib_dir = os.path.join('torchvision')
+lib_dir = os.path.join(os.path.dirname(__file__), '..')
 extension = os.path.basename(torch._C.__file__).rsplit('.', 1)[1]
 custom_op_lib = os.path.join(lib_dir, 'custom_ops.' + extension)
 torch.ops.load_library(custom_op_lib)

--- a/torchvision/ops/boxes.py
+++ b/torchvision/ops/boxes.py
@@ -1,5 +1,5 @@
 import torch
-from torchvision.extension import _lazy_import
+import torchvision.ops._custom_ops
 
 
 def nms(boxes, scores, iou_threshold):
@@ -29,8 +29,7 @@ def nms(boxes, scores, iou_threshold):
         of the elements that have been kept
         by NMS, sorted in decreasing order of scores
     """
-    _C = _lazy_import()
-    return _C.nms(boxes, scores, iou_threshold)
+    return torch.ops.torchvision.nms(boxes, scores, iou_threshold)
 
 
 def batched_nms(boxes, scores, idxs, iou_threshold):

--- a/torchvision/ops/roi_align.py
+++ b/torchvision/ops/roi_align.py
@@ -9,6 +9,8 @@ from torch.nn.modules.utils import _pair
 from torchvision.extension import _lazy_import
 from ._utils import convert_boxes_to_roi_format
 
+import torchvision.ops._custom_ops
+
 
 class _RoIAlignFunction(Function):
     @staticmethod
@@ -66,6 +68,10 @@ def roi_align(input, boxes, output_size, spatial_scale=1.0, sampling_ratio=-1):
     rois = boxes
     if not isinstance(rois, torch.Tensor):
         rois = convert_boxes_to_roi_format(rois)
+    if torch._C._get_tracing_state():
+        return torch.ops.torchvision.roi_align_forward(input, rois, spatial_scale,
+                                                       output_size[0], output_size[1],
+                                                       sampling_ratio)
     return _RoIAlignFunction.apply(input, rois, output_size, spatial_scale, sampling_ratio)
 
 

--- a/torchvision/ops/roi_align.py
+++ b/torchvision/ops/roi_align.py
@@ -68,10 +68,12 @@ def roi_align(input, boxes, output_size, spatial_scale=1.0, sampling_ratio=-1):
     rois = boxes
     if not isinstance(rois, torch.Tensor):
         rois = convert_boxes_to_roi_format(rois)
+    # TODO: Change this to support backwards, which we
+    #       do not currently support when JIT tracing.
     if torch._C._get_tracing_state():
-        return torch.ops.torchvision.roi_align_forward(input, rois, spatial_scale,
-                                                       output_size[0], output_size[1],
-                                                       sampling_ratio)
+        return torch.ops.torchvision.roi_align(input, rois, spatial_scale,
+                                               output_size[0], output_size[1],
+                                               sampling_ratio)
     return _RoIAlignFunction.apply(input, rois, output_size, spatial_scale, sampling_ratio)
 
 

--- a/torchvision/ops/roi_pool.py
+++ b/torchvision/ops/roi_pool.py
@@ -9,6 +9,8 @@ from torch.nn.modules.utils import _pair
 from torchvision.extension import _lazy_import
 from ._utils import convert_boxes_to_roi_format
 
+import torchvision.ops._custom_ops
+
 
 class _RoIPoolFunction(Function):
     @staticmethod
@@ -59,6 +61,10 @@ def roi_pool(input, boxes, output_size, spatial_scale=1.0):
     rois = boxes
     if not isinstance(rois, torch.Tensor):
         rois = convert_boxes_to_roi_format(rois)
+    if torch._C._get_tracing_state():
+        output, _ = torch.ops.torchvision.roi_pool_forward(input, rois, spatial_scale,
+                                                           output_size[0], output_size[1])
+        return output
     return _RoIPoolFunction.apply(input, rois, output_size, spatial_scale)
 
 

--- a/torchvision/ops/roi_pool.py
+++ b/torchvision/ops/roi_pool.py
@@ -61,9 +61,11 @@ def roi_pool(input, boxes, output_size, spatial_scale=1.0):
     rois = boxes
     if not isinstance(rois, torch.Tensor):
         rois = convert_boxes_to_roi_format(rois)
+    # TODO: Change this to support backwards, which we
+    #       do not currently support when JIT tracing.
     if torch._C._get_tracing_state():
-        output, _ = torch.ops.torchvision.roi_pool_forward(input, rois, spatial_scale,
-                                                           output_size[0], output_size[1])
+        output, _ = torch.ops.torchvision.roi_pool(input, rois, spatial_scale,
+                                                   output_size[0], output_size[1])
         return output
     return _RoIPoolFunction.apply(input, rois, output_size, spatial_scale)
 


### PR DESCRIPTION
- Create a library for the custom ops.
- Register Roi_Align, Roi_Pool and NMS as PyTorch custom ops.
- Implement the ONNX symbolics for Roi_Align, Roi_Pool and NMS.
- Add tests for exporting the ops to ONNX.