### PR TITLE
Add TorchHub tests to torchvision

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,6 +76,7 @@ install:
 
 script:
   - pytest --cov-config .coveragerc --cov torchvision --cov $TV_INSTALL_PATH test
+  - pytest test/test_hub.py
 
 after_success:
   # Necessary to run coverage combine to rewrite paths from

--- a/test/test_hub.py
+++ b/test/test_hub.py
@@ -1,0 +1,58 @@
+import torch.hub as hub
+import tempfile
+import shutil
+import os
+import sys
+import unittest
+
+
+def sum_of_model_parameters(model):
+    s = 0
+    for p in model.parameters():
+        s += p.sum()
+    return s
+
+
+SUM_OF_PRETRAINED_RESNET18_PARAMS = -12703.99609375
+
+
+class TestHub(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # Only run this check ONCE before all tests start.
+        # - If torchvision is imported before all tests start, e.g. we might find _C.so
+        #   which doesn't exist in downloaded zip but in the installed wheel.
+        # - After the first test is run, torchvision is already in sys.modules due to
+        #   Python cache as we run all hub tests in the same python process.
+        if 'torchvision' in sys.modules:
+            raise RuntimeError('TestHub must start without torchvision imported')
+
+    def test_load_from_github(self):
+        hub_model = hub.load(
+            'pytorch/vision',
+            'resnet18',
+            pretrained=True,
+            progress=False)
+        self.assertEqual(sum_of_model_parameters(hub_model).item(),
+                         SUM_OF_PRETRAINED_RESNET18_PARAMS)
+
+    def test_set_dir(self):
+        temp_dir = tempfile.gettempdir()
+        hub.set_dir(temp_dir)
+        hub_model = hub.load(
+            'pytorch/vision',
+            'resnet18',
+            pretrained=True,
+            progress=False)
+        self.assertEqual(sum_of_model_parameters(hub_model).item(),
+                         SUM_OF_PRETRAINED_RESNET18_PARAMS)
+        assert os.path.exists(temp_dir + '/pytorch_vision_master')
+        shutil.rmtree(temp_dir + '/pytorch_vision_master')
+
+    def test_list_entrypoints(self):
+        entry_lists = hub.list('pytorch/vision', force_reload=True)
+        self.assertIn('resnet18', entry_lists)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_hub.py
+++ b/test/test_hub.py
@@ -16,16 +16,14 @@ def sum_of_model_parameters(model):
 SUM_OF_PRETRAINED_RESNET18_PARAMS = -12703.99609375
 
 
+@unittest.skipIf('torchvision' in sys.modules,
+                 'TestHub must start without torchvision imported')
 class TestHub(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        # Only run this check ONCE before all tests start.
-        # - If torchvision is imported before all tests start, e.g. we might find _C.so
-        #   which doesn't exist in downloaded zip but in the installed wheel.
-        # - After the first test is run, torchvision is already in sys.modules due to
-        #   Python cache as we run all hub tests in the same python process.
-        if 'torchvision' in sys.modules:
-            raise RuntimeError('TestHub must start without torchvision imported')
+    # Only run this check ONCE before all tests start.
+    # - If torchvision is imported before all tests start, e.g. we might find _C.so
+    #   which doesn't exist in downloaded zip but in the installed wheel.
+    # - After the first test is run, torchvision is already in sys.modules due to
+    #   Python cache as we run all hub tests in the same python process.
 
     def test_load_from_github(self):
         hub_model = hub.load(


### PR DESCRIPTION
Drop-in [replacement for PyTorch Hub tests](https://github.com/pytorch/pytorch/blob/7d637de77190ce33d09c4685a4453fbf56af2743/test/test_utils.py#L514-L557).

I only modified a few things:
- `assertObjectIn` -> `assertIn`
- `SUM_OF_PRETRAINED_RESNET18_PARAMS = -12703.992365` -> `-12703.99609375`