### PR TITLE
Unify video backend

### DIFF
--- a/test/test_io.py
+++ b/test/test_io.py
@@ -63,7 +63,7 @@ def temp_video(num_frames, height, width, fps, lossless=False, video_codec=None,
 
 
 @unittest.skipIf(av is None, "PyAV unavailable")
-@unittest.skipIf('win' in sys.platform, 'temporarily disabled on Windows')
+@unittest.skipIf(sys.platform == 'win32', 'temporarily disabled on Windows')
 class Tester(unittest.TestCase):
     # compression adds artifacts, thus we add a tolerance of
     # 6 in 0-255 range

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -62,6 +62,8 @@ def temp_video(num_frames, height, width, fps, lossless=False, video_codec=None,
         yield f.name, data
 
 
+@unittest.skipIf(get_video_backend() != "pyav" and not io._HAS_VIDEO_OPT,
+    "video_reader backend not available")
 @unittest.skipIf(av is None, "PyAV unavailable")
 @unittest.skipIf(sys.platform == 'win32', 'temporarily disabled on Windows')
 class Tester(unittest.TestCase):

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -63,7 +63,7 @@ def temp_video(num_frames, height, width, fps, lossless=False, video_codec=None,
 
 
 @unittest.skipIf(get_video_backend() != "pyav" and not io._HAS_VIDEO_OPT,
-    "video_reader backend not available")
+                 "video_reader backend not available")
 @unittest.skipIf(av is None, "PyAV unavailable")
 @unittest.skipIf(sys.platform == 'win32', 'temporarily disabled on Windows')
 class Tester(unittest.TestCase):

--- a/test/test_io_opt.py
+++ b/test/test_io_opt.py
@@ -1,0 +1,12 @@
+import unittest
+from torchvision import set_video_backend
+import test_io
+
+
+set_video_backend('video_reader')
+
+
+if __name__ == '__main__':
+    suite = unittest.TestLoader().loadTestsFromModule(test_io)
+    unittest.TextTestRunner(verbosity=1).run(suite)
+    #unittest.main()

--- a/test/test_io_opt.py
+++ b/test/test_io_opt.py
@@ -9,4 +9,3 @@ set_video_backend('video_reader')
 if __name__ == '__main__':
     suite = unittest.TestLoader().loadTestsFromModule(test_io)
     unittest.TextTestRunner(verbosity=1).run(suite)
-    #unittest.main()

--- a/test/test_video_reader.py
+++ b/test/test_video_reader.py
@@ -25,7 +25,7 @@ else:
     from urllib.error import URLError
 
 
-from torchvision.io._video_opt import _HAS_VIDEO_OPT
+from torchvision.io import _HAS_VIDEO_OPT
 
 
 VIDEO_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "assets", "videos")

--- a/torchvision/io/__init__.py
+++ b/torchvision/io/__init__.py
@@ -1,4 +1,4 @@
-from .video import write_video, read_video, read_video_timestamps
+from .video import write_video, read_video, read_video_timestamps, _HAS_VIDEO_OPT
 from ._video_opt import (
     _read_video_from_file,
     _read_video_timestamps_from_file,
@@ -6,7 +6,6 @@ from ._video_opt import (
     _read_video_from_memory,
     _read_video_timestamps_from_memory,
     _probe_video_from_memory,
-    _HAS_VIDEO_OPT,
 )
 
 

--- a/torchvision/io/_video_opt.py
+++ b/torchvision/io/_video_opt.py
@@ -347,7 +347,7 @@ def _probe_video_from_memory(video_data):
     return info
 
 
-def read_video(filename, start_pts=0, end_pts=None, pts_unit='pts'):
+def _read_video(filename, start_pts=0, end_pts=None, pts_unit='pts'):
     if end_pts is None:
         end_pts = float("inf")
 
@@ -394,7 +394,7 @@ def read_video(filename, start_pts=0, end_pts=None, pts_unit='pts'):
     )
 
 
-def read_video_timestamps(filename, pts_unit='pts'):
+def _read_video_timestamps(filename, pts_unit='pts'):
     if pts_unit == 'pts':
         warnings.warn("The pts_unit 'pts' gives wrong results and will be removed in a " +
                       "follow-up version. Please use pts_unit 'sec'.")

--- a/torchvision/io/_video_opt.py
+++ b/torchvision/io/_video_opt.py
@@ -1,21 +1,9 @@
 from fractions import Fraction
 import math
 import numpy as np
-import os
 import torch
-import imp
 import warnings
 
-
-_HAS_VIDEO_OPT = False
-
-try:
-    lib_dir = os.path.join(os.path.dirname(__file__), '..')
-    _, path, description = imp.find_module("video_reader", [lib_dir])
-    torch.ops.load_library(path)
-    _HAS_VIDEO_OPT = True
-except (ImportError, OSError):
-    pass
 
 default_timebase = Fraction(0, 1)
 

--- a/torchvision/io/video.py
+++ b/torchvision/io/video.py
@@ -209,7 +209,7 @@ def read_video(filename, start_pts=0, end_pts=None, pts_unit='pts'):
 
     from torchvision import get_video_backend
     if get_video_backend() != "pyav":
-        return _video_opt.read_video(filename, start_pts, end_pts, pts_unit)
+        return _video_opt._read_video(filename, start_pts, end_pts, pts_unit)
 
     _check_av_available()
 
@@ -296,7 +296,7 @@ def read_video_timestamps(filename, pts_unit='pts'):
     """
     from torchvision import get_video_backend
     if get_video_backend() != "pyav":
-        return _video_opt.read_video_timestamps(filename, pts_unit)
+        return _video_opt._read_video_timestamps(filename, pts_unit)
 
     _check_av_available()
 

--- a/torchvision/io/video.py
+++ b/torchvision/io/video.py
@@ -1,11 +1,25 @@
 import re
+import imp
 import gc
+import os
 import torch
 import numpy as np
 import math
 import warnings
 
 from . import _video_opt
+
+
+_HAS_VIDEO_OPT = False
+
+try:
+    lib_dir = os.path.join(os.path.dirname(__file__), '..')
+    _, path, description = imp.find_module("video_reader", [lib_dir])
+    torch.ops.load_library(path)
+    _HAS_VIDEO_OPT = True
+except (ImportError, OSError):
+    pass
+
 
 try:
     import av

--- a/torchvision/io/video.py
+++ b/torchvision/io/video.py
@@ -5,6 +5,8 @@ import numpy as np
 import math
 import warnings
 
+from . import _video_opt
+
 try:
     import av
     av.logging.set_level(av.logging.ERROR)
@@ -190,6 +192,11 @@ def read_video(filename, start_pts=0, end_pts=None, pts_unit='pts'):
         metadata for the video and audio. Can contain the fields video_fps (float)
         and audio_fps (int)
     """
+
+    from torchvision import get_video_backend
+    if get_video_backend() != "pyav":
+        return _video_opt.read_video(filename, start_pts, end_pts, pts_unit)
+
     _check_av_available()
 
     if end_pts is None:
@@ -273,6 +280,10 @@ def read_video_timestamps(filename, pts_unit='pts'):
         the frame rate for the video
 
     """
+    from torchvision import get_video_backend
+    if get_video_backend() != "pyav":
+        return _video_opt.read_video_timestamps(filename, pts_unit)
+
     _check_av_available()
 
     video_frames = []


### PR DESCRIPTION
This PR makes `set_video_backend` to actually do something inside `read_video` and `read_video_timestamps`.
It unifies the interface of both backends, and also add separate unittest for each backend.

I had to move the video reader initialization because it was causing reference cycles with the code.

cc @stephenyan1231 for review