### PR TITLE
Fix bug on transforms.RandomErasing.get_params

### DIFF
--- a/torchvision/transforms/transforms.py
+++ b/torchvision/transforms/transforms.py
@@ -1253,7 +1253,7 @@ class RandomErasing(object):
         Returns:
             tuple: params (i, j, h, w, v) to be passed to ``erase`` for random erasing.
         """
-        img_c, img_h, img_w = img.shape
+        img_c, img_h, img_w = img.size
         area = img_h * img_w
 
         for attempt in range(10):


### PR DESCRIPTION
`shape` -> `size` in transforms.RandomErasing.get_params

Because PIL.Image doesn't have an attribute `shape` but `size`.