### PR TITLE
Remove batchnorm in DeepLabV3 ASPPPooling module

### DIFF
--- a/torchvision/models/segmentation/deeplabv3.py
+++ b/torchvision/models/segmentation/deeplabv3.py
@@ -52,7 +52,6 @@ class ASPPPooling(nn.Sequential):
         super(ASPPPooling, self).__init__(
             nn.AdaptiveAvgPool2d(1),
             nn.Conv2d(in_channels, out_channels, 1, bias=False),
-            nn.BatchNorm2d(out_channels),
             nn.ReLU())
 
     def forward(self, x):


### PR DESCRIPTION
DeepLabV3 failed to perform training with an error:
```ValueError: Expected more than 1 value per channel when training, got input size torch.Size([1, 256, 1, 1])```

PyTorch Batch Normalization 2D layer does not support input with spatial shape `1x1`, but `AdaptiveAvgPool2d(1)` [here](https://github.com/pytorch/vision/blob/2d7c0667a5b1f4827a9bed828df20218af2a9081/torchvision/models/segmentation/deeplabv3.py#L53) always produce tensors with such shape.

torch version: 1.2.0