### PR TITLE
add metadata to video dataset classes. bug fix. more robustness

### DIFF
--- a/test/test_datasets_video_utils.py
+++ b/test/test_datasets_video_utils.py
@@ -6,7 +6,6 @@ import unittest
 
 from torchvision import io
 from torchvision.datasets.video_utils import VideoClips, unfold
-from torchvision import get_video_backend
 
 from common_utils import get_tmp_dir
 
@@ -62,23 +61,22 @@ class Tester(unittest.TestCase):
     @unittest.skipIf(not io.video._av_available(), "this test requires av")
     @unittest.skipIf('win' in sys.platform, 'temporarily disabled on Windows')
     def test_video_clips(self):
-        _backend = get_video_backend()
         with get_list_of_videos(num_videos=3) as video_list:
-            video_clips = VideoClips(video_list, 5, 5, _backend=_backend)
+            video_clips = VideoClips(video_list, 5, 5)
             self.assertEqual(video_clips.num_clips(), 1 + 2 + 3)
             for i, (v_idx, c_idx) in enumerate([(0, 0), (1, 0), (1, 1), (2, 0), (2, 1), (2, 2)]):
                 video_idx, clip_idx = video_clips.get_clip_location(i)
                 self.assertEqual(video_idx, v_idx)
                 self.assertEqual(clip_idx, c_idx)
 
-            video_clips = VideoClips(video_list, 6, 6, _backend=_backend)
+            video_clips = VideoClips(video_list, 6, 6)
             self.assertEqual(video_clips.num_clips(), 0 + 1 + 2)
             for i, (v_idx, c_idx) in enumerate([(1, 0), (2, 0), (2, 1)]):
                 video_idx, clip_idx = video_clips.get_clip_location(i)
                 self.assertEqual(video_idx, v_idx)
                 self.assertEqual(clip_idx, c_idx)
 
-            video_clips = VideoClips(video_list, 6, 1, _backend=_backend)
+            video_clips = VideoClips(video_list, 6, 1)
             self.assertEqual(video_clips.num_clips(), 0 + (10 - 6 + 1) + (15 - 6 + 1))
             for i, v_idx, c_idx in [(0, 1, 0), (4, 1, 4), (5, 2, 0), (6, 2, 1)]:
                 video_idx, clip_idx = video_clips.get_clip_location(i)
@@ -87,9 +85,8 @@ class Tester(unittest.TestCase):
 
     @unittest.skip("Moved to reference scripts for now")
     def test_video_sampler(self):
-        _backend = get_video_backend()
         with get_list_of_videos(num_videos=3, sizes=[25, 25, 25]) as video_list:
-            video_clips = VideoClips(video_list, 5, 5, _backend=_backend)
+            video_clips = VideoClips(video_list, 5, 5)
             sampler = RandomClipSampler(video_clips, 3)  # noqa: F821
             self.assertEqual(len(sampler), 3 * 3)
             indices = torch.tensor(list(iter(sampler)))
@@ -100,9 +97,8 @@ class Tester(unittest.TestCase):
 
     @unittest.skip("Moved to reference scripts for now")
     def test_video_sampler_unequal(self):
-        _backend = get_video_backend()
         with get_list_of_videos(num_videos=3, sizes=[10, 25, 25]) as video_list:
-            video_clips = VideoClips(video_list, 5, 5, _backend=_backend)
+            video_clips = VideoClips(video_list, 5, 5)
             sampler = RandomClipSampler(video_clips, 3)  # noqa: F821
             self.assertEqual(len(sampler), 2 + 3 + 3)
             indices = list(iter(sampler))
@@ -120,11 +116,10 @@ class Tester(unittest.TestCase):
     @unittest.skipIf(not io.video._av_available(), "this test requires av")
     @unittest.skipIf('win' in sys.platform, 'temporarily disabled on Windows')
     def test_video_clips_custom_fps(self):
-        _backend = get_video_backend()
         with get_list_of_videos(num_videos=3, sizes=[12, 12, 12], fps=[3, 4, 6]) as video_list:
             num_frames = 4
             for fps in [1, 3, 4, 10]:
-                video_clips = VideoClips(video_list, num_frames, num_frames, fps, _backend=_backend)
+                video_clips = VideoClips(video_list, num_frames, num_frames, fps)
                 for i in range(video_clips.num_clips()):
                     video, audio, info, video_idx = video_clips.get_clip(i)
                     self.assertEqual(video.shape[0], num_frames)

--- a/torchvision/__init__.py
+++ b/torchvision/__init__.py
@@ -1,3 +1,5 @@
+import warnings
+
 from torchvision import models
 from torchvision import datasets
 from torchvision import ops

--- a/torchvision/__init__.py
+++ b/torchvision/__init__.py
@@ -57,7 +57,10 @@ def set_video_backend(backend):
         raise ValueError(
             "Invalid video backend '%s'. Options are 'pyav' and 'video_reader'" % backend
         )
-    _video_backend = backend
+    if backend == "video_reader" and not io._HAS_VIDEO_OPT:
+        warnings.warn("video_reader video backend is not available")
+    else:
+        _video_backend = backend
 
 
 def get_video_backend():

--- a/torchvision/datasets/hmdb51.py
+++ b/torchvision/datasets/hmdb51.py
@@ -1,9 +1,9 @@
 import glob
 import os
 
-from .video_utils import VideoClips
 from .utils import list_dir
 from .folder import make_dataset
+from .video_utils import VideoClips
 from .vision import VisionDataset
 
 
@@ -51,9 +51,8 @@ class HMDB51(VisionDataset):
 
     def __init__(self, root, annotation_path, frames_per_clip, step_between_clips=1,
                  frame_rate=None, fold=1, train=True, transform=None,
-                 _precomputed_metadata=None, num_workers=1):
-        from torchvision import get_video_backend
-
+                 _precomputed_metadata=None, num_workers=1, _video_width=0,
+                 _video_height=0, _video_min_dimension=0, _audio_samples=0):
         super(HMDB51, self).__init__(root)
         if not 1 <= fold <= 3:
             raise ValueError("fold should be between 1 and 3, got {}".format(fold))
@@ -73,8 +72,11 @@ class HMDB51(VisionDataset):
             step_between_clips,
             frame_rate,
             _precomputed_metadata,
-            _backend=get_video_backend(),
             num_workers=num_workers,
+            _video_width=_video_width,
+            _video_height=_video_height,
+            _video_min_dimension=_video_min_dimension,
+            _audio_samples=_audio_samples,
         )
         self.video_clips_metadata = video_clips.metadata
         self.indices = self._select_fold(video_list, annotation_path, fold, train)

--- a/torchvision/datasets/hmdb51.py
+++ b/torchvision/datasets/hmdb51.py
@@ -51,7 +51,9 @@ class HMDB51(VisionDataset):
 
     def __init__(self, root, annotation_path, frames_per_clip, step_between_clips=1,
                  frame_rate=None, fold=1, train=True, transform=None,
-                 _precomputed_metadata=None):
+                 _precomputed_metadata=None, num_workers=1):
+        from torchvision import get_video_backend
+
         super(HMDB51, self).__init__(root)
         if not 1 <= fold <= 3:
             raise ValueError("fold should be between 1 and 3, got {}".format(fold))
@@ -71,10 +73,17 @@ class HMDB51(VisionDataset):
             step_between_clips,
             frame_rate,
             _precomputed_metadata,
+            _backend=get_video_backend(),
+            num_workers=num_workers,
         )
+        self.video_clips_metadata = video_clips.metadata
         self.indices = self._select_fold(video_list, annotation_path, fold, train)
         self.video_clips = video_clips.subset(self.indices)
         self.transform = transform
+
+    @property
+    def metadata(self):
+        return self.video_clips_metadata
 
     def _select_fold(self, video_list, annotation_path, fold, train):
         target_tag = 1 if train else 2

--- a/torchvision/datasets/kinetics.py
+++ b/torchvision/datasets/kinetics.py
@@ -37,7 +37,10 @@ class Kinetics400(VisionDataset):
     """
 
     def __init__(self, root, frames_per_clip, step_between_clips=1, frame_rate=None,
-                 extensions=('avi',), transform=None, _precomputed_metadata=None):
+                 extensions=('avi',), transform=None, _precomputed_metadata=None,
+                 num_workers=1):
+        from torchvision import get_video_backend
+
         super(Kinetics400, self).__init__(root)
         extensions = ('avi',)
 
@@ -52,8 +55,14 @@ class Kinetics400(VisionDataset):
             step_between_clips,
             frame_rate,
             _precomputed_metadata,
+            _backend=get_video_backend(),
+            num_workers=num_workers,
         )
         self.transform = transform
+
+    @property
+    def metadata(self):
+        return self.video_clips.metadata
 
     def __len__(self):
         return self.video_clips.num_clips()

--- a/torchvision/datasets/kinetics.py
+++ b/torchvision/datasets/kinetics.py
@@ -1,6 +1,6 @@
-from .video_utils import VideoClips
 from .utils import list_dir
 from .folder import make_dataset
+from .video_utils import VideoClips
 from .vision import VisionDataset
 
 
@@ -38,9 +38,8 @@ class Kinetics400(VisionDataset):
 
     def __init__(self, root, frames_per_clip, step_between_clips=1, frame_rate=None,
                  extensions=('avi',), transform=None, _precomputed_metadata=None,
-                 num_workers=1):
-        from torchvision import get_video_backend
-
+                 num_workers=1, _video_width=0, _video_height=0,
+                 _video_min_dimension=0, _audio_samples=0):
         super(Kinetics400, self).__init__(root)
         extensions = ('avi',)
 
@@ -55,8 +54,11 @@ class Kinetics400(VisionDataset):
             step_between_clips,
             frame_rate,
             _precomputed_metadata,
-            _backend=get_video_backend(),
             num_workers=num_workers,
+            _video_width=_video_width,
+            _video_height=_video_height,
+            _video_min_dimension=_video_min_dimension,
+            _audio_samples=_audio_samples,
         )
         self.transform = transform
 

--- a/torchvision/datasets/ucf101.py
+++ b/torchvision/datasets/ucf101.py
@@ -1,9 +1,9 @@
 import glob
 import os
 
-from .video_utils import VideoClips
 from .utils import list_dir
 from .folder import make_dataset
+from .video_utils import VideoClips
 from .vision import VisionDataset
 
 
@@ -44,9 +44,8 @@ class UCF101(VisionDataset):
 
     def __init__(self, root, annotation_path, frames_per_clip, step_between_clips=1,
                  frame_rate=None, fold=1, train=True, transform=None,
-                 _precomputed_metadata=None, num_workers=1):
-        from torchvision import get_video_backend
-
+                 _precomputed_metadata=None, num_workers=1, _video_width=0,
+                 _video_height=0, _video_min_dimension=0, _audio_samples=0):
         super(UCF101, self).__init__(root)
         if not 1 <= fold <= 3:
             raise ValueError("fold should be between 1 and 3, got {}".format(fold))
@@ -66,9 +65,13 @@ class UCF101(VisionDataset):
             step_between_clips,
             frame_rate,
             _precomputed_metadata,
-            _backend=get_video_backend(),
             num_workers=num_workers,
+            _video_width=_video_width,
+            _video_height=_video_height,
+            _video_min_dimension=_video_min_dimension,
+            _audio_samples=_audio_samples,
         )
+        self.video_clips_metadata = video_clips.metadata
         self.indices = self._select_fold(video_list, annotation_path, fold, train)
         self.video_clips = video_clips.subset(self.indices)
         self.transform = transform

--- a/torchvision/datasets/ucf101.py
+++ b/torchvision/datasets/ucf101.py
@@ -44,7 +44,9 @@ class UCF101(VisionDataset):
 
     def __init__(self, root, annotation_path, frames_per_clip, step_between_clips=1,
                  frame_rate=None, fold=1, train=True, transform=None,
-                 _precomputed_metadata=None):
+                 _precomputed_metadata=None, num_workers=1):
+        from torchvision import get_video_backend
+
         super(UCF101, self).__init__(root)
         if not 1 <= fold <= 3:
             raise ValueError("fold should be between 1 and 3, got {}".format(fold))
@@ -64,10 +66,16 @@ class UCF101(VisionDataset):
             step_between_clips,
             frame_rate,
             _precomputed_metadata,
+            _backend=get_video_backend(),
+            num_workers=num_workers,
         )
         self.indices = self._select_fold(video_list, annotation_path, fold, train)
         self.video_clips = video_clips.subset(self.indices)
         self.transform = transform
+
+    @property
+    def metadata(self):
+        return self.video_clips_metadata
 
     def _select_fold(self, video_list, annotation_path, fold, train):
         name = "train" if train else "test"

--- a/torchvision/datasets/video_utils.py
+++ b/torchvision/datasets/video_utils.py
@@ -220,7 +220,8 @@ class VideoClips(object):
         else:
             for video_pts, info in zip(self.video_pts, self.info):
                 if "video_fps" in info:
-                    clips, idxs = self.compute_clips_for_video(video_pts, num_frames, step, info["video_fps"], frame_rate)
+                    clips, idxs = self.compute_clips_for_video(
+                        video_pts, num_frames, step, info["video_fps"], frame_rate)
                     self.clips.append(clips)
                     self.resampling_idxs.append(idxs)
                 else:

--- a/torchvision/io/__init__.py
+++ b/torchvision/io/__init__.py
@@ -1,8 +1,8 @@
 from .video import write_video, read_video, read_video_timestamps
-from ._video_opt import _read_video_from_file, _read_video_timestamps_from_file
+from ._video_opt import _read_video_from_file, _read_video_timestamps_from_file, _HAS_VIDEO_OPT
 
 
 __all__ = [
     'write_video', 'read_video', 'read_video_timestamps',
-    '_read_video_from_file', '_read_video_timestamps_from_file',
+    '_read_video_from_file', '_read_video_timestamps_from_file', '_HAS_VIDEO_OPT',
 ]


### PR DESCRIPTION
Make a few changes to to dataset classes, including ucf101, hmdb51 and kinetics, as well as `VideoClips` class
- expose property `metadata`
- being able to choose video backend according to global setting
- Make class `VideoClips` more robust when video decoding fail for some videos
- fix bugs