### PR TITLE
make shufflenet and resnet scriptable

### DIFF
--- a/test/test_models.py
+++ b/test/test_models.py
@@ -33,7 +33,7 @@ torchub_models = {
     "fcn_resnet101": False,
     "googlenet": False,
     "densenet121": False,
-    "resnet18": False,
+    "resnet18": True,
     "alexnet": True,
     "shufflenet_v2_x1_0": True,
     "squeezenet1_0": True,

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -35,7 +35,7 @@ torchub_models = {
     "densenet121": False,
     "resnet18": False,
     "alexnet": True,
-    "shufflenet_v2_x1_0": False,
+    "shufflenet_v2_x1_0": True,
     "squeezenet1_0": True,
     "vgg11": True,
     "inception_v3": False,

--- a/torchvision/models/resnet.py
+++ b/torchvision/models/resnet.py
@@ -34,6 +34,7 @@ def conv1x1(in_planes, out_planes, stride=1):
 
 class BasicBlock(nn.Module):
     expansion = 1
+    __constants__ = ['downsample']
 
     def __init__(self, inplanes, planes, stride=1, downsample=None, groups=1,
                  base_width=64, dilation=1, norm_layer=None):

--- a/torchvision/models/resnet.py
+++ b/torchvision/models/resnet.py
@@ -34,6 +34,7 @@ def conv1x1(in_planes, out_planes, stride=1):
 
 class BasicBlock(nn.Module):
     expansion = 1
+    __constants__ = ['downsample']
 
     def __init__(self, inplanes, planes, stride=1, downsample=None, groups=1,
                  base_width=64, dilation=1, norm_layer=None):
@@ -50,10 +51,12 @@ class BasicBlock(nn.Module):
         self.relu = nn.ReLU(inplace=True)
         self.conv2 = conv3x3(planes, planes)
         self.bn2 = norm_layer(planes)
-        self.downsample = downsample if downsample is not None else nn.Sequential()
+        self.downsample = downsample
         self.stride = stride
 
     def forward(self, x):
+        identity = x
+
         out = self.conv1(x)
         out = self.bn1(out)
         out = self.relu(out)
@@ -61,8 +64,8 @@ class BasicBlock(nn.Module):
         out = self.conv2(out)
         out = self.bn2(out)
 
-        # if downsample is None in __init__ then self.downsample set to is Identity
-        identity = self.downsample(x)
+        if self.downsample is not None:
+            identity = self.downsample(x)
 
         out += identity
         out = self.relu(out)

--- a/torchvision/models/resnet.py
+++ b/torchvision/models/resnet.py
@@ -34,7 +34,6 @@ def conv1x1(in_planes, out_planes, stride=1):
 
 class BasicBlock(nn.Module):
     expansion = 1
-    __constants__ = ['downsample']
 
     def __init__(self, inplanes, planes, stride=1, downsample=None, groups=1,
                  base_width=64, dilation=1, norm_layer=None):
@@ -51,12 +50,10 @@ class BasicBlock(nn.Module):
         self.relu = nn.ReLU(inplace=True)
         self.conv2 = conv3x3(planes, planes)
         self.bn2 = norm_layer(planes)
-        self.downsample = downsample
+        self.downsample = downsample if downsample is not None else nn.Sequential()
         self.stride = stride
 
     def forward(self, x):
-        identity = x
-
         out = self.conv1(x)
         out = self.bn1(out)
         out = self.relu(out)
@@ -64,8 +61,8 @@ class BasicBlock(nn.Module):
         out = self.conv2(out)
         out = self.bn2(out)
 
-        if self.downsample is not None:
-            identity = self.downsample(x)
+        # if downsample is None in __init__ then self.downsample set to is Identity
+        identity = self.downsample(x)
 
         out += identity
         out = self.relu(out)

--- a/torchvision/models/shufflenetv2.py
+++ b/torchvision/models/shufflenetv2.py
@@ -1,6 +1,5 @@
 import torch
 import torch.nn as nn
-from torch import Tensor
 from .utils import load_state_dict_from_url
 
 
@@ -18,7 +17,7 @@ model_urls = {
 
 
 def channel_shuffle(x, groups):
-    # type: (Tensor, int) -> Tensor
+    # type: (torch.Tensor, int) -> torch.Tensor
     batchsize, num_channels, height, width = x.data.size()
     channels_per_group = num_channels // groups
 

--- a/torchvision/models/shufflenetv2.py
+++ b/torchvision/models/shufflenetv2.py
@@ -17,6 +17,7 @@ model_urls = {
 
 
 def channel_shuffle(x, groups):
+    # type: (Tensor, int) -> Tensor
     batchsize, num_channels, height, width = x.data.size()
     channels_per_group = num_channels // groups
 
@@ -51,6 +52,8 @@ class InvertedResidual(nn.Module):
                 nn.BatchNorm2d(branch_features),
                 nn.ReLU(inplace=True),
             )
+        else:
+            self.branch1 = nn.Sequential()
 
         self.branch2 = nn.Sequential(
             nn.Conv2d(inp if (self.stride > 1) else branch_features,

--- a/torchvision/models/shufflenetv2.py
+++ b/torchvision/models/shufflenetv2.py
@@ -1,5 +1,6 @@
 import torch
 import torch.nn as nn
+from torch import Tensor
 from .utils import load_state_dict_from_url
 
 


### PR DESCRIPTION
ShuffleNet:
- added type annotations 
- previously `branch1` was only conditionally defined

Resnet:
- need to add `downsample` to constants so that script can compile when it is None
