### PR TITLE
Add adjustment operations for RGB Tensor Images.

### DIFF
--- a/test/test_functional_tensor.py
+++ b/test/test_functional_tensor.py
@@ -44,7 +44,7 @@ class Tester(unittest.TestCase):
         for _ in range(20):
             channels = 3
             dims = torch.randint(1, 50, (2,))
-            shape = (channels, *dims)
+            shape = (channels, dims[0], dims[1])
 
             if torch.randint(0, 2, (1,)) == 0:
                 img = torch.rand(*shape, dtype=torch.float)

--- a/test/test_functional_tensor.py
+++ b/test/test_functional_tensor.py
@@ -55,7 +55,7 @@ class Tester(unittest.TestCase):
             for f, ft in fns:
 
                 ft_img = ft(img, factor)
-                if img.dtype == torch.uint8:
+                if not img.dtype.is_floating_point:
                     ft_img = ft_img.to(torch.float) / 255
 
                 img_pil = transforms.ToPILImage()(img)

--- a/test/test_functional_tensor.py
+++ b/test/test_functional_tensor.py
@@ -1,3 +1,4 @@
+from __future__ import division
 import torch
 import torchvision.transforms as transforms
 import torchvision.transforms.functional_tensor as F_t

--- a/torchvision/transforms/functional_tensor.py
+++ b/torchvision/transforms/functional_tensor.py
@@ -107,14 +107,10 @@ def adjust_saturation(img, saturation_factor):
 
 
 def _blend(img1, img2, ratio):
-    bound = 255 if _is_int(img1.dtype) else 1
+    bound = 1 if img1.dtype.is_floating_point else 255
     return (ratio * img1 + (1 - ratio) * img2).clamp(0, bound).to(img1.dtype)
 
 
 def _rgb_to_grayscale(img):
     # ITU-R 601-2 luma transform, as used in PIL.
     return (0.2989 * img[0] + 0.5870 * img[1] + 0.1140 * img[2]).to(img.dtype)
-
-
-def _is_int(dtype):
-    return dtype in (torch.uint8, torch.int8, torch.int16, torch.int32, torch.int64)


### PR DESCRIPTION
Right now, we have operations on PIL images, but we want to have a version of the operations that act directly on Tensor images, as discussed in issue #1375 .

Here, we add such operations for adjust_brightness, adjust_contrast and adjust_saturation.

In PIL, those functions are implemented by generating a degenerate image from the first, and then interpolating them together.
- https://github.com/python-pillow/Pillow/blob/master/src/PIL/ImageEnhance.py
- https://github.com/python-pillow/Pillow/blob/master/src/libImaging/Blend.c

A few caveats:
* Since PIL operates on uint8, and the tensor operations might be on float, we can get slightly different values because of int truncation; in particular, in testing, we check that the images are equal up to a small difference.
* We assume here that the images are RGB; in particular, to handle an alpha channel, we would need to check whether the image has an alpha, in which case we copy it in the degenerate image.
* adjust_contrast and adjust_saturation rely on grayscale images; since the pull request #1505 is working on it, I made a temporary function, _rgb_to_grayscale, to be replaced once #1505 is done.