### PR TITLE
test: Updated assert in test_hub

### DIFF
--- a/test/test_hub.py
+++ b/test/test_hub.py
@@ -44,7 +44,7 @@ class TestHub(unittest.TestCase):
             progress=False)
         self.assertEqual(sum_of_model_parameters(hub_model).item(),
                          SUM_OF_PRETRAINED_RESNET18_PARAMS)
-        assert os.path.exists(temp_dir + '/pytorch_vision_master')
+        self.assertTrue(os.path.exists(temp_dir + '/pytorch_vision_master'))
         shutil.rmtree(temp_dir + '/pytorch_vision_master')
 
     def test_list_entrypoints(self):


### PR DESCRIPTION
This PR updates all raw `assert` to the corresponding `unittest.TestCase` assert method for tests related to `torch.hub` as suggested by #1483.
The specific test was run locally with success, any feedback is welcome!