### PR TITLE
Fix DeprecationWarning for collections.Iterable import

### DIFF
--- a/torchvision/datasets/lsun.py
+++ b/torchvision/datasets/lsun.py
@@ -5,7 +5,11 @@ import os.path
 import six
 import string
 import sys
-from collections import Iterable
+
+if sys.version_info[:2] < (3, 3):
+    from collections import Iterable
+else:
+    from collections.abc import Iterable
 
 if sys.version_info[0] == 2:
     import cPickle as pickle

--- a/torchvision/datasets/lsun.py
+++ b/torchvision/datasets/lsun.py
@@ -6,7 +6,7 @@ import six
 import string
 import sys
 
-if sys.version_info[:2] < (3, 3):
+if sys.version_info < (3, 3):
     from collections import Iterable
 else:
     from collections.abc import Iterable


### PR DESCRIPTION
In Python 3.7, when you run the following import:
```python
from collections import Iterable
```
you see the following deprecation warning:
```
DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
```
This PR future-proofs the LSUN dataset by importing `Iterable` from the new `collections.abc` module. This should allow the LSUN dataset to work with Python 3.8 when it is released. See also #600.