### PR TITLE
Base classes for ffmpeg based decoder for video, audio, and subtitles.

### DIFF
--- a/torchvision/csrc/decoder/audio_sampler.cpp
+++ b/torchvision/csrc/decoder/audio_sampler.cpp
@@ -1,0 +1,199 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include "audio_sampler.h"
+#include <glog/logging.h>
+#include "util.h"
+
+// www.ffmpeg.org/doxygen/1.1/doc_2examples_2resampling_audio_8c-example.html#a24
+
+#ifndef SWR_CH_MAX
+#define SWR_CH_MAX 32
+#endif
+
+namespace ffmpeg {
+
+namespace {
+int preparePlanes(
+    const AudioFormat& fmt,
+    const uint8_t* buffer,
+    int numSamples,
+    uint8_t** planes) {
+  int result;
+  if ((result = av_samples_fill_arrays(
+           planes,
+           nullptr, // linesize is not needed
+           buffer,
+           fmt.channels,
+           numSamples,
+           (AVSampleFormat)fmt.format,
+           1)) < 0) {
+    LOG(CRITICAL) << "av_samples_fill_arrays failed, err: "
+                  << Util::generateErrorDesc(result)
+                  << ", numSamples: " << numSamples << ", fmt: " << fmt.format;
+  }
+  return result;
+}
+} // namespace
+
+AudioSampler::AudioSampler(void* logCtx) : logCtx_(logCtx) {}
+
+AudioSampler::~AudioSampler() {
+  cleanUp();
+}
+
+void AudioSampler::shutdown() {
+  cleanUp();
+}
+
+bool AudioSampler::init(const SamplerParameters& params) {
+  cleanUp();
+
+  if (params.type != MediaType::TYPE_AUDIO) {
+    LOG(CRITICAL) << "Invalid media type, expected MediaType::TYPE_AUDIO";
+    return false;
+  }
+
+  swrContext_ = swr_alloc_set_opts(
+      nullptr,
+      av_get_default_channel_layout(params.out.audio.channels),
+      (AVSampleFormat)params.out.audio.format,
+      params.out.audio.samples,
+      av_get_default_channel_layout(params.in.audio.channels),
+      (AVSampleFormat)params.in.audio.format,
+      params.in.audio.samples,
+      0,
+      logCtx_);
+  if (swrContext_ == nullptr) {
+    LOG(CRITICAL) << "Cannot allocate SwrContext";
+    return false;
+  }
+
+  int result;
+  if ((result = swr_init(swrContext_)) < 0) {
+    LOG(CRITICAL) << "swr_init faield, err: " << Util::generateErrorDesc(result)
+                  << ", in -> format: " << params.in.audio.format
+                  << ", channels: " << params.in.audio.channels
+                  << ", samples: " << params.in.audio.samples
+                  << ", out -> format: " << params.out.audio.format
+                  << ", channels: " << params.out.audio.channels
+                  << ", samples: " << params.out.audio.samples;
+    return false;
+  }
+
+  // set formats
+  params_ = params;
+  return true;
+}
+
+int AudioSampler::numOutputSamples(int inSamples) const {
+  return av_rescale_rnd(
+      swr_get_delay(swrContext_, params_.in.audio.samples) + inSamples,
+      params_.out.audio.samples,
+      params_.in.audio.samples,
+      AV_ROUND_UP);
+}
+
+int AudioSampler::getSamplesBytes(AVFrame* frame) const {
+  return av_get_bytes_per_sample((AVSampleFormat)params_.out.audio.format) *
+      numOutputSamples(frame ? frame->nb_samples : 0) *
+      params_.out.audio.channels;
+}
+
+int AudioSampler::sample(
+    const uint8_t* inPlanes[],
+    int inNumSamples,
+    ByteStorage* out,
+    int outNumSamples) {
+  uint8_t* outPlanes[SWR_CH_MAX] = {nullptr};
+  int result;
+  if ((result = preparePlanes(
+           params_.out.audio, out->writableTail(), outNumSamples, outPlanes)) <
+      0) {
+    return result;
+  }
+
+  if ((result = swr_convert(
+           swrContext_, &outPlanes[0], outNumSamples, inPlanes, inNumSamples)) <
+      0) {
+    LOG(CRITICAL) << "swr_convert faield, err: "
+                  << Util::generateErrorDesc(result);
+    return result;
+  }
+
+  CHECK_LE(result, outNumSamples);
+
+  if ((result = av_samples_get_buffer_size(
+           nullptr,
+           params_.out.audio.channels,
+           result,
+           (AVSampleFormat)params_.out.audio.format,
+           1)) > 0) {
+    out->append(result);
+  }
+  return result;
+}
+
+int AudioSampler::sample(AVFrame* frame, ByteStorage* out) {
+  const auto outNumSamples = numOutputSamples(frame ? frame->nb_samples : 0);
+
+  if (!outNumSamples) {
+    return 0;
+  }
+
+  const auto samplesBytes =
+      av_get_bytes_per_sample((AVSampleFormat)params_.out.audio.format) *
+      outNumSamples * params_.out.audio.channels;
+
+  // bytes must be allocated
+  CHECK_LE(samplesBytes, out->tail());
+
+  return sample(
+      frame ? (const uint8_t**)&frame->data[0] : nullptr,
+      frame ? frame->nb_samples : 0,
+      out,
+      outNumSamples);
+}
+
+int AudioSampler::sample(const ByteStorage* in, ByteStorage* out) {
+  const auto inSampleSize =
+      av_get_bytes_per_sample((AVSampleFormat)params_.in.audio.format);
+
+  const auto inNumSamples =
+      !in ? 0 : in->length() / inSampleSize / params_.in.audio.channels;
+
+  const auto outNumSamples = numOutputSamples(inNumSamples);
+
+  if (!outNumSamples) {
+    return 0;
+  }
+
+  const auto samplesBytes =
+      av_get_bytes_per_sample((AVSampleFormat)params_.out.audio.format) *
+      outNumSamples * params_.out.audio.channels;
+
+  out->clear();
+  out->ensure(samplesBytes);
+
+  uint8_t* inPlanes[SWR_CH_MAX] = {nullptr};
+  int result;
+  if (in &&
+      (result = preparePlanes(
+           params_.in.audio, in->data(), inNumSamples, inPlanes)) < 0) {
+    return result;
+  }
+
+  return sample(
+      in ? (const uint8_t**)inPlanes : nullptr,
+      inNumSamples,
+      out,
+      outNumSamples);
+}
+
+void AudioSampler::cleanUp() {
+  if (swrContext_) {
+    swr_free(&swrContext_);
+    swrContext_ = nullptr;
+  }
+}
+
+} // namespace ffmpeg

--- a/torchvision/csrc/decoder/audio_sampler.h
+++ b/torchvision/csrc/decoder/audio_sampler.h
@@ -1,0 +1,56 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#pragma once
+
+#include "defs.h"
+
+extern "C" {
+#include <libswresample/swresample.h>
+}
+
+namespace ffmpeg {
+
+/**
+ * Class transcode audio frames from one format into another
+ */
+
+class AudioSampler : public MediaSampler {
+ public:
+  explicit AudioSampler(void* logCtx);
+  ~AudioSampler() override;
+
+  // MediaSampler overrides
+  bool init(const SamplerParameters& params) override;
+  MediaType getMediaType() const override {
+    return MediaType::TYPE_AUDIO;
+  }
+  FormatUnion getInputFormat() const override {
+    return params_.in;
+  }
+  FormatUnion getOutFormat() const override {
+    return params_.out;
+  }
+  int sample(const ByteStorage* in, ByteStorage* out) override;
+  void shutdown() override;
+
+  int getSamplesBytes(AVFrame* frame) const;
+  int sample(AVFrame* frame, ByteStorage* out);
+
+ private:
+  // close resources
+  void cleanUp();
+  // helper functions for rescaling, cropping, etc.
+  int numOutputSamples(int inSamples) const;
+  int sample(
+      const uint8_t* inPlanes[],
+      int inNumSamples,
+      ByteStorage* out,
+      int outNumSamples);
+
+ private:
+  SamplerParameters params_;
+  SwrContext* swrContext_{nullptr};
+  void* logCtx_{nullptr};
+};
+
+} // namespace ffmpeg

--- a/torchvision/csrc/decoder/audio_stream.cpp
+++ b/torchvision/csrc/decoder/audio_stream.cpp
@@ -1,0 +1,120 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include "audio_stream.h"
+#include <glog/logging.h>
+#include <limits>
+#include "util.h"
+
+namespace ffmpeg {
+
+namespace {
+bool operator==(const AudioFormat& x, const AVCodecContext& y) {
+  return x.samples == y.sample_rate && x.channels == y.channels &&
+      x.format == y.sample_fmt;
+}
+
+AudioFormat& toAudioFormat(AudioFormat& x, const AVCodecContext& y) {
+  x.samples = y.sample_rate;
+  x.channels = y.channels;
+  x.format = y.sample_fmt;
+  return x;
+}
+} // namespace
+
+AudioStream::AudioStream(
+    AVFormatContext* inputCtx,
+    int index,
+    bool convertPtsToWallTime,
+    const AudioFormat& format)
+    : Stream(inputCtx, index, convertPtsToWallTime), format_(format) {}
+
+AudioStream::~AudioStream() {
+  if (sampler_) {
+    sampler_->shutdown();
+    sampler_.reset();
+  }
+}
+
+void AudioStream::ensureSampler() {
+  if (!sampler_) {
+    sampler_ = std::make_unique<AudioSampler>(codecCtx_);
+  }
+}
+
+int AudioStream::initFormat() {
+  // set output format
+  if (format_.samples == 0) {
+    format_.samples = codecCtx_->sample_rate;
+  }
+  if (format_.channels == 0) {
+    format_.channels = codecCtx_->channels;
+  }
+  if (format_.format == AV_SAMPLE_FMT_NONE) {
+    format_.format = codecCtx_->sample_fmt;
+  }
+
+  return format_.samples != 0 && format_.channels != 0 &&
+          format_.format != AV_SAMPLE_FMT_NONE
+      ? 0
+      : -1;
+}
+
+int AudioStream::estimateBytes(bool flush) {
+  ensureSampler();
+  if (!(sampler_->getInputFormat().audio == *codecCtx_)) {
+    // - reinit sampler
+    SamplerParameters params;
+    params.type = MediaType::TYPE_AUDIO;
+    params.out.audio = format_;
+    toAudioFormat(params.in.audio, *codecCtx_);
+    if (flush || !sampler_->init(params)) {
+      return -1;
+    }
+
+    VLOG(1) << "Set input audio sampler format"
+            << ", samples: " << params.in.audio.samples
+            << ", channels: " << params.in.audio.channels
+            << ", format: " << params.in.audio.format
+            << " : output audio sampler format"
+            << ", samples: " << format_.samples
+            << ", channels: " << format_.channels
+            << ", format: " << format_.format;
+  }
+  return sampler_->getSamplesBytes(frame_);
+}
+
+int AudioStream::copyFrameBytes(ByteStorage* out, bool flush) {
+  ensureSampler();
+  return sampler_->sample(flush ? nullptr : frame_, out);
+}
+
+void AudioStream::setHeader(DecoderHeader* header) {
+  header->seqno = numGenerator_++;
+
+  if (codecCtx_->time_base.num != 0) {
+    header->pts = av_rescale_q(
+        av_frame_get_best_effort_timestamp(frame_),
+        codecCtx_->time_base,
+        AV_TIME_BASE_Q);
+  } else {
+    // If the codec time_base is missing then we would've skipped the
+    // rescalePackage step to rescale to codec time_base, so here we can
+    // rescale straight from the stream time_base into AV_TIME_BASE_Q.
+    header->pts = av_rescale_q(
+        av_frame_get_best_effort_timestamp(frame_),
+        inputCtx_->streams[index_]->time_base,
+        AV_TIME_BASE_Q);
+  }
+
+  if (convertPtsToWallTime_) {
+    keeper_.adjust(header->pts);
+  }
+
+  header->keyFrame = 1;
+  header->fps = std::numeric_limits<double>::quiet_NaN();
+  header->format.type = TYPE_AUDIO;
+  header->format.stream = index_;
+  header->format.format.audio = format_;
+}
+
+} // namespace ffmpeg

--- a/torchvision/csrc/decoder/audio_stream.h
+++ b/torchvision/csrc/decoder/audio_stream.h
@@ -1,0 +1,42 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#pragma once
+
+#include "audio_sampler.h"
+#include "stream.h"
+#include "time_keeper.h"
+
+namespace ffmpeg {
+
+/**
+ * Class uses FFMPEG library to decode one audio stream.
+ */
+
+class AudioStream : public Stream {
+ public:
+  AudioStream(
+      AVFormatContext* inputCtx,
+      int index,
+      bool convertPtsToWallTime,
+      const AudioFormat& format);
+  ~AudioStream() override;
+
+ private:
+  // Stream overrides
+  MediaType getMediaType() const override {
+    return TYPE_AUDIO;
+  }
+  int initFormat() override;
+  int estimateBytes(bool flush) override;
+  int copyFrameBytes(ByteStorage* out, bool flush) override;
+  void setHeader(DecoderHeader* header) override;
+
+  void ensureSampler();
+
+ private:
+  AudioFormat format_;
+  std::unique_ptr<AudioSampler> sampler_;
+  TimeKeeper keeper_;
+};
+
+} // namespace ffmpeg

--- a/torchvision/csrc/decoder/cc_stream.cpp
+++ b/torchvision/csrc/decoder/cc_stream.cpp
@@ -1,0 +1,22 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include "cc_stream.h"
+
+namespace ffmpeg {
+
+AVCodec* CCStream::findCodec(AVCodecContext* ctx) {
+  if (ctx->codec_id == AV_CODEC_ID_BIN_DATA &&
+      ctx->codec_type == AVMEDIA_TYPE_DATA) {
+    // obtain subtitles codec
+    ctx->codec_id = AV_CODEC_ID_MOV_TEXT;
+    ctx->codec_type = AVMEDIA_TYPE_SUBTITLE;
+  }
+  return Stream::findCodec(ctx);
+}
+
+void CCStream::setHeader(DecoderHeader* header) {
+  SubtitleStream::setHeader(header);
+  header->format.type = TYPE_CC;
+}
+
+} // namespace ffmpeg

--- a/torchvision/csrc/decoder/cc_stream.h
+++ b/torchvision/csrc/decoder/cc_stream.h
@@ -1,0 +1,26 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#pragma once
+
+#include "subtitle_stream.h"
+
+namespace ffmpeg {
+
+/**
+ * Class uses FFMPEG library to decode one closed captions stream.
+ */
+class CCStream : public SubtitleStream {
+ public:
+  using SubtitleStream::SubtitleStream;
+
+ private:
+  // Stream overrides
+  MediaType getMediaType() const override {
+    return TYPE_CC;
+  }
+
+  void setHeader(DecoderHeader* header) override;
+  AVCodec* findCodec(AVCodecContext* ctx) override;
+};
+
+} // namespace ffmpeg

--- a/torchvision/csrc/decoder/decoder.cpp
+++ b/torchvision/csrc/decoder/decoder.cpp
@@ -1,0 +1,568 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include "decoder.h"
+#include <glog/logging.h>
+#include <future>
+#include <iostream>
+#include <mutex>
+#include "audio_stream.h"
+#include "cc_stream.h"
+#include "subtitle_stream.h"
+#include "util.h"
+#include "video_stream.h"
+
+namespace ffmpeg {
+
+namespace {
+
+constexpr ssize_t kMinSeekBufferSize = 4 * 1024;
+constexpr ssize_t kMaxSeekBufferSize = 64 * 1024 * 1024;
+constexpr size_t kIoBufferSize = 4 * 1024;
+constexpr size_t kLogBufferSize = 1024;
+
+int ffmpeg_lock(void** mutex, enum AVLockOp op) {
+  std::mutex** handle = (std::mutex**)mutex;
+  switch (op) {
+    case AV_LOCK_CREATE:
+      *handle = new std::mutex();
+      break;
+    case AV_LOCK_OBTAIN:
+      (*handle)->lock();
+      break;
+    case AV_LOCK_RELEASE:
+      (*handle)->unlock();
+      break;
+    case AV_LOCK_DESTROY:
+      delete *handle;
+      break;
+  }
+  return 0;
+}
+
+bool mapFfmpegType(AVMediaType media, MediaType* type) {
+  switch (media) {
+    case AVMEDIA_TYPE_AUDIO:
+      *type = TYPE_AUDIO;
+      return true;
+    case AVMEDIA_TYPE_VIDEO:
+      *type = TYPE_VIDEO;
+      return true;
+    case AVMEDIA_TYPE_SUBTITLE:
+      *type = TYPE_SUBTITLE;
+      return true;
+    case AVMEDIA_TYPE_DATA:
+      *type = TYPE_CC;
+      return true;
+    default:
+      return false;
+  }
+}
+
+std::unique_ptr<Stream> createStream(
+    MediaType type,
+    AVFormatContext* ctx,
+    int idx,
+    bool convertPtsToWallTime,
+    const FormatUnion& format,
+    int64_t loggingUuid) {
+  switch (type) {
+    case TYPE_AUDIO:
+      return std::make_unique<AudioStream>(
+          ctx, idx, convertPtsToWallTime, format.audio);
+    case TYPE_VIDEO:
+      return std::make_unique<VideoStream>(
+          // negative loggingUuid indicates video streams.
+          ctx,
+          idx,
+          convertPtsToWallTime,
+          format.video,
+          -loggingUuid);
+    case TYPE_SUBTITLE:
+      return std::make_unique<SubtitleStream>(
+          ctx, idx, convertPtsToWallTime, format.subtitle);
+    case TYPE_CC:
+      return std::make_unique<CCStream>(
+          ctx, idx, convertPtsToWallTime, format.subtitle);
+    default:
+      return nullptr;
+  }
+}
+
+} // Namespace
+
+/* static */
+void Decoder::logFunction(void* avcl, int level, const char* cfmt, va_list vl) {
+  if (!avcl) {
+    // Nothing can be done here
+    return;
+  }
+
+  AVClass* avclass = *reinterpret_cast<AVClass**>(avcl);
+  if (!avclass) {
+    // Nothing can be done here
+    return;
+  }
+  Decoder* decoder = nullptr;
+  if (strcmp(avclass->class_name, "AVFormatContext") == 0) {
+    AVFormatContext* context = reinterpret_cast<AVFormatContext*>(avcl);
+    if (context) {
+      decoder = reinterpret_cast<Decoder*>(context->opaque);
+    }
+  } else if (strcmp(avclass->class_name, "AVCodecContext") == 0) {
+    AVCodecContext* context = reinterpret_cast<AVCodecContext*>(avcl);
+    if (context) {
+      decoder = reinterpret_cast<Decoder*>(context->opaque);
+    }
+  } else if (strcmp(avclass->class_name, "AVIOContext") == 0) {
+    AVIOContext* context = reinterpret_cast<AVIOContext*>(avcl);
+    // only if opaque was assigned to Decoder pointer
+    if (context && context->read_packet == Decoder::readFunction) {
+      decoder = reinterpret_cast<Decoder*>(context->opaque);
+    }
+  } else if (strcmp(avclass->class_name, "SWResampler") == 0) {
+    // expect AVCodecContext as parent
+    if (avclass->parent_log_context_offset) {
+      AVClass** parent =
+          *(AVClass***)(((uint8_t*)avcl) + avclass->parent_log_context_offset);
+      AVCodecContext* context = reinterpret_cast<AVCodecContext*>(parent);
+      if (context) {
+        decoder = reinterpret_cast<Decoder*>(context->opaque);
+      }
+    }
+  } else if (strcmp(avclass->class_name, "SWScaler") == 0) {
+    // cannot find a way to pass context pointer through SwsContext struct
+  } else {
+    VLOG(2) << "Unknown context class: " << avclass->class_name;
+  }
+
+  if (decoder != nullptr && decoder->enableLogLevel(level)) {
+    char buf[kLogBufferSize] = {0};
+    // Format the line
+    int* prefix = decoder->getPrintPrefix();
+    *prefix = 1;
+    av_log_format_line(avcl, level, cfmt, vl, buf, sizeof(buf) - 1, prefix);
+    // pass message to the decoder instance
+    std::string msg(buf);
+    decoder->logCallback(level, msg);
+  }
+}
+
+bool Decoder::enableLogLevel(int level) const {
+  return ssize_t(level) <= params_.logLevel;
+}
+
+void Decoder::logCallback(int level, const std::string& message) {
+  LOG(INFO) << "Msg, level: " << level << ", msg: " << message;
+}
+
+/* static */
+int Decoder::shutdownFunction(void* ctx) {
+  Decoder* decoder = (Decoder*)ctx;
+  if (decoder == nullptr) {
+    return 1;
+  }
+  return decoder->shutdownCallback();
+}
+
+int Decoder::shutdownCallback() {
+  return interrupted_ ? 1 : 0;
+}
+
+/* static */
+int Decoder::readFunction(void* opaque, uint8_t* buf, int size) {
+  Decoder* decoder = reinterpret_cast<Decoder*>(opaque);
+  if (decoder == nullptr) {
+    return 0;
+  }
+  return decoder->readCallback(buf, size);
+}
+
+/* static */
+int64_t Decoder::seekFunction(void* opaque, int64_t offset, int whence) {
+  Decoder* decoder = reinterpret_cast<Decoder*>(opaque);
+  if (decoder == nullptr) {
+    return -1;
+  }
+  return decoder->seekCallback(offset, whence);
+}
+
+int Decoder::readCallback(uint8_t* buf, int size) {
+  return seekableBuffer_.read(buf, size, params_.timeoutMs);
+}
+
+int64_t Decoder::seekCallback(int64_t offset, int whence) {
+  return seekableBuffer_.seek(offset, whence);
+}
+
+/* static */
+void Decoder::initOnce() {
+  static std::once_flag flagInit;
+  std::call_once(flagInit, []() {
+    av_register_all();
+    avcodec_register_all();
+    avformat_network_init();
+    // register ffmpeg lock manager
+    av_lockmgr_register(&ffmpeg_lock);
+    av_log_set_callback(Decoder::logFunction);
+    av_log_set_level(AV_LOG_ERROR);
+    LOG(INFO) << "Registered ffmpeg libs";
+  });
+}
+
+Decoder::Decoder() {
+  initOnce();
+}
+
+Decoder::~Decoder() {
+  cleanUp();
+}
+
+bool Decoder::init(const DecoderParameters& params, DecoderInCallback&& in) {
+  cleanUp();
+
+  if ((params.uri.empty() || in) && (!params.uri.empty() || !in)) {
+    LOG(ERROR) << "Either external URI gets provided"
+               << " or explicit input callback";
+    return false;
+  }
+
+  // set callback and params
+  params_ = params;
+
+  auto tmpCtx = avformat_alloc_context();
+
+  if (!tmpCtx) {
+    LOG(CRITICAL) << "Cannot allocate format context";
+    return false;
+  }
+
+  if (in) {
+    const size_t avioCtxBufferSize = kIoBufferSize;
+    uint8_t* avioCtxBuffer = (uint8_t*)av_malloc(avioCtxBufferSize);
+    if (!avioCtxBuffer) {
+      LOG(ERROR) << "av_malloc cannot allocate " << avioCtxBufferSize
+                 << " bytes";
+      avformat_close_input(&tmpCtx);
+      cleanUp();
+      return false;
+    }
+
+    bool canSeek = seekableBuffer_.init(
+        std::forward<DecoderInCallback>(in),
+        kMinSeekBufferSize,
+        kMaxSeekBufferSize,
+        params_.timeoutMs);
+
+    if (!(avioCtx_ = avio_alloc_context(
+              avioCtxBuffer,
+              avioCtxBufferSize,
+              0,
+              reinterpret_cast<void*>(this),
+              &Decoder::readFunction,
+              nullptr,
+              canSeek ? &Decoder::seekFunction : nullptr))) {
+      LOG(ERROR) << "avio_alloc_context failed";
+      av_free(avioCtxBuffer);
+      avformat_close_input(&tmpCtx);
+      cleanUp();
+      return false;
+    }
+
+    tmpCtx->pb = avioCtx_;
+  }
+
+  interrupted_ = false;
+  // ffmpeg avformat_open_input call can hang if media source doesn't respond
+  // set a guard for handle such situations
+  std::promise<bool> p;
+  std::future<bool> f = p.get_future();
+  std::thread guard([&f, this]() {
+    auto timeout = std::chrono::milliseconds(params_.timeoutMs);
+    if (std::future_status::timeout == f.wait_for(timeout)) {
+      LOG(CRITICAL) << "Cannot open stream within " << params_.timeoutMs
+                    << " ms";
+      interrupted_ = true;
+    }
+  });
+
+  tmpCtx->opaque = reinterpret_cast<void*>(this);
+  tmpCtx->interrupt_callback.callback = Decoder::shutdownFunction;
+  tmpCtx->interrupt_callback.opaque = reinterpret_cast<void*>(this);
+
+  // add network timeout
+  tmpCtx->flags |= AVFMT_FLAG_NONBLOCK;
+
+  AVDictionary* options = nullptr;
+  av_dict_set_int(&options, "analyzeduration", params_.timeoutMs * 1000, 0);
+  av_dict_set_int(&options, "stimeout", params_.timeoutMs * 1000, 0);
+
+  int result = 0;
+  if (params_.isImage) {
+    const char* fmtName = "image2";
+    switch (seekableBuffer_.getImageType()) {
+      case ImageType::JPEG:
+        fmtName = "jpeg_pipe";
+        break;
+      case ImageType::PNG:
+        fmtName = "png_pipe";
+        break;
+      case ImageType::TIFF:
+        fmtName = "tiff_pipe";
+        break;
+      default:
+        break;
+    }
+    AVInputFormat* fmt = av_find_input_format(fmtName);
+    result = avformat_open_input(&tmpCtx, nullptr, fmt, &options);
+  } else {
+    result =
+        avformat_open_input(&tmpCtx, params_.uri.c_str(), nullptr, &options);
+  }
+  av_dict_free(&options);
+
+  p.set_value(true);
+  guard.join();
+
+  inputCtx_ = tmpCtx;
+
+  if (result < 0 || interrupted_) {
+    LOG(ERROR) << "avformat_open_input failed, error: "
+               << Util::generateErrorDesc(result);
+    cleanUp();
+    return false;
+  }
+
+  result = avformat_find_stream_info(inputCtx_, nullptr);
+
+  if (result < 0) {
+    LOG(ERROR) << "avformat_find_stream_info failed, error: "
+               << Util::generateErrorDesc(result);
+    cleanUp();
+    return false;
+  }
+
+  if (!activateStreams()) {
+    LOG(ERROR) << "Cannot activate streams";
+    cleanUp();
+    return false;
+  }
+
+  onInit();
+
+  LOG(INFO) << "Decoder initialized, log level: " << params_.logLevel;
+  return true;
+}
+
+bool Decoder::activateStreams() {
+  for (int i = 0; i < inputCtx_->nb_streams; i++) {
+    // - find the corespondent format at params_.formats set
+    MediaFormat format;
+    const auto media = inputCtx_->streams[i]->codec->codec_type;
+    if (!mapFfmpegType(media, &format.type)) {
+      VLOG(1) << "Stream media: " << media << " at index " << i
+              << " gets ignored, unknown type";
+
+      continue; // unsupported type
+    }
+
+    // check format
+    auto it = params_.formats.find(format);
+    if (it == params_.formats.end()) {
+      VLOG(1) << "Stream type: " << format.type << " at index: " << i
+              << " gets ignored, caller is not interested";
+      continue; // clients don't care about this media format
+    }
+
+    // do we have stream of this type?
+    auto stream = findByType(format);
+
+    // should we process this stream?
+
+    if (it->stream == -2 || // all streams of this type are welcome
+        (!stream && (it->stream == -1 || it->stream == i))) { // new stream
+      VLOG(1) << "Stream type: " << format.type << " found, at index: " << i;
+      auto stream = createStream(
+          format.type,
+          inputCtx_,
+          i,
+          params_.convertPtsToWallTime,
+          it->format,
+          params_.loggingUuid);
+      CHECK(stream);
+      if (stream->openCodec() < 0) {
+        LOG(ERROR) << "Cannot open codec " << i;
+        return false;
+      }
+      streams_.emplace(i, std::move(stream));
+    }
+  }
+
+  return true;
+}
+
+void Decoder::shutdown() {
+  cleanUp();
+}
+
+void Decoder::cleanUp() {
+  if (!interrupted_) {
+    interrupted_ = true;
+  }
+
+  if (inputCtx_) {
+    for (auto& stream : streams_) {
+      // Drain stream buffers.
+      DecoderOutputMessage msg;
+      while (msg.payload = createByteStorage(0),
+             stream.second->flush(&msg) > 0) {
+      }
+      stream.second.reset();
+    }
+    streams_.clear();
+    avformat_close_input(&inputCtx_);
+  }
+  if (avioCtx_) {
+    av_freep(&avioCtx_->buffer);
+    av_freep(&avioCtx_);
+  }
+
+  // reset callback
+  seekableBuffer_.shutdown();
+}
+
+int Decoder::getBytes(size_t workingTimeInMs) {
+  // decode frames until cache is full and leave thread
+  // once decode() method gets called and grab some bytes
+  // run this method again
+  // init package
+  AVPacket avPacket;
+  av_init_packet(&avPacket);
+  avPacket.data = nullptr;
+  avPacket.size = 0;
+
+  auto end = std::chrono::steady_clock::now() +
+      std::chrono::milliseconds(workingTimeInMs);
+  // return true if elapsed time less than timeout
+  auto watcher = [end]() -> bool {
+    return std::chrono::steady_clock::now() <= end;
+  };
+
+  int result = ETIMEDOUT;
+  size_t decodingErrors = 0;
+  while (!interrupted_ && watcher()) {
+    result = av_read_frame(inputCtx_, &avPacket);
+    if (result == AVERROR(EAGAIN)) {
+      VLOG(4) << "Decoder is busy...";
+      result = 0; // reset error, EAGAIN is not an error at all
+      break;
+    } else if (result == AVERROR_EOF) {
+      flushStreams();
+      VLOG(1) << "End of stream";
+      result = ENODATA;
+      break;
+    } else if (result < 0) {
+      flushStreams();
+      LOG(ERROR) << "Error detected: " << Util::generateErrorDesc(result);
+      break;
+    }
+
+    // get stream
+    auto stream = findByIndex(avPacket.stream_index);
+    if (stream == nullptr) {
+      av_packet_unref(&avPacket);
+      continue;
+    }
+
+    stream->rescalePackage(&avPacket);
+
+    AVPacket copyPacket = avPacket;
+
+    size_t numConsecutiveNoBytes = 0;
+    // it can be only partial decoding of the package bytes
+    do {
+      // decode package
+      if ((result = processPacket(stream, &copyPacket)) < 0) {
+        break;
+      }
+
+      if (result == 0 && params_.maxProcessNoBytes != 0 &&
+          ++numConsecutiveNoBytes > params_.maxProcessNoBytes) {
+        LOG(CRITICAL) << "Exceeding max amount of consecutive no bytes";
+        break;
+      }
+      if (result > 0) {
+        numConsecutiveNoBytes = 0;
+      }
+
+      copyPacket.size -= result;
+      copyPacket.data += result;
+    } while (copyPacket.size > 0);
+
+    // post loop check
+    if (result < 0) {
+      if (params_.maxPackageErrors != 0 && // check errors
+          ++decodingErrors >= params_.maxPackageErrors) { // reached the limit
+        break;
+      }
+    } else {
+      decodingErrors = 0; // reset on success
+    }
+
+    result = 0;
+
+    av_packet_unref(&avPacket);
+  }
+
+  av_packet_unref(&avPacket);
+
+  return result;
+}
+
+Stream* Decoder::findByIndex(int streamIndex) const {
+  auto it = streams_.find(streamIndex);
+  return it != streams_.end() ? it->second.get() : nullptr;
+}
+
+Stream* Decoder::findByType(const MediaFormat& format) const {
+  for (auto& stream : streams_) {
+    if (stream.second->getMediaType() == format.type) {
+      return stream.second.get();
+    }
+  }
+  return nullptr;
+}
+
+int Decoder::processPacket(Stream* stream, AVPacket* packet) {
+  // decode package
+  int gotFrame = 0;
+  int result, processed;
+  DecoderOutputMessage msg;
+  msg.payload = createByteStorage(0);
+  if ((result = stream->decodeFrame(packet, &gotFrame)) >= 0 && gotFrame &&
+      (processed = stream->getFrameBytes(&msg)) > 0) {
+    push(std::move(msg));
+  }
+  return result;
+}
+
+void Decoder::flushStreams() {
+  VLOG(1) << "Flushing streams...";
+  for (auto& stream : streams_) {
+    DecoderOutputMessage msg;
+    while (msg.payload = createByteStorage(0), stream.second->flush(&msg) > 0) {
+      push(std::move(msg));
+    }
+  }
+}
+
+int Decoder::decode_all(const DecoderOutCallback& callback) {
+  int result;
+  do {
+    DecoderOutputMessage out;
+    if (0 == (result = decode(&out, params_.timeoutMs))) {
+      callback(std::move(out));
+    }
+  } while (result == 0);
+  return result;
+}
+} // namespace ffmpeg

--- a/torchvision/csrc/decoder/decoder.h
+++ b/torchvision/csrc/decoder/decoder.h
@@ -1,0 +1,74 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#pragma once
+
+#include "seekable_buffer.h"
+#include "stream.h"
+
+namespace ffmpeg {
+
+/**
+ * Class uses FFMPEG library to decode media streams.
+ * Media bytes can be explicitly provided through read-callback
+ * or fetched internally by FFMPEG library
+ */
+class Decoder : public MediaDecoder {
+ public:
+  Decoder();
+  ~Decoder() override;
+
+  // MediaDecoder overrides
+  bool init(const DecoderParameters& params, DecoderInCallback&& in) override;
+  int decode_all(const DecoderOutCallback& callback) override;
+  void shutdown() override;
+
+ protected:
+  // function does actual work, derived class calls it in working thread
+  // periodically. On success method returns 0, ENOADATA on EOF and error on
+  // unrecoverable error.
+  int getBytes(size_t workingTimeInMs = 100);
+
+  // Derived class must override method and consume the provided message
+  virtual void push(DecoderOutputMessage&& buffer) = 0;
+
+  // Fires on init call
+  virtual void onInit() {}
+
+ public:
+  // C-style FFMPEG API requires C/static methods for callbacks
+  static void logFunction(void* avcl, int level, const char* cfmt, va_list vl);
+  static int shutdownFunction(void* ctx);
+  static int readFunction(void* opaque, uint8_t* buf, int size);
+  static int64_t seekFunction(void* opaque, int64_t offset, int whence);
+  // can be called by any classes or API
+  static void initOnce();
+
+  int* getPrintPrefix() {
+    return &printPrefix;
+  }
+
+ private:
+  // mark below function for a proper invocation
+  virtual bool enableLogLevel(int level) const;
+  virtual void logCallback(int level, const std::string& message);
+  virtual int readCallback(uint8_t* buf, int size);
+  virtual int64_t seekCallback(int64_t offset, int whence);
+  virtual int shutdownCallback();
+
+  bool activateStreams();
+  Stream* findByIndex(int streamIndex) const;
+  Stream* findByType(const MediaFormat& format) const;
+  int processPacket(Stream* stream, AVPacket* packet);
+  void flushStreams();
+  void cleanUp();
+
+ protected:
+  DecoderParameters params_;
+  SeekableBuffer seekableBuffer_;
+  int printPrefix{1};
+  std::atomic<bool> interrupted_{false};
+  AVFormatContext* inputCtx_{nullptr};
+  AVIOContext* avioCtx_{nullptr};
+  std::unordered_map<ssize_t, std::unique_ptr<Stream>> streams_;
+};
+} // namespace ffmpeg

--- a/torchvision/csrc/decoder/defs.h
+++ b/torchvision/csrc/decoder/defs.h
@@ -1,0 +1,267 @@
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <set>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+namespace ffmpeg {
+
+// bit mask of formats, keep them in form 2^n
+enum MediaType : size_t {
+  TYPE_AUDIO = 1,
+  TYPE_VIDEO = 2,
+  TYPE_SUBTITLE = 4,
+  TYPE_CC = 8, // closed captions from transport streams
+};
+
+// audio
+struct AudioFormat {
+  // fields are initialized for the auto detection
+  // caller can specify some/all of field values if specific output is desirable
+  bool operator==(const AudioFormat& x) const {
+    return x.format == format && x.samples == samples && x.channels == channels;
+  }
+
+  size_t samples{0}; // number samples per second (frequency)
+  size_t channels{0}; // number of channels
+  ssize_t format{-1}; // AVSampleFormat, auto AV_SAMPLE_FMT_NONE
+  size_t padding[2];
+  // -- alignment 40 bytes
+};
+
+// video
+struct VideoFormat {
+  // fields are initialized for the auto detection
+  // caller can specify some/all of field values if specific output is desirable
+  bool operator==(const VideoFormat& x) const {
+    return x.format == format && x.width == width && x.height == height;
+  }
+
+  size_t width{0}; // width in pixels
+  size_t height{0}; // height in pixels
+  ssize_t format{-1}; // AVPixelFormat, auto AV_PIX_FMT_NONE
+  size_t minDimension{0}; // choose min dimension and rescale accordingly
+  size_t cropImage{0}; // request image crop
+  // -- alignment 40 bytes
+};
+
+// subtitle/cc
+struct SubtitleFormat {
+  ssize_t type{0}; // AVSubtitleType, auto SUBTITLE_NONE
+  size_t padding[4];
+  // -- alignment 40 bytes
+};
+
+union FormatUnion {
+  FormatUnion() : audio() {}
+  explicit FormatUnion(int) : video() {}
+  explicit FormatUnion(char) : subtitle() {}
+  explicit FormatUnion(double) : subtitle() {}
+  AudioFormat audio;
+  VideoFormat video;
+  SubtitleFormat subtitle;
+  // -- alignment 40 bytes
+};
+
+/*
+  MediaFormat data structure serves as input/output parameter.
+  Caller assigns values for input formats
+  or leave default values for auto detection
+  For output formats all fields will be set to the specific values
+*/
+
+struct MediaFormat {
+  // for using map/set data structures
+  bool operator<(const MediaFormat& x) const {
+    return type < x.type;
+  }
+  bool operator==(const MediaFormat& x) const {
+    if (type != x.type) {
+      return false;
+    }
+    switch (type) {
+      case TYPE_AUDIO:
+        return format.audio == x.format.audio;
+      case TYPE_VIDEO:
+        return format.video == x.format.video;
+      case TYPE_SUBTITLE:
+      case TYPE_CC:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  MediaFormat() : type(TYPE_AUDIO), stream(-1), format() {}
+  explicit MediaFormat(int x) : type(TYPE_VIDEO), stream(-1), format(x) {}
+  explicit MediaFormat(char x) : type(TYPE_SUBTITLE), stream(-1), format(x) {}
+  explicit MediaFormat(double x) : type(TYPE_CC), stream(-1), format(x) {}
+  // format type
+  MediaType type;
+  // stream index:
+  // set -1 for one stream auto detection, -2 for all streams auto detection,
+  // >= 0, specified stream, if caller knows the stream index (unlikely)
+  ssize_t stream;
+  // union keeps one of the possible formats, defined by MediaType
+  FormatUnion format;
+};
+
+struct DecoderParameters {
+  // local file, remote file, http url, rtmp stream uri, etc. anything that
+  // ffmpeg can recognize
+  std::string uri;
+  // timeout on getting bytes for decoding
+  size_t timeoutMs{1000};
+  // logging level, default AV_LOG_PANIC
+  ssize_t logLevel{0};
+  // when decoder would give up, 0 means never
+  size_t maxPackageErrors{0};
+  // max allowed consecutive times no bytes are processed. 0 means for infinite.
+  size_t maxProcessNoBytes{0};
+  // logging id
+  int64_t loggingUuid{0};
+  // adjust header pts to the epoch time
+  bool convertPtsToWallTime{false};
+  // indicate if input stream is an encoded image
+  bool isImage{false};
+  // what media types should be processed, default none
+  std::set<MediaFormat> formats;
+};
+
+struct DecoderHeader {
+  // message id, from 0 till ...
+  size_t seqno{0};
+  // decoded timestamp in microseconds from either beginning of the stream or
+  // from epoch time, see DecoderParameters::convertPtsToWallTime
+  ssize_t pts{0};
+  // decoded key frame
+  size_t keyFrame{0};
+  // frames per second, valid only for video streams
+  double fps{0};
+  // format specifies what kind frame is in a payload
+  MediaFormat format;
+};
+
+// Abstract interface ByteStorage class
+class ByteStorage {
+ public:
+  virtual ~ByteStorage() = default;
+  // makes sure that buffer has at least n bytes available for writing, if not
+  // storage must reallocate memory.
+  virtual void ensure(size_t n) = 0;
+  // caller must not to write more than available bytes
+  virtual uint8_t* writableTail() = 0;
+  // caller confirms that n bytes were written to the writable tail
+  virtual void append(size_t n) = 0;
+  // caller confirms that n bytes were read from the read buffer
+  virtual void trim(size_t n) = 0;
+  // gives an access to the beginning of the read buffer
+  virtual const uint8_t* data() const = 0;
+  // returns the stored size in bytes
+  virtual size_t length() const = 0;
+  // returns available capacity for writable tail
+  virtual size_t tail() const = 0;
+  // clears content, keeps capacity
+  virtual void clear() = 0;
+};
+
+struct DecoderOutputMessage {
+  DecoderHeader header;
+  std::unique_ptr<ByteStorage> payload;
+};
+
+using DecoderInCallback =
+    std::function<int(uint8_t* out, int size, uint64_t timeoutMs)>;
+
+using DecoderOutCallback = std::function<void(DecoderOutputMessage&&)>;
+
+/**
+ * Abstract class for decoding media bytes
+ * It has two diffrent modes. Internal media bytes retrieval for given uri and
+ * external media bytes provider in case of memory streams
+ */
+class MediaDecoder {
+ public:
+  virtual ~MediaDecoder() = default;
+
+  /**
+   * Initializes media decoder with parameters,
+   * calls callback when media bytes are available.
+   * Media bytes get fetched internally from provided URI
+   * or invokes provided input callback to get media bytes.
+   * Input callback must be empty for the internal media provider
+   */
+  virtual bool init(
+      const DecoderParameters& params,
+      DecoderInCallback&& in) = 0;
+
+  /**
+   * Polls available decoded bytes from decoder
+   * Returns error code, 0 - for success
+   */
+  virtual int decode(DecoderOutputMessage* out, uint64_t timeoutMs) = 0;
+
+  /**
+   * Polls available decoded bytes from decoder, till EOF or error
+   */
+  virtual int decode_all(const DecoderOutCallback& callback) = 0;
+
+  /**
+   * Stops calling callback, releases resources
+   */
+  virtual void shutdown() = 0;
+
+  /**
+   * Factory to create ByteStorage class instances, particular implementation is
+   * left to the derived class. Caller provides the initially allocated size
+   */
+  virtual std::unique_ptr<ByteStorage> createByteStorage(size_t n) = 0;
+};
+
+struct SamplerParameters {
+  MediaType type{TYPE_AUDIO};
+  FormatUnion in;
+  FormatUnion out;
+  int64_t loggingUuid{0};
+};
+
+/**
+ * Abstract class for sampling media bytes
+ */
+class MediaSampler {
+ public:
+  virtual ~MediaSampler() = default;
+
+  /**
+   * Initializes media sampler with parameters
+   */
+  virtual bool init(const SamplerParameters& params) = 0;
+
+  /**
+   * Samples media bytes
+   * Returns error code < 0, or >=0 - for success, indicating number of bytes
+   * processed.
+   * set @in to null for flushing data
+   */
+  virtual int sample(const ByteStorage* in, ByteStorage* out) = 0;
+
+  /*
+    Returns media type
+   */
+  virtual MediaType getMediaType() const = 0;
+
+  /*
+   Returns formats
+   */
+  virtual FormatUnion getInputFormat() const = 0;
+  virtual FormatUnion getOutFormat() const = 0;
+
+  /**
+   * Releases resources
+   */
+  virtual void shutdown() = 0;
+};
+} // namespace ffmpeg

--- a/torchvision/csrc/decoder/seekable_buffer.cpp
+++ b/torchvision/csrc/decoder/seekable_buffer.cpp
@@ -1,0 +1,129 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include "seekable_buffer.h"
+#include <glog/logging.h>
+#include <chrono>
+
+extern "C" {
+#include <libavformat/avio.h>
+}
+
+namespace ffmpeg {
+
+bool SeekableBuffer::init(
+    DecoderInCallback&& in,
+    ssize_t minSize,
+    ssize_t maxSize,
+    uint64_t timeoutMs) {
+  inCallback_ = std::forward<DecoderInCallback>(in);
+  len_ = minSize;
+  buffer_.resize(len_);
+  pos_ = 0;
+  end_ = 0;
+  eof_ = 0;
+
+  auto end =
+      std::chrono::steady_clock::now() + std::chrono::milliseconds(timeoutMs);
+  auto watcher = [end]() -> bool {
+    return std::chrono::steady_clock::now() <= end;
+  };
+
+  while (!eof_ && end_ < maxSize && watcher()) {
+    // lets read all bytes into available buffer
+    auto res = inCallback_(buffer_.data() + end_, len_ - end_, timeoutMs);
+    if (res > 0) {
+      end_ += res;
+      if (end_ == len_) {
+        len_ = std::min(len_ * 4, maxSize);
+        buffer_.resize(len_);
+      }
+    } else if (res == 0) {
+      eof_ = 1;
+    } else {
+      // error
+      return false;
+    }
+  }
+
+  if (buffer_.size() > 2 && buffer_[0] == 0xFF && buffer_[1] == 0xD8 &&
+      buffer_[2] == 0xFF) {
+    imageType_ = ImageType::JPEG;
+  } else if (
+      buffer_.size() > 3 && buffer_[1] == 'P' && buffer_[2] == 'N' &&
+      buffer_[3] == 'G') {
+    imageType_ = ImageType::PNG;
+  } else if (
+      buffer_.size() > 1 &&
+      ((buffer_[0] == 0x49 && buffer_[1] == 0x49) ||
+       (buffer_[0] == 0x4D && buffer_[1] == 0x4D))) {
+    imageType_ = ImageType::TIFF;
+  }
+
+  return eof_ != 0;
+}
+
+int SeekableBuffer::read(uint8_t* buf, int size, uint64_t timeoutMs) {
+  // 1. pos_ < end_
+  if (pos_ < end_) {
+    auto available = std::min(int(end_ - pos_), size);
+    memcpy(buf, buffer_.data() + pos_, available);
+    pos_ += available;
+    return available;
+  } else if (!eof_) {
+    auto res = inCallback_(buf, size, timeoutMs); // read through
+    if (res > 0) {
+      pos_ += res;
+      if (pos_ > end_ && !buffer_.empty()) {
+        std::vector<uint8_t>().swap(buffer_);
+      }
+    } else if (res == 0) {
+      eof_ = 1;
+    }
+    return res;
+  } else {
+    return 0;
+  }
+}
+
+int64_t SeekableBuffer::seek(int64_t offset, int whence) {
+  // remove force flag
+  whence &= ~AVSEEK_FORCE;
+  // get size request
+  int size = whence & AVSEEK_SIZE;
+  // remove size flag
+  whence &= ~AVSEEK_SIZE;
+
+  if (size) {
+    return end_;
+  } else {
+    switch (whence) {
+      case SEEK_SET:
+        if (offset <= end_) {
+          pos_ = offset;
+          return pos_;
+        }
+        break;
+      case SEEK_END:
+        if (eof_ && pos_ <= end_ && offset < 0 && end_ + offset >= 0) {
+          pos_ = end_ + offset;
+          return end_;
+        }
+        break;
+      case SEEK_CUR:
+        if (pos_ + offset <= end_) {
+          pos_ += offset;
+          return pos_ + offset;
+        }
+        break;
+      default:
+        LOG(CRITICAL) << "Unknown whence flag gets provided: " << whence;
+    }
+  }
+  return AVERROR(EINVAL); // we have no idea what the media size is
+}
+
+void SeekableBuffer::shutdown() {
+  inCallback_ = nullptr;
+}
+
+} // namespace ffmpeg

--- a/torchvision/csrc/decoder/seekable_buffer.h
+++ b/torchvision/csrc/decoder/seekable_buffer.h
@@ -1,0 +1,46 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#pragma once
+
+#include "defs.h"
+
+namespace ffmpeg {
+
+/**
+ * Class uses internal buffer to store initial size bytes as a seekable cache
+ * from Media provider and let ffmpeg to seek and read bytes from cache
+ * and beyond - reading bytes directly from Media provider
+ */
+enum class ImageType {
+  UNKNOWN = 0,
+  JPEG = 1,
+  PNG = 2,
+  TIFF = 3,
+};
+
+class SeekableBuffer {
+ public:
+  // try to fill out buffer, returns true if EOF detected (seek will supported)
+  bool init(
+      DecoderInCallback&& in,
+      ssize_t minSize,
+      ssize_t maxSize,
+      uint64_t timeoutMs);
+  int read(uint8_t* buf, int size, uint64_t timeoutMs);
+  int64_t seek(int64_t offset, int whence);
+  void shutdown();
+  ImageType getImageType() const {
+    return imageType_;
+  }
+
+ private:
+  DecoderInCallback inCallback_;
+  std::vector<uint8_t> buffer_; // resized at init time
+  ssize_t len_{0}; // current buffer size
+  ssize_t pos_{0}; // current position (SEEK_CUR iff pos_ < end_)
+  ssize_t end_{0}; // bytes in buffer [0, buffer_.size()]
+  ssize_t eof_{0}; // indicates the EOF
+  ImageType imageType_{ImageType::UNKNOWN};
+};
+
+} // namespace ffmpeg

--- a/torchvision/csrc/decoder/stream.cpp
+++ b/torchvision/csrc/decoder/stream.cpp
@@ -1,0 +1,142 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include "stream.h"
+#include <glog/logging.h>
+#include "util.h"
+
+namespace ffmpeg {
+
+namespace {
+const size_t kDecoderHeaderSize = sizeof(DecoderHeader);
+}
+
+Stream::Stream(AVFormatContext* inputCtx, int index, bool convertPtsToWallTime)
+    : inputCtx_(inputCtx),
+      index_(index),
+      convertPtsToWallTime_(convertPtsToWallTime) {}
+
+Stream::~Stream() {
+  if (frame_) {
+    av_free(frame_); // Copyright 2004-present Facebook. All Rights Reserved.
+  }
+  if (codecCtx_) {
+    avcodec_close(codecCtx_);
+  }
+}
+
+AVCodec* Stream::findCodec(AVCodecContext* ctx) {
+  return avcodec_find_decoder(ctx->codec_id);
+}
+
+int Stream::openCodec() {
+  auto codecCtx = inputCtx_->streams[index_]->codec;
+  AVCodec* codec = findCodec(codecCtx);
+
+  if (!codec) {
+    LOG(ERROR) << "findCodec failed for codec_id: " << int(codecCtx->codec_id);
+    return -1;
+  }
+
+  auto result = avcodec_open2(codecCtx, codec, nullptr);
+  if (result < 0) {
+    LOG(ERROR) << "avcodec_open2 failed, error: "
+               << Util::generateErrorDesc(result);
+    return result;
+  } else {
+    VLOG(1) << "avcodec_open2 opened codec id: " << codecCtx->codec_id;
+  }
+
+  codecCtx_ = codecCtx;
+
+  frame_ = av_frame_alloc();
+
+  return initFormat();
+}
+
+// rescale package
+void Stream::rescalePackage(AVPacket* packet) {
+  if (codecCtx_->time_base.num != 0) {
+    av_packet_rescale_ts(
+        packet, inputCtx_->streams[index_]->time_base, codecCtx_->time_base);
+  }
+}
+
+int Stream::analyzePacket(const AVPacket* packet, int* gotFramePtr) {
+  int consumed = 0;
+  int result = avcodec_send_packet(codecCtx_, packet);
+  if (result == AVERROR(EAGAIN)) {
+    *gotFramePtr = 0; // no bytes get consumed, fetch frame
+  } else if (result == AVERROR_EOF) {
+    *gotFramePtr = 0; // more than one flush packet
+    if (packet) {
+      // got packet after flush, this is error
+      return result;
+    }
+  } else if (result < 0) {
+    LOG(ERROR) << "avcodec_send_packet failed, err: "
+               << Util::generateErrorDesc(result);
+    return result; // error
+  } else {
+    consumed = packet ? packet->size : 0; // all bytes get consumed
+  }
+
+  result = avcodec_receive_frame(codecCtx_, frame_);
+
+  if (result >= 0) {
+    *gotFramePtr = 1; // frame is available
+  } else if (result == AVERROR(EAGAIN)) {
+    *gotFramePtr = 0; // no frames at this time, needs more packets
+    if (!consumed) {
+      // precaution, if no packages got consumed and no frames are available
+      return result;
+    }
+  } else if (result == AVERROR_EOF) {
+    *gotFramePtr = 0; // the last frame has been flushed
+    // precaution, if no more frames are available assume we consume all bytes
+    consumed = packet ? packet->size : 0;
+  } else { // error
+    LOG(ERROR) << "avcodec_receive_frame failed, err: "
+               << Util::generateErrorDesc(result);
+    return result;
+  }
+  return consumed;
+}
+
+int Stream::decodeFrame(const AVPacket* packet, int* gotFramePtr) {
+  return analyzePacket(packet, gotFramePtr);
+}
+
+int Stream::getFrameBytes(DecoderOutputMessage* out) {
+  return fillBuffer(out, false);
+}
+
+int Stream::flush(DecoderOutputMessage* out) {
+  int gotFramePtr = 0;
+  int result = -1;
+  if (analyzePacket(nullptr, &gotFramePtr) >= 0 && gotFramePtr &&
+      (result = fillBuffer(out, false)) > 0) {
+    return result;
+  } else if ((result = fillBuffer(out, true)) > 0) {
+    return result;
+  }
+  return result;
+}
+
+int Stream::fillBuffer(DecoderOutputMessage* out, bool flush) {
+  int result = -1;
+  if (!codecCtx_) {
+    LOG(INFO) << "Codec is not initialized";
+    return result;
+  }
+
+  // init sampler, if any and return required bytes
+  if ((result = estimateBytes(flush)) < 0) {
+    return result;
+  }
+  // assign message
+  setHeader(&out->header);
+  out->payload->ensure(result);
+  return copyFrameBytes(out->payload.get(), flush);
+}
+
+} // namespace ffmpeg

--- a/torchvision/csrc/decoder/stream.h
+++ b/torchvision/csrc/decoder/stream.h
@@ -1,0 +1,69 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#pragma once
+
+#include <atomic>
+#include "defs.h"
+
+extern "C" {
+#include <libavformat/avformat.h>
+#include <libavformat/avio.h>
+#include <libavutil/imgutils.h>
+}
+
+namespace ffmpeg {
+
+/**
+ * Class uses FFMPEG library to decode one media stream (audio or video).
+ */
+
+class Stream {
+ public:
+  Stream(AVFormatContext* inputCtx, int index, bool convertPtsToWallTime);
+  virtual ~Stream();
+
+  // returns 0 - on success or negative error
+  int openCodec();
+  // returns number processed bytes from packet, or negative error
+  int decodeFrame(const AVPacket* packet, int* gotFramePtr);
+  // returns stream index
+  int getIndex() const {
+    return index_;
+  }
+  // returns number decoded/sampled bytes
+  int getFrameBytes(DecoderOutputMessage* out);
+  // returns number decoded/sampled bytes
+  int flush(DecoderOutputMessage* out);
+  // rescale package
+  void rescalePackage(AVPacket* packet);
+  // return media type
+  virtual MediaType getMediaType() const = 0;
+
+ protected:
+  virtual int initFormat() = 0;
+  // returns number processed bytes from packet, or negative error
+  virtual int analyzePacket(const AVPacket* packet, int* gotFramePtr);
+  // returns number decoded/sampled bytes, or negative error
+  virtual int copyFrameBytes(ByteStorage* out, bool flush) = 0;
+  // initialize codec, returns output buffer size, or negative error
+  virtual int estimateBytes(bool flush) = 0;
+  // sets output format
+  virtual void setHeader(DecoderHeader* header) = 0;
+  // finds codec
+  virtual AVCodec* findCodec(AVCodecContext* ctx);
+
+ private:
+  int fillBuffer(DecoderOutputMessage* out, bool flush);
+
+ protected:
+  AVFormatContext* const inputCtx_;
+  const int index_;
+  const bool convertPtsToWallTime_;
+
+  AVCodecContext* codecCtx_{nullptr};
+  AVFrame* frame_{nullptr};
+
+  std::atomic<size_t> numGenerator_{0};
+};
+
+} // namespace ffmpeg

--- a/torchvision/csrc/decoder/subtitle_sampler.cpp
+++ b/torchvision/csrc/decoder/subtitle_sampler.cpp
@@ -1,0 +1,46 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include "subtitle_sampler.h"
+#include "util.h"
+
+namespace ffmpeg {
+
+SubtitleSampler::~SubtitleSampler() {
+  cleanUp();
+}
+
+void SubtitleSampler::shutdown() {
+  cleanUp();
+}
+
+bool SubtitleSampler::init(const SamplerParameters& params) {
+  cleanUp();
+  // set formats
+  params_ = params;
+  return true;
+}
+
+int SubtitleSampler::getSamplesBytes(AVSubtitle* sub) const {
+  return Util::size(*sub);
+}
+
+int SubtitleSampler::sample(AVSubtitle* sub, ByteStorage* out) {
+  if (!sub) {
+    return 0; // flush
+  }
+
+  return Util::serialize(*sub, out);
+}
+
+int SubtitleSampler::sample(const ByteStorage* in, ByteStorage* out) {
+  if (in) {
+    // Get a writable copy
+    *out = *in;
+    return out->length();
+  }
+  return 0;
+}
+
+void SubtitleSampler::cleanUp() {}
+
+} // namespace ffmpeg

--- a/torchvision/csrc/decoder/subtitle_sampler.h
+++ b/torchvision/csrc/decoder/subtitle_sampler.h
@@ -1,0 +1,51 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#pragma once
+
+#include "defs.h"
+
+extern "C" {
+#include <libavcodec/avcodec.h>
+}
+
+namespace ffmpeg {
+
+/**
+ * Class transcode audio frames from one format into another
+ */
+
+class SubtitleSampler : public MediaSampler {
+ public:
+  SubtitleSampler() = default;
+  ~SubtitleSampler() override;
+
+  bool init(const SamplerParameters& params) override;
+  MediaType getMediaType() const override {
+    return MediaType::TYPE_VIDEO;
+  }
+  FormatUnion getInputFormat() const override {
+    return params_.in;
+  }
+  FormatUnion getOutFormat() const override {
+    return params_.out;
+  }
+  int sample(const ByteStorage* in, ByteStorage* out) override;
+  void shutdown() override;
+
+  // returns number processed/scaling bytes
+  int sample(AVSubtitle* sub, ByteStorage* out);
+  int getSamplesBytes(AVSubtitle* sub) const;
+
+  // helper serialization/deserialization methods
+  static void serialize(const AVSubtitle& sub, ByteStorage* out);
+  static bool deserialize(const ByteStorage& buf, AVSubtitle* sub);
+
+ private:
+  // close resources
+  void cleanUp();
+
+ private:
+  SamplerParameters params_;
+};
+
+} // namespace ffmpeg

--- a/torchvision/csrc/decoder/subtitle_stream.cpp
+++ b/torchvision/csrc/decoder/subtitle_stream.cpp
@@ -1,0 +1,107 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include "subtitle_stream.h"
+#include <glog/logging.h>
+#include <limits>
+#include "util.h"
+
+namespace ffmpeg {
+
+namespace {
+
+bool operator==(const SubtitleFormat&, const AVCodecContext&) {
+  return true;
+}
+
+SubtitleFormat& toSubtitleFormat(SubtitleFormat& x, const AVCodecContext&) {
+  return x;
+}
+} // namespace
+
+SubtitleStream::SubtitleStream(
+    AVFormatContext* inputCtx,
+    int index,
+    bool convertPtsToWallTime,
+    const SubtitleFormat& format)
+    : Stream(inputCtx, index, convertPtsToWallTime), format_(format) {
+  memset(&sub_, 0, sizeof(sub_));
+}
+
+void SubtitleStream::releaseSubtitle() {
+  if (sub_.release) {
+    avsubtitle_free(&sub_);
+    memset(&sub_, 0, sizeof(sub_));
+  }
+}
+
+SubtitleStream::~SubtitleStream() {
+  releaseSubtitle();
+  sampler_.shutdown();
+}
+
+int SubtitleStream::initFormat() {
+  if (!codecCtx_->subtitle_header) {
+    LOG(CRITICAL) << "No subtitle header found";
+  } else {
+    LOG(INFO) << "Subtitle header found!";
+  }
+  return 0;
+}
+
+int SubtitleStream::analyzePacket(const AVPacket* packet, int* gotFramePtr) {
+  // clean-up
+  releaseSubtitle();
+  // check flush packet
+  AVPacket avPacket;
+  av_init_packet(&avPacket);
+  avPacket.data = nullptr;
+
+  auto pkt = packet ? *packet : avPacket;
+  int result = avcodec_decode_subtitle2(codecCtx_, &sub_, gotFramePtr, &pkt);
+
+  if (result < 0) {
+    VLOG(1) << "avcodec_decode_subtitle2 failed, err: "
+            << Util::generateErrorDesc(result);
+  } else if (result == 0) {
+    result = packet ? packet->size : 0; // discard the rest of the package
+  }
+
+  sub_.release = *gotFramePtr;
+  return result;
+}
+
+int SubtitleStream::estimateBytes(bool flush) {
+  if (!(sampler_.getInputFormat().subtitle == *codecCtx_)) {
+    // - reinit sampler
+    SamplerParameters params;
+    params.type = MediaType::TYPE_SUBTITLE;
+    toSubtitleFormat(params.in.subtitle, *codecCtx_);
+    if (flush || !sampler_.init(params)) {
+      return -1;
+    }
+
+    VLOG(1) << "Set input subtitle sampler format";
+  }
+  return sampler_.getSamplesBytes(&sub_);
+}
+
+int SubtitleStream::copyFrameBytes(ByteStorage* out, bool flush) {
+  return sampler_.sample(flush ? nullptr : &sub_, out);
+}
+
+void SubtitleStream::setHeader(DecoderHeader* header) {
+  header->seqno = numGenerator_++;
+
+  header->pts = sub_.pts; // already in us
+
+  if (convertPtsToWallTime_) {
+    keeper_.adjust(header->pts);
+  }
+
+  header->keyFrame = 0;
+  header->fps = std::numeric_limits<double>::quiet_NaN();
+  header->format.type = TYPE_SUBTITLE;
+  header->format.stream = index_;
+  header->format.format.subtitle = format_;
+}
+} // namespace ffmpeg

--- a/torchvision/csrc/decoder/subtitle_stream.h
+++ b/torchvision/csrc/decoder/subtitle_stream.h
@@ -1,0 +1,49 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#pragma once
+
+#include "stream.h"
+#include "subtitle_sampler.h"
+#include "time_keeper.h"
+
+namespace ffmpeg {
+
+/**
+ * Class uses FFMPEG library to decode one subtitle stream.
+ */
+struct AVSubtitleKeeper : AVSubtitle {
+  int64_t release{0};
+};
+
+class SubtitleStream : public Stream {
+ public:
+  SubtitleStream(
+      AVFormatContext* inputCtx,
+      int index,
+      bool convertPtsToWallTime,
+      const SubtitleFormat& format);
+  ~SubtitleStream() override;
+
+ protected:
+  void setHeader(DecoderHeader* header) override;
+
+ private:
+  // Stream overrides
+  MediaType getMediaType() const override {
+    return TYPE_SUBTITLE;
+  }
+
+  int initFormat() override;
+  int analyzePacket(const AVPacket* packet, int* gotFramePtr) override;
+  int estimateBytes(bool flush) override;
+  int copyFrameBytes(ByteStorage* out, bool flush) override;
+  void releaseSubtitle();
+
+ private:
+  SubtitleFormat format_;
+  SubtitleSampler sampler_;
+  TimeKeeper keeper_;
+  AVSubtitleKeeper sub_;
+};
+
+} // namespace ffmpeg

--- a/torchvision/csrc/decoder/sync_decoder.cpp
+++ b/torchvision/csrc/decoder/sync_decoder.cpp
@@ -1,0 +1,113 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include "sync_decoder.h"
+#include <glog/logging.h>
+
+namespace ffmpeg {
+
+SyncDecoder::VectorByteStorage::VectorByteStorage(size_t n) {
+  buffer_.resize(n);
+}
+
+void SyncDecoder::VectorByteStorage::ensure(size_t n) {
+  if (tail() < n) {
+    buffer_.resize(offset_ + length_ + n);
+  }
+}
+
+uint8_t* SyncDecoder::VectorByteStorage::writableTail() {
+  CHECK_LE(offset_ + length_, buffer_.size());
+  return buffer_.data() + offset_ + length_;
+}
+
+void SyncDecoder::VectorByteStorage::append(size_t n) {
+  CHECK_LE(n, tail());
+  length_ += n;
+}
+
+void SyncDecoder::VectorByteStorage::trim(size_t n) {
+  CHECK_LE(n, length_);
+  offset_ += n;
+  length_ -= n;
+}
+
+const uint8_t* SyncDecoder::VectorByteStorage::data() const {
+  return buffer_.data() + offset_;
+}
+
+size_t SyncDecoder::VectorByteStorage::length() const {
+  return length_;
+}
+
+size_t SyncDecoder::VectorByteStorage::tail() const {
+  auto size = buffer_.size();
+  CHECK_LE(offset_ + length_, buffer_.size());
+  return size - offset_ - length_;
+}
+
+void SyncDecoder::VectorByteStorage::clear() {
+  buffer_.clear();
+  offset_ = 0;
+  length_ = 0;
+}
+
+SyncDecoder::SyncDecoder(const SyncDecoderSettings& settings)
+    : settings_(settings) {}
+
+std::unique_ptr<ByteStorage> SyncDecoder::createByteStorage(size_t n) {
+  return std::make_unique<VectorByteStorage>(n);
+}
+
+void SyncDecoder::onInit() {
+  eof_ = false;
+  stop_ = false;
+  queue_.clear();
+
+  if (settings_.startOffsetMs != 0) {
+    av_seek_frame(
+        inputCtx_,
+        -1,
+        settings_.startOffsetMs * AV_TIME_BASE / 1000,
+        AVSEEK_FLAG_FRAME | AVSEEK_FLAG_ANY);
+  }
+}
+
+int SyncDecoder::decode(DecoderOutputMessage* out, uint64_t timeoutMs) {
+  if (stop_) {
+    shutdown();
+    eof_ = true;
+    stop_ = false;
+  }
+
+  if (eof_ && queue_.empty()) {
+    return ENODATA;
+  }
+
+  if (queue_.empty()) {
+    int result = getBytes(timeoutMs);
+    eof_ = result == ENODATA;
+
+    if (result && result != ENODATA) {
+      return result;
+    }
+
+    // still empty
+    if (queue_.empty()) {
+      return ETIMEDOUT;
+    }
+  }
+
+  *out = std::move(queue_.front());
+  queue_.pop_front();
+  return 0;
+}
+
+void SyncDecoder::push(DecoderOutputMessage&& buffer) {
+  if (settings_.endOffsetMs != -1 &&
+      settings_.endOffsetMs * 1000 > buffer.header.pts) {
+    stop_ = true;
+    return;
+  }
+  queue_.push_back(std::move(buffer));
+}
+} // namespace ffmpeg

--- a/torchvision/csrc/decoder/sync_decoder.h
+++ b/torchvision/csrc/decoder/sync_decoder.h
@@ -1,0 +1,57 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#pragma once
+
+#include <list>
+#include "decoder.h"
+
+namespace ffmpeg {
+
+struct SyncDecoderSettings {
+  // start offset
+  int64_t startOffsetMs{0};
+  // end offset
+  int64_t endOffsetMs{-1};
+};
+
+/**
+ * Class uses FFMPEG library to decode media streams.
+ * Media bytes can be explicitly provided through read-callback
+ * or fetched internally by FFMPEG library
+ */
+class SyncDecoder : public Decoder {
+  class VectorByteStorage : public ByteStorage {
+   public:
+    VectorByteStorage(size_t n);
+    void ensure(size_t n) override;
+    uint8_t* writableTail() override;
+    void append(size_t n) override;
+    void trim(size_t n) override;
+    const uint8_t* data() const override;
+    size_t length() const override;
+    size_t tail() const override;
+    void clear() override;
+
+   private:
+    size_t offset_{0};
+    size_t length_{0};
+    std::vector<uint8_t> buffer_;
+  };
+
+ public:
+  explicit SyncDecoder(const SyncDecoderSettings& settings);
+
+  int decode(DecoderOutputMessage* out, uint64_t timeoutMs) override;
+
+ private:
+  void push(DecoderOutputMessage&& buffer) override;
+  void onInit() override;
+  std::unique_ptr<ByteStorage> createByteStorage(size_t n) override;
+
+ private:
+  std::list<DecoderOutputMessage> queue_;
+  SyncDecoderSettings settings_;
+  bool eof_{false};
+  bool stop_{false};
+};
+} // namespace ffmpeg

--- a/torchvision/csrc/decoder/time_keeper.cpp
+++ b/torchvision/csrc/decoder/time_keeper.cpp
@@ -1,0 +1,40 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include "time_keeper.h"
+
+extern "C" {
+#include <libavutil/avutil.h>
+}
+
+namespace ffmpeg {
+
+namespace {
+const ssize_t kMaxTimeBaseDiference = 10;
+}
+
+ssize_t TimeKeeper::adjust(ssize_t& decoderTimestamp) {
+  const ssize_t now = std::chrono::duration_cast<std::chrono::microseconds>(
+                          std::chrono::system_clock::now().time_since_epoch())
+                          .count();
+
+  if (startTime_ == 0) {
+    startTime_ = now;
+  }
+  if (streamTimestamp_ == 0) {
+    streamTimestamp_ = decoderTimestamp;
+  }
+
+  const auto runOut = startTime_ + decoderTimestamp - streamTimestamp_;
+
+  if (std::labs((now - runOut) / AV_TIME_BASE) > kMaxTimeBaseDiference) {
+    streamTimestamp_ = startTime_ - now + decoderTimestamp;
+  }
+
+  const auto sleepAdvised = runOut - now;
+
+  decoderTimestamp += startTime_ - streamTimestamp_;
+
+  return sleepAdvised > 0 ? sleepAdvised : 0;
+}
+
+} // namespace ffmpeg

--- a/torchvision/csrc/decoder/time_keeper.h
+++ b/torchvision/csrc/decoder/time_keeper.h
@@ -1,0 +1,27 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#pragma once
+
+#include <stdlib.h>
+#include <chrono>
+
+namespace ffmpeg {
+
+/**
+ * Class keeps the track of the decoded timestamps (us) for media streams.
+ */
+
+class TimeKeeper {
+ public:
+  TimeKeeper() = default;
+
+  // adjust provided @timestamp to the corrected value
+  // return advised sleep time before next frame processing in (us)
+  ssize_t adjust(ssize_t& decoderTimestamp);
+
+ private:
+  ssize_t startTime_{0};
+  ssize_t streamTimestamp_{0};
+};
+
+} // namespace ffmpeg

--- a/torchvision/csrc/decoder/util.cpp
+++ b/torchvision/csrc/decoder/util.cpp
@@ -1,0 +1,374 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include "util.h"
+#include <glog/logging.h>
+
+namespace ffmpeg {
+
+namespace Serializer {
+
+// fixed size types
+template <typename T>
+inline size_t getSize(const T& x) {
+  return sizeof(x);
+}
+
+template <typename T>
+inline bool serializeItem(
+    uint8_t* dest,
+    size_t len,
+    size_t& pos,
+    const T& src) {
+  VLOG(6) << "Generic serializeItem";
+  const auto required = sizeof(src);
+  if (len < pos + required) {
+    return false;
+  }
+  memcpy(dest + pos, &src, required);
+  pos += required;
+  return true;
+}
+
+template <typename T>
+inline bool deserializeItem(
+    const uint8_t* src,
+    size_t len,
+    size_t& pos,
+    T& dest) {
+  const auto required = sizeof(dest);
+  if (len < pos + required) {
+    return false;
+  }
+  memcpy(&dest, src + pos, required);
+  pos += required;
+  return true;
+}
+
+// AVSubtitleRect specialization
+inline size_t getSize(const AVSubtitleRect& x) {
+  auto rectBytes = [](const AVSubtitleRect& y) -> size_t {
+    size_t s = 0;
+    switch (y.type) {
+      case SUBTITLE_BITMAP:
+        for (int i = 0; i < y.nb_colors; ++i) {
+          s += sizeof(y.pict.linesize[i]);
+          s += y.pict.linesize[i];
+        }
+        break;
+      case SUBTITLE_TEXT:
+        s += sizeof(size_t);
+        s += strlen(y.text);
+        break;
+      case SUBTITLE_ASS:
+        s += sizeof(size_t);
+        s += strlen(y.ass);
+        break;
+      default:
+        break;
+    }
+    return s;
+  };
+  return getSize(x.x) + getSize(x.y) + getSize(x.w) + getSize(x.h) +
+      getSize(x.nb_colors) + getSize(x.type) + getSize(x.flags) + rectBytes(x);
+}
+
+// AVSubtitle specialization
+inline size_t getSize(const AVSubtitle& x) {
+  auto rectBytes = [](const AVSubtitle& y) -> size_t {
+    size_t s = getSize(y.num_rects);
+    for (unsigned i = 0; i < y.num_rects; ++i) {
+      s += getSize(*y.rects[i]);
+    }
+    return s;
+  };
+  return getSize(x.format) + getSize(x.start_display_time) +
+      getSize(x.end_display_time) + getSize(x.pts) + rectBytes(x);
+}
+
+inline bool serializeItem(
+    uint8_t* dest,
+    size_t len,
+    size_t& pos,
+    const AVSubtitleRect& src) {
+  auto rectSerialize =
+      [](uint8_t* d, size_t l, size_t& p, const AVSubtitleRect& x) -> size_t {
+    switch (x.type) {
+      case SUBTITLE_BITMAP:
+        for (int i = 0; i < x.nb_colors; ++i) {
+          if (!serializeItem(d, l, p, x.pict.linesize[i])) {
+            return false;
+          }
+          if (p + x.pict.linesize[i] > l) {
+            return false;
+          }
+          memcpy(d + p, x.pict.data[i], x.pict.linesize[i]);
+          p += x.pict.linesize[i];
+        }
+        return true;
+      case SUBTITLE_TEXT: {
+        const size_t s = strlen(x.text);
+        if (!serializeItem(d, l, p, s)) {
+          return false;
+        }
+        if (p + s > l) {
+          return false;
+        }
+        memcpy(d + p, x.text, s);
+        p += s;
+        return true;
+      }
+      case SUBTITLE_ASS: {
+        const size_t s = strlen(x.ass);
+        if (!serializeItem(d, l, p, s)) {
+          return false;
+        }
+        if (p + s > l) {
+          return false;
+        }
+        memcpy(d + p, x.ass, s);
+        p += s;
+        return true;
+      }
+      default:
+        return true;
+    }
+  };
+  return serializeItem(dest, len, pos, src.x) &&
+      serializeItem(dest, len, pos, src.y) &&
+      serializeItem(dest, len, pos, src.w) &&
+      serializeItem(dest, len, pos, src.h) &&
+      serializeItem(dest, len, pos, src.nb_colors) &&
+      serializeItem(dest, len, pos, src.type) &&
+      serializeItem(dest, len, pos, src.flags) &&
+      rectSerialize(dest, len, pos, src);
+}
+
+inline bool serializeItem(
+    uint8_t* dest,
+    size_t len,
+    size_t& pos,
+    const AVSubtitle& src) {
+  auto rectSerialize =
+      [](uint8_t* d, size_t l, size_t& p, const AVSubtitle& x) -> bool {
+    bool res = serializeItem(d, l, p, x.num_rects);
+    for (unsigned i = 0; res && i < x.num_rects; ++i) {
+      res = serializeItem(d, l, p, *(x.rects[i]));
+    }
+    return res;
+  };
+  VLOG(6) << "AVSubtitle serializeItem";
+  return serializeItem(dest, len, pos, src.format) &&
+      serializeItem(dest, len, pos, src.start_display_time) &&
+      serializeItem(dest, len, pos, src.end_display_time) &&
+      serializeItem(dest, len, pos, src.pts) &&
+      rectSerialize(dest, len, pos, src);
+}
+
+inline bool deserializeItem(
+    const uint8_t* src,
+    size_t len,
+    size_t& pos,
+    AVSubtitleRect& dest) {
+  auto rectDeserialize =
+      [](const uint8_t* y, size_t l, size_t& p, AVSubtitleRect& x) -> bool {
+    switch (x.type) {
+      case SUBTITLE_BITMAP:
+        for (int i = 0; i < x.nb_colors; ++i) {
+          if (!deserializeItem(y, l, p, x.pict.linesize[i])) {
+            return false;
+          }
+          if (p + x.pict.linesize[i] > l) {
+            return false;
+          }
+          x.pict.data[i] = (uint8_t*)av_malloc(x.pict.linesize[i]);
+          memcpy(x.pict.data[i], y + p, x.pict.linesize[i]);
+          p += x.pict.linesize[i];
+        }
+        return true;
+      case SUBTITLE_TEXT: {
+        size_t s = 0;
+        if (!deserializeItem(y, l, p, s)) {
+          return false;
+        }
+        if (p + s > l) {
+          return false;
+        }
+        x.text = (char*)av_malloc(s + 1);
+        memcpy(x.text, y + p, s);
+        x.text[s] = 0;
+        p += s;
+        return true;
+      }
+      case SUBTITLE_ASS: {
+        size_t s = 0;
+        if (!deserializeItem(y, l, p, s)) {
+          return false;
+        }
+        if (p + s > l) {
+          return false;
+        }
+        x.ass = (char*)av_malloc(s + 1);
+        memcpy(x.ass, y + p, s);
+        x.ass[s] = 0;
+        p += s;
+        return true;
+      }
+      default:
+        return true;
+    }
+  };
+
+  return deserializeItem(src, len, pos, dest.x) &&
+      deserializeItem(src, len, pos, dest.y) &&
+      deserializeItem(src, len, pos, dest.w) &&
+      deserializeItem(src, len, pos, dest.h) &&
+      deserializeItem(src, len, pos, dest.nb_colors) &&
+      deserializeItem(src, len, pos, dest.type) &&
+      deserializeItem(src, len, pos, dest.flags) &&
+      rectDeserialize(src, len, pos, dest);
+}
+
+inline bool deserializeItem(
+    const uint8_t* src,
+    size_t len,
+    size_t& pos,
+    AVSubtitle& dest) {
+  auto rectDeserialize =
+      [](const uint8_t* y, size_t l, size_t& p, AVSubtitle& x) -> bool {
+    bool res = deserializeItem(y, l, p, x.num_rects);
+    if (res && x.num_rects) {
+      x.rects =
+          (AVSubtitleRect**)av_malloc(x.num_rects * sizeof(AVSubtitleRect*));
+    }
+    for (unsigned i = 0; res && i < x.num_rects; ++i) {
+      x.rects[i] = (AVSubtitleRect*)av_malloc(sizeof(AVSubtitleRect));
+      memset(x.rects[i], 0, sizeof(AVSubtitleRect));
+      res = deserializeItem(y, l, p, *x.rects[i]);
+    }
+    return res;
+  };
+  return deserializeItem(src, len, pos, dest.format) &&
+      deserializeItem(src, len, pos, dest.start_display_time) &&
+      deserializeItem(src, len, pos, dest.end_display_time) &&
+      deserializeItem(src, len, pos, dest.pts) &&
+      rectDeserialize(src, len, pos, dest);
+}
+} // namespace Serializer
+
+namespace Util {
+std::string generateErrorDesc(int errorCode) {
+  std::array<char, 1024> buffer;
+  if (av_strerror(errorCode, buffer.data(), buffer.size()) < 0) {
+    return std::string("Unknown error code: ") + std::to_string(errorCode);
+  }
+  buffer.back() = 0;
+  return std::string(buffer.data());
+}
+
+size_t serialize(const AVSubtitle& sub, ByteStorage* out) {
+  const auto len = size(sub);
+  CHECK_LE(len, out->tail());
+  size_t pos = 0;
+  if (!Serializer::serializeItem(out->writableTail(), len, pos, sub)) {
+    return 0;
+  }
+  out->append(len);
+  return len;
+}
+
+bool deserialize(const ByteStorage& buf, AVSubtitle* sub) {
+  size_t pos = 0;
+  return Serializer::deserializeItem(buf.data(), buf.length(), pos, *sub);
+}
+
+size_t size(const AVSubtitle& sub) {
+  return Serializer::getSize(sub);
+}
+
+bool validateVideoFormat(const VideoFormat& f) {
+  /*
+  Valid parameters values for decoder
+  ______________________________________________________________
+  |  W  |  H  | minDimension | cropImage |  algorithm           |
+  |_____________________________________________________________|
+  |  0  |  0  |     0        |  N/A      |   original           |
+  |_____________________________________________________________|
+  |  >0 |  0  |     N/A      |  N/A      |   scale keeping W    |
+  |_____________________________________________________________|
+  |  0  |  >0 |     N/A      |  N/A      |   scale keeping H    |
+  |_____________________________________________________________|
+  |  >0 |  >0 |     N/A      |   0       |   stretch/scale      |
+  |_____________________________________________________________|
+  |  >0 |  >0 |     N/A      |   >0      |   scale/crop         |
+  |_____________________________________________________________|
+  |  0  |  0  |     >0       |  N/A      |scale to min dimension|
+  |_____|_____|______________|___________|______________________|
+  */
+  return (f.width == 0 && // #1 and #6
+          f.height == 0 && f.cropImage == 0) ||
+      (f.width != 0 && // #4 and #5
+       f.height != 0 && f.minDimension == 0) ||
+      (((f.width != 0 && // #2
+         f.height == 0) ||
+        (f.width == 0 && // #3
+         f.height != 0)) &&
+       f.minDimension == 0 && f.cropImage == 0);
+}
+
+void setFormatDimensions(
+    size_t& destW,
+    size_t& destH,
+    size_t userW,
+    size_t userH,
+    size_t srcW,
+    size_t srcH,
+    size_t minDimension,
+    size_t cropImage) {
+  // rounding rules
+  // int -> double -> round up
+  // if fraction is >= 0.5 or round down if fraction is < 0.5
+  // int result = double(value) + 0.5
+  // here we rounding double to int according to the above rule
+  if (userW == 0 && userH == 0) {
+    if (minDimension > 0) {
+      if (srcW > srcH) {
+        // landscape
+        destH = minDimension;
+        destW = round(double(srcW * minDimension) / srcH);
+      } else {
+        // portrait
+        destW = minDimension;
+        destH = round(double(srcH * minDimension) / srcW);
+      }
+    } else {
+      destW = srcW;
+      destH = srcH;
+    }
+  } else if (userW != 0 && userH == 0) {
+    destW = userW;
+    destH = round(double(srcH * userW) / srcW);
+  } else if (userW == 0 && userH != 0) {
+    destW = round(double(srcW * userH) / srcH);
+    destH = userH;
+  } else { // userW != 0 && userH != 0
+    if (cropImage == 0) {
+      destW = userW;
+      destH = userH;
+    } else {
+      double userSlope = double(userH) / userW;
+      double srcSlope = double(srcH) / srcW;
+      if (srcSlope < userSlope) {
+        destW = round(double(srcW * userH) / srcH);
+        destH = userH;
+      } else {
+        destW = userW;
+        destH = round(double(srcH * userW) / srcW);
+      }
+    }
+  }
+  // prevent zeros
+  destW = std::max(destW, 1UL);
+  destH = std::max(destH, 1UL);
+}
+} // namespace Util
+} // namespace ffmpeg

--- a/torchvision/csrc/decoder/util.h
+++ b/torchvision/csrc/decoder/util.h
@@ -1,0 +1,33 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#pragma once
+
+#include "defs.h"
+
+extern "C" {
+#include <libavcodec/avcodec.h>
+}
+
+namespace ffmpeg {
+
+/**
+ * FFMPEG library utility functions.
+ */
+
+namespace Util {
+std::string generateErrorDesc(int errorCode);
+size_t serialize(const AVSubtitle& sub, ByteStorage* out);
+bool deserialize(const ByteStorage& buf, AVSubtitle* sub);
+size_t size(const AVSubtitle& sub);
+void setFormatDimensions(
+    size_t& destW,
+    size_t& destH,
+    size_t userW,
+    size_t userH,
+    size_t srcW,
+    size_t srcH,
+    size_t minDimension,
+    size_t cropImage);
+bool validateVideoFormat(const VideoFormat& format);
+} // namespace Util
+} // namespace ffmpeg

--- a/torchvision/csrc/decoder/video_sampler.cpp
+++ b/torchvision/csrc/decoder/video_sampler.cpp
@@ -1,0 +1,275 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include "video_sampler.h"
+#include <glog/logging.h>
+#include "util.h"
+
+extern "C" {
+#include <libavutil/imgutils.h>
+}
+
+// www.ffmpeg.org/doxygen/0.5/swscale-example_8c-source.html
+
+namespace ffmpeg {
+
+namespace {
+int preparePlanes(
+    const VideoFormat& fmt,
+    const uint8_t* buffer,
+    uint8_t** planes,
+    int* lineSize) {
+  int result;
+
+  if ((result = av_image_fill_arrays(
+           planes,
+           lineSize,
+           buffer,
+           (AVPixelFormat)fmt.format,
+           fmt.width,
+           fmt.height,
+           1)) < 0) {
+    LOG(CRITICAL) << "av_image_fill_arrays failed, err: "
+                  << Util::generateErrorDesc(result);
+  }
+  return result;
+}
+
+int transformImage(
+    SwsContext* context,
+    const uint8_t* const srcSlice[],
+    int srcStride[],
+    VideoFormat inFormat,
+    VideoFormat outFormat,
+    uint8_t* out,
+    uint8_t* planes[],
+    int lines[]) {
+  int result;
+  if ((result = preparePlanes(outFormat, out, planes, lines)) < 0) {
+    return result;
+  }
+
+  if ((result = sws_scale(
+           context, srcSlice, srcStride, 0, inFormat.height, planes, lines)) <
+      0) {
+    LOG(CRITICAL) << "sws_scale failed, err: "
+                  << Util::generateErrorDesc(result);
+    return result;
+  }
+  return 0;
+}
+} // namespace
+
+VideoSampler::VideoSampler(int swsFlags, int64_t loggingUuid)
+    : swsFlags_(swsFlags), loggingUuid_(loggingUuid) {}
+
+VideoSampler::~VideoSampler() {
+  cleanUp();
+}
+
+void VideoSampler::shutdown() {
+  cleanUp();
+}
+
+bool VideoSampler::init(const SamplerParameters& params) {
+  cleanUp();
+
+  if (params.out.video.cropImage != 0) {
+    if (!Util::validateVideoFormat(params.out.video)) {
+      LOG(CRITICAL) << "Invalid video format"
+                    << ", width: " << params.out.video.width
+                    << ", height: " << params.out.video.height
+                    << ", format: " << params.out.video.format
+                    << ", minDimension: " << params.out.video.minDimension
+                    << ", crop: " << params.out.video.cropImage;
+
+      return false;
+    }
+
+    scaleFormat_.format = params.out.video.format;
+    Util::setFormatDimensions(
+        scaleFormat_.width,
+        scaleFormat_.height,
+        params.out.video.width,
+        params.out.video.height,
+        params.in.video.width,
+        params.in.video.height,
+        0,
+        1);
+
+    if (!(scaleFormat_ == params_.out.video)) { // crop required
+      cropContext_ = sws_getContext(
+          params.out.video.width,
+          params.out.video.height,
+          (AVPixelFormat)params_.out.video.format,
+          params.out.video.width,
+          params.out.video.height,
+          (AVPixelFormat)params.out.video.format,
+          swsFlags_,
+          nullptr,
+          nullptr,
+          nullptr);
+
+      if (!cropContext_) {
+        LOG(CRITICAL) << "sws_getContext failed for crop context";
+        return false;
+      }
+
+      const auto scaleImageSize = av_image_get_buffer_size(
+          (AVPixelFormat)scaleFormat_.format,
+          scaleFormat_.width,
+          scaleFormat_.height,
+          1);
+      scaleBuffer_.resize(scaleImageSize);
+    }
+  } else {
+    scaleFormat_ = params.out.video;
+  }
+
+  VLOG(1) << "Input format #" << loggingUuid_ << ", width "
+          << params.in.video.width << ", height " << params.in.video.height
+          << ", format " << params.in.video.format << ", minDimension "
+          << params.in.video.minDimension << ", cropImage "
+          << params.in.video.cropImage;
+  VLOG(1) << "Scale format #" << loggingUuid_ << ", width "
+          << scaleFormat_.width << ", height " << scaleFormat_.height
+          << ", format " << scaleFormat_.format << ", minDimension "
+          << scaleFormat_.minDimension << ", cropImage "
+          << scaleFormat_.cropImage;
+  VLOG(1) << "Crop format #" << loggingUuid_ << ", width "
+          << params.out.video.width << ", height " << params.out.video.height
+          << ", format " << params.out.video.format << ", minDimension "
+          << params.out.video.minDimension << ", cropImage "
+          << params.out.video.cropImage;
+
+  scaleContext_ = sws_getContext(
+      params.in.video.width,
+      params.in.video.height,
+      (AVPixelFormat)params.in.video.format,
+      scaleFormat_.width,
+      scaleFormat_.height,
+      (AVPixelFormat)scaleFormat_.format,
+      swsFlags_,
+      nullptr,
+      nullptr,
+      nullptr);
+
+  // set output format
+  params_ = params;
+
+  return scaleContext_ != nullptr;
+}
+
+int VideoSampler::getImageBytes() const {
+  return av_image_get_buffer_size(
+      (AVPixelFormat)params_.out.video.format,
+      params_.out.video.width,
+      params_.out.video.height,
+      1);
+}
+
+int VideoSampler::sample(
+    const uint8_t* const srcSlice[],
+    int srcStride[],
+    ByteStorage* out,
+    bool allocateBuffer) {
+  int result;
+  // scaled and cropped image
+  const auto outImageSize = getImageBytes();
+  if (allocateBuffer) {
+    out->clear();
+    out->ensure(outImageSize);
+  }
+  CHECK_LE(outImageSize, out->tail());
+
+  uint8_t* scalePlanes[4] = {nullptr};
+  int scaleLines[4] = {0};
+  // perform scale first
+  if ((result = transformImage(
+           scaleContext_,
+           srcSlice,
+           srcStride,
+           params_.in.video,
+           scaleFormat_,
+           // for crop use internal buffer
+           cropContext_ ? scaleBuffer_.data() : out->writableTail(),
+           scalePlanes,
+           scaleLines))) {
+    return result;
+  }
+
+  // is crop required?
+  if (cropContext_) {
+    uint8_t* cropPlanes[4] = {nullptr};
+    int cropLines[4] = {0};
+
+    if (params_.out.video.height < scaleFormat_.height) {
+      // Destination image is wider of source image: cut top and bottom
+      for (size_t i = 0; i < 4 && scalePlanes[i] != nullptr; ++i) {
+        scalePlanes[i] += scaleLines[i] *
+            (scaleFormat_.height - params_.out.video.height) / 2;
+      }
+    } else {
+      // Source image is wider of destination image: cut sides
+      for (size_t i = 0; i < 4 && scalePlanes[i] != nullptr; ++i) {
+        scalePlanes[i] += scaleLines[i] *
+            (scaleFormat_.width - params_.out.video.width) / 2 /
+            scaleFormat_.width;
+      }
+    }
+
+    // crop image
+    if ((result = transformImage(
+             cropContext_,
+             scalePlanes,
+             scaleLines,
+             params_.out.video,
+             params_.out.video,
+             out->writableTail(),
+             cropPlanes,
+             cropLines))) {
+      return result;
+    }
+  }
+
+  out->append(outImageSize);
+  return outImageSize;
+}
+
+int VideoSampler::sample(AVFrame* frame, ByteStorage* out) {
+  if (!frame) {
+    return 0; // no flush for videos
+  }
+
+  return sample(frame->data, frame->linesize, out, false);
+}
+
+int VideoSampler::sample(const ByteStorage* in, ByteStorage* out) {
+  if (!in) {
+    return 0; // no flush for videos
+  }
+
+  int result;
+  uint8_t* inPlanes[4] = {nullptr};
+  int inLineSize[4] = {0};
+
+  if ((result = preparePlanes(
+           params_.in.video, in->data(), inPlanes, inLineSize)) < 0) {
+    return result;
+  }
+
+  return sample(inPlanes, inLineSize, out, true);
+}
+
+void VideoSampler::cleanUp() {
+  if (scaleContext_) {
+    sws_freeContext(scaleContext_);
+    scaleContext_ = nullptr;
+  }
+  if (cropContext_) {
+    sws_freeContext(cropContext_);
+    cropContext_ = nullptr;
+    scaleBuffer_.clear();
+  }
+}
+
+} // namespace ffmpeg

--- a/torchvision/csrc/decoder/video_sampler.h
+++ b/torchvision/csrc/decoder/video_sampler.h
@@ -1,0 +1,62 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#pragma once
+
+#include "defs.h"
+
+extern "C" {
+#include <libavformat/avformat.h>
+#include "libswscale/swscale.h"
+}
+
+namespace ffmpeg {
+
+/**
+ * Class transcode video frames from one format into another
+ */
+
+class VideoSampler : public MediaSampler {
+ public:
+  VideoSampler(int swsFlags = SWS_AREA, int64_t loggingUuid = 0);
+
+  ~VideoSampler() override;
+
+  // MediaSampler overrides
+  bool init(const SamplerParameters& params) override;
+  MediaType getMediaType() const override {
+    return MediaType::TYPE_VIDEO;
+  }
+  FormatUnion getInputFormat() const override {
+    return params_.in;
+  }
+  FormatUnion getOutFormat() const override {
+    return params_.out;
+  }
+  int sample(const ByteStorage* in, ByteStorage* out) override;
+  void shutdown() override;
+
+  // returns number processed/scaling bytes
+  int sample(AVFrame* frame, ByteStorage* out);
+  int getImageBytes() const;
+
+ private:
+  // close resources
+  void cleanUp();
+  // helper functions for rescaling, cropping, etc.
+  int sample(
+      const uint8_t* const srcSlice[],
+      int srcStride[],
+      ByteStorage* out,
+      bool allocateBuffer);
+
+ private:
+  SamplerParameters params_;
+  VideoFormat scaleFormat_;
+  SwsContext* scaleContext_{nullptr};
+  SwsContext* cropContext_{nullptr};
+  int swsFlags_{SWS_AREA};
+  std::vector<uint8_t> scaleBuffer_;
+  int64_t loggingUuid_{0};
+};
+
+} // namespace ffmpeg

--- a/torchvision/csrc/decoder/video_stream.cpp
+++ b/torchvision/csrc/decoder/video_stream.cpp
@@ -1,0 +1,142 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include "video_stream.h"
+#include <glog/logging.h>
+#include "util.h"
+
+namespace ffmpeg {
+
+namespace {
+bool operator==(const VideoFormat& x, const AVFrame& y) {
+  return x.width == y.width && x.height == y.height && x.format == y.format;
+}
+
+VideoFormat& toVideoFormat(VideoFormat& x, const AVFrame& y) {
+  x.width = y.width;
+  x.height = y.height;
+  x.format = y.format;
+  return x;
+}
+} // namespace
+
+VideoStream::VideoStream(
+    AVFormatContext* inputCtx,
+    int index,
+    bool convertPtsToWallTime,
+    const VideoFormat& format,
+    int64_t loggingUuid)
+    : Stream(inputCtx, index, convertPtsToWallTime),
+      format_(format),
+      loggingUuid_(loggingUuid) {}
+
+VideoStream::~VideoStream() {
+  if (sampler_) {
+    sampler_->shutdown();
+    sampler_.reset();
+  }
+}
+
+void VideoStream::ensureSampler() {
+  if (!sampler_) {
+    sampler_ = std::make_unique<VideoSampler>(SWS_AREA, loggingUuid_);
+  }
+}
+
+int VideoStream::initFormat() {
+  // set output format
+  if (!Util::validateVideoFormat(format_)) {
+    LOG(CRITICAL) << "Invalid video format"
+                  << ", width: " << format_.width
+                  << ", height: " << format_.height
+                  << ", format: " << format_.format
+                  << ", minDimension: " << format_.minDimension
+                  << ", crop: " << format_.cropImage;
+    return -1;
+  }
+
+  // keep aspect ratio
+  Util::setFormatDimensions(
+      format_.width,
+      format_.height,
+      format_.width,
+      format_.height,
+      codecCtx_->width,
+      codecCtx_->height,
+      format_.minDimension,
+      0);
+
+  if (format_.format == AV_PIX_FMT_NONE) {
+    format_.format = codecCtx_->pix_fmt;
+  }
+  return format_.width != 0 && format_.height != 0 &&
+          format_.format != AV_PIX_FMT_NONE
+      ? 0
+      : -1;
+}
+
+int VideoStream::estimateBytes(bool flush) {
+  ensureSampler();
+  // check if input format gets changed
+  if (!flush && !(sampler_->getInputFormat().video == *frame_)) {
+    // - reinit sampler
+    SamplerParameters params;
+    params.type = MediaType::TYPE_VIDEO;
+    params.out.video = format_;
+    toVideoFormat(params.in.video, *frame_);
+    if (!sampler_->init(params)) {
+      return -1;
+    }
+
+    VLOG(1) << "Set input video sampler format"
+            << ", width: " << params.in.video.width
+            << ", height: " << params.in.video.height
+            << ", format: " << params.in.video.format
+            << " : output video sampler format"
+            << ", width: " << format_.width << ", height: " << format_.height
+            << ", format: " << format_.format
+            << ", minDimension: " << format_.minDimension
+            << ", crop: " << format_.cropImage;
+  }
+  return sampler_->getImageBytes();
+}
+
+int VideoStream::copyFrameBytes(ByteStorage* out, bool flush) {
+  ensureSampler();
+  return sampler_->sample(flush ? nullptr : frame_, out);
+}
+
+void VideoStream::setHeader(DecoderHeader* header) {
+  header->seqno = numGenerator_++;
+
+  if (codecCtx_->time_base.num != 0) {
+    header->pts = av_rescale_q(
+        av_frame_get_best_effort_timestamp(frame_),
+        codecCtx_->time_base,
+        AV_TIME_BASE_Q);
+  } else {
+    // If the codec time_base is missing then we would've skipped the
+    // rescalePackage step to rescale to codec time_base, so here we can
+    // rescale straight from the stream time_base into AV_TIME_BASE_Q.
+    header->pts = av_rescale_q(
+        av_frame_get_best_effort_timestamp(frame_),
+        inputCtx_->streams[index_]->time_base,
+        AV_TIME_BASE_Q);
+  }
+
+  if (convertPtsToWallTime_) {
+    keeper_.adjust(header->pts);
+  }
+
+  header->keyFrame = frame_->key_frame;
+  auto fpsRational = inputCtx_->streams[index_]->avg_frame_rate;
+  if (fpsRational.den) {
+    header->fps = av_q2d(fpsRational);
+  } else {
+    header->fps = std::numeric_limits<double>::quiet_NaN();
+  }
+  header->format.stream = index_;
+  header->format.type = TYPE_VIDEO;
+  header->format.format.video = format_;
+}
+
+} // namespace ffmpeg

--- a/torchvision/csrc/decoder/video_stream.h
+++ b/torchvision/csrc/decoder/video_stream.h
@@ -1,0 +1,44 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#pragma once
+
+#include "stream.h"
+#include "time_keeper.h"
+#include "video_sampler.h"
+
+namespace ffmpeg {
+
+/**
+ * Class uses FFMPEG library to decode one video stream.
+ */
+
+class VideoStream : public Stream {
+ public:
+  VideoStream(
+      AVFormatContext* inputCtx,
+      int index,
+      bool convertPtsToWallTime,
+      const VideoFormat& format,
+      int64_t loggingUuid = 0);
+  ~VideoStream() override;
+
+ private:
+  // Stream overrides
+  MediaType getMediaType() const override {
+    return TYPE_VIDEO;
+  }
+  int initFormat() override;
+  int estimateBytes(bool flush) override;
+  int copyFrameBytes(ByteStorage* out, bool flush) override;
+  void setHeader(DecoderHeader* header) override;
+
+  void ensureSampler();
+
+ private:
+  VideoFormat format_;
+  std::unique_ptr<VideoSampler> sampler_;
+  TimeKeeper keeper_;
+  int64_t loggingUuid_{0};
+};
+
+} // namespace ffmpeg


### PR DESCRIPTION
Base decoder doesn't define how memory (ByteStorage) is implemented, it's up to the derive class.
sync_decoder class is an example.
Also base decoder API doesn't define in what thread decoding will be performed.
sync_decoder class provides an example how to do decoding in the caller thread.
sync_decoder also demonstrated how only part of the video can be decoded (valid only for seekable streams, i.e. files, memory).