### PR TITLE
Fix reference training script for Mask R-CNN for PyTorch 1.2

### DIFF
--- a/references/detection/coco_eval.py
+++ b/references/detection/coco_eval.py
@@ -109,7 +109,7 @@ class CocoEvaluator(object):
             labels = prediction["labels"].tolist()
 
             rles = [
-                mask_util.encode(np.array(mask[0, :, :, np.newaxis], order="F"))[0]
+                mask_util.encode(np.array(mask[0, :, :, np.newaxis], dtype=np.uint8, order="F"))[0]
                 for mask in masks
             ]
             for rle in rles:


### PR DESCRIPTION
Fix reference training script for Mask R-CNN for PyTorch 1.2: during the evaluation run after each epoch, mask output datatype became bool in PyTorch 1.2. But, pycocotools expects uint8 as input.