### PR TITLE
extend video reader to support fast video probing

### DIFF
--- a/test/test_io.py
+++ b/test/test_io.py
@@ -87,6 +87,22 @@ class Tester(unittest.TestCase):
             self.assertTrue(data.equal(lv))
             self.assertEqual(info["video_fps"], 5)
 
+    @unittest.skipIf(not io._HAS_VIDEO_OPT, "video_reader backend is not chosen")
+    def test_probe_video_from_file(self):
+        with temp_video(10, 300, 300, 5) as (f_name, data):
+            video_info = io._probe_video_from_file(f_name)
+            self.assertAlmostEqual(video_info["video_duration"], 2, delta=0.1)
+            self.assertAlmostEqual(video_info["video_fps"], 5, delta=0.1)
+
+    @unittest.skipIf(not io._HAS_VIDEO_OPT, "video_reader backend is not chosen")
+    def test_probe_video_from_memory(self):
+        with temp_video(10, 300, 300, 5) as (f_name, data):
+            with open(f_name, "rb") as fp:
+                filebuffer = fp.read()
+            video_info = io._probe_video_from_memory(filebuffer)
+            self.assertAlmostEqual(video_info["video_duration"], 2, delta=0.1)
+            self.assertAlmostEqual(video_info["video_fps"], 5, delta=0.1)
+
     def test_read_timestamps(self):
         with temp_video(10, 300, 300, 5) as (f_name, data):
             if _video_backend == "pyav":

--- a/torchvision/csrc/cpu/video_reader/FfmpegAudioStream.cpp
+++ b/torchvision/csrc/cpu/video_reader/FfmpegAudioStream.cpp
@@ -49,6 +49,7 @@ void FfmpegAudioStream::updateStreamDecodeParams() {
     mediaFormat_.format.audio.timeBaseDen =
         inputCtx_->streams[index_]->time_base.den;
   }
+  mediaFormat_.format.audio.duration = inputCtx_->streams[index_]->duration;
 }
 
 int FfmpegAudioStream::initFormat() {

--- a/torchvision/csrc/cpu/video_reader/FfmpegDecoder.h
+++ b/torchvision/csrc/cpu/video_reader/FfmpegDecoder.h
@@ -75,6 +75,19 @@ class FfmpegDecoder {
       const uint8_t* buffer,
       int64_t size,
       DecoderOutput& decoderOutput);
+  // return 0 on success
+  // return negative number on failure
+  int probeFile(
+      std::unique_ptr<DecoderParameters> params,
+      const std::string& filename,
+      DecoderOutput& decoderOutput);
+  // return 0 on success
+  // return negative number on failure
+  int probeMemory(
+      std::unique_ptr<DecoderParameters> params,
+      const uint8_t* buffer,
+      int64_t size,
+      DecoderOutput& decoderOutput);
 
   void cleanUp();
 
@@ -89,6 +102,13 @@ class FfmpegDecoder {
   // return 0 on success
   // return negative number on failure
   int decodeLoop(
+      std::unique_ptr<DecoderParameters> params,
+      const std::string& filename,
+      bool isDecodeFile,
+      FfmpegAvioContext& ioctx,
+      DecoderOutput& decoderOutput);
+
+  int probeVideo(
       std::unique_ptr<DecoderParameters> params,
       const std::string& filename,
       bool isDecodeFile,

--- a/torchvision/csrc/cpu/video_reader/FfmpegVideoStream.cpp
+++ b/torchvision/csrc/cpu/video_reader/FfmpegVideoStream.cpp
@@ -48,6 +48,7 @@ void FfmpegVideoStream::updateStreamDecodeParams() {
     mediaFormat_.format.video.timeBaseDen =
         inputCtx_->streams[index_]->time_base.den;
   }
+  mediaFormat_.format.video.duration = inputCtx_->streams[index_]->duration;
 }
 
 int FfmpegVideoStream::initFormat() {

--- a/torchvision/csrc/cpu/video_reader/Interface.h
+++ b/torchvision/csrc/cpu/video_reader/Interface.h
@@ -48,6 +48,7 @@ struct VideoFormat {
   int timeBaseNum{0};
   int timeBaseDen{1}; // numerator and denominator of time base
   float fps{0.0};
+  int64_t duration{0};  // duration of the stream, in stream time base
 };
 
 struct AudioFormat {
@@ -60,6 +61,7 @@ struct AudioFormat {
   int64_t startPts{0}, endPts{0}; // Start and end presentation timestamp
   int timeBaseNum{0};
   int timeBaseDen{1}; // numerator and denominator of time base
+  int64_t duration{0};  // duration of the stream, in stream time base
 };
 
 union FormatUnion {

--- a/torchvision/csrc/cpu/video_reader/Interface.h
+++ b/torchvision/csrc/cpu/video_reader/Interface.h
@@ -48,7 +48,7 @@ struct VideoFormat {
   int timeBaseNum{0};
   int timeBaseDen{1}; // numerator and denominator of time base
   float fps{0.0};
-  int64_t duration{0};  // duration of the stream, in stream time base
+  int64_t duration{0}; // duration of the stream, in stream time base
 };
 
 struct AudioFormat {
@@ -61,7 +61,7 @@ struct AudioFormat {
   int64_t startPts{0}, endPts{0}; // Start and end presentation timestamp
   int timeBaseNum{0};
   int timeBaseDen{1}; // numerator and denominator of time base
-  int64_t duration{0};  // duration of the stream, in stream time base
+  int64_t duration{0}; // duration of the stream, in stream time base
 };
 
 union FormatUnion {

--- a/torchvision/csrc/cpu/video_reader/VideoReader.cpp
+++ b/torchvision/csrc/cpu/video_reader/VideoReader.cpp
@@ -27,8 +27,6 @@ PyMODINIT_FUNC PyInit_video_reader(void) {
 
 namespace video_reader {
 
-bool glog_initialized = false;
-
 class UnknownPixelFormatException : public exception {
   const char* what() const throw() override {
     return "Unknown pixel format";
@@ -167,11 +165,6 @@ torch::List<torch::Tensor> readVideo(
     int64_t audioEndPts,
     int64_t audioTimeBaseNum,
     int64_t audioTimeBaseDen) {
-  if (!glog_initialized) {
-    glog_initialized = true;
-    // google::InitGoogleLogging("VideoReader");
-  }
-
   unique_ptr<DecoderParameters> params = util::getDecoderParams(
       seekFrameMargin,
       getPtsOnly,
@@ -209,6 +202,8 @@ torch::List<torch::Tensor> readVideo(
   torch::Tensor videoFramePts = torch::zeros({0}, torch::kLong);
   torch::Tensor videoTimeBase = torch::zeros({0}, torch::kInt);
   torch::Tensor videoFps = torch::zeros({0}, torch::kFloat);
+  torch::Tensor videoDuration = torch::zeros({0}, torch::kLong);
+
   if (readVideoStream == 1) {
     auto it = decoderOutput.media_data_.find(TYPE_VIDEO);
     if (it != decoderOutput.media_data_.end()) {
@@ -236,6 +231,10 @@ torch::List<torch::Tensor> readVideo(
       videoFps = torch::zeros({1}, torch::kFloat);
       float* videoFpsData = videoFps.data_ptr<float>();
       videoFpsData[0] = it->second.format_.video.fps;
+
+      videoDuration = torch::zeros({1}, torch::kLong);
+      int64_t* videoDurationData = videoDuration.data_ptr<int64_t>();
+      videoDurationData[0] = it->second.format_.video.duration;
     } else {
       VLOG(1) << "Miss video stream";
     }
@@ -246,6 +245,7 @@ torch::List<torch::Tensor> readVideo(
   torch::Tensor audioFramePts = torch::zeros({0}, torch::kLong);
   torch::Tensor audioTimeBase = torch::zeros({0}, torch::kInt);
   torch::Tensor audioSampleRate = torch::zeros({0}, torch::kInt);
+  torch::Tensor audioDuration = torch::zeros({0}, torch::kLong);
   if (readAudioStream == 1) {
     auto it = decoderOutput.media_data_.find(TYPE_AUDIO);
     if (it != decoderOutput.media_data_.end()) {
@@ -275,6 +275,10 @@ torch::List<torch::Tensor> readVideo(
       audioSampleRate = torch::zeros({1}, torch::kInt);
       int* audioSampleRateData = audioSampleRate.data_ptr<int>();
       audioSampleRateData[0] = it->second.format_.audio.samples;
+
+      audioDuration = torch::zeros({1}, torch::kLong);
+      int64_t* audioDurationData = audioDuration.data_ptr<int64_t>();
+      audioDurationData[0] = it->second.format_.audio.duration;
     } else {
       VLOG(1) << "Miss audio stream";
     }
@@ -285,10 +289,12 @@ torch::List<torch::Tensor> readVideo(
   result.push_back(std::move(videoFramePts));
   result.push_back(std::move(videoTimeBase));
   result.push_back(std::move(videoFps));
+  result.push_back(std::move(videoDuration));
   result.push_back(std::move(audioFrame));
   result.push_back(std::move(audioFramePts));
   result.push_back(std::move(audioTimeBase));
   result.push_back(std::move(audioSampleRate));
+  result.push_back(std::move(audioDuration));
 
   return result;
 }
@@ -378,10 +384,118 @@ torch::List<torch::Tensor> readVideoFromFile(
       audioTimeBaseDen);
 }
 
+torch::List<torch::Tensor> probeVideo(
+    bool isReadFile,
+    const torch::Tensor& input_video,
+    std::string videoPath)
+{
+  unique_ptr<DecoderParameters> params = util::getDecoderParams(
+      0,  // seekFrameMargin
+      0,  // getPtsOnly
+      1,  // readVideoStream
+      0,  // width
+      0,  // height
+      0,  // minDimension
+      0,  // videoStartPts
+      0,  // videoEndPts
+      0,  // videoTimeBaseNum
+      1,  // videoTimeBaseDen
+      1,  // readAudioStream
+      0,  // audioSamples
+      0,  // audioChannels
+      0,  // audioStartPts
+      0,  // audioEndPts
+      0,  // audioTimeBaseNum
+      1   //audioTimeBaseDen
+  );
+
+  FfmpegDecoder decoder;
+  DecoderOutput decoderOutput;
+  if (isReadFile) {
+    decoder.probeFile(std::move(params), videoPath, decoderOutput);
+  } else {
+    decoder.probeMemory(
+        std::move(params),
+        input_video.data_ptr<uint8_t>(),
+        input_video.size(0),
+        decoderOutput);
+  }
+  // video section
+  torch::Tensor videoTimeBase = torch::zeros({0}, torch::kInt);
+  torch::Tensor videoFps = torch::zeros({0}, torch::kFloat);
+  torch::Tensor videoDuration = torch::zeros({0}, torch::kLong);
+
+  auto it = decoderOutput.media_data_.find(TYPE_VIDEO);
+  if (it != decoderOutput.media_data_.end()) {
+    VLOG(1) << "Find video stream";
+    videoTimeBase = torch::zeros({2}, torch::kInt);
+    int* videoTimeBaseData = videoTimeBase.data_ptr<int>();
+    videoTimeBaseData[0] = it->second.format_.video.timeBaseNum;
+    videoTimeBaseData[1] = it->second.format_.video.timeBaseDen;
+
+    videoFps = torch::zeros({1}, torch::kFloat);
+    float* videoFpsData = videoFps.data_ptr<float>();
+    videoFpsData[0] = it->second.format_.video.fps;
+
+    videoDuration = torch::zeros({1}, torch::kLong);
+    int64_t* videoDurationData = videoDuration.data_ptr<int64_t>();
+    videoDurationData[0] = it->second.format_.video.duration;
+  } else {
+    VLOG(1) << "Miss video stream";
+  }
+
+  // audio section
+  torch::Tensor audioTimeBase = torch::zeros({0}, torch::kInt);
+  torch::Tensor audioSampleRate = torch::zeros({0}, torch::kInt);
+  torch::Tensor audioDuration = torch::zeros({0}, torch::kLong);
+
+  it = decoderOutput.media_data_.find(TYPE_AUDIO);
+  if (it != decoderOutput.media_data_.end()) {
+    VLOG(1) << "Find audio stream";
+    audioTimeBase = torch::zeros({2}, torch::kInt);
+    int* audioTimeBaseData = audioTimeBase.data_ptr<int>();
+    audioTimeBaseData[0] = it->second.format_.audio.timeBaseNum;
+    audioTimeBaseData[1] = it->second.format_.audio.timeBaseDen;
+
+    audioSampleRate = torch::zeros({1}, torch::kInt);
+    int* audioSampleRateData = audioSampleRate.data_ptr<int>();
+    audioSampleRateData[0] = it->second.format_.audio.samples;
+
+    audioDuration = torch::zeros({1}, torch::kLong);
+    int64_t* audioDurationData = audioDuration.data_ptr<int64_t>();
+    audioDurationData[0] = it->second.format_.audio.duration;
+  } else {
+    VLOG(1) << "Miss audio stream";
+  }
+
+  torch::List<torch::Tensor> result;
+  result.push_back(std::move(videoTimeBase));
+  result.push_back(std::move(videoFps));
+  result.push_back(std::move(videoDuration));
+  result.push_back(std::move(audioTimeBase));
+  result.push_back(std::move(audioSampleRate));
+  result.push_back(std::move(audioDuration));
+
+  return result;
+}
+
+torch::List<torch::Tensor> probeVideoFromMemory(torch::Tensor input_video) {
+  return probeVideo(false, input_video, "");
+}
+
+torch::List<torch::Tensor> probeVideoFromFile(std::string videoPath) {
+  torch::Tensor dummy_input_video = torch::ones({0});
+  return probeVideo(true, dummy_input_video, videoPath);
+}
+
 } // namespace video_reader
 
 static auto registry = torch::RegisterOperators()
                            .op("video_reader::read_video_from_memory",
                                &video_reader::readVideoFromMemory)
                            .op("video_reader::read_video_from_file",
-                               &video_reader::readVideoFromFile);
+                               &video_reader::readVideoFromFile)
+                           .op("video_reader::probe_video_from_memory",
+                               &video_reader::probeVideoFromMemory)
+                           .op("video_reader::probe_video_from_file",
+                               &video_reader::probeVideoFromFile);

--- a/torchvision/csrc/cpu/video_reader/VideoReader.cpp
+++ b/torchvision/csrc/cpu/video_reader/VideoReader.cpp
@@ -387,26 +387,25 @@ torch::List<torch::Tensor> readVideoFromFile(
 torch::List<torch::Tensor> probeVideo(
     bool isReadFile,
     const torch::Tensor& input_video,
-    std::string videoPath)
-{
+    std::string videoPath) {
   unique_ptr<DecoderParameters> params = util::getDecoderParams(
-      0,  // seekFrameMargin
-      0,  // getPtsOnly
-      1,  // readVideoStream
-      0,  // width
-      0,  // height
-      0,  // minDimension
-      0,  // videoStartPts
-      0,  // videoEndPts
-      0,  // videoTimeBaseNum
-      1,  // videoTimeBaseDen
-      1,  // readAudioStream
-      0,  // audioSamples
-      0,  // audioChannels
-      0,  // audioStartPts
-      0,  // audioEndPts
-      0,  // audioTimeBaseNum
-      1   //audioTimeBaseDen
+      0, // seekFrameMargin
+      0, // getPtsOnly
+      1, // readVideoStream
+      0, // width
+      0, // height
+      0, // minDimension
+      0, // videoStartPts
+      0, // videoEndPts
+      0, // videoTimeBaseNum
+      1, // videoTimeBaseDen
+      1, // readAudioStream
+      0, // audioSamples
+      0, // audioChannels
+      0, // audioStartPts
+      0, // audioEndPts
+      0, // audioTimeBaseNum
+      1 // audioTimeBaseDen
   );
 
   FfmpegDecoder decoder;

--- a/torchvision/io/__init__.py
+++ b/torchvision/io/__init__.py
@@ -2,15 +2,17 @@ from .video import write_video, read_video, read_video_timestamps
 from ._video_opt import (
     _read_video_from_file,
     _read_video_timestamps_from_file,
+    _probe_video_from_file,
     _read_video_from_memory,
     _read_video_timestamps_from_memory,
+    _probe_video_from_memory,
     _HAS_VIDEO_OPT,
 )
 
 
 __all__ = [
     'write_video', 'read_video', 'read_video_timestamps',
-    '_read_video_from_file', '_read_video_timestamps_from_file',
-    '_read_video_from_memory', '_read_video_timestamps_from_memory',
+    '_read_video_from_file', '_read_video_timestamps_from_file', '_probe_video_from_file',
+    '_read_video_from_memory', '_read_video_timestamps_from_memory', '_probe_video_from_memory',
     '_HAS_VIDEO_OPT',
 ]

--- a/torchvision/io/_video_opt.py
+++ b/torchvision/io/_video_opt.py
@@ -39,7 +39,7 @@ def _fill_info(vtimebase, vfps, vduration, atimebase, asample_rate, aduration):
         info["audio_timebase"] = Fraction(atimebase[0].item(), atimebase[1].item())
         if aduration.numel() > 0:
             audio_duration = aduration.item() * info["audio_timebase"]
-            info["audio_duration"] == audio_duration
+            info["audio_duration"] = audio_duration
     if asample_rate.numel() > 0:
         info["audio_sample_rate"] = asample_rate.item()
 


### PR DESCRIPTION
# Changes
Extend video reader to support probing the video quickly for getting video meta information
- In `io` module, add new methods `_probe_video_from_file` and `_probe_video_from_memory`

# unit test
- `python test/test_video_reader.py`
- `python test/test_io.py`
