### PR TITLE
Fix DeformConv2d creation with integer kernel size

### DIFF
--- a/torchvision/ops/deform_conv.py
+++ b/torchvision/ops/deform_conv.py
@@ -79,7 +79,8 @@ class DeformConv2d(nn.Module):
         self.groups = groups
         self.offset_groups = offset_groups
 
-        self.weight = Parameter(torch.empty(out_channels, in_channels // groups, kernel_size[0], kernel_size[1]))
+        self.weight = Parameter(torch.empty(out_channels, in_channels // groups,
+                                            self.kernel_size[0], self.kernel_size[1]))
 
         if bias:
             self.bias = Parameter(torch.empty(out_channels))


### PR DESCRIPTION
When the kernel size for `DeformConv2d` is given as an integer, it is ensured to be a tuple with `self.kernel_size = _pair(kernel_size)`, but the weight was using the original input instead of the guaranteed pair, which failed because int is not subscriptable.