### PR TITLE
Fix inconsistent NMS implementation between CPU and CUDA

### DIFF
--- a/torchvision/csrc/cpu/nms_cpu.cpp
+++ b/torchvision/csrc/cpu/nms_cpu.cpp
@@ -61,7 +61,7 @@ at::Tensor nms_cpu_kernel(
       auto h = std::max(static_cast<scalar_t>(0), yy2 - yy1);
       auto inter = w * h;
       auto ovr = inter / (iarea + areas[j] - inter);
-      if (ovr >= iou_threshold)
+      if (ovr > iou_threshold)
         suppressed[j] = 1;
     }
   }

--- a/torchvision/csrc/cuda/nms_cuda.cu
+++ b/torchvision/csrc/cuda/nms_cuda.cu
@@ -72,7 +72,6 @@ __global__ void nms_kernel(
 at::Tensor nms_cuda(const at::Tensor& dets,
     const at::Tensor& scores,
     float iou_threshold) {
-  using scalar_t = float;
   AT_ASSERTM(dets.type().is_cuda(), "dets must be a CUDA tensor");
   AT_ASSERTM(scores.type().is_cuda(), "scores must be a CUDA tensor");
   at::cuda::CUDAGuard device_guard(dets.device());


### PR DESCRIPTION
There was an inconsistency in how `nms_threshold` was handled in NMS between CPU and GPU. More precisely, the difference arises with proposals that satisfy `overlap == nms_threshold`.

We used `ovr >= iou_threshold` for CPU https://github.com/pytorch/vision/blob/cd1748443afb1ccd168a3b3da29317ca5d4cd253/torchvision/csrc/cpu/nms_cpu.cpp#L64 and `ovr > iou_threshold` for CUDA https://github.com/pytorch/vision/blob/cd1748443afb1ccd168a3b3da29317ca5d4cd253/torchvision/csrc/cuda/nms_cuda.cu#L63

This was caught during test refactorings in https://github.com/pytorch/vision/pull/1551, which exposed this inconsistency.

cc @rbgirshick @ppwwyyxx 