### PR TITLE
SegmentationDataset [feature proposal and demo]

### DIFF
--- a/torchvision/datasets/folder.py
+++ b/torchvision/datasets/folder.py
@@ -247,7 +247,7 @@ class SegmentationDataset(VisionDataset):
     """
 
     def __init__(self, root, folders=('images', 'labels'), image_loader=pil_loader,
-                label_loader=default_label_loader, transforms=None, is_valid_file=None):
+                 label_loader=default_label_loader, transforms=None, is_valid_file=None):
         super(SegmentationDataset, self).__init__(root, transforms)
         # check if the required folders exist
         self.images_dir = os.path.join(root, folders[0])


### PR DESCRIPTION
In addition to #1315, I propose a new dataset subclass for loading samples compatible with the processing pipeline. In essence, if we have a root folder containing `images` and `labels` subfolders, this class loads and returns samples in form of tuples `(image, label)`. We can pass a `SegmentationCompose` directly to it, immediately allowing data preprocessing/augmentations, just like with `ImageFolder` and `Compose`.

This is just a proposal/prototype, so some desired features are missing (e.g. checking for file validity, size matching assertions, etc.). Yes, I know that the normal flow for feature proposals is to start with an issue, but since I've already written it (as I need something like this in my own work), I decided to open a PR. I hope you don't mind and we can discuss it here - besides, that might be easier with a code example ;)

Example usage:
```python
import torch
import torchvision as tv

src = tv.datasets.folder.SegmentationDataset(root='path/to/my_dataset')
image, label = src[0]
print(image)
print(label)
```

But with #1315 we could take this a step further:
```python
import torch
import torchvision as tv

tfs = tv.transforms.SegmentationCompose([
    tv.transforms.RandomCrop(400),
    tv.transforms.ToTensor(),
])
src = tv.datasets.folder.SegmentationDataset(
    root='path/to/my_dataset',
    transforms=tfs
)
ldr = torch.utils.data.DataLoader(src, batch_size=1)
for i, b in enumerate(ldr):
    print(b[0].shape, b[0].type(), b[0].numpy().max())
    print(b[1].shape, b[1].type(), b[1].numpy().max())
```