### PR TITLE
fix resnext script

### DIFF
--- a/torchvision/models/segmentation/deeplabv3.py
+++ b/torchvision/models/segmentation/deeplabv3.py
@@ -57,7 +57,8 @@ class ASPPPooling(nn.Sequential):
 
     def forward(self, x):
         size = x.shape[-2:]
-        x = super(ASPPPooling, self).forward(x)
+        for mod in self:
+            x = mod(x)
         return F.interpolate(x, size=size, mode='bilinear', align_corners=False)
 
 


### PR DESCRIPTION
resnext inherits from Sequential. Custom sequential forwards are now supported, but super calls are not. 