### PR TITLE
Fix CUDA builds on Windows

### DIFF
--- a/torchvision/csrc/cuda/PSROIAlign_cuda.cu
+++ b/torchvision/csrc/cuda/PSROIAlign_cuda.cu
@@ -336,7 +336,10 @@ std::tuple<at::Tensor, at::Tensor> PSROIAlign_forward_cuda(
 
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
-  dim3 grid(std::min(at::cuda::ATenCeilDiv(output_size, 512L), 4096L));
+  dim3 grid(std::min(
+      at::cuda::ATenCeilDiv(
+          static_cast<int64_t>(output_size), static_cast<int64_t>(512)),
+      static_cast<int64_t>(4096)));
   dim3 block(512);
 
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
@@ -395,7 +398,10 @@ at::Tensor PSROIAlign_backward_cuda(
 
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
-  dim3 grid(std::min(at::cuda::ATenCeilDiv(grad.numel(), 512L), 4096L));
+  dim3 grid(std::min(
+      at::cuda::ATenCeilDiv(
+          static_cast<int64_t>(grad.numel()), static_cast<int64_t>(512)),
+      static_cast<int64_t>(4096)));
   dim3 block(512);
 
   // handle possibly empty gradients

--- a/torchvision/csrc/cuda/PSROIPool_cuda.cu
+++ b/torchvision/csrc/cuda/PSROIPool_cuda.cu
@@ -173,7 +173,10 @@ std::tuple<at::Tensor, at::Tensor> PSROIPool_forward_cuda(
 
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
-  dim3 grid(std::min(at::cuda::ATenCeilDiv(output_size, 512L), 4096L));
+  dim3 grid(std::min(
+      at::cuda::ATenCeilDiv(
+          static_cast<int64_t>(output_size), static_cast<int64_t>(512)),
+      static_cast<int64_t>(4096)));
   dim3 block(512);
 
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
@@ -229,7 +232,10 @@ at::Tensor PSROIPool_backward_cuda(
 
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
-  dim3 grid(std::min(at::cuda::ATenCeilDiv(grad.numel(), 512L), 4096L));
+  dim3 grid(std::min(
+      at::cuda::ATenCeilDiv(
+          static_cast<int64_t>(grad.numel()), static_cast<int64_t>(512)),
+      static_cast<int64_t>(4096)));
   dim3 block(512);
 
   // handle possibly empty gradients


### PR DESCRIPTION
CUDA builds on Windows were failing after #1410 was merged, with errors like
```
D:/_work/1/s/packaging/windows/vision/torchvision/csrc/cuda/PSROIAlign_cuda.cu(339): error: no instance of function template "at::cuda::ATenCeilDiv" matches the argument list
              argument types are: (int64_t, long)
  
  D:/_work/1/s/packaging/windows/vision/torchvision/csrc/cuda/PSROIAlign_cuda.cu(339): error: no instance of overloaded function "std::min" matches the argument list
              argument types are: (<error-type>, long)
  
  D:/_work/1/s/packaging/windows/vision/torchvision/csrc/cuda/PSROIAlign_cuda.cu(398): error: no instance of function template "at::cuda::ATenCeilDiv" matches the argument list
              argument types are: (int64_t, long)
  
  D:/_work/1/s/packaging/windows/vision/torchvision/csrc/cuda/PSROIAlign_cuda.cu(398): error: no instance of overloaded function "std::min" matches the argument list
              argument types are: (<error-type>, long)
```
see https://dev.azure.com/pytorch/PyTorch/_build/results?buildId=17560 for the full logs.

This PR fix it following an approach similar to https://github.com/pytorch/vision/pull/953