### PR TITLE
Modify gels to lstsq

### DIFF
--- a/torchvision/transforms/functional.py
+++ b/torchvision/transforms/functional.py
@@ -437,7 +437,7 @@ def _get_perspective_coeffs(startpoints, endpoints):
 
     A = torch.tensor(matrix, dtype=torch.float)
     B = torch.tensor(startpoints, dtype=torch.float).view(8)
-    res = torch.gels(B, A)[0]
+    res = torch.lstsq(B, A)[0]
     return res.squeeze_(1).tolist()
 
 


### PR DESCRIPTION
This is to prevent the deprecation warning when calling the perspective transform.

**Note: this is BC-breaking**