### PR TITLE
[BC-breaking] Change pts_unit to sec

### DIFF
--- a/torchvision/io/_video_opt.py
+++ b/torchvision/io/_video_opt.py
@@ -347,7 +347,7 @@ def _probe_video_from_memory(video_data):
     return info
 
 
-def _read_video(filename, start_pts=0, end_pts=None, pts_unit='pts'):
+def _read_video(filename, start_pts=0, end_pts=None, pts_unit='sec'):
     if end_pts is None:
         end_pts = float("inf")
 
@@ -401,7 +401,7 @@ def _read_video(filename, start_pts=0, end_pts=None, pts_unit='pts'):
     return vframes, aframes, _info
 
 
-def _read_video_timestamps(filename, pts_unit='pts'):
+def _read_video_timestamps(filename, pts_unit='sec'):
     if pts_unit == 'pts':
         warnings.warn("The pts_unit 'pts' gives wrong results and will be removed in a " +
                       "follow-up version. Please use pts_unit 'sec'.")

--- a/torchvision/io/video.py
+++ b/torchvision/io/video.py
@@ -177,7 +177,7 @@ def _align_audio_frames(aframes, audio_frames, ref_start, ref_end):
     return aframes[:, s_idx:e_idx]
 
 
-def read_video(filename, start_pts=0, end_pts=None, pts_unit='pts'):
+def read_video(filename, start_pts=0, end_pts=None, pts_unit='sec'):
     """
     Reads a video from a file, returning both the video frames as well as
     the audio frames
@@ -272,7 +272,7 @@ def _can_read_timestamps_from_packets(container):
     return False
 
 
-def read_video_timestamps(filename, pts_unit='pts'):
+def read_video_timestamps(filename, pts_unit='sec'):
     """
     List the video frames timestamps.
 


### PR DESCRIPTION
We have had at least one release with `pts_unit='pts'`, and this gives wrong results for audio (it can be unaligned).

This is a BC-breaking change because now we will need to recreate the cache for video datasets, but it's a better thing to do in the long run because of the AV sync issues.

cc @bjuncek @jguerin-fb @stephenyan1231 