### PR TITLE
Make shear operation area preserving

### DIFF
--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -1098,16 +1098,28 @@ class Tester(unittest.TestCase):
         def _test_transformation(a, t, s, sh):
             a_rad = math.radians(a)
             s_rad = [math.radians(sh_) for sh_ in sh]
+            cx, cy = cnt
+            tx, ty = t
+            sx, sy = s_rad
+            rot = a_rad
+
             # 1) Check transformation matrix:
-            c_matrix = np.array([[1.0, 0.0, cnt[0]], [0.0, 1.0, cnt[1]], [0.0, 0.0, 1.0]])
-            c_inv_matrix = np.linalg.inv(c_matrix)
-            t_matrix = np.array([[1.0, 0.0, t[0]],
-                                 [0.0, 1.0, t[1]],
-                                 [0.0, 0.0, 1.0]])
-            r_matrix = np.array([[s * math.cos(a_rad + s_rad[1]), -s * math.sin(a_rad + s_rad[0]), 0.0],
-                                 [s * math.sin(a_rad + s_rad[1]), s * math.cos(a_rad + s_rad[0]), 0.0],
-                                 [0.0, 0.0, 1.0]])
-            true_matrix = np.dot(t_matrix, np.dot(c_matrix, np.dot(r_matrix, c_inv_matrix)))
+            C = np.array([[1, 0, cx],
+                          [0, 1, cy],
+                          [0, 0, 1]])
+            T = np.array([[1, 0, tx],
+                          [0, 1, ty],
+                          [0, 0, 1]])
+            Cinv = np.linalg.inv(C)
+
+            RSS = np.array(
+                [[s * math.cos(rot + sy), -s * math.sin(rot + sx), 0],
+                 [s * math.sin(rot + sy),  s * math.cos(rot + sx), 0],
+                 [0, 0, 1]]
+                )
+
+            true_matrix = T @ C @ RSS @ Cinv
+
             result_matrix = _to_3x3_inv(F._get_inverse_affine_matrix(center=cnt, angle=a,
                                                                      translate=t, scale=s, shear=sh))
             self.assertLess(np.sum(np.abs(true_matrix - result_matrix)), 1e-10)

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -1125,9 +1125,9 @@ class Tester(unittest.TestCase):
                             [-math.tan(sy), 1, 0],
                             [0, 0, 1]])
 
-            RSS = RS @ SHy @ SHx
+            RSS = np.matmul(RS, np.matmul(SHy, SHx))
 
-            true_matrix = T @ C @ RSS @ Cinv
+            true_matrix = np.matmul(T, np.matmul(C, np.matmul(RSS, Cinv)))
 
             result_matrix = _to_3x3_inv(F._get_inverse_affine_matrix(center=cnt, angle=a,
                                                                      translate=t, scale=s, shear=sh))

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -1112,11 +1112,20 @@ class Tester(unittest.TestCase):
                           [0, 0, 1]])
             Cinv = np.linalg.inv(C)
 
-            RSS = np.array(
-                [[s * math.cos(rot + sy), -s * math.sin(rot + sx), 0],
-                 [s * math.sin(rot + sy),  s * math.cos(rot + sx), 0],
-                 [0, 0, 1]]
-                )
+            RS = np.array(
+                [[s * math.cos(rot), -s * math.sin(rot), 0],
+                 [s * math.sin(rot), s * math.cos(rot), 0],
+                 [0, 0, 1]])
+
+            SHx = np.array([[1, -math.tan(sx), 0],
+                            [0, 1, 0],
+                            [0, 0, 1]])
+
+            SHy = np.array([[1, 0, 0],
+                            [-math.tan(sy), 1, 0],
+                            [0, 0, 1]])
+
+            RSS = RS @ SHy @ SHx
 
             true_matrix = T @ C @ RSS @ Cinv
 

--- a/torchvision/transforms/functional.py
+++ b/torchvision/transforms/functional.py
@@ -770,7 +770,7 @@ def _get_inverse_affine_matrix(center, angle, translate, scale, shear):
     d = -sin(rot - sy) * tan(sx) / cos(sy) + cos(rot)
 
     # Inverted rotation matrix with scale and shear
-    # det([[a, b], [c, d]]) == 1
+    # det([[a, b], [c, d]]) == 1, since det(rotation) = 1 and det(shear) = 1
     M = [d, -b, 0,
          -c, a, 0]
     M = [x / scale for x in M]

--- a/torchvision/transforms/functional.py
+++ b/torchvision/transforms/functional.py
@@ -741,35 +741,36 @@ def _get_inverse_affine_matrix(center, angle, translate, scale, shear):
     #                              [     0                  0          1]
     # Thus, the inverse is M^-1 = C * RSS^-1 * C^-1 * T^-1
 
-    angle = math.radians(angle)
-    if isinstance(shear, (tuple, list)) and len(shear) == 2:
-        shear = [math.radians(s) for s in shear]
-    elif isinstance(shear, numbers.Number):
-        shear = math.radians(shear)
+    if isinstance(shear, numbers.Number):
         shear = [shear, 0]
-    else:
+
+    if not isinstance(shear, (tuple, list)) and len(shear) == 2:
         raise ValueError(
             "Shear should be a single value or a tuple/list containing " +
             "two values. Got {}".format(shear))
-    scale = 1.0 / scale
+
+    rot = math.radians(angle)
+    sx, sy = [math.radians(s) for s in shear]
+
+    cx, cy = center
+    tx, ty = translate
 
     # Inverted rotation matrix with scale and shear
-    d = math.cos(angle + shear[0]) * math.cos(angle + shear[1]) + \
-        math.sin(angle + shear[0]) * math.sin(angle + shear[1])
-    matrix = [
-        math.cos(angle + shear[0]), math.sin(angle + shear[0]), 0,
-        -math.sin(angle + shear[1]), math.cos(angle + shear[1]), 0
+    det = math.cos(rot + sx) * math.cos(rot + sy) + math.sin(rot + sx) * math.sin(rot + sy)
+    M = [
+        math.cos(rot + sx), math.sin(rot + sx), 0,
+        -math.sin(rot + sy), math.cos(rot + sy), 0
     ]
-    matrix = [scale / d * m for m in matrix]
+    M = [x / (scale * det) for x in M]
 
     # Apply inverse of translation and of center translation: RSS^-1 * C^-1 * T^-1
-    matrix[2] += matrix[0] * (-center[0] - translate[0]) + matrix[1] * (-center[1] - translate[1])
-    matrix[5] += matrix[3] * (-center[0] - translate[0]) + matrix[4] * (-center[1] - translate[1])
+    M[2] += M[0] * (-cx - tx) + M[1] * (-cy - ty)
+    M[5] += M[3] * (-cx - tx) + M[4] * (-cy - ty)
 
     # Apply center translation: C * RSS^-1 * C^-1 * T^-1
-    matrix[2] += center[0]
-    matrix[5] += center[1]
-    return matrix
+    M[2] += cx
+    M[5] += cy
+    return M
 
 
 def affine(img, angle, translate, scale, shear, resample=0, fillcolor=None):


### PR DESCRIPTION
This PR handles issue #1185.

PR #1371 attempted to fix this, but noticed the issue that the formula did not give the same shear direction - the reason for this is that the formulas in #1185 used a different sign for the shear. 

So, to fix the problem, we just have to replace the signs of shear_x and shear_y in the matrix formula from #1185.

I verified the formula by hand, and by the following sympy code:

```
from sympy import Matrix, cos, sin, tan, simplify
from sympy.abc import x, y, phi

Xs = Matrix(
        [[1, -tan(x)],
         [0, 1]]
        )

Ys = Matrix(
        [[1, 0],
         [-tan(y), 1]]
        )

R = Matrix(
        [[cos(phi), -sin(phi)],
         [sin(phi), cos(phi)]]
        )

RSS = Matrix(
        [[cos(phi - y)/cos(y), -cos(phi - y)*tan(x)/cos(y) - sin(phi)],
         [sin(phi - y)/cos(y), -sin(phi - y)*tan(x)/cos(y) + cos(phi)]])

print(simplify(R * Ys * Xs - RSS))
# Matrix([[0, 0], [0, 0]])

```

(One thing I'm uncertain is whether there is really a gain of performance by avoiding to calculate the explicit matrices and inverses, since the matrices are small and numpy can be quite efficient - I might run some time comparisons to check.)