### PR TITLE
Add MultiImageFolder dataset

### DIFF
--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -109,7 +109,7 @@ class Tester(unittest.TestCase):
 
             # test if the datasets outputs all images correctly
             for i in range(len(dataset)):
-                self.assertEqual([*true_samples[i]], dataset[i])
+                self.assertEqual([ *true_samples[i] ], dataset[i])
 
             # redo all tests with specified valid image files
             dataset = torchvision.datasets.MultiImageFolder(directories=directories, loader=lambda x: x,

--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -113,7 +113,7 @@ class Tester(unittest.TestCase):
 
             # redo all tests with specified valid image files
             dataset = torchvision.datasets.MultiImageFolder(directories=directories, loader=lambda x: x,
-                                                            is_valid_file=lambda x: '3' in x)
+                                                            is_valid_file=lambda x: '3.png' in x)
             true_samples = [true_samples[2]]
 
             # test if all images were detected correctly and in the proper order
@@ -123,7 +123,7 @@ class Tester(unittest.TestCase):
 
             # test if the datasets outputs all images correctly
             for i in range(len(dataset)):
-                self.assertEqual([*true_samples[i]], dataset[i])
+                self.assertEqual([ *true_samples[i] ], dataset[i])
 
     @mock.patch('torchvision.datasets.mnist.download_and_extract_archive')
     def test_mnist(self, mock_download_extract):

--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -109,7 +109,7 @@ class Tester(unittest.TestCase):
 
             # test if the datasets outputs all images correctly
             for i in range(len(dataset)):
-                self.assertEqual([ true_samples[i][0], true_samples[i][1] ], dataset[i])
+                self.assertEqual([true_samples[i][0], true_samples[i][1]], dataset[i])
 
             # redo all tests with specified valid image files
             dataset = torchvision.datasets.MultiImageFolder(directories=directories, loader=lambda x: x,
@@ -123,7 +123,7 @@ class Tester(unittest.TestCase):
 
             # test if the datasets outputs all images correctly
             for i in range(len(dataset)):
-                self.assertEqual([ true_samples[i][0], true_samples[i][1] ], dataset[i])
+                self.assertEqual([true_samples[i][0], true_samples[i][1]], dataset[i])
 
     @mock.patch('torchvision.datasets.mnist.download_and_extract_archive')
     def test_mnist(self, mock_download_extract):

--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -109,12 +109,12 @@ class Tester(unittest.TestCase):
 
             # test if the datasets outputs all images correctly
             for i in range(len(dataset)):
-                self.assertEqual(true_samples[i], dataset[i])
+                self.assertEqual([*true_samples[i]], dataset[i])
 
             # redo all tests with specified valid image files
             dataset = torchvision.datasets.MultiImageFolder(directories=directories, loader=lambda x: x,
                                                             is_valid_file=lambda x: '3' in x)
-            true_samples = [['a3.png', 'b3.png']]
+            true_samples = [true_samples[2]]
 
             # test if all images were detected correctly and in the proper order
             self.assertEqual(len(true_samples), len(dataset.samples))
@@ -123,7 +123,7 @@ class Tester(unittest.TestCase):
 
             # test if the datasets outputs all images correctly
             for i in range(len(dataset)):
-                self.assertEqual(true_samples[i], dataset[i])
+                self.assertEqual([*true_samples[i]], dataset[i])
 
     @mock.patch('torchvision.datasets.mnist.download_and_extract_archive')
     def test_mnist(self, mock_download_extract):

--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -109,7 +109,7 @@ class Tester(unittest.TestCase):
 
             # test if the datasets outputs all images correctly
             for i in range(len(dataset)):
-                self.assertEqual([ *true_samples[i] ], dataset[i])
+                self.assertEqual([ true_samples[i][0], true_samples[i][1] ], dataset[i])
 
             # redo all tests with specified valid image files
             dataset = torchvision.datasets.MultiImageFolder(directories=directories, loader=lambda x: x,
@@ -123,7 +123,7 @@ class Tester(unittest.TestCase):
 
             # test if the datasets outputs all images correctly
             for i in range(len(dataset)):
-                self.assertEqual([ *true_samples[i] ], dataset[i])
+                self.assertEqual([ true_samples[i][0], true_samples[i][1] ], dataset[i])
 
     @mock.patch('torchvision.datasets.mnist.download_and_extract_archive')
     def test_mnist(self, mock_download_extract):

--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -87,13 +87,13 @@ class Tester(unittest.TestCase):
             os.makedirs(os.path.join(root, 'a'))
             a = []
             for filename in ('a1.png', 'a2.png', 'a3.png'):
-                result = Image.fromarray((np.random.rand(20, 20) * 255).astype(numpy.uint8))
+                result = Image.fromarray((np.random.rand(20, 20) * 255).astype(np.uint8))
                 result.save(os.path.join(root, 'a', filename))
                 a.append(os.path.join(root, 'a', filename))
             os.makedirs(os.path.join(root, 'b'))
             b = []
             for filename in ('b1.png', 'b2.png', 'b3.png'):
-                result = Image.fromarray((np.random.rand(20, 20) * 128).astype(numpy.uint8))
+                result = Image.fromarray((np.random.rand(20, 20) * 128).astype(np.uint8))
                 result.save(os.path.join(root, 'b', filename))
                 b.append(os.path.join(root, 'b', filename))
 

--- a/torchvision/datasets/__init__.py
+++ b/torchvision/datasets/__init__.py
@@ -24,7 +24,7 @@ from .hmdb51 import HMDB51
 from .ucf101 import UCF101
 
 __all__ = ('LSUN', 'LSUNClass',
-           'ImageFolder', 'DatasetFolder', 'FakeData',
+           'ImageFolder', 'DatasetFolder','MultiImageFolder', 'FakeData',
            'CocoCaptions', 'CocoDetection',
            'CIFAR10', 'CIFAR100', 'EMNIST', 'FashionMNIST', 'QMNIST',
            'MNIST', 'KMNIST', 'STL10', 'SVHN', 'PhotoTour', 'SEMEION',

--- a/torchvision/datasets/__init__.py
+++ b/torchvision/datasets/__init__.py
@@ -1,5 +1,5 @@
 from .lsun import LSUN, LSUNClass
-from .folder import ImageFolder, DatasetFolder
+from .folder import ImageFolder, DatasetFolder, MultiImageFolder
 from .coco import CocoCaptions, CocoDetection
 from .cifar import CIFAR10, CIFAR100
 from .stl10 import STL10
@@ -24,7 +24,7 @@ from .hmdb51 import HMDB51
 from .ucf101 import UCF101
 
 __all__ = ('LSUN', 'LSUNClass',
-           'ImageFolder', 'DatasetFolder','MultiImageFolder', 'FakeData',
+           'ImageFolder', 'DatasetFolder', 'MultiImageFolder', 'FakeData',
            'CocoCaptions', 'CocoDetection',
            'CIFAR10', 'CIFAR100', 'EMNIST', 'FashionMNIST', 'QMNIST',
            'MNIST', 'KMNIST', 'STL10', 'SVHN', 'PhotoTour', 'SEMEION',

--- a/torchvision/datasets/folder.py
+++ b/torchvision/datasets/folder.py
@@ -221,7 +221,7 @@ def make_dataset_noclass(dir, extensions=None, is_valid_file=None):
         def is_valid_file(x):
             return has_file_allowed_extension(x, extensions)
     if not os.path.isdir(dir):
-        raise ValueError(dir+" is not a directory")
+        raise ValueError(dir + " is not a directory")
     for root, _, fnames in sorted(os.walk(dir)):
         for fname in sorted(fnames):
             path = os.path.join(root, fname)
@@ -265,13 +265,14 @@ class MultiImageFolder(data.Dataset):
         self.loader = loader
         self.extensions = IMG_EXTENSIONS if is_valid_file is None else None
 
-        sampleslist = [make_dataset_noclass(self.directories[i], self.extensions, is_valid_file) for i in range(len(self.directories))]
+        sampleslist = [make_dataset_noclass(self.directories[i], self.extensions,
+                                            is_valid_file) for i in range(len(self.directories))]
         for list1 in sampleslist:
             if len(list1) != len(sampleslist[0]):
                 raise ValueError("All directories must contain the same number of images.")
             if len(list1) == 0:
                 raise (RuntimeError("At least one of the directories does not contain any valid file.\n"
-                                    "Supported extensions are: " + ",".join(extensions)))
+                                    "Supported extensions are: " + ",".join(IMG_EXTENSIONS)))
         self.samples = list(zip(*sampleslist))
 
     def __getitem__(self, index):
@@ -280,7 +281,7 @@ class MultiImageFolder(data.Dataset):
             index (int): Index
 
         Returns:
-            tuple: (img1, img2, ...) where each image is taken from each of the 
+            tuple: (img1, img2, ...) where each image is taken from each of the
                 initialization directories in the same order.
         """
         paths = self.samples[index]


### PR DESCRIPTION
This new kind of dataset enables the user to use neural networks that have an arbitrary number of input/output images such as for super resolution, image transformation, segmentation, depth computation, etc.

Signed-off-by: Sebastien ESKENAZI <s.eskenaz@pixelz.com>