### PR TITLE
Fix for loading models with num_batches_tracked in frozen batch norm

### DIFF
--- a/torchvision/ops/misc.py
+++ b/torchvision/ops/misc.py
@@ -130,6 +130,16 @@ class FrozenBatchNorm2d(torch.nn.Module):
         self.register_buffer("running_mean", torch.zeros(n))
         self.register_buffer("running_var", torch.ones(n))
 
+    def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict,
+                              missing_keys, unexpected_keys, error_msgs):
+        num_batches_tracked_key = prefix + 'num_batches_tracked'
+        if num_batches_tracked_key in state_dict:
+            del state_dict[num_batches_tracked_key]
+
+        super(FrozenBatchNorm2d, self)._load_from_state_dict(
+            state_dict, prefix, local_metadata, strict,
+            missing_keys, unexpected_keys, error_msgs)
+
     def forward(self, x):
         # move reshapes to the beginning
         # to make it fuser-friendly


### PR DESCRIPTION
Fixes wide_resnet model loading with frozen batch norm which unlike other resnets have num_batches_tracked buffer. Errors out in load_state_dict without this. Suggested by @fmassa