### PR TITLE
Enable ONNX Test for MaskRcnn 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ before_install:
   - pip install typing
   - |
     if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then
-      pip install onnxruntime
+      pip install -q --user -i https://test.pypi.org/simple/ ort-nightly==1.0.0.dev1123
     fi
   - conda install av -c conda-forge
 

--- a/test/test_onnx.py
+++ b/test/test_onnx.py
@@ -329,11 +329,10 @@ class ONNXExporterTester(unittest.TestCase):
 
         assert torch.all(out2.eq(out_trace2))
 
-    @unittest.skip("Disable test until Resize opset 11 is implemented in ONNX Runtime")
     def test_mask_rcnn(self):
         images, test_images = self.get_test_images()
 
-        model = models.detection.mask_rcnn.maskrcnn_resnet50_fpn(pretrained=True)
+        model = models.detection.mask_rcnn.maskrcnn_resnet50_fpn(pretrained=True, min_size=200, max_size=300)
         model.eval()
         model(images)
         self.run_model(model, [(images,), (test_images,)])


### PR DESCRIPTION
MaskRcnn should now be exportable to ONNX.

For more information on exporting this model, follow instructions in : https://github.com/pytorch/vision/pull/1555#issue-336945183