### PR TITLE
Support Exporting Mask Rcnn to ONNX

### DIFF
--- a/test/test_onnx.py
+++ b/test/test_onnx.py
@@ -1,6 +1,7 @@
 import io
 import torch
 from torchvision import ops
+from torchvision import models
 from torchvision.models.detection.transform import GeneralizedRCNNTransform
 
 from collections import OrderedDict
@@ -128,6 +129,24 @@ class ONNXExporterTester(unittest.TestCase):
         boxes1[:, 2:] += boxes1[:, :2]
 
         self.run_model(TransformModule(), [(i, [boxes],), (i1, [boxes1],)])
+
+    def get_test_images(self):
+        image_url = "http://farm3.staticflickr.com/2469/3915380994_2e611b1779_z.jpg"
+        image = self.get_image_from_url(url=image_url)
+        image_url2 = "https://pytorch.org/tutorials/_static/img/tv_tutorial/tv_image05.png"
+        image2 = self.get_image_from_url(url=image_url2)
+        images = [image]
+        test_images = [image2]
+        return images, test_images
+
+    @unittest.skip("Disable test until Resize opset 11 is implemented in ONNX Runtime")
+    def test_mask_rcnn(self):
+        images, test_images = self.get_test_images(self)
+
+        model = models.detection.mask_rcnn.maskrcnn_resnet50_fpn(pretrained=True)
+        model.eval()
+        model(images)
+        self.run_model(model, [(images,), (test_images,)])
 
 
 if __name__ == '__main__':

--- a/torchvision/models/detection/roi_heads.py
+++ b/torchvision/models/detection/roi_heads.py
@@ -1,4 +1,5 @@
 import torch
+import torchvision
 
 import torch.nn.functional as F
 from torch import nn
@@ -73,7 +74,11 @@ def maskrcnn_inference(x, labels):
     index = torch.arange(num_masks, device=labels.device)
     mask_prob = mask_prob[index, labels][:, None]
 
-    mask_prob = mask_prob.split(boxes_per_image, dim=0)
+    if torchvision._is_tracing():
+        # TODO : remove when dynamic split supported in ONNX
+        mask_prob = (mask_prob,)
+    else:
+        mask_prob = mask_prob.split(boxes_per_image, dim=0)
 
     return mask_prob
 
@@ -250,10 +255,29 @@ def keypointrcnn_inference(x, boxes):
     return kp_probs, kp_scores
 
 
+def _onnx_expand_boxes(boxes, scale):
+    w_half = (boxes[:, 2] - boxes[:, 0]) * .5
+    h_half = (boxes[:, 3] - boxes[:, 1]) * .5
+    x_c = (boxes[:, 2] + boxes[:, 0]) * .5
+    y_c = (boxes[:, 3] + boxes[:, 1]) * .5
+
+    w_half = w_half.to(dtype=torch.float32) * scale
+    h_half = h_half.to(dtype=torch.float32) * scale
+
+    boxes_exp0 = x_c - w_half
+    boxes_exp1 = y_c - h_half
+    boxes_exp2 = x_c + w_half
+    boxes_exp3 = y_c + h_half
+    boxes_exp = torch.stack((boxes_exp0, boxes_exp1, boxes_exp2, boxes_exp3), 1)
+    return boxes_exp
+
+
 # the next two functions should be merged inside Masker
 # but are kept here for the moment while we need them
 # temporarily for paste_mask_in_image
 def expand_boxes(boxes, scale):
+    if torchvision._is_tracing():
+        return _onnx_expand_boxes(boxes, scale)
     w_half = (boxes[:, 2] - boxes[:, 0]) * .5
     h_half = (boxes[:, 3] - boxes[:, 1]) * .5
     x_c = (boxes[:, 2] + boxes[:, 0]) * .5
@@ -272,7 +296,10 @@ def expand_boxes(boxes, scale):
 
 def expand_masks(mask, padding):
     M = mask.shape[-1]
-    scale = float(M + 2 * padding) / M
+    if torchvision._is_tracing():
+        scale = (M + 2 * padding).to(torch.float32) / M.to(torch.float32)
+    else:
+        scale = float(M + 2 * padding) / M
     padded_mask = torch.nn.functional.pad(mask, (padding,) * 4)
     return padded_mask, scale
 
@@ -303,11 +330,70 @@ def paste_mask_in_image(mask, box, im_h, im_w):
     return im_mask
 
 
+def _onnx_paste_mask_in_image(mask, box, im_h, im_w):
+    one = torch.ones(1, dtype=torch.int64)
+    zero = torch.zeros(1, dtype=torch.int64)
+
+    w = (box[2] - box[0] + one)
+    h = (box[3] - box[1] + one)
+    w = torch.max(torch.cat((w, one)))
+    h = torch.max(torch.cat((h, one)))
+
+    # Set shape to [batchxCxHxW]
+    mask = mask.expand((1, 1, mask.size(0), mask.size(1)))
+
+    # Resize mask
+    mask = torch.nn.functional.interpolate(mask, size=(int(h), int(w)), mode='bilinear', align_corners=False)
+    mask = mask[0][0]
+
+    x_0 = torch.max(torch.cat((box[0].unsqueeze(0), zero)))
+    x_1 = torch.min(torch.cat((box[2].unsqueeze(0) + one, im_w.unsqueeze(0))))
+    y_0 = torch.max(torch.cat((box[1].unsqueeze(0), zero)))
+    y_1 = torch.min(torch.cat((box[3].unsqueeze(0) + one, im_h.unsqueeze(0))))
+
+    unpaded_im_mask = mask[(y_0 - box[1]):(y_1 - box[1]),
+                           (x_0 - box[0]):(x_1 - box[0])]
+
+    # TODO : replace below with a dynamic padding when support is added in ONNX
+
+    # pad y
+    zeros_y0 = torch.zeros(y_0, unpaded_im_mask.size(1))
+    zeros_y1 = torch.zeros(im_h - y_1, unpaded_im_mask.size(1))
+    concat_0 = torch.cat((zeros_y0,
+                          unpaded_im_mask.to(dtype=torch.float32),
+                          zeros_y1), 0)
+
+    # pad x
+    zeros_x0 = torch.zeros(concat_0.size(0), x_0)
+    zeros_x1 = torch.zeros(concat_0.size(0), im_w - x_1)
+    im_mask = torch.cat((zeros_x0,
+                         concat_0,
+                         zeros_x1), 1)
+    return im_mask
+
+
+@torch.jit.script
+def _onnx_paste_masks_in_image_loop(masks, boxes, img_shape):
+    im_h = img_shape[0]
+    im_w = img_shape[1]
+    res_append = torch.zeros(0, im_h, im_w)
+    for i in range(masks.size(0)):
+        mask_res = _onnx_paste_mask_in_image(masks[i][0], boxes[i], im_h, im_w)
+        mask_res = mask_res.unsqueeze(0)
+        res_append = torch.cat((res_append, mask_res))
+    return res_append
+
+
 def paste_masks_in_image(masks, boxes, img_shape, padding=1):
     masks, scale = expand_masks(masks, padding=padding)
-    boxes = expand_boxes(boxes, scale).to(dtype=torch.int64).tolist()
+    boxes = expand_boxes(boxes, scale).to(dtype=torch.int64)
     # im_h, im_w = img_shape.tolist()
     im_h, im_w = img_shape
+
+    if torchvision._is_tracing():
+        return _onnx_paste_masks_in_image_loop(masks, boxes, torch.tensor(img_shape))[:, None]
+
+    boxes = boxes.tolist()
     res = [
         paste_mask_in_image(m[0], b, im_h, im_w)
         for m, b in zip(masks, boxes)


### PR DESCRIPTION
In addition to #1401 , these are the last changes to export Maskrcnn to ONNX.
https://github.com/pytorch/pytorch/pull/27566 and https://github.com/pytorch/pytorch/pull/26549.
Like for Faster rcnn, for now we will only be able to export with a batch of 1 (until we support dynamic cases for split).

The test is disabled until the referenced PRs are merged and Resize is implemented in opset 11.