### PR TITLE
Temporary fix to remove ffmpeg from build time

### DIFF
--- a/packaging/torchvision/meta.yaml
+++ b/packaging/torchvision/meta.yaml
@@ -12,8 +12,6 @@ requirements:
   host:
     - python
     - setuptools
-    - av
-    - six # TODO remove me, only until https://github.com/pytorch/pytorch/pull/27282 gets merged
     {{ environ.get('CONDA_PYTORCH_BUILD_CONSTRAINT') }}
     {{ environ.get('CONDA_CUDATOOLKIT_CONSTRAINT') }}
     {{ environ.get('CONDA_CPUONLY_FEATURE') }}
@@ -23,8 +21,6 @@ requirements:
     - pillow >=4.1.1
     - numpy >=1.11
     - six
-    - av
-    - six # TODO remove me, only until https://github.com/pytorch/pytorch/pull/27282 gets merged
     {{ environ.get('CONDA_PYTORCH_CONSTRAINT') }}
     {{ environ.get('CONDA_CUDATOOLKIT_CONSTRAINT') }}
 
@@ -52,7 +48,6 @@ test:
     - av
     - ca-certificates
     - typing
-    - six # TODO remove me, only until https://github.com/pytorch/pytorch/pull/27282 gets merged
   commands:
     pytest .
 


### PR DESCRIPTION
This PR should enable us to get back into a state where we can build nightlies for torchvision.

This is temporary until we add a switch that makes CI depend on ffmpeg during PR testing but not for nightlies / binary build.

Note that we still build with ffmpeg on TravisCI, so this should give some signal.

cc @stephenyan1231 