### PR TITLE
Remove download for ImageNet

### DIFF
--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -108,14 +108,14 @@ class Tester(unittest.TestCase):
             img, target = dataset[0]
             self.assertEqual(dataset.class_to_idx[dataset.classes[0]], target)
 
-    @mock.patch('torchvision.datasets.utils.download_url')
+    @mock.patch('torchvision.datasets.imagenet.ImageNet._verify_archive')
     @unittest.skipIf(not HAS_SCIPY, "scipy unavailable")
-    def test_imagenet(self, mock_download):
+    def test_imagenet(self, mock_check):
         with imagenet_root() as root:
-            dataset = torchvision.datasets.ImageNet(root, split='train', download=True)
+            dataset = torchvision.datasets.ImageNet(root, split='train')
             self.generic_classification_dataset_test(dataset)
 
-            dataset = torchvision.datasets.ImageNet(root, split='val', download=True)
+            dataset = torchvision.datasets.ImageNet(root, split='val')
             self.generic_classification_dataset_test(dataset)
 
     @mock.patch('torchvision.datasets.cifar.check_integrity')

--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -109,9 +109,8 @@ class Tester(unittest.TestCase):
             self.assertEqual(dataset.class_to_idx[dataset.classes[0]], target)
 
     @mock.patch('torchvision.datasets.imagenet._verify_archive')
-    @mock.patch('torchvision.datasets.imagenet.ImageNet._verify_archive')
     @unittest.skipIf(not HAS_SCIPY, "scipy unavailable")
-    def test_imagenet(self, mock_verify_external, mock_verify_internal):
+    def test_imagenet(self, mock_verify):
         with imagenet_root() as root:
             dataset = torchvision.datasets.ImageNet(root, split='train')
             self.generic_classification_dataset_test(dataset)

--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -108,9 +108,10 @@ class Tester(unittest.TestCase):
             img, target = dataset[0]
             self.assertEqual(dataset.class_to_idx[dataset.classes[0]], target)
 
+    @mock.patch('torchvision.datasets.imagenet._verify_archive')
     @mock.patch('torchvision.datasets.imagenet.ImageNet._verify_archive')
     @unittest.skipIf(not HAS_SCIPY, "scipy unavailable")
-    def test_imagenet(self, mock_check):
+    def test_imagenet(self, mock_verify_external, mock_verify_internal):
         with imagenet_root() as root:
             dataset = torchvision.datasets.ImageNet(root, split='train')
             self.generic_classification_dataset_test(dataset)

--- a/torchvision/datasets/imagenet.py
+++ b/torchvision/datasets/imagenet.py
@@ -179,7 +179,8 @@ def parse_train_archive(root, file=None, folder="train"):
     train_root = os.path.join(root, folder)
     extract_archive(os.path.join(root, file), train_root)
 
-    for archive in [os.path.join(train_root, file) for file in os.listdir(train_root)]:
+    archives = [os.path.join(train_root, archive) for archive in os.listdir(train_root)]
+    for archive in archives:
         extract_archive(archive, os.path.splitext(archive)[0], remove_finished=True)
 
 
@@ -208,10 +209,10 @@ def parse_val_archive(root, file=None, wnids=None, folder="val"):
     val_root = os.path.join(root, folder)
     extract_archive(os.path.join(root, file), val_root)
 
-    img_files = sorted([os.path.join(val_root, file) for file in os.listdir(val_root)])
+    images = sorted([os.path.join(val_root, image) for image in os.listdir(val_root)])
 
     for wnid in set(wnids):
         os.mkdir(os.path.join(val_root, wnid))
 
-    for wnid, img_file in zip(wnids, img_files):
+    for wnid, img_file in zip(wnids, images):
         shutil.move(img_file, os.path.join(val_root, wnid, os.path.basename(img_file)))

--- a/torchvision/datasets/imagenet.py
+++ b/torchvision/datasets/imagenet.py
@@ -1,5 +1,4 @@
 import warnings
-from contextlib import contextmanager
 import os
 import shutil
 import tempfile

--- a/torchvision/datasets/imagenet.py
+++ b/torchvision/datasets/imagenet.py
@@ -47,7 +47,7 @@ class ImageNet(ImageFolder):
     """
 
     def __init__(self, root, split='train', download=None, **kwargs):
-        if download is None:
+        if download is not None:
             msg = ("The use of the download flag is deprecated, since the public "
                    "download links were removed by the dataset authors. To use this "
                    "dataset, you need to download the archives externally. Afterwards "

--- a/torchvision/datasets/imagenet.py
+++ b/torchvision/datasets/imagenet.py
@@ -207,11 +207,3 @@ def parse_val_archive(archive, wnids=None, folder=None):
     for wnid, img_file in zip(wnids, img_files):
         shutil.move(img_file, os.path.join(folder, wnid, os.path.basename(img_file)))
 
-
-def _splitexts(root):
-    exts = []
-    ext = '.'
-    while ext:
-        root, ext = os.path.splitext(root)
-        exts.append(ext)
-    return root, ''.join(reversed(exts))

--- a/torchvision/datasets/imagenet.py
+++ b/torchvision/datasets/imagenet.py
@@ -206,4 +206,3 @@ def parse_val_archive(archive, wnids=None, folder=None):
 
     for wnid, img_file in zip(wnids, img_files):
         shutil.move(img_file, os.path.join(folder, wnid, os.path.basename(img_file)))
-

--- a/torchvision/datasets/imagenet.py
+++ b/torchvision/datasets/imagenet.py
@@ -73,28 +73,28 @@ class ImageNet(ImageFolder):
                              for cls in clss}
 
     def extract_archives(self):
-        def check_archive(archive_dict):
-            file = archive_dict["file"]
-            md5 = archive_dict["md5"]
-            archive = os.path.join(self.root, file)
-            if not check_integrity(archive, md5):
-                msg = ("The file {} is not present in the root directory. You need to "
-                       "download it externally and place it in {}.")
-                raise RuntimeError(msg.format(file, self.root))
-
-            return archive
-
         if not check_integrity(self.meta_file):
-            archive = check_archive(ARCHIVE_DICT['devkit'])
+            archive_dict = ARCHIVE_DICT['devkit']
+            archive = os.path.join(self.root, archive_dict["file"])
+            self._verify_archive(archive, archive_dict["md5"])
+
             parse_devkit_archive(archive)
 
         if not os.path.isdir(self.split_folder):
-            archive = check_archive(ARCHIVE_DICT[self.split])
+            archive_dict = ARCHIVE_DICT[self.split]
+            archive = os.path.join(self.root, archive_dict["file"])
+            self._verify_archive(archive, archive_dict["md5"])
 
             if self.split == 'train':
                 parse_train_archive(archive)
             elif self.split == 'val':
                 parse_val_archive(archive)
+
+    def _verify_archive(self, archive, md5):
+        if not check_integrity(archive, md5):
+            msg = ("The file {} is not present in the root directory or corrupted. "
+                   "You need to download it externally and place it in {}.")
+            raise RuntimeError(msg.format(os.path.basename(archive), self.root))
 
     @property
     def meta_file(self):

--- a/torchvision/datasets/imagenet.py
+++ b/torchvision/datasets/imagenet.py
@@ -182,7 +182,7 @@ def parse_train_archive(archive, folder=None):
 
     extract_archive(archive, folder)
 
-    for archive in [os.path.join(folder, archive) for archive in os.listdir(folder)]:
+    for archive in [os.path.join(folder, file) for file in os.listdir(folder)]:
         extract_archive(archive, os.path.splitext(archive)[0], remove_finished=True)
 
 

--- a/torchvision/datasets/imagenet.py
+++ b/torchvision/datasets/imagenet.py
@@ -44,7 +44,6 @@ class ImageNet(ImageFolder):
         imgs (list): List of (image path, class_index) tuples
         targets (list): The class_index value for each image in the dataset
     """
-
     def __init__(self, root, split='train', download=None, **kwargs):
         if download is None:
             download = False
@@ -116,13 +115,13 @@ class ImageNet(ImageFolder):
 
 
 def parse_devkit_archive(archive, meta_file=None):
-    """
+    """Parse the devkit archive of the ImageNet2012 classification dataset and save
+    the meta information in a binary file.
 
     Args:
-        archive:
-        meta_file:
+        archive (str): Path to the devkit archive
+        meta_file (str, optional): Optional name for the meta information file
     """
-    # FIXME
     import scipy.io as sio
 
     def parse_meta(devkit_root):
@@ -171,15 +170,12 @@ def load_meta_file(root, filename=META_FILE_NAME):
 
 
 def parse_train_archive(archive, folder=None):
-    # FIXME
-    """
+    """Parse the train images archive of the ImageNet2012 classification dataset and
+    prepare it for usage with the ImageNet dataset.
 
     Args:
-        archive:
-        folder:
-
-    Returns:
-
+        archive (str): Path to the train images archive
+        folder (str, optional): Optional name for train images folder
     """
     if folder is None:
         folder = os.path.join(os.path.dirname(archive), "train")
@@ -191,13 +187,15 @@ def parse_train_archive(archive, folder=None):
 
 
 def parse_val_archive(archive, wnids=None, folder=None):
-    # FIXME
-    """
+    """Parse the validation images archive of the ImageNet2012 classification dataset
+    and prepare it for usage with the ImageNet dataset.
 
     Args:
-        archive:
-        wnids:
-        folder:
+        archive (str): Path to the validation images archive
+        wnids (list, optional): List of WordNet IDs of the validation images. If None
+            is given, the IDs are tried to be loaded from the meta information binary
+            file in the same directory as the archive.
+        folder (str, optional): Optional name for validation images folder
     """
     root = os.path.dirname(archive)
     if wnids is None:


### PR DESCRIPTION
addresses #1453 

I introduced the function `parse_train_archive` and `parse_val_archive` and changed `parse_devkit` to take in an `str` pointing to an archive. Users that downloaded the dataset externally can use them to prepare the folders.