### PR TITLE
Update FaceHub's allowDirectMerges value

### DIFF
--- a/browser-extension.json
+++ b/browser-extension.json
@@ -1,5 +1,5 @@
 {
-  "allowDirectMerges": ["master", "pytorch:master"],
+  "allowDirectMerges": ["master", "pytorch:master", "fb-config"],
   "allowBotCommands": false,
   "internalRepository": "fbsource"
 }

--- a/browser-extension.json
+++ b/browser-extension.json
@@ -1,5 +1,5 @@
 {
-  "allowDirectMerges": ["master"],
+  "allowDirectMerges": ["master", "pytorch:master"],
   "allowBotCommands": false,
   "internalRepository": "fbsource"
 }


### PR DESCRIPTION
There might be a bug in FaceHub where allowDirectMerges pulls "pytorch:master" as the branch name from the HTML when the pull request was made from a fork. This should workaround that.