### PR TITLE
one line for detection rpn work normally with cuda

### DIFF
--- a/torchvision/models/detection/rpn.py
+++ b/torchvision/models/detection/rpn.py
@@ -62,7 +62,7 @@ class AnchorGenerator(nn.Module):
         return base_anchors.round()
 
     def set_cell_anchors(self, device):
-        if self.cell_anchors is not None:
+        if self.cell_anchors is not None and device == self.cell_anchors[0].devcie:
             return self.cell_anchors
         cell_anchors = [
             self.generate_anchors(


### PR DESCRIPTION
The origin code, for example for detection: model.cuda()(torch.tensor([1,3,128,128], dtype = torch.float).cuda()), will raise error because the anchor tensor is still on the "cpu". This fix make the 
code work more pytorch way.