### PR TITLE
Change all torch::nn::init::Nonlinearity::{name} and torch::nn::init::FanMode::{name} usage to torch::k{name}

### DIFF
--- a/torchvision/csrc/models/mnasnet.cpp
+++ b/torchvision/csrc/models/mnasnet.cpp
@@ -111,8 +111,8 @@ void MNASNetImpl::_initialize_weights() {
       torch::nn::init::kaiming_normal_(
           M->weight,
           0,
-          torch::nn::init::FanMode::FanOut,
-          torch::nn::init::Nonlinearity::ReLU);
+          torch::kFanOut,
+          torch::kReLU);
     else if (auto M = dynamic_cast<torch::nn::BatchNormImpl*>(module.get())) {
       torch::nn::init::ones_(M->weight);
       torch::nn::init::zeros_(M->bias);

--- a/torchvision/csrc/models/mobilenet.cpp
+++ b/torchvision/csrc/models/mobilenet.cpp
@@ -135,7 +135,7 @@ MobileNetV2Impl::MobileNetV2Impl(
   for (auto& module : modules(/*include_self=*/false)) {
     if (auto M = dynamic_cast<torch::nn::Conv2dImpl*>(module.get())) {
       torch::nn::init::kaiming_normal_(
-          M->weight, 0, torch::nn::init::FanMode::FanOut);
+          M->weight, 0, torch::kFanOut);
       if (M->options.with_bias())
         torch::nn::init::zeros_(M->bias);
     } else if (auto M = dynamic_cast<torch::nn::BatchNormImpl*>(module.get())) {

--- a/torchvision/csrc/models/resnet.h
+++ b/torchvision/csrc/models/resnet.h
@@ -146,8 +146,8 @@ ResNetImpl<Block>::ResNetImpl(
       torch::nn::init::kaiming_normal_(
           M->weight,
           /*a=*/0,
-          torch::nn::init::FanMode::FanOut,
-          torch::nn::init::Nonlinearity::ReLU);
+          torch::kFanOut,
+          torch::kReLU);
     else if (auto M = dynamic_cast<torch::nn::BatchNormImpl*>(module.get())) {
       torch::nn::init::constant_(M->weight, 1);
       torch::nn::init::constant_(M->bias, 0);

--- a/torchvision/csrc/models/vgg.cpp
+++ b/torchvision/csrc/models/vgg.cpp
@@ -35,8 +35,8 @@ void VGGImpl::_initialize_weights() {
       torch::nn::init::kaiming_normal_(
           M->weight,
           /*a=*/0,
-          torch::nn::init::FanMode::FanOut,
-          torch::nn::init::Nonlinearity::ReLU);
+          torch::kFanOut,
+          torch::kReLU);
       torch::nn::init::constant_(M->bias, 0);
     } else if (auto M = dynamic_cast<torch::nn::BatchNormImpl*>(module.get())) {
       torch::nn::init::constant_(M->weight, 1);


### PR DESCRIPTION
To improve the UX for passing enum values in C++ API, we are moving to use `torch::kReLU` instead of `torch::nn::init::Nonlinearity::ReLU` to represent a `ReLU` enum (PR: https://github.com/pytorch/pytorch/pull/26837). This PR updates the enum usage in torchvision C++ code to the new version, so that the CI in https://github.com/pytorch/pytorch/pull/26837 would be green and we can officially move to using the new enum representation.

### Test Plan
1. Wait for https://github.com/pytorch/pytorch/pull/27051 to be merged.
2. Since torchvision's CI is based on PyTorch nightly, we need to wait for a new nightly build to happen.
3. CI for this PR needs to be green using the new nightly build.
4. After merging this PR, re-running CI for https://github.com/pytorch/pytorch/pull/26837 should make it green.
