### PR TITLE
Fix nightly builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,8 +18,11 @@ commands:
           name: Checkout merge branch
           command: |
             set -ex
-            git fetch --force origin ${CIRCLE_BRANCH}/merge:merged/${CIRCLE_BRANCH}
-            git checkout "merged/$CIRCLE_BRANCH"
+            BRANCH=$(git rev-parse --abbrev-ref HEAD)
+            if [[ "$BRANCH" != "master" ]]; then
+              git fetch --force origin ${CIRCLE_BRANCH}/merge:merged/${CIRCLE_BRANCH}
+              git checkout "merged/$CIRCLE_BRANCH"
+            fi
 
 binary_common: &binary_common
   parameters:

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -18,8 +18,11 @@ commands:
           name: Checkout merge branch
           command: |
             set -ex
-            git fetch --force origin ${CIRCLE_BRANCH}/merge:merged/${CIRCLE_BRANCH}
-            git checkout "merged/$CIRCLE_BRANCH"
+            BRANCH=$(git rev-parse --abbrev-ref HEAD)
+            if [[ "$BRANCH" != "master" ]]; then
+              git fetch --force origin ${CIRCLE_BRANCH}/merge:merged/${CIRCLE_BRANCH}
+              git checkout "merged/$CIRCLE_BRANCH"
+            fi
 
 binary_common: &binary_common
   parameters:

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,7 @@ install:
     cd -
 
 script:
-  - pytest --cov-config .coveragerc --cov torchvision --cov $TV_INSTALL_PATH test
+  - pytest --cov-config .coveragerc --cov torchvision --cov $TV_INSTALL_PATH -k 'not TestVideoReader' test
   - pytest test/test_hub.py
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,7 @@ install:
     cd -
 
 script:
-  - pytest --cov-config .coveragerc --cov torchvision --cov $TV_INSTALL_PATH -k 'not TestVideoReader' test
+  - pytest --cov-config .coveragerc --cov torchvision --cov $TV_INSTALL_PATH -k 'not TestVideoReader not TestVideoTransforms' test
   - pytest test/test_hub.py
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,7 @@ install:
     cd -
 
 script:
-  - pytest --cov-config .coveragerc --cov torchvision --cov $TV_INSTALL_PATH -k 'not TestVideoReader not TestVideoTransforms' test
+  - pytest --cov-config .coveragerc --cov torchvision --cov $TV_INSTALL_PATH -k 'not TestVideoReader and not TestVideoTransforms' test
   - pytest test/test_hub.py
 
 after_success:

--- a/test/test_transforms_video.py
+++ b/test/test_transforms_video.py
@@ -11,7 +11,7 @@ except ImportError:
     stats = None
 
 
-class Tester(unittest.TestCase):
+class TestVideoTransforms(unittest.TestCase):
 
     def test_random_crop_video(self):
         numFrames = random.randint(4, 128)

--- a/torchvision/datasets/utils.py
+++ b/torchvision/datasets/utils.py
@@ -229,7 +229,7 @@ def extract_archive(from_path, to_path=None, remove_finished=False):
         with tarfile.open(from_path, 'r:gz') as tar:
             tar.extractall(path=to_path)
     elif _is_tarxz(from_path) and PY3:
-        # .tar.xz archive only supported in Python 3.x  
+        # .tar.xz archive only supported in Python 3.x
         with tarfile.open(from_path, 'r:xz') as tar:
             tar.extractall(path=to_path)
     elif _is_gzip(from_path):


### PR DESCRIPTION
Nightly builds on master have been failing after https://github.com/pytorch/vision/pull/1344 got merged [with error](https://circleci.com/gh/pytorch/vision/16762?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link)
```bash
#!/bin/bash -eo pipefail
set -ex
git fetch --force origin ${CIRCLE_BRANCH}/merge:merged/${CIRCLE_BRANCH}
git checkout "merged/$CIRCLE_BRANCH"
+ git fetch --force origin master/merge:merged/master
fatal: Couldn't find remote ref master/merge
Killed by signal 1.

Exited with code 128
```
because the PR assumed that CI would only run on PR branches.
This PR skips rebasing if CI is run on master.