### PR TITLE
Improve error message and avoid segfault in DeformConv2d

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -467,11 +467,9 @@ class DeformConvTester(OpTester, unittest.TestCase):
         out_channels = 2
         kernel_size = (3, 2)
         groups = 2
-        offset_groups = 3
 
         layer = ops.DeformConv2d(in_channels, out_channels, kernel_size, stride=stride, padding=padding,
-                                 dilation=dilation, groups=groups, offset_groups=offset_groups).to(device=x.device,
-                                                                                                   dtype=x.dtype)
+                                 dilation=dilation, groups=groups).to(device=x.device, dtype=x.dtype)
         res = layer(x, offset)
 
         weight = layer.weight.data
@@ -479,6 +477,11 @@ class DeformConvTester(OpTester, unittest.TestCase):
         expected = self.expected_fn(x, weight, offset, bias, stride=stride, padding=padding, dilation=dilation)
 
         self.assertTrue(torch.allclose(res, expected), '\nres:\n{}\nexpected:\n{}'.format(res, expected))
+
+        # test for wrong sizes
+        with self.assertRaises(RuntimeError):
+            wrong_offset = torch.rand_like(offset[:, :2])
+            res = layer(x, wrong_offset)
 
     def _test_backward(self, device, contiguous):
         x, weight, offset, bias, stride, padding, dilation = self.get_fn_args(device, contiguous)

--- a/torchvision/csrc/cpu/DeformConv_cpu.cpp
+++ b/torchvision/csrc/cpu/DeformConv_cpu.cpp
@@ -296,16 +296,16 @@ at::Tensor DeformConv2d_forward_cpu(
 
   TORCH_CHECK(weight.size(1) * n_weight_grps == input.size(1));
   TORCH_CHECK(weight.size(0) % n_weight_grps == 0);
+  TORCH_CHECK(
+      (offset.size(1) == n_offset_grps * 2 * weight_h * weight_w),
+      "offset.shape[1] is not valid: got: ",
+      offset.size(1),
+      " expected: ",
+      n_offset_grps * 2 * weight_h * weight_w);
   TORCH_CHECK(input.size(1) % n_offset_grps == 0);
 
   TORCH_CHECK(
       (offset.size(0) == input.size(0)), "invalid batch size of offset");
-  TORCH_CHECK(
-      (offset.size(1) == n_offset_grps * 2 * weight_h * weight_w),
-      "got: ",
-      offset.size(1),
-      " expected: ",
-      n_offset_grps * 2 * weight_h * weight_w);
   TORCH_CHECK(
       (offset.size(2) == out_h && offset.size(3) == out_w),
       "offset output dims: (",

--- a/torchvision/csrc/cuda/DeformConv_cuda.cu
+++ b/torchvision/csrc/cuda/DeformConv_cuda.cu
@@ -314,16 +314,16 @@ at::Tensor DeformConv2d_forward_cuda(
 
   TORCH_CHECK(weight.size(1) * n_weight_grps == input.size(1));
   TORCH_CHECK(weight.size(0) % n_weight_grps == 0);
+  TORCH_CHECK(
+      (offset.size(1) == n_offset_grps * 2 * weight_h * weight_w),
+      "offset.shape[1] is not valid: got: ",
+      offset.size(1),
+      " expected: ",
+      n_offset_grps * 2 * weight_h * weight_w);
   TORCH_CHECK(input.size(1) % n_offset_grps == 0);
 
   TORCH_CHECK(
       (offset.size(0) == input.size(0)), "invalid batch size of offset");
-  TORCH_CHECK(
-      (offset.size(1) == n_offset_grps * 2 * weight_h * weight_w),
-      "got: ",
-      offset.size(1),
-      " expected: ",
-      n_offset_grps * 2 * weight_h * weight_w);
   TORCH_CHECK(
       (offset.size(2) == out_h && offset.size(3) == out_w),
       "offset output dims: (",


### PR DESCRIPTION
Addresses the problem discussed in https://github.com/pytorch/vision/pull/1640

cc @pedrofreire @jungomi 