### PR TITLE
Improve similarity reference by adding recall and visualisation

### DIFF
--- a/references/similarity/README.md
+++ b/references/similarity/README.md
@@ -21,6 +21,15 @@ python train.py 			# Runs training script with default args
 
 Running the training script as is should yield 97% accuracy on the FMNIST test set within 10 epochs.
 
+Once you have trained your model, you can visualize the output with the visualization script.
+
+To run the visualisation script:
+
+```bash
+python visualize.py -h # Lists all optional arguments
+python visualize.py --model-path epoch_10__ckpt.pth # Run the default visualisation
+```
+
 ### Loss ###
 `TripletMarginLoss` is a loss function which takes in a triplet of samples. A valid triplet has an:
 

--- a/references/similarity/model.py
+++ b/references/similarity/model.py
@@ -7,7 +7,9 @@ class EmbeddingNet(nn.Module):
     def __init__(self, backbone=None):
         super(EmbeddingNet, self).__init__()
         if backbone is None:
-            backbone = models.resnet50(num_classes=128)
+            backbone = models.resnet50(pretrained=True)
+            num_ftrs = backbone.fc.in_features
+            backbone.fc = nn.Linear(num_ftrs, 128)
 
         self.backbone = backbone
 

--- a/references/similarity/train.py
+++ b/references/similarity/train.py
@@ -164,7 +164,7 @@ def parse_args():
                         help='Number of unique labels/classes per batch')
     parser.add_argument('-k', '--samples-per-label', default=8, type=int,
                         help='Number of samples per label in a batch')
-    parser.add_argument('--eval-batch-size', default=512, type=int)
+    parser.add_argument('--eval-batch-size', default=128, type=int)
     parser.add_argument('--epochs', default=10, type=int, metavar='N',
                         help='Number of training epochs to run')
     parser.add_argument('-j', '--workers', default=4, type=int, metavar='N',

--- a/references/similarity/train.py
+++ b/references/similarity/train.py
@@ -32,8 +32,8 @@ def train_epoch(model, optimizer, criterion, data_loader, device, epoch, print_f
         if i % print_freq == print_freq - 1:
             i += 1
             avg_loss = running_loss / print_freq
-            avg_trip = 100.0 * running_frac_pos_triplets / print_freq
-            print('[{:d}, {:d}] | loss: {:.4f} | % avg hard triplets: {:.2f}%'.format(epoch, i, avg_loss, avg_trip))
+            avg_trip = running_frac_pos_triplets / print_freq
+            print('[{:d}, {:d}] | loss: {:.4f} | % avg hard triplets: {:.2%}%'.format(epoch, i, avg_loss, avg_trip))
             running_loss = 0
             running_frac_pos_triplets = 0
 

--- a/references/similarity/train.py
+++ b/references/similarity/train.py
@@ -48,10 +48,9 @@ def find_best_threshold(dists, targets, device):
             best_thresh = thresh
             best_correct = correct
 
-    accuracy = 100.0 * best_correct / dists.size(0)
+    accuracy = best_correct / dists.size(0)
 
     return best_thresh, accuracy
-
 
 @torch.no_grad()
 def evaluate(model, loader, device):
@@ -77,9 +76,12 @@ def evaluate(model, loader, device):
     dists = dists[mask == 1]
     targets = targets[mask == 1]
 
-    threshold, accuracy = find_best_threshold(dists, targets, device)
+    distance_threshold, distance_accuracy = find_best_threshold(dists, targets, device)
 
-    print('accuracy: {:.3f}%, threshold: {:.2f}'.format(accuracy, threshold))
+    distance_recall = torch.sum(dists[targets == True] < distance_threshold).item()
+    distance_recall /= dists.size(0)
+
+    print('distance accuracy: {:.2%} distance recall: {:.2%}'.format(distance_accuracy, distance_recall))   
 
 
 def save(model, epoch, save_dir, file_name):

--- a/references/similarity/visualize.py
+++ b/references/similarity/visualize.py
@@ -1,0 +1,91 @@
+import argparse
+
+import torch
+from torch.utils.data import DataLoader
+import torchvision.transforms as transforms
+from torchvision.datasets import FashionMNIST
+
+from sklearn import manifold
+import seaborn as sns
+import pandas as pd
+import matplotlib.pyplot as plt
+
+from model import EmbeddingNet
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='PyTorch Embedding Learning Visualisation')
+
+    parser.add_argument('--model-path', type=str, required=True)
+
+    parser.add_argument('--dataset-dir', default='/tmp/fmnist/',
+                        help='FashionMNIST dataset directory path')
+    parser.add_argument('--eval-batch-size', default=128, type=int)
+    parser.add_argument('-j', '--workers', default=4, type=int, metavar='N',
+                        help='Number of data loading workers')
+
+    parser.add_argument('--perplexity', type=int, default=100)
+
+    return parser.parse_args()
+
+@torch.no_grad()
+def evaluate(model, loader, device):
+    model.eval()
+    embeds, labels = [], []
+    dists, targets = None, None
+
+    for data in loader:
+        samples, _labels = data[0].to(device), data[1]
+        out = model(samples)
+        embeds.append(out)
+        labels.append(_labels)
+
+    embeds = torch.cat(embeds, dim=0).cpu().numpy()
+    labels = torch.cat(labels, dim=0).cpu().numpy()
+
+    return embeds, labels
+
+def create_tsne(embedds, perplexity = 100):
+    tsne = manifold.TSNE(n_components=2, init='pca', random_state=0, perplexity=perplexity)
+    return tsne.fit_transform(embedds)
+
+def main(args):
+    device = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
+
+    print('loading model and creating data loader')
+
+    model = EmbeddingNet()
+    model.load_state_dict(torch.load(args.model_path))
+
+    model.to(device)
+
+    transform = transforms.Compose([transforms.Lambda(lambda image: image.convert('RGB')),
+                                    transforms.Resize((224, 224)),
+                                    transforms.ToTensor()])
+
+    test_dataset = FashionMNIST(args.dataset_dir, train=False, transform=transform, download=True)
+    print('fashion mnist classes: {}'.format(test_dataset.classes))
+
+    test_loader = DataLoader(test_dataset, batch_size=args.eval_batch_size,
+                             shuffle=False,
+                             num_workers=args.workers)
+
+
+    print('evaluating model on test dataset')
+    embeds, labels = evaluate(model, test_loader, device)
+
+    print('computing 2D embedding')
+    embeds2D = create_tsne(embeds, args.perplexity)
+
+    data = pd.DataFrame({'x': embeds2D[:, 0], 'y': embeds2D[:, 1], 'label': labels})
+    data['class'] = data['label'].map(lambda i: test_dataset.classes[i])
+    
+    plot = sns.scatterplot(x='x', y='y', hue='class', data=data)
+    plot.figure.savefig('fashion_mnist_embedding.png')
+
+    plt.show()
+
+if __name__ == '__main__':
+    args = parse_args()
+    main(args)
+
+    


### PR DESCRIPTION
This PR added recall and F1 score metrics to the evaluation function in the similarity reference example. The recall was surprisingly low; after training for ten epochs the metrics were, 

accuracy: 97.13% recall: 8.33% f1: 0.15
 
. This makes sense as our pair-wise distances are highly imbalanced with only ~10% of distances being between samples of the same class. The `find_best_threshold` function was then modified to maximise the F1 score instead of just accuracy. 

threshold: 1.07 accuracy: 86.05% recall: 9.91% f1: 0.18

This was a slight improvement; the confusion is more obvious I've added a visualisation script that shows a t-sne embedding of the feature vectors produced by the EmbeddingModel. It shows that the model gets confused between similar classes, T-Shirt & Shirt, Sneakers & Ankle Boot, ect. 

![fashion_mnist_embedding](https://user-images.githubusercontent.com/7763205/69834718-16e61c00-1234-11ea-9964-b32353ffc53c.png)

The visualisation script adds dependencies on sklearn, matplotlib, pandas, and seaborn (I was lazy). 

This PR also;
- 09ae7be reduces the default `--eval-batch-size` from 512 to 128, which is a better default for most GPUs. Kept on getting out of memory errors on an 8GB GTX 1070. 
- 458d742 swapping to .2% str format




