### PR TITLE
[video] exposing _backend in datasets

### DIFF
--- a/torchvision/datasets/hmdb51.py
+++ b/torchvision/datasets/hmdb51.py
@@ -51,7 +51,7 @@ class HMDB51(VisionDataset):
 
     def __init__(self, root, annotation_path, frames_per_clip, step_between_clips=1,
                  frame_rate=None, fold=1, train=True, transform=None,
-                 _precomputed_metadata=None):
+                 _precomputed_metadata=None, _backend="pyav"):
         super(HMDB51, self).__init__(root)
         if not 1 <= fold <= 3:
             raise ValueError("fold should be between 1 and 3, got {}".format(fold))
@@ -71,6 +71,7 @@ class HMDB51(VisionDataset):
             step_between_clips,
             frame_rate,
             _precomputed_metadata,
+            _backend=_backend
         )
         self.indices = self._select_fold(video_list, annotation_path, fold, train)
         self.video_clips = video_clips.subset(self.indices)

--- a/torchvision/datasets/kinetics.py
+++ b/torchvision/datasets/kinetics.py
@@ -37,7 +37,7 @@ class Kinetics400(VisionDataset):
     """
 
     def __init__(self, root, frames_per_clip, step_between_clips=1, frame_rate=None,
-                 extensions=('avi',), transform=None, _precomputed_metadata=None):
+                 extensions=('avi',), transform=None, _precomputed_metadata=None, _backend="pyav"):
         super(Kinetics400, self).__init__(root)
         extensions = ('avi',)
 
@@ -52,6 +52,7 @@ class Kinetics400(VisionDataset):
             step_between_clips,
             frame_rate,
             _precomputed_metadata,
+            _backend=_backend
         )
         self.transform = transform
 

--- a/torchvision/datasets/ucf101.py
+++ b/torchvision/datasets/ucf101.py
@@ -44,7 +44,7 @@ class UCF101(VisionDataset):
 
     def __init__(self, root, annotation_path, frames_per_clip, step_between_clips=1,
                  frame_rate=None, fold=1, train=True, transform=None,
-                 _precomputed_metadata=None):
+                 _precomputed_metadata=None, _backend="pyav"):
         super(UCF101, self).__init__(root)
         if not 1 <= fold <= 3:
             raise ValueError("fold should be between 1 and 3, got {}".format(fold))
@@ -64,6 +64,7 @@ class UCF101(VisionDataset):
             step_between_clips,
             frame_rate,
             _precomputed_metadata,
+            _backend=_backend
         )
         self.indices = self._select_fold(video_list, annotation_path, fold, train)
         self.video_clips = video_clips.subset(self.indices)


### PR DESCRIPTION
A simple PR that exposes the new experimental backend for training purposes. Using it allows for an overall speedup in multiGPU setups.

Specifically, I found the new backend to be:
1. on average 0.2s faster per iteration for equivalent model
2. on average 7min (stdev: 3) minutes faster per training epoch

The tests were done using 64 GPU setup across 8 machines, for 4 different models.