### PR TITLE
Added CMake config support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,8 +24,14 @@ file(GLOB MODELS_SOURCES torchvision/csrc/models/*.h torchvision/csrc/models/*.c
 
 add_library(${PROJECT_NAME} SHARED ${MODELS_SOURCES} ${OPERATOR_SOURCES})
 target_link_libraries(${PROJECT_NAME} PUBLIC "${TORCH_LIBRARIES}")
+set_target_properties(${PROJECT_NAME} PROPERTIES EXPORT_NAME Vision)
 
-install(TARGETS ${PROJECT_NAME} DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
+install(TARGETS
+        ${PROJECT_NAME}
+        EXPORT TorchVisionConfig
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
+        INCLUDES DESTINATION include
+        )
 install(FILES ${HEADERS} DESTINATION ${CMAKE_INSTALL_PREFIX}/include/${PROJECT_NAME})
 install(FILES
   torchvision/csrc/cpu/vision_cpu.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ file(GLOB MODELS_SOURCES torchvision/csrc/models/*.h torchvision/csrc/models/*.c
 
 add_library(${PROJECT_NAME} SHARED ${MODELS_SOURCES} ${OPERATOR_SOURCES})
 target_link_libraries(${PROJECT_NAME} PRIVATE ${TORCH_LIBRARIES} pybind11::pybind11)
-set_target_properties(${PROJECT_NAME} PROPERTIES EXPORT_NAME Vision)
+set_target_properties(${PROJECT_NAME} PROPERTIES EXPORT_NAME TorchVision)
 
 target_include_directories(${PROJECT_NAME} INTERFACE
   $<BUILD_INTERFACE:${HEADERS}>
@@ -56,10 +56,10 @@ install(EXPORT TorchVisionTargets
 install(FILES ${HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME})
 install(FILES
   torchvision/csrc/cpu/vision_cpu.h
-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/include/${PROJECT_NAME}/cpu)
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/cpu)
 if(WITH_CUDA)
   install(FILES
     torchvision/csrc/cuda/vision_cuda.h 
-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/include/${PROJECT_NAME}/cuda)
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/cuda)
 endif()
-install(FILES ${MODELS_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/include/${PROJECT_NAME}/models)
+install(FILES ${MODELS_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/models)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0)
 project(torchvision)
 set(CMAKE_CXX_STANDARD 14)
+set(TORCHVISION_VERSION 0.5.0)
 
 option(WITH_CUDA "Enable CUDA support" OFF)
 
@@ -12,8 +13,6 @@ endif()
 find_package(Torch REQUIRED)
 find_package(pybind11 REQUIRED)
 
-include_directories(${PYTHON_INCLUDE_DIR})
-
 file(GLOB HEADERS torchvision/csrc/*.h)
 file(GLOB OPERATOR_SOURCES torchvision/csrc/cpu/*.h torchvision/csrc/cpu/*.cpp)
 if(WITH_CUDA)
@@ -23,22 +22,44 @@ file(GLOB MODELS_HEADERS torchvision/csrc/models/*.h)
 file(GLOB MODELS_SOURCES torchvision/csrc/models/*.h torchvision/csrc/models/*.cpp)
 
 add_library(${PROJECT_NAME} SHARED ${MODELS_SOURCES} ${OPERATOR_SOURCES})
-target_link_libraries(${PROJECT_NAME} PUBLIC "${TORCH_LIBRARIES}")
+target_link_libraries(${PROJECT_NAME} PRIVATE ${TORCH_LIBRARIES} pybind11::pybind11)
 set_target_properties(${PROJECT_NAME} PROPERTIES EXPORT_NAME Vision)
 
-install(TARGETS
-        ${PROJECT_NAME}
-        EXPORT TorchVisionConfig
-        DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
-        INCLUDES DESTINATION include
-        )
-install(FILES ${HEADERS} DESTINATION ${CMAKE_INSTALL_PREFIX}/include/${PROJECT_NAME})
+target_include_directories(${PROJECT_NAME} INTERFACE
+  $<BUILD_INTERFACE:${HEADERS}>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
+
+set(TORCHVISION_CMAKECONFIG_INSTALL_DIR "share/cmake/TorchVision" CACHE STRING "install path for TorchVisionConfig.cmake")
+
+configure_package_config_file(cmake/TorchVisionConfig.cmake.in
+  "${CMAKE_CURRENT_BINARY_DIR}/TorchVisionConfig.cmake"
+  INSTALL_DESTINATION ${TORCHVISION_CMAKECONFIG_INSTALL_DIR})
+
+write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/TorchVisionConfigVersion.cmake
+  VERSION ${TORCHVISION_VERSION}
+  COMPATIBILITY AnyNewerVersion)
+
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/TorchVisionConfig.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/TorchVisionConfigVersion.cmake
+  DESTINATION ${TORCHVISION_CMAKECONFIG_INSTALL_DIR})
+
+install(TARGETS ${PROJECT_NAME}
+  EXPORT TorchVisionTargets)
+
+install(EXPORT TorchVisionTargets
+  NAMESPACE TorchVision::
+  DESTINATION ${TORCHVISION_CMAKECONFIG_INSTALL_DIR})
+
+install(FILES ${HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME})
 install(FILES
   torchvision/csrc/cpu/vision_cpu.h
-  DESTINATION ${CMAKE_INSTALL_PREFIX}/include/${PROJECT_NAME}/cpu)
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/include/${PROJECT_NAME}/cpu)
 if(WITH_CUDA)
   install(FILES
     torchvision/csrc/cuda/vision_cuda.h 
-    DESTINATION ${CMAKE_INSTALL_PREFIX}/include/${PROJECT_NAME}/cuda)
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/include/${PROJECT_NAME}/cuda)
 endif()
-install(FILES ${MODELS_HEADERS} DESTINATION ${CMAKE_INSTALL_PREFIX}/include/${PROJECT_NAME}/models)
+install(FILES ${MODELS_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/include/${PROJECT_NAME}/models)

--- a/README.rst
+++ b/README.rst
@@ -75,12 +75,15 @@ Installation From source:
     make 
     make install
 
-Once installed, the library can be accessed in cmake (after properly configuring ``CMAKE_PREFIX_PATH``) via the :code:`Torch::Vision` target:
+Once installed, the library can be accessed in cmake (after properly configuring ``CMAKE_PREFIX_PATH``) via the :code:`TorchVision::Vision` target:
 
 .. code:: rest
 
-	find_package(TorchVision)
-	target_link_libraries(my-target Torch::Vision)
+	find_package(TorchVision REQUIRED)
+	target_link_libraries(my-target TorchVision::Vision)
+
+The ``TorchVision`` package will also automatically look for the ``Torch`` and ``pybind11`` packages and add them as dependencies to ``my-target``,
+so make sure that they are also available to cmake via the ``CMAKE_PREFIX_PATH``.
 
 Documentation
 =============

--- a/README.rst
+++ b/README.rst
@@ -75,6 +75,13 @@ Installation From source:
     make 
     make install
 
+Once installed, the library can be accessed in cmake (after properly configuring ``CMAKE_PREFIX_PATH``) via the :code:`Torch::Vision` target:
+
+.. code:: rest
+
+	find_package(TorchVision)
+	target_link_libraries(my-target Torch::Vision)
+
 Documentation
 =============
 You can find the API documentation on the pytorch website: http://pytorch.org/docs/master/torchvision/

--- a/cmake/TorchVisionConfig.cmake.in
+++ b/cmake/TorchVisionConfig.cmake.in
@@ -1,0 +1,37 @@
+# TorchVisionConfig.cmake
+# --------------------
+#
+# Exported targets:: Vision
+#
+
+@PACKAGE_INIT@
+
+set(PN TorchVision)
+
+# location of include/torchvision
+set(${PN}_INCLUDE_DIR "${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_INCLUDEDIR@")
+
+set(${PN}_LIBRARY "")
+set(${PN}_DEFINITIONS USING_${PN})
+
+check_required_components(${PN})
+
+
+if(NOT (CMAKE_VERSION VERSION_LESS 3.0))
+#-----------------------------------------------------------------------------
+# Don't include targets if this file is being picked up by another
+# project which has already built this as a subproject
+#-----------------------------------------------------------------------------
+if(NOT TARGET ${PN}::Vision)
+include("${CMAKE_CURRENT_LIST_DIR}/${PN}Targets.cmake")
+
+if(NOT TARGET torch_library)
+find_package(Torch REQUIRED)
+endif()
+if(NOT TARGET pybind11::pybind11)
+find_package(pybind11 REQUIRED)
+endif()
+target_link_libraries(TorchVision::Vision INTERFACE ${TORCH_LIBRARIES} pybind11::pybind11)
+
+endif()
+endif()

--- a/cmake/TorchVisionConfig.cmake.in
+++ b/cmake/TorchVisionConfig.cmake.in
@@ -22,7 +22,7 @@ if(NOT (CMAKE_VERSION VERSION_LESS 3.0))
 # Don't include targets if this file is being picked up by another
 # project which has already built this as a subproject
 #-----------------------------------------------------------------------------
-if(NOT TARGET ${PN}::Vision)
+if(NOT TARGET ${PN}::TorchVision)
 include("${CMAKE_CURRENT_LIST_DIR}/${PN}Targets.cmake")
 
 if(NOT TARGET torch_library)
@@ -31,7 +31,7 @@ endif()
 if(NOT TARGET pybind11::pybind11)
 find_package(pybind11 REQUIRED)
 endif()
-target_link_libraries(TorchVision::Vision INTERFACE ${TORCH_LIBRARIES} pybind11::pybind11)
+target_link_libraries(TorchVision::TorchVision INTERFACE ${TORCH_LIBRARIES} pybind11::pybind11)
 
 endif()
 endif()


### PR DESCRIPTION
Added support to generate a TorchVisionConfig.cmake file which generates a `Torch::Vision` target that can be used in cmake-based projects.

Addresses #1046 