### PR TITLE
[video dataset]expose more arguments of VideoClips in video datasets

### DIFF
--- a/torchvision/datasets/hmdb51.py
+++ b/torchvision/datasets/hmdb51.py
@@ -50,7 +50,8 @@ class HMDB51(VisionDataset):
     }
 
     def __init__(self, root, annotation_path, frames_per_clip, step_between_clips=1,
-                 fold=1, train=True, transform=None):
+                 frame_rate=None, precomputed_metadata=None, fold=1, train=True,
+                 transform=None):
         super(HMDB51, self).__init__(root)
         if not 1 <= fold <= 3:
             raise ValueError("fold should be between 1 and 3, got {}".format(fold))
@@ -64,7 +65,13 @@ class HMDB51(VisionDataset):
         self.samples = make_dataset(self.root, class_to_idx, extensions, is_valid_file=None)
         self.classes = classes
         video_list = [x[0] for x in self.samples]
-        video_clips = VideoClips(video_list, frames_per_clip, step_between_clips)
+        video_clips = VideoClips(
+            video_list,
+            frames_per_clip,
+            step_between_clips,
+            frame_rate,
+            precomputed_metadata,
+        )
         self.indices = self._select_fold(video_list, annotation_path, fold, train)
         self.video_clips = video_clips.subset(self.indices)
         self.transform = transform

--- a/torchvision/datasets/hmdb51.py
+++ b/torchvision/datasets/hmdb51.py
@@ -50,8 +50,8 @@ class HMDB51(VisionDataset):
     }
 
     def __init__(self, root, annotation_path, frames_per_clip, step_between_clips=1,
-                 frame_rate=None, precomputed_metadata=None, fold=1, train=True,
-                 transform=None):
+                 frame_rate=None, precomputed_metadata=None, precomputed_metadata_filepath=None,
+                 save_metadata_filepath=None, fold=1, train=True, transform=None):
         super(HMDB51, self).__init__(root)
         if not 1 <= fold <= 3:
             raise ValueError("fold should be between 1 and 3, got {}".format(fold))
@@ -71,7 +71,11 @@ class HMDB51(VisionDataset):
             step_between_clips,
             frame_rate,
             precomputed_metadata,
+            precomputed_metadata_filepath,
         )
+        if save_metadata_filepath:
+            video_clips.save_metadata(save_metadata_filepath)
+
         self.indices = self._select_fold(video_list, annotation_path, fold, train)
         self.video_clips = video_clips.subset(self.indices)
         self.transform = transform

--- a/torchvision/datasets/hmdb51.py
+++ b/torchvision/datasets/hmdb51.py
@@ -4,10 +4,10 @@ import os
 from .video_utils import VideoClips
 from .utils import list_dir
 from .folder import make_dataset
-from .vision import VisionDataset
+from .vision import VisionVideoDataset
 
 
-class HMDB51(VisionDataset):
+class HMDB51(VisionVideoDataset):
     """
     HMDB51 <http://serre-lab.clps.brown.edu/resource/hmdb-a-large-human-motion-database/>`_
     dataset.
@@ -50,8 +50,8 @@ class HMDB51(VisionDataset):
     }
 
     def __init__(self, root, annotation_path, frames_per_clip, step_between_clips=1,
-                 frame_rate=None, precomputed_metadata=None, precomputed_metadata_filepath=None,
-                 save_metadata_filepath=None, fold=1, train=True, transform=None):
+                 frame_rate=None, precomputed_metadata=None, fold=1, train=True,
+                 transform=None):
         super(HMDB51, self).__init__(root)
         if not 1 <= fold <= 3:
             raise ValueError("fold should be between 1 and 3, got {}".format(fold))
@@ -71,10 +71,8 @@ class HMDB51(VisionDataset):
             step_between_clips,
             frame_rate,
             precomputed_metadata,
-            precomputed_metadata_filepath,
         )
-        if save_metadata_filepath:
-            video_clips.save_metadata(save_metadata_filepath)
+        self.metadata = video_clips.get_metadata()
 
         self.indices = self._select_fold(video_list, annotation_path, fold, train)
         self.video_clips = video_clips.subset(self.indices)

--- a/torchvision/datasets/kinetics.py
+++ b/torchvision/datasets/kinetics.py
@@ -37,7 +37,8 @@ class Kinetics400(VisionDataset):
     """
 
     def __init__(self, root, frames_per_clip, step_between_clips=1, frame_rate=None,
-                 precomputed_metadata=None, transform=None):
+                 precomputed_metadata=None, precomputed_metadata_filepath=None,
+                 save_metadata_filepath=None, transform=None):
         super(Kinetics400, self).__init__(root)
         extensions = ('avi',)
 
@@ -52,7 +53,11 @@ class Kinetics400(VisionDataset):
             step_between_clips,
             frame_rate,
             precomputed_metadata,
+            precomputed_metadata_filepath,
         )
+        if save_metadata_filepath:
+            self.video_clips.save_metadata(save_metadata_filepath)
+
         self.transform = transform
 
     def __len__(self):

--- a/torchvision/datasets/kinetics.py
+++ b/torchvision/datasets/kinetics.py
@@ -36,7 +36,8 @@ class Kinetics400(VisionDataset):
         label (int): class of the video clip
     """
 
-    def __init__(self, root, frames_per_clip, step_between_clips=1, transform=None):
+    def __init__(self, root, frames_per_clip, step_between_clips=1, frame_rate=None,
+                 precomputed_metadata=None, transform=None):
         super(Kinetics400, self).__init__(root)
         extensions = ('avi',)
 
@@ -45,7 +46,13 @@ class Kinetics400(VisionDataset):
         self.samples = make_dataset(self.root, class_to_idx, extensions, is_valid_file=None)
         self.classes = classes
         video_list = [x[0] for x in self.samples]
-        self.video_clips = VideoClips(video_list, frames_per_clip, step_between_clips)
+        self.video_clips = VideoClips(
+            video_list,
+            frames_per_clip,
+            step_between_clips,
+            frame_rate,
+            precomputed_metadata,
+        )
         self.transform = transform
 
     def __len__(self):

--- a/torchvision/datasets/kinetics.py
+++ b/torchvision/datasets/kinetics.py
@@ -1,10 +1,10 @@
 from .video_utils import VideoClips
 from .utils import list_dir
 from .folder import make_dataset
-from .vision import VisionDataset
+from .vision import VisionVideoDataset
 
 
-class Kinetics400(VisionDataset):
+class Kinetics400(VisionVideoDataset):
     """
     `Kinetics-400 <https://deepmind.com/research/open-source/open-source-datasets/kinetics/>`_
     dataset.
@@ -37,8 +37,7 @@ class Kinetics400(VisionDataset):
     """
 
     def __init__(self, root, frames_per_clip, step_between_clips=1, frame_rate=None,
-                 precomputed_metadata=None, precomputed_metadata_filepath=None,
-                 save_metadata_filepath=None, transform=None):
+                 precomputed_metadata=None, transform=None):
         super(Kinetics400, self).__init__(root)
         extensions = ('avi',)
 
@@ -53,10 +52,8 @@ class Kinetics400(VisionDataset):
             step_between_clips,
             frame_rate,
             precomputed_metadata,
-            precomputed_metadata_filepath,
         )
-        if save_metadata_filepath:
-            self.video_clips.save_metadata(save_metadata_filepath)
+        self.metadata = self.video_clips.get_metadata()
 
         self.transform = transform
 

--- a/torchvision/datasets/ucf101.py
+++ b/torchvision/datasets/ucf101.py
@@ -4,10 +4,10 @@ import os
 from .video_utils import VideoClips
 from .utils import list_dir
 from .folder import make_dataset
-from .vision import VisionDataset
+from .vision import VisionVideoDataset
 
 
-class UCF101(VisionDataset):
+class UCF101(VisionVideoDataset):
     """
     UCF101 <https://www.crcv.ucf.edu/data/UCF101.php>`_ dataset.
 
@@ -43,8 +43,8 @@ class UCF101(VisionDataset):
     """
 
     def __init__(self, root, annotation_path, frames_per_clip, step_between_clips=1,
-                 frame_rate=None, precomputed_metadata=None, precomputed_metadata_filepath=None,
-                 save_metadata_filepath=None, fold=1, train=True, transform=None):
+                 frame_rate=None, precomputed_metadata=None, fold=1, train=True,
+                 transform=None):
         super(UCF101, self).__init__(root)
         if not 1 <= fold <= 3:
             raise ValueError("fold should be between 1 and 3, got {}".format(fold))
@@ -64,10 +64,8 @@ class UCF101(VisionDataset):
             step_between_clips,
             frame_rate,
             precomputed_metadata,
-            precomputed_metadata_filepath,
         )
-        if save_metadata_filepath:
-            video_clips.save_metadata(save_metadata_filepath)
+        self.metadata = video_clips.get_metadata()
 
         self.indices = self._select_fold(video_list, annotation_path, fold, train)
         self.video_clips = video_clips.subset(self.indices)

--- a/torchvision/datasets/ucf101.py
+++ b/torchvision/datasets/ucf101.py
@@ -43,7 +43,8 @@ class UCF101(VisionDataset):
     """
 
     def __init__(self, root, annotation_path, frames_per_clip, step_between_clips=1,
-                 fold=1, train=True, transform=None):
+                 frame_rate=None, precomputed_metadata=None, fold=1, train=True,
+                 transform=None):
         super(UCF101, self).__init__(root)
         if not 1 <= fold <= 3:
             raise ValueError("fold should be between 1 and 3, got {}".format(fold))
@@ -57,7 +58,13 @@ class UCF101(VisionDataset):
         self.samples = make_dataset(self.root, class_to_idx, extensions, is_valid_file=None)
         self.classes = classes
         video_list = [x[0] for x in self.samples]
-        video_clips = VideoClips(video_list, frames_per_clip, step_between_clips)
+        video_clips = VideoClips(
+            video_list,
+            frames_per_clip,
+            step_between_clips,
+            frame_rate,
+            precomputed_metadata,
+        )
         self.indices = self._select_fold(video_list, annotation_path, fold, train)
         self.video_clips = video_clips.subset(self.indices)
         self.transform = transform

--- a/torchvision/datasets/ucf101.py
+++ b/torchvision/datasets/ucf101.py
@@ -43,8 +43,8 @@ class UCF101(VisionDataset):
     """
 
     def __init__(self, root, annotation_path, frames_per_clip, step_between_clips=1,
-                 frame_rate=None, precomputed_metadata=None, fold=1, train=True,
-                 transform=None):
+                 frame_rate=None, precomputed_metadata=None, precomputed_metadata_filepath=None,
+                 save_metadata_filepath=None, fold=1, train=True, transform=None):
         super(UCF101, self).__init__(root)
         if not 1 <= fold <= 3:
             raise ValueError("fold should be between 1 and 3, got {}".format(fold))
@@ -64,7 +64,11 @@ class UCF101(VisionDataset):
             step_between_clips,
             frame_rate,
             precomputed_metadata,
+            precomputed_metadata_filepath,
         )
+        if save_metadata_filepath:
+            video_clips.save_metadata(save_metadata_filepath)
+
         self.indices = self._select_fold(video_list, annotation_path, fold, train)
         self.video_clips = video_clips.subset(self.indices)
         self.transform = transform

--- a/torchvision/datasets/video_utils.py
+++ b/torchvision/datasets/video_utils.py
@@ -94,12 +94,6 @@ class VideoClips(object):
         self.video_pts = metadata["video_pts"]
         self.video_fps = metadata["video_fps"]
 
-    def get_metadata(self):
-        return {
-            "video_pts": self.video_pts,
-            "video_fps": self.video_fps,
-        }
-
     def subset(self, indices):
         video_paths = [self.video_paths[i] for i in indices]
         video_pts = [self.video_pts[i] for i in indices]

--- a/torchvision/datasets/video_utils.py
+++ b/torchvision/datasets/video_utils.py
@@ -94,6 +94,12 @@ class VideoClips(object):
         self.video_pts = metadata["video_pts"]
         self.video_fps = metadata["video_fps"]
 
+    def get_metadata(self):
+        return {
+            "video_pts": self.video_pts,
+            "video_fps": self.video_fps,
+        }
+
     def subset(self, indices):
         video_paths = [self.video_paths[i] for i in indices]
         video_pts = [self.video_pts[i] for i in indices]

--- a/torchvision/datasets/vision.py
+++ b/torchvision/datasets/vision.py
@@ -51,6 +51,22 @@ class VisionDataset(data.Dataset):
         return ""
 
 
+class VisionVideoDataset(VisionDataset):
+    def __init__(self, root, transforms=None, transform=None, target_transform=None):
+        super(VisionVideoDataset, self).__init__(
+            root,
+            transforms=transforms,
+            transform=transform,
+            target_transform=target_transform,
+        )
+
+    def get_metadata(self):
+        if hasattr(self, "metadata"):
+            return self.metadata
+        else:
+            return None
+
+
 class StandardTransform(object):
     def __init__(self, transform=None, target_transform=None):
         self.transform = transform


### PR DESCRIPTION
- In `__init__()` method of class `VideoClips`, two arguments `frame_rate` and `_precomputed_metadata` are not yet exposed in dataset classes for hmdb51, ucf101 and kinetics400.  This PR updates dataset classes to expose those 2 arguments.
- Add a class `VisionVideoDataset` to abstract out API `get_metadata()`. The caller can retrieve video dataset metadata and decide how to cache it. This is dependent on a previous PR (https://github.com/pytorch/vision/pull/1303/)