### PR TITLE
[BC-breaking] Update KeypointRCNN weights

### DIFF
--- a/torchvision/models/detection/keypoint_rcnn.py
+++ b/torchvision/models/detection/keypoint_rcnn.py
@@ -262,7 +262,7 @@ model_urls = {
     'keypointrcnn_resnet50_fpn_coco_legacy':
         'https://download.pytorch.org/models/keypointrcnn_resnet50_fpn_coco-9f466800.pth',
     'keypointrcnn_resnet50_fpn_coco':
-        'https://download.pytorch.org/models/keypointrcnn_resnet50_fpn_coco-28dcbd4f.pth',
+        'https://download.pytorch.org/models/keypointrcnn_resnet50_fpn_coco-a6cb4ff4.pth',
 }
 
 

--- a/torchvision/models/detection/keypoint_rcnn.py
+++ b/torchvision/models/detection/keypoint_rcnn.py
@@ -262,7 +262,7 @@ model_urls = {
     'keypointrcnn_resnet50_fpn_coco_legacy':
         'https://download.pytorch.org/models/keypointrcnn_resnet50_fpn_coco-9f466800.pth',
     'keypointrcnn_resnet50_fpn_coco':
-        'https://download.pytorch.org/models/keypointrcnn_resnet50_fpn_coco-a6cb4ff4.pth',
+        'https://download.pytorch.org/models/keypointrcnn_resnet50_fpn_coco-fc266e95.pth',
 }
 
 

--- a/torchvision/models/detection/keypoint_rcnn.py
+++ b/torchvision/models/detection/keypoint_rcnn.py
@@ -258,8 +258,11 @@ class KeypointRCNNPredictor(nn.Module):
 
 
 model_urls = {
-    'keypointrcnn_resnet50_fpn_coco':
+    # legacy model for BC reasons, see https://github.com/pytorch/vision/issues/1606
+    'keypointrcnn_resnet50_fpn_coco_legacy':
         'https://download.pytorch.org/models/keypointrcnn_resnet50_fpn_coco-9f466800.pth',
+    'keypointrcnn_resnet50_fpn_coco':
+        'https://download.pytorch.org/models/keypointrcnn_resnet50_fpn_coco-28dcbd4f.pth',
 }
 
 
@@ -311,7 +314,10 @@ def keypointrcnn_resnet50_fpn(pretrained=False, progress=True,
     backbone = resnet_fpn_backbone('resnet50', pretrained_backbone)
     model = KeypointRCNN(backbone, num_classes, num_keypoints=num_keypoints, **kwargs)
     if pretrained:
-        state_dict = load_state_dict_from_url(model_urls['keypointrcnn_resnet50_fpn_coco'],
+        key = 'keypointrcnn_resnet50_fpn_coco'
+        if pretrained == 'legacy':
+            key += '_legacy'
+        state_dict = load_state_dict_from_url(model_urls[key],
                                               progress=progress)
         model.load_state_dict(state_dict)
     return model


### PR DESCRIPTION
Fixes https://github.com/pytorch/vision/issues/1606

We support old weights by passing `pretrained='legacy'`, but the default behavior is to pick the new set of weights.
As such, this is a BC-breaking change.

So if users relied on the pretrained features from KeypointRCNN for training classifiers (and only saved the classifiers, picking the weight from torchvision pretrained model), they will need to change to `pretrained='legacy'`.