### PR TITLE
Fix EMNSIT download URL

### DIFF
--- a/torchvision/datasets/mnist.py
+++ b/torchvision/datasets/mnist.py
@@ -226,7 +226,10 @@ class EMNIST(MNIST):
         target_transform (callable, optional): A function/transform that takes in the
             target and transforms it.
     """
-    # Updated URL from https://www.westernsydney.edu.au/bens/home/reproducible_research/emnist
+    # Updated URL from https://www.nist.gov/node/1298471/emnist-dataset since the
+    # _official_ download link
+    # https://cloudstor.aarnet.edu.au/plus/s/ZNmuFiuQTqZlu9W/download
+    # is (currently) unavailable
     url = 'http://www.itl.nist.gov/iaui/vip/cs_links/EMNIST/gzip.zip'
     splits = ('byclass', 'bymerge', 'balanced', 'letters', 'digits', 'mnist')
 

--- a/torchvision/datasets/mnist.py
+++ b/torchvision/datasets/mnist.py
@@ -227,7 +227,7 @@ class EMNIST(MNIST):
             target and transforms it.
     """
     # Updated URL from https://www.westernsydney.edu.au/bens/home/reproducible_research/emnist
-    url = 'https://cloudstor.aarnet.edu.au/plus/s/ZNmuFiuQTqZlu9W/download'
+    url = 'http://www.itl.nist.gov/iaui/vip/cs_links/EMNIST/gzip.zip'
     splits = ('byclass', 'bymerge', 'balanced', 'letters', 'digits', 'mnist')
 
     def __init__(self, root, split, **kwargs):


### PR DESCRIPTION
fixes #1296 

@fmassa The link you provided works as drop-in replacement. The website looks official to me, since it comprises citing information and so on. Do you want me to include a comment why this does not link to the [_official_ dataset](https://www.westernsydney.edu.au/bens/home/reproducible_research/emnist) website?