### PR TITLE
Fix make_grid: support any number of channels in tensor

### DIFF
--- a/torchvision/utils.py
+++ b/torchvision/utils.py
@@ -74,7 +74,8 @@ def make_grid(tensor, nrow=8, padding=2,
     xmaps = min(nrow, nmaps)
     ymaps = int(math.ceil(float(nmaps) / xmaps))
     height, width = int(tensor.size(2) + padding), int(tensor.size(3) + padding)
-    grid = tensor.new_full((3, height * ymaps + padding, width * xmaps + padding), pad_value)
+    num_channels = tensor.size(1)
+    grid = tensor.new_full((num_channels, height * ymaps + padding, width * xmaps + padding), pad_value)
     k = 0
     for y in irange(ymaps):
         for x in irange(xmaps):


### PR DESCRIPTION
At the moment, one can't use `make_grid` if images in the input tensor (of size B x C x H x W) are RGBA.
This PR checks the number of channels, C, before creating the `grid` tensor.