### PR TITLE
remove BC-breaking changes

### DIFF
--- a/test/test_models.py
+++ b/test/test_models.py
@@ -43,12 +43,12 @@ def get_available_video_models():
 # so that we do not have to introduce BC changes.
 
 script_test_models = [
-    # "deeplabv3_resnet101", temp disabled
+    "deeplabv3_resnet101",
     "mobilenet_v2",
     "resnext50_32x4d",
-    # "fcn_resnet101", temp disabled
+    "fcn_resnet101",
     "googlenet",
-    # "densenet121", temp disabled
+    "densenet121",
     "resnet18",
     "alexnet",
     "shufflenet_v2_x1_0",

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -39,9 +39,6 @@ def get_available_video_models():
 # but the test was too slow. not included are detection models, because
 # they are not yet supported in JIT.
 
-# Temp disabled modules: disabled until https://github.com/pytorch/pytorch/pull/28988 lands
-# so that we do not have to introduce BC changes.
-
 script_test_models = [
     "deeplabv3_resnet101",
     "mobilenet_v2",

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -38,13 +38,17 @@ def get_available_video_models():
 # models that are in torch hub, as well as r3d_18. we tried testing all models
 # but the test was too slow. not included are detection models, because
 # they are not yet supported in JIT.
+
+# Temp disabled modules: disabled until https://github.com/pytorch/pytorch/pull/28988 lands
+# so that we do not have to introduce BC changes.
+
 script_test_models = [
-    "deeplabv3_resnet101",
+    # "deeplabv3_resnet101", temp disabled
     "mobilenet_v2",
     "resnext50_32x4d",
-    "fcn_resnet101",
+    # "fcn_resnet101", temp disabled
     "googlenet",
-    "densenet121",
+    # "densenet121", temp disabled
     "resnet18",
     "alexnet",
     "shufflenet_v2_x1_0",

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -38,7 +38,6 @@ def get_available_video_models():
 # models that are in torch hub, as well as r3d_18. we tried testing all models
 # but the test was too slow. not included are detection models, because
 # they are not yet supported in JIT.
-
 script_test_models = [
     "deeplabv3_resnet101",
     "mobilenet_v2",

--- a/torchvision/models/_utils.py
+++ b/torchvision/models/_utils.py
@@ -5,7 +5,7 @@ from torch import nn
 from torch.jit.annotations import Dict
 
 
-class IntermediateLayerGetter(nn.Module):
+class IntermediateLayerGetter(nn.ModuleDict):
     """
     Module wrapper that returns intermediate layers from a model
 
@@ -45,8 +45,6 @@ class IntermediateLayerGetter(nn.Module):
     def __init__(self, model, return_layers):
         if not set(return_layers).issubset([name for name, _ in model.named_children()]):
             raise ValueError("return_layers are not present in model")
-        super(IntermediateLayerGetter, self).__init__()
-
         orig_return_layers = return_layers
         return_layers = {k: v for k, v in return_layers.items()}
         layers = OrderedDict()
@@ -57,33 +55,14 @@ class IntermediateLayerGetter(nn.Module):
             if not return_layers:
                 break
 
-        self.layers = nn.ModuleDict(layers)
+        super(IntermediateLayerGetter, self).__init__(layers)
         self.return_layers = orig_return_layers
 
     def forward(self, x):
         out = OrderedDict()
-        for name, module in self.layers.items():
+        for name, module in self.items():
             x = module(x)
             if name in self.return_layers:
                 out_name = self.return_layers[name]
                 out[out_name] = x
         return out
-
-    @torch.jit.ignore
-    def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict,
-                              missing_keys, unexpected_keys, error_msgs):
-        version = local_metadata.get('version', None)
-        if (version is None or version < 2):
-            # now we have a new nesting level for torchscript support
-            for new_key in self.state_dict().keys():
-                # remove prefix "layers."
-                old_key = new_key[len("layers."):]
-                old_key = prefix + old_key
-                new_key = prefix + new_key
-                if old_key in state_dict:
-                    value = state_dict[old_key]
-                    del state_dict[old_key]
-                    state_dict[new_key] = value
-        super(IntermediateLayerGetter, self)._load_from_state_dict(
-            state_dict, prefix, local_metadata, strict,
-            missing_keys, unexpected_keys, error_msgs)


### PR DESCRIPTION
`IntermediateLayerGetter` and `DenseBlock` were re-written to be supported in script, along the way introducing BC changes that required `_load_from_state_dict` logic. 

This removes those changes, moving them to `ModuleDict`. Once https://github.com/pytorch/pytorch/pull/28988 lands we can re-enable these scripting tests.