### PR TITLE
Support empty target_type for CelebA dataset

### DIFF
--- a/torchvision/datasets/celeba.py
+++ b/torchvision/datasets/celeba.py
@@ -21,7 +21,7 @@ class CelebA(VisionDataset):
                 ``bbox`` (np.array shape=(4,) dtype=int): bounding box (x, y, width, height)
                 ``landmarks`` (np.array shape=(10,) dtype=int): landmark points (lefteye_x, lefteye_y, righteye_x,
                     righteye_y, nose_x, nose_y, leftmouth_x, leftmouth_y, rightmouth_x, rightmouth_y)
-            If empty, no target will be returned. Defaults to ``attr``.
+            Defaults to ``attr``. If empty, ``None`` will be returned as target.
         transform (callable, optional): A function/transform that  takes in an PIL image
             and returns a transformed version. E.g, ``transforms.ToTensor``
         target_transform (callable, optional): A function/transform that takes in the

--- a/torchvision/datasets/celeba.py
+++ b/torchvision/datasets/celeba.py
@@ -59,6 +59,9 @@ class CelebA(VisionDataset):
         else:
             self.target_type = [target_type]
 
+        if not self.target_type and self.target_transform is not None:
+            raise RuntimeError('target_transform is specified but target_type is empty')
+
         if download:
             self.download()
 

--- a/torchvision/datasets/celeba.py
+++ b/torchvision/datasets/celeba.py
@@ -120,32 +120,32 @@ class CelebA(VisionDataset):
     def __getitem__(self, index):
         X = PIL.Image.open(os.path.join(self.root, self.base_folder, "img_align_celeba", self.filename[index]))
 
+        target = []
+        for t in self.target_type:
+            if t == "attr":
+                target.append(self.attr[index, :])
+            elif t == "identity":
+                target.append(self.identity[index, 0])
+            elif t == "bbox":
+                target.append(self.bbox[index, :])
+            elif t == "landmarks":
+                target.append(self.landmarks_align[index, :])
+            else:
+                # TODO: refactor with utils.verify_str_arg
+                raise ValueError("Target type \"{}\" is not recognized.".format(t))
+
         if self.transform is not None:
             X = self.transform(X)
 
-        if not self.target_type:
-            return X, None
-        else:
-            target = []
-            for t in self.target_type:
-                if t == "attr":
-                    target.append(self.attr[index, :])
-                elif t == "identity":
-                    target.append(self.identity[index, 0])
-                elif t == "bbox":
-                    target.append(self.bbox[index, :])
-                elif t == "landmarks":
-                    target.append(self.landmarks_align[index, :])
-                else:
-                    # TODO: refactor with utils.verify_str_arg
-                    raise ValueError("Target type \"{}\" is not recognized.".format(t))
-
+        if target:
             target = tuple(target) if len(target) > 1 else target[0]
 
             if self.target_transform is not None:
                 target = self.target_transform(target)
+        else:
+            target = None
 
-            return X, target
+        return X, target
 
     def __len__(self):
         return len(self.attr)

--- a/torchvision/datasets/celeba.py
+++ b/torchvision/datasets/celeba.py
@@ -124,7 +124,7 @@ class CelebA(VisionDataset):
             X = self.transform(X)
 
         if not self.target_type:
-            return X
+            return X, None
         else:
             target = []
             for t in self.target_type:


### PR DESCRIPTION
Previously, passing `target_type=[]` wouldn't work because of [this line](https://github.com/pytorch/vision/blob/4886ccc/torchvision/datasets/celeba.py#L136):

```python
celeba = CelebA('whatever/dir', target_type=[])
celeba[0]  # IndexError: list index out of range
```

This is a workaround that returns only `X` instead of `X, target` if `target_type` is empty.