### PR TITLE
Make R-CNN models less verbose in script mode

### DIFF
--- a/torchvision/models/detection/generalized_rcnn.py
+++ b/torchvision/models/detection/generalized_rcnn.py
@@ -77,7 +77,7 @@ class GeneralizedRCNN(nn.Module):
 
         if torch.jit.is_scripting():
             if not self._has_warned:
-                warnings.warn("RCNN always returns a (Losses, Detections tuple in scripting)")
+                warnings.warn("RCNN always returns a (Losses, Detections) tuple in scripting")
                 self._has_warned = True
             return (losses, detections)
         else:

--- a/torchvision/models/detection/generalized_rcnn.py
+++ b/torchvision/models/detection/generalized_rcnn.py
@@ -30,6 +30,8 @@ class GeneralizedRCNN(nn.Module):
         self.backbone = backbone
         self.rpn = rpn
         self.roi_heads = roi_heads
+        # used only on torchscript mode
+        self._has_warned = False
 
     @torch.jit.unused
     def eager_outputs(self, losses, detections):
@@ -74,7 +76,9 @@ class GeneralizedRCNN(nn.Module):
         losses.update(proposal_losses)
 
         if torch.jit.is_scripting():
-            warnings.warn("RCNN always returns a (Losses, Detections tuple in scripting)")
+            if not self._has_warned:
+                warnings.warn("RCNN always returns a (Losses, Detections tuple in scripting)")
+                self._has_warned = True
             return (losses, detections)
         else:
             return self.eager_outputs(losses, detections)


### PR DESCRIPTION
We don't need to print a warning at every forward.

Additionally, I'm thinking about adding an option for the release after this one to allow for returning both the losses and the targets, including in eager mode.
But the details should be fleshed out a bit, so I'm keeping this as is for now