### PR TITLE
UCF101 fails if root directory ends in "/"

### DIFF
--- a/torchvision/datasets/kinetics.py
+++ b/torchvision/datasets/kinetics.py
@@ -1,5 +1,5 @@
-from .utils import list_dir
 from .folder import make_dataset
+from .utils import list_dir
 from .video_utils import VideoClips
 from .vision import VisionDataset
 
@@ -74,6 +74,10 @@ class Kinetics400(VisionDataset):
         label = self.samples[video_idx][1]
 
         if self.transform is not None:
-            video = self.transform(video)
+            transformed_video = []
+            for counter, image in enumerate(video):
+                image = self.transform(image)
+                transformed_video.append(image)
+            video = torch.stack(transformed_video)
 
         return video, audio, label

--- a/torchvision/datasets/ucf101.py
+++ b/torchvision/datasets/ucf101.py
@@ -1,5 +1,6 @@
 import glob
 import os
+from pathlib import Path
 
 from .utils import list_dir
 from .folder import make_dataset
@@ -91,8 +92,11 @@ class UCF101(VisionDataset):
             data = [x[0] for x in data]
             selected_files.extend(data)
         selected_files = set(selected_files)
-        #Remove root directory from selected_files, if the resulting video is in selected_files, add its index
-        indices = [i for i in range(len(video_list)) if video_list[i][len(self.root) + 0:] in selected_files]
+        indices = []
+        for i in range(len(video_list)):
+            path = Path(video_list[i])
+            if str(path.relative_to(path.parent.parent)) in selected_files:
+                indices.append(i)
         return indices
 
     def __len__(self):

--- a/torchvision/datasets/ucf101.py
+++ b/torchvision/datasets/ucf101.py
@@ -91,7 +91,8 @@ class UCF101(VisionDataset):
             data = [x[0] for x in data]
             selected_files.extend(data)
         selected_files = set(selected_files)
-        indices = [i for i in range(len(video_list)) if video_list[i][len(self.root) + 1:] in selected_files]
+        #Remove root directory from selected_files, if the resulting video is in selected_files, add its index
+        indices = [i for i in range(len(video_list)) if video_list[i][len(self.root) + 0:] in selected_files]
         return indices
 
     def __len__(self):

--- a/torchvision/datasets/ucf101.py
+++ b/torchvision/datasets/ucf101.py
@@ -2,8 +2,10 @@ import glob
 import os
 from pathlib import Path
 
-from .utils import list_dir
+import torch
+
 from .folder import make_dataset
+from .utils import list_dir
 from .video_utils import VideoClips
 from .vision import VisionDataset
 
@@ -98,7 +100,6 @@ class UCF101(VisionDataset):
             if str(path.relative_to(path.parent.parent)) in selected_files:
                 indices.append(i)
         return indices
-
     def __len__(self):
         return self.video_clips.num_clips()
 
@@ -107,6 +108,10 @@ class UCF101(VisionDataset):
         label = self.samples[self.indices[video_idx]][1]
 
         if self.transform is not None:
-            video = self.transform(video)
+            transformed_video = []
+            for counter, image in enumerate(video):
+                image = self.transform(image)
+                transformed_video.append(image)
+            video = torch.stack(transformed_video)
 
         return video, audio, label


### PR DESCRIPTION
Previously when the UCF101 dataset was trying to find indices, if the root directory given ended with "/" it would clip the first character of the string that it was looking for which would cause the dataset to fail.

For example, if the dataset was trying to check if "./ucf_data/videos/Bowling/v_Bowling_g06_c01.avi'" index should be added to the indices list, it would instead check if "owling/v_Bowling_g06_c01.avi' is in the set "selected_files". 

Changing the 1: to a 0: would only allow root directories ending with "/" to pass. So instead I propose using the PathLib library when checking paths.
