### PR TITLE
compute loss if targets is present instead of checking for self.training

### DIFF
--- a/torchvision/models/detection/generalized_rcnn.py
+++ b/torchvision/models/detection/generalized_rcnn.py
@@ -36,18 +36,21 @@ class GeneralizedRCNN(nn.Module):
 
         Returns:
             result (list[BoxList] or dict[Tensor]): the output from the model.
-                During training, it returns a dict[Tensor] which contains the losses.
-                During testing, it returns list[BoxList] contains additional fields
+                if targets are provided it returns a dict[Tensor] which contains the losses.
+                else it returns list[BoxList] contains additional fields
                 like `scores`, `labels` and `mask` (for Mask R-CNN models).
 
         """
         if self.training and targets is None:
             raise ValueError("In training mode, targets should be passed")
+
         original_image_sizes = [img.shape[-2:] for img in images]
         images, targets = self.transform(images, targets)
         features = self.backbone(images.tensors)
+
         if isinstance(features, torch.Tensor):
             features = OrderedDict([(0, features)])
+
         proposals, proposal_losses = self.rpn(images, features, targets)
         detections, detector_losses = self.roi_heads(features, proposals, images.image_sizes, targets)
         detections = self.transform.postprocess(detections, images.image_sizes, original_image_sizes)
@@ -56,7 +59,4 @@ class GeneralizedRCNN(nn.Module):
         losses.update(detector_losses)
         losses.update(proposal_losses)
 
-        if self.training:
-            return losses
-
-        return detections
+        return losses, detections

--- a/torchvision/models/detection/rpn.py
+++ b/torchvision/models/detection/rpn.py
@@ -436,7 +436,7 @@ class RegionProposalNetwork(torch.nn.Module):
         boxes, scores = self.filter_proposals(proposals, objectness, images.image_sizes, num_anchors_per_level)
 
         losses = {}
-        if self.training:
+        if targets:
             labels, matched_gt_boxes = self.assign_targets_to_anchors(anchors, targets)
             regression_targets = self.box_coder.encode(matched_gt_boxes, anchors)
             loss_objectness, loss_rpn_box_reg = self.compute_loss(


### PR DESCRIPTION
Fix for #1574 

Why:
Current code assume that loss is only useful in training mode.
This is not true, users might want validation and test loss.

How:
1. We replace current logic of checking for training mode by checking if targets are provided.
If targets are provided then we assume users are interested in loss.

2. We always return a loss dictionary even if it is empty.
This makes the API consistent and users do not have to change code between eval and training mode
