### PR TITLE
Fix torchvision install due to zippeg egg

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -206,7 +206,7 @@ setup(
     # Package info
     packages=find_packages(exclude=('test',)),
 
-    zip_safe=True,
+    zip_safe=False,
     install_requires=requirements,
     extras_require={
         "scipy": ["scipy"],


### PR DESCRIPTION
Fixes https://github.com/pytorch/vision/issues/1489

When compiling torchvision with `zip_safe=True` via `python setup.py install`, setuptools would generate a zippeg egg file. This made it impossible for custom extensions (which have recently been added) to work, because they would need to be unzipped beforehand.

This used to work with C++ extensions which relied on pybind11 because they were proper Python extensions, which were imported via `import torchvision._C`, and setuptools generated special code for handling it. This is not the case anymore with custom ops, which are just libs without any Python information.

Thanks for @tangorn and @pedrofreire for raising up the issue and giving a repro.