### PR TITLE
Better handle corrupted videos

### DIFF
--- a/test/test_io.py
+++ b/test/test_io.py
@@ -236,6 +236,23 @@ class Tester(unittest.TestCase):
             self.assertEqual(len(lv), 4)
             self.assertTrue(data[4:8].equal(lv))
 
+    def test_read_video_corrupted_file(self):
+        with tempfile.NamedTemporaryFile(suffix='.mp4') as f:
+            f.write(b'This is not an mpg4 file')
+            video, audio, info = io.read_video(f.name)
+            self.assertIsInstance(video, torch.Tensor)
+            self.assertIsInstance(audio, torch.Tensor)
+            self.assertEqual(video.numel(), 0)
+            self.assertEqual(audio.numel(), 0)
+            self.assertEqual(info, {})
+
+    def test_read_video_timestamps_corrupted_file(self):
+        with tempfile.NamedTemporaryFile(suffix='.mp4') as f:
+            f.write(b'This is not an mpg4 file')
+            video_pts, video_fps = io.read_video_timestamps(f.name)
+            self.assertEqual(video_pts, [])
+            self.assertIs(video_fps, None)
+
     # TODO add tests for audio
 
 

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -253,6 +253,24 @@ class Tester(unittest.TestCase):
             self.assertEqual(video_pts, [])
             self.assertIs(video_fps, None)
 
+    def test_read_video_partially_corrupted_file(self):
+        with temp_video(5, 4, 4, 5, lossless=True) as (f_name, data):
+            with open(f_name, 'r+b') as f:
+                size = os.path.getsize(f_name)
+                bytes_to_overwrite = size // 10
+                # seek to the middle of the file
+                f.seek(5 * bytes_to_overwrite)
+                # corrupt 10% of the file from the middle
+                f.write(b'\xff' * bytes_to_overwrite)
+            # this exercises the container.decode assertion check
+            video, audio, info = io.read_video(f.name, pts_unit='sec')
+            # check that size is not equal to 5, but 3
+            self.assertEqual(len(video), 3)
+            # but the valid decoded content is still correct
+            self.assertTrue(video[:3].equal(data[:3]))
+            # and the last few frames are wrong
+            self.assertFalse(video.equal(data))
+
     # TODO add tests for audio
 
 

--- a/torchvision/io/video.py
+++ b/torchvision/io/video.py
@@ -124,13 +124,17 @@ def _read_from_stream(container, start_offset, end_offset, pts_unit, stream, str
         # print("Corrupted file?", container.name)
         return []
     buffer_count = 0
-    for idx, frame in enumerate(container.decode(**stream_name)):
-        frames[frame.pts] = frame
-        if frame.pts >= end_offset:
-            if should_buffer and buffer_count < max_buffer_size:
-                buffer_count += 1
-                continue
-            break
+    try:
+        for idx, frame in enumerate(container.decode(**stream_name)):
+            frames[frame.pts] = frame
+            if frame.pts >= end_offset:
+                if should_buffer and buffer_count < max_buffer_size:
+                    buffer_count += 1
+                    continue
+                break
+    except av.AVError:
+        # TODO add a warning
+        pass
     # ensure that the results are sorted wrt the pts
     result = [frames[i] for i in sorted(frames) if start_offset <= frames[i].pts <= end_offset]
     if start_offset > 0 and start_offset not in frames:

--- a/torchvision/io/video.py
+++ b/torchvision/io/video.py
@@ -210,7 +210,10 @@ def read_video(filename, start_pts=0, end_pts=None, pts_unit='pts'):
         if container.streams.video:
             video_frames = _read_from_stream(container, start_pts, end_pts, pts_unit,
                                              container.streams.video[0], {'video': 0})
-            info["video_fps"] = float(container.streams.video[0].average_rate)
+            video_fps = container.streams.video[0].average_rate
+            # guard against potentially corrupted files
+            if video_fps is not None:
+                info["video_fps"] = float(video_fps)
 
         if container.streams.audio:
             audio_frames = _read_from_stream(container, start_pts, end_pts, pts_unit,


### PR DESCRIPTION
Fixes https://github.com/pytorch/vision/issues/1271 and https://github.com/pytorch/vision/issues/1327

This PR adds a `try: except` guards to the locations where we access the file. This should make it more robust to corrupted videos, as before we were only handling errors during `seek`, and now he handle it both during container creation (i.e., if the header is corrupted, as in https://github.com/pytorch/vision/issues/1271) or when parts of the file are corrupted (as in https://github.com/pytorch/vision/issues/1327).

cc @bjuncek @stephenyan1231 