### PR TITLE
Support local cached pretrained model files in "torchvision.models.densenet"

### DIFF
--- a/torchvision/models/densenet.py
+++ b/torchvision/models/densenet.py
@@ -178,7 +178,7 @@ def _load_state_dict(model, model_url, progress, cached_model_dir):
     model.load_state_dict(state_dict)
 
 
-def _densenet(arch, growth_rate, block_config, num_init_features, pretrained, progress, cached_model_dir,
+def _densenet(arch, growth_rate, block_config, num_init_features, pretrained, progress, cached_model_dir=None,
               **kwargs):
     model = DenseNet(growth_rate, block_config, num_init_features, **kwargs)
     if pretrained:

--- a/torchvision/models/densenet.py
+++ b/torchvision/models/densenet.py
@@ -160,7 +160,7 @@ class DenseNet(nn.Module):
         return out
 
 
-def _load_state_dict(model, model_url, progress):
+def _load_state_dict(model, model_url, pretrained_model_dir, progress):
     # '.'s are no longer allowed in module names, but previous _DenseLayer
     # has keys 'norm.1', 'relu.1', 'conv.1', 'norm.2', 'relu.2', 'conv.2'.
     # They are also in the checkpoints in model_urls. This pattern is used
@@ -168,7 +168,7 @@ def _load_state_dict(model, model_url, progress):
     pattern = re.compile(
         r'^(.*denselayer\d+\.(?:norm|relu|conv))\.((?:[12])\.(?:weight|bias|running_mean|running_var))$')
 
-    state_dict = load_state_dict_from_url(model_url, progress=progress)
+    state_dict = load_state_dict_from_url(model_url, model_dir=pretrained_model_dir, progress=progress)
     for key in list(state_dict.keys()):
         res = pattern.match(key)
         if res:
@@ -178,11 +178,11 @@ def _load_state_dict(model, model_url, progress):
     model.load_state_dict(state_dict)
 
 
-def _densenet(arch, growth_rate, block_config, num_init_features, pretrained, progress,
+def _densenet(arch, growth_rate, block_config, num_init_features, pretrained, pretrained_model_dir, progress,
               **kwargs):
     model = DenseNet(growth_rate, block_config, num_init_features, **kwargs)
     if pretrained:
-        _load_state_dict(model, model_urls[arch], progress)
+        _load_state_dict(model, model_urls[arch], pretrained_model_dir, progress)
     return model
 
 

--- a/torchvision/models/densenet.py
+++ b/torchvision/models/densenet.py
@@ -160,7 +160,7 @@ class DenseNet(nn.Module):
         return out
 
 
-def _load_state_dict(model, model_url, pretrained_model_dir, progress):
+def _load_state_dict(model, model_url, progress, cached_model_dir):
     # '.'s are no longer allowed in module names, but previous _DenseLayer
     # has keys 'norm.1', 'relu.1', 'conv.1', 'norm.2', 'relu.2', 'conv.2'.
     # They are also in the checkpoints in model_urls. This pattern is used
@@ -168,7 +168,7 @@ def _load_state_dict(model, model_url, pretrained_model_dir, progress):
     pattern = re.compile(
         r'^(.*denselayer\d+\.(?:norm|relu|conv))\.((?:[12])\.(?:weight|bias|running_mean|running_var))$')
 
-    state_dict = load_state_dict_from_url(model_url, model_dir=pretrained_model_dir, progress=progress)
+    state_dict = load_state_dict_from_url(model_url, model_dir=cached_model_dir, progress=progress)
     for key in list(state_dict.keys()):
         res = pattern.match(key)
         if res:
@@ -178,11 +178,11 @@ def _load_state_dict(model, model_url, pretrained_model_dir, progress):
     model.load_state_dict(state_dict)
 
 
-def _densenet(arch, growth_rate, block_config, num_init_features, pretrained, pretrained_model_dir, progress,
+def _densenet(arch, growth_rate, block_config, num_init_features, pretrained, progress, cached_model_dir,
               **kwargs):
     model = DenseNet(growth_rate, block_config, num_init_features, **kwargs)
     if pretrained:
-        _load_state_dict(model, model_urls[arch], pretrained_model_dir, progress)
+        _load_state_dict(model, model_urls[arch], progress, cached_model_dir)
     return model
 
 


### PR DESCRIPTION
Issue: Currently only downloading from model_urls is permitted in densenet.py, which makes users cannot use model files in local paths.

Solution: Support passing "model_dir" to "load_state_dict_from_url" func will solve this problem.