### PR TITLE
Revert "Change all torch::nn::init::Nonlinearity::{name} and torch::nn::init::FanMode::{name} to torch::k{name}"

### DIFF
--- a/torchvision/csrc/models/mnasnet.cpp
+++ b/torchvision/csrc/models/mnasnet.cpp
@@ -109,7 +109,10 @@ void MNASNetImpl::_initialize_weights() {
   for (auto& module : modules(/*include_self=*/false)) {
     if (auto M = dynamic_cast<torch::nn::Conv2dImpl*>(module.get()))
       torch::nn::init::kaiming_normal_(
-          M->weight, 0, torch::kFanOut, torch::kReLU);
+          M->weight,
+          0,
+          torch::nn::init::FanMode::FanOut,
+          torch::nn::init::Nonlinearity::ReLU);
     else if (auto M = dynamic_cast<torch::nn::BatchNormImpl*>(module.get())) {
       torch::nn::init::ones_(M->weight);
       torch::nn::init::zeros_(M->bias);

--- a/torchvision/csrc/models/mobilenet.cpp
+++ b/torchvision/csrc/models/mobilenet.cpp
@@ -134,7 +134,8 @@ MobileNetV2Impl::MobileNetV2Impl(
 
   for (auto& module : modules(/*include_self=*/false)) {
     if (auto M = dynamic_cast<torch::nn::Conv2dImpl*>(module.get())) {
-      torch::nn::init::kaiming_normal_(M->weight, 0, torch::kFanOut);
+      torch::nn::init::kaiming_normal_(
+          M->weight, 0, torch::nn::init::FanMode::FanOut);
       if (M->options.with_bias())
         torch::nn::init::zeros_(M->bias);
     } else if (auto M = dynamic_cast<torch::nn::BatchNormImpl*>(module.get())) {

--- a/torchvision/csrc/models/resnet.h
+++ b/torchvision/csrc/models/resnet.h
@@ -146,8 +146,8 @@ ResNetImpl<Block>::ResNetImpl(
       torch::nn::init::kaiming_normal_(
           M->weight,
           /*a=*/0,
-          torch::kFanOut,
-          torch::kReLU);
+          torch::nn::init::FanMode::FanOut,
+          torch::nn::init::Nonlinearity::ReLU);
     else if (auto M = dynamic_cast<torch::nn::BatchNormImpl*>(module.get())) {
       torch::nn::init::constant_(M->weight, 1);
       torch::nn::init::constant_(M->bias, 0);

--- a/torchvision/csrc/models/vgg.cpp
+++ b/torchvision/csrc/models/vgg.cpp
@@ -35,8 +35,8 @@ void VGGImpl::_initialize_weights() {
       torch::nn::init::kaiming_normal_(
           M->weight,
           /*a=*/0,
-          torch::kFanOut,
-          torch::kReLU);
+          torch::nn::init::FanMode::FanOut,
+          torch::nn::init::Nonlinearity::ReLU);
       torch::nn::init::constant_(M->bias, 0);
     } else if (auto M = dynamic_cast<torch::nn::BatchNormImpl*>(module.get())) {
       torch::nn::init::constant_(M->weight, 1);


### PR DESCRIPTION
Reverts pytorch/vision#1394

This PR is not available for the 1.3 branch, so reverting this for now