### PR TITLE
Fix randomresized params flaky

### DIFF
--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -142,7 +142,7 @@ class Tester(unittest.TestCase):
         size = 100
         epsilon = 0.05
         min_scale = 0.25
-        for _ in range(1000):
+        for _ in range(10):
             scale_min = max(round(random.random(), 2), min_scale)
             scale_range = (scale_min, scale_min + round(random.random(), 2))
             aspect_min = max(round(random.random(), 2), epsilon)

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -141,8 +141,9 @@ class Tester(unittest.TestCase):
         img = to_pil_image(img)
         size = 100
         epsilon = 0.05
-        for _ in range(10):
-            scale_min = round(random.random(), 2)
+        min_scale = 0.25
+        for _ in range(1000):
+            scale_min = max(round(random.random(), 2), min_scale)
             scale_range = (scale_min, scale_min + round(random.random(), 2))
             aspect_min = max(round(random.random(), 2), epsilon)
             aspect_ratio_range = (aspect_min, aspect_min + round(random.random(), 2))

--- a/torchvision/transforms/transforms.py
+++ b/torchvision/transforms/transforms.py
@@ -639,13 +639,13 @@ class RandomResizedCrop(object):
 
         for attempt in range(10):
             target_area = random.uniform(*scale) * area
-            log_ratio = (math.log(min(ratio)), math.log(max(ratio)))
+            log_ratio = (math.log(ratio[0]), math.log(ratio[1]))
             aspect_ratio = math.exp(random.uniform(*log_ratio))
 
             w = int(round(math.sqrt(target_area * aspect_ratio)))
             h = int(round(math.sqrt(target_area / aspect_ratio)))
 
-            if w <= img.size[0] and h <= img.size[1]:
+            if 0 < w <= img.size[0] and 0 < h <= img.size[1]:
                 i = random.randint(0, img.size[1] - h)
                 j = random.randint(0, img.size[0] - w)
                 return i, j, h, w

--- a/torchvision/transforms/transforms.py
+++ b/torchvision/transforms/transforms.py
@@ -639,7 +639,7 @@ class RandomResizedCrop(object):
 
         for attempt in range(10):
             target_area = random.uniform(*scale) * area
-            log_ratio = (math.log(ratio[0]), math.log(ratio[1]))
+            log_ratio = (math.log(min(ratio)), math.log(max(ratio)))
             aspect_ratio = math.exp(random.uniform(*log_ratio))
 
             w = int(round(math.sqrt(target_area * aspect_ratio)))


### PR DESCRIPTION
Fixes https://github.com/pytorch/vision/issues/1170

The flakiness is due to the rounding in
https://github.com/pytorch/vision/blob/5537790bb7f873c5e7e6ae8b415cb75878fd0a58/torchvision/transforms/transforms.py#L645-L646
We are guaranteed that the floating point values for the dimensions gives an aspect ratio between the requested range, but after rounding this doesn't hold anymore.

One possible fix would be to re-check that this is still the case after rounding in https://github.com/pytorch/vision/blob/5537790bb7f873c5e7e6ae8b415cb75878fd0a58/torchvision/transforms/transforms.py#L648  similar to what was done in https://github.com/pytorch/vision/pull/1181, but this won't guard us from going outside of the requested aspect ratio in the fallback implementation in https://github.com/pytorch/vision/blob/5537790bb7f873c5e7e6ae8b415cb75878fd0a58/torchvision/transforms/transforms.py#L653-L665

Given that for arbitrary values of `scale`, `ratio` and sizes there is no guarantee that there exists an integer value that satisfies all the constraints, I decided instead to keep the implementation the same, but to increase the minimum scale that is allowed during the tests, so that rounding differences are amortized, and tests passes much more often.

The only fix that is done in the transforms here is to avoid empty-sized dimensions to be returned, which was a problem with the previous implementation.