### PR TITLE
separate logic of getting video reader library path

### DIFF
--- a/torchvision/io/_video_opt.py
+++ b/torchvision/io/_video_opt.py
@@ -1,17 +1,14 @@
 from fractions import Fraction
 import numpy as np
-import os
 import torch
-import imp
 import warnings
-
+from torchvision.lib_utils import find_video_reader_library_path
 
 _HAS_VIDEO_OPT = False
 
 try:
-    lib_dir = os.path.join(os.path.dirname(__file__), '..')
-    _, path, description = imp.find_module("video_reader", [lib_dir])
-    torch.ops.load_library(path)
+    video_reader_library_path = find_video_reader_library_path()
+    torch.ops.load_library(video_reader_library_path)
     _HAS_VIDEO_OPT = True
 except (ImportError, OSError):
     warnings.warn("video reader based on ffmpeg c++ ops not available")

--- a/torchvision/lib_utils.py
+++ b/torchvision/lib_utils.py
@@ -1,0 +1,8 @@
+import imp
+import os
+
+
+def find_video_reader_library_path():
+    lib_dir = os.path.dirname(__file__)
+    _, path, description = imp.find_module("video_reader", [lib_dir])
+    return path


### PR DESCRIPTION
# Motivation
The current implementation of getting path of video reader library file only works for OSS, and is not usable for Facebook internal use cases. 
Separate this logic out in the new `lib_utils.py` module, which can be readily replaced within Facebook.

# unit test
`python test/test_video_reader.py`
