### PR TITLE
Add Peak Finding Operation

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -499,6 +499,63 @@ class DeformConvTester(OpTester, unittest.TestCase):
         gradcheck(lambda z, off, wei, bi: script_func(z, off, wei, bi, stride, padding, dilation),
                   (x, offset, weight, bias), nondet_tol=1e-5)
 
+class PeaksMask2D(unittest.TestCase):
+    def test_constant_value(self):
+        heatmap = torch.ones((1, 19, 72, 144))
+
+        peak_mask = ops.peaksmask2D(heatmap, threshold=0.5)
+
+        expt_peak_mask = torch.zeros_like(heatmap, dtype=torch.bool)
+        assert (peak_mask == expt_peak_mask).all()
+
+    def test_constant_high_threshold(self):
+        heatmap = torch.ones((1, 19, 72, 144))
+
+        peak_mask = ops.peaksmask2D(heatmap, threshold=1.1)
+
+        expt_peak_mask = torch.zeros_like(heatmap, dtype=torch.bool)
+        assert (peak_mask == expt_peak_mask).all()
+
+    def test_single_peak(self):
+        heatmap = torch.ones((1, 19, 72, 144))
+        heatmap[0, 5, 10, 12] = 1.2
+
+        peak_mask = ops.peaksmask2D(heatmap, threshold=0.5)
+
+        expt_peak_mask = torch.zeros_like(heatmap, dtype=torch.bool)
+        expt_peak_mask[0, 5, 10, 12] = True
+        assert (peak_mask == expt_peak_mask).all()
+
+    def test_single_peak_high_threshold(self):
+        heatmap = torch.ones((1, 19, 72, 144))
+        heatmap[0, 5, 10, 12] = 1.2
+
+        peak_mask = ops.peaksmask2D(heatmap, threshold=1.3)
+
+        expt_peak_mask = torch.zeros_like(heatmap, dtype=torch.bool)
+        assert (peak_mask == expt_peak_mask).all()
+
+    def test_flat_peak(self):
+        heatmap = torch.ones((1, 19, 72, 144))
+        heatmap[0, 5, 10, 12] = 1.2
+        heatmap[0, 5, 11, 12] = 1.2
+
+        peak_mask = ops.peaksmask2D(heatmap, threshold=0.5)
+
+        expt_peak_mask = torch.zeros_like(heatmap, dtype=torch.bool)
+        expt_peak_mask[0, 5, 10, 12] = True
+        assert (peak_mask == expt_peak_mask).all()
+
+    def test_flat_peak_high_threshold(self):
+        heatmap = torch.ones((1, 19, 72, 144))
+        heatmap[0, 5, 10, 12] = 1.2
+        heatmap[0, 5, 11, 12] = 1.2
+
+        peak_mask = ops.peaksmask2D(heatmap, threshold=1.3)
+
+        expt_peak_mask = torch.zeros_like(heatmap, dtype=torch.bool)
+        assert (peak_mask == expt_peak_mask).all()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/torchvision/ops/__init__.py
+++ b/torchvision/ops/__init__.py
@@ -7,6 +7,7 @@ from .ps_roi_align import ps_roi_align, PSRoIAlign
 from .ps_roi_pool import ps_roi_pool, PSRoIPool
 from .poolers import MultiScaleRoIAlign
 from .feature_pyramid_network import FeaturePyramidNetwork
+from .peak_detection import peaksmask2D
 
 from ._register_onnx_ops import _register_custom_op
 
@@ -16,5 +17,5 @@ _register_custom_op()
 __all__ = [
     'deform_conv2d', 'DeformConv2d', 'nms', 'roi_align', 'RoIAlign', 'roi_pool',
     'RoIPool', '_new_empty_tensor', 'ps_roi_align', 'PSRoIAlign', 'ps_roi_pool',
-    'PSRoIPool', 'MultiScaleRoIAlign', 'FeaturePyramidNetwork'
+    'PSRoIPool', 'MultiScaleRoIAlign', 'FeaturePyramidNetwork', 'peaksmask2D'
 ]

--- a/torchvision/ops/peak_detection.py
+++ b/torchvision/ops/peak_detection.py
@@ -1,0 +1,51 @@
+import torch
+
+def peaksmask2D(heatmap: torch.tensor, threshold: float):
+    """
+    Performs peak detection across a batch of 2D heatmaps with a 3x3 window. Peaks cannot be found on
+    pixels bordering the image. 
+
+    Arguments:
+        heatmap (Tensor[batch_size, in_channels, in_height, in_width]): input tensor
+        threshold (float): the minimum magnitude of the peak
+
+    Returns:
+        output (Tensor[batch_size, in_channels, in_height, in_width]): boolean mask of where the peaks are
+
+    Examples::
+        >>> # in ObjectsAsPoitnts you use peaks in heatmap to lookup
+        >>> # the value in boxes and offsets;
+        >>> heatmaps, boxes, offsets = model(images)
+        >>> peaks = peaks2D_mask(heatmaps)
+        >>> # now use our peak mask to extract values
+        >>> bbox_shapes = boxes[peaks]
+        >>> bbox_offsets = offsets[peaks]
+        >>> confidences = heatmaps[peaks]
+    """
+
+    heatmap_top_left = heatmap[:, :, :-2, :-2]
+    heatmap_top = heatmap[:, :, :-2, 1:-1]
+    heatmap_top_right = heatmap[:, :, :-2, 2:]
+
+    heatmap_left = heatmap[:, :, 1:-1, :-2]
+    heatmap_crop = heatmap[:, :, 1:-1, 1:-1]
+    heatmap_right = heatmap[:, :, 1:-1, 2:]
+
+    heatmap_bottom_left = heatmap[:, :, 2:, :-2]
+    heatmap_bottom = heatmap[:, :, 2:, 1:-1]
+    heatmap_bottom_right = heatmap[:, :, 2:, 2:]
+
+    is_peak = heatmap_crop > threshold
+    is_peak &= heatmap_top_left < heatmap_crop
+    is_peak &= heatmap_top < heatmap_crop
+    is_peak &= heatmap_top_right < heatmap_crop
+    is_peak &= heatmap_left < heatmap_crop
+    is_peak &= heatmap_bottom_left < heatmap_crop
+    is_peak &= heatmap_right <= heatmap_crop
+    is_peak &= heatmap_bottom <= heatmap_crop
+    is_peak &= heatmap_bottom_right <= heatmap_crop
+
+    full_is_peak = torch.zeros_like(heatmap, dtype=torch.bool)
+    full_is_peak[:, :, 1:-1, 1:-1] = is_peak
+
+    return full_is_peak


### PR DESCRIPTION
Hey; 

I couldn't find any peak finding operations in torchvision; so I've been converting output heatmaps to numpy arrays and using skimage. I thought it'd be better to just do it in pytorch instead and add it to torchvision! 

Its a common post-processing operation found in a wide range of computer vision models; from pose-estimation to object-detection and learnt image features.

@fmassa - Is this something you're interested in adding? If so I'll add some more test cases.
