### PR TITLE
Make CircleCI checkout merge commit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,20 @@ version: 2.1
 orbs:
   win: circleci/windows@1.0.0
 
+commands:
+  checkout_merge:
+    description: "checkout merge branch"
+    steps:
+      - checkout
+      - run:
+          name: Checkout merge branch
+          command: |
+            set -ex
+            git fetch --force origin ${CIRCLE_BRANCH}/merge:remotes/origin/${CIRCLE_BRANCH}
+            git reset --hard "$CIRCLE_SHA1"
+            git checkout -q -B "$CIRCLE_BRANCH"
+            git reset --hard "$CIRCLE_SHA1"
+
 binary_common: &binary_common
   parameters:
     # Edit these defaults to do a release`
@@ -60,7 +74,7 @@ jobs:
       - image: << parameters.wheel_docker_image >>
     resource_class: 2xlarge+
     steps:
-      - checkout
+      - checkout_merge
       - run: packaging/build_wheel.sh
       - store_artifacts:
           path: dist
@@ -75,7 +89,7 @@ jobs:
       - image: "soumith/conda-cuda"
     resource_class: 2xlarge+
     steps:
-      - checkout
+      - checkout_merge
       - run: packaging/build_conda.sh
       - store_artifacts:
           path: /opt/conda/conda-bld/linux-64
@@ -90,7 +104,7 @@ jobs:
       image: ubuntu-1604:201903-01
     resource_class: gpu.medium
     steps:
-    - checkout
+    - checkout_merge
     - run:
         name: Setup environment
         command: |
@@ -159,7 +173,7 @@ jobs:
       name: win/vs2019
       shell: bash.exe
     steps:
-      - checkout
+      - checkout_merge
       - run:
           command: |
             choco install miniconda3
@@ -173,7 +187,7 @@ jobs:
     macos:
       xcode: "9.0"
     steps:
-      - checkout
+      - checkout_merge
       - run:
           # Cannot easily deduplicate this as source'ing activate
           # will set environment variables which we need to propagate
@@ -195,7 +209,7 @@ jobs:
     macos:
       xcode: "9.0"
     steps:
-      - checkout
+      - checkout_merge
       - run:
           command: |
             curl -o conda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,10 +18,8 @@ commands:
           name: Checkout merge branch
           command: |
             set -ex
-            git fetch --force origin ${CIRCLE_BRANCH}/merge:remotes/origin/${CIRCLE_BRANCH}
-            git reset --hard "$CIRCLE_SHA1"
-            git checkout -q -B "$CIRCLE_BRANCH"
-            git reset --hard "$CIRCLE_SHA1"
+            git fetch --force origin ${CIRCLE_BRANCH}/merge:merged/${CIRCLE_BRANCH}
+            git checkout "merged/$CIRCLE_BRANCH"
 
 binary_common: &binary_common
   parameters:

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -9,6 +9,20 @@ version: 2.1
 orbs:
   win: circleci/windows@1.0.0
 
+commands:
+  checkout_merge:
+    description: "checkout merge branch"
+    steps:
+      - checkout
+      - run:
+          name: Checkout merge branch
+          command: |
+            set -ex
+            git fetch --force origin ${CIRCLE_BRANCH}/merge:remotes/origin/${CIRCLE_BRANCH}
+            git reset --hard "$CIRCLE_SHA1"
+            git checkout -q -B "$CIRCLE_BRANCH"
+            git reset --hard "$CIRCLE_SHA1"
+
 binary_common: &binary_common
   parameters:
     # Edit these defaults to do a release`
@@ -60,7 +74,7 @@ jobs:
       - image: << parameters.wheel_docker_image >>
     resource_class: 2xlarge+
     steps:
-      - checkout
+      - checkout_merge
       - run: packaging/build_wheel.sh
       - store_artifacts:
           path: dist
@@ -75,7 +89,7 @@ jobs:
       - image: "soumith/conda-cuda"
     resource_class: 2xlarge+
     steps:
-      - checkout
+      - checkout_merge
       - run: packaging/build_conda.sh
       - store_artifacts:
           path: /opt/conda/conda-bld/linux-64
@@ -90,7 +104,7 @@ jobs:
       image: ubuntu-1604:201903-01
     resource_class: gpu.medium
     steps:
-    - checkout
+    - checkout_merge
     - run:
         name: Setup environment
         command: |
@@ -159,7 +173,7 @@ jobs:
       name: win/vs2019
       shell: bash.exe
     steps:
-      - checkout
+      - checkout_merge
       - run:
           command: |
             choco install miniconda3
@@ -173,7 +187,7 @@ jobs:
     macos:
       xcode: "9.0"
     steps:
-      - checkout
+      - checkout_merge
       - run:
           # Cannot easily deduplicate this as source'ing activate
           # will set environment variables which we need to propagate
@@ -195,7 +209,7 @@ jobs:
     macos:
       xcode: "9.0"
     steps:
-      - checkout
+      - checkout_merge
       - run:
           command: |
             curl -o conda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -18,10 +18,8 @@ commands:
           name: Checkout merge branch
           command: |
             set -ex
-            git fetch --force origin ${CIRCLE_BRANCH}/merge:remotes/origin/${CIRCLE_BRANCH}
-            git reset --hard "$CIRCLE_SHA1"
-            git checkout -q -B "$CIRCLE_BRANCH"
-            git reset --hard "$CIRCLE_SHA1"
+            git fetch --force origin ${CIRCLE_BRANCH}/merge:merged/${CIRCLE_BRANCH}
+            git checkout "merged/$CIRCLE_BRANCH"
 
 binary_common: &binary_common
   parameters:

--- a/.circleci/regenerate.py
+++ b/.circleci/regenerate.py
@@ -76,7 +76,8 @@ def generate_upload_workflow(base_workflow_name, os_type, btype, cu_version):
 
 
 def indent(indentation, data_list):
-    return ("\n" + " " * indentation).join(yaml.dump(data_list).splitlines())
+    return ("\n" + " " * indentation).join(
+        yaml.dump(data_list, default_flow_style=False).splitlines())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This makes tests run not on the PR branch, but the PR branch rebased on top of master instead.
This is safer because the tests now signal the status of master if a PR gets merged.