### PR TITLE
.circleci: Bump python3.7 -> python3.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -349,6 +349,24 @@ workflows:
           cu_version: cu101
           name: binary_linux_wheel_py3.7_cu101
           python_version: '3.7'
+      - binary_linux_wheel:
+          cu_version: cpu
+          name: binary_linux_wheel_py3.8_cpu
+          python_version: '3.8'
+      - binary_linux_wheel:
+          cu_version: cu92
+          name: binary_linux_wheel_py3.8_cu92
+          python_version: '3.8'
+          wheel_docker_image: pytorch/manylinux-cuda92
+      - binary_linux_wheel:
+          cu_version: cu100
+          name: binary_linux_wheel_py3.8_cu100
+          python_version: '3.8'
+          wheel_docker_image: pytorch/manylinux-cuda100
+      - binary_linux_wheel:
+          cu_version: cu101
+          name: binary_linux_wheel_py3.8_cu101
+          python_version: '3.8'
       - binary_macos_wheel:
           cu_version: cpu
           name: binary_macos_wheel_py3.5_cpu
@@ -361,6 +379,10 @@ workflows:
           cu_version: cpu
           name: binary_macos_wheel_py3.7_cpu
           python_version: '3.7'
+      - binary_macos_wheel:
+          cu_version: cpu
+          name: binary_macos_wheel_py3.8_cpu
+          python_version: '3.8'
       - binary_linux_conda:
           cu_version: cpu
           name: binary_linux_conda_py3.5_cpu
@@ -415,6 +437,24 @@ workflows:
           cu_version: cu101
           name: binary_linux_conda_py3.7_cu101
           python_version: '3.7'
+      - binary_linux_conda:
+          cu_version: cpu
+          name: binary_linux_conda_py3.8_cpu
+          python_version: '3.8'
+      - binary_linux_conda:
+          cu_version: cu92
+          name: binary_linux_conda_py3.8_cu92
+          python_version: '3.8'
+          wheel_docker_image: pytorch/manylinux-cuda92
+      - binary_linux_conda:
+          cu_version: cu100
+          name: binary_linux_conda_py3.8_cu100
+          python_version: '3.8'
+          wheel_docker_image: pytorch/manylinux-cuda100
+      - binary_linux_conda:
+          cu_version: cu101
+          name: binary_linux_conda_py3.8_cu101
+          python_version: '3.8'
       - binary_macos_conda:
           cu_version: cpu
           name: binary_macos_conda_py3.5_cpu
@@ -427,6 +467,10 @@ workflows:
           cu_version: cpu
           name: binary_macos_conda_py3.7_cpu
           python_version: '3.7'
+      - binary_macos_conda:
+          cu_version: cpu
+          name: binary_macos_conda_py3.8_cpu
+          python_version: '3.8'
       - binary_linux_conda_cuda:
           name: torchvision_linux_py3.7_cu100
           python_version: "3.7"
@@ -641,6 +685,72 @@ workflows:
           requires:
           - nightly_binary_linux_wheel_py3.7_cu101
           subfolder: cu101/
+      - binary_linux_wheel:
+          cu_version: cpu
+          filters:
+            branches:
+              only: nightly
+          name: nightly_binary_linux_wheel_py3.8_cpu
+          python_version: '3.8'
+      - binary_wheel_upload:
+          context: org-member
+          filters:
+            branches:
+              only: nightly
+          name: nightly_binary_linux_wheel_py3.8_cpu_upload
+          requires:
+          - nightly_binary_linux_wheel_py3.8_cpu
+          subfolder: cpu/
+      - binary_linux_wheel:
+          cu_version: cu92
+          filters:
+            branches:
+              only: nightly
+          name: nightly_binary_linux_wheel_py3.8_cu92
+          python_version: '3.8'
+          wheel_docker_image: pytorch/manylinux-cuda92
+      - binary_wheel_upload:
+          context: org-member
+          filters:
+            branches:
+              only: nightly
+          name: nightly_binary_linux_wheel_py3.8_cu92_upload
+          requires:
+          - nightly_binary_linux_wheel_py3.8_cu92
+          subfolder: cu92/
+      - binary_linux_wheel:
+          cu_version: cu100
+          filters:
+            branches:
+              only: nightly
+          name: nightly_binary_linux_wheel_py3.8_cu100
+          python_version: '3.8'
+          wheel_docker_image: pytorch/manylinux-cuda100
+      - binary_wheel_upload:
+          context: org-member
+          filters:
+            branches:
+              only: nightly
+          name: nightly_binary_linux_wheel_py3.8_cu100_upload
+          requires:
+          - nightly_binary_linux_wheel_py3.8_cu100
+          subfolder: cu100/
+      - binary_linux_wheel:
+          cu_version: cu101
+          filters:
+            branches:
+              only: nightly
+          name: nightly_binary_linux_wheel_py3.8_cu101
+          python_version: '3.8'
+      - binary_wheel_upload:
+          context: org-member
+          filters:
+            branches:
+              only: nightly
+          name: nightly_binary_linux_wheel_py3.8_cu101_upload
+          requires:
+          - nightly_binary_linux_wheel_py3.8_cu101
+          subfolder: cu101/
       - binary_macos_wheel:
           cu_version: cpu
           filters:
@@ -688,6 +798,22 @@ workflows:
           name: nightly_binary_macos_wheel_py3.7_cpu_upload
           requires:
           - nightly_binary_macos_wheel_py3.7_cpu
+          subfolder: ''
+      - binary_macos_wheel:
+          cu_version: cpu
+          filters:
+            branches:
+              only: nightly
+          name: nightly_binary_macos_wheel_py3.8_cpu
+          python_version: '3.8'
+      - binary_wheel_upload:
+          context: org-member
+          filters:
+            branches:
+              only: nightly
+          name: nightly_binary_macos_wheel_py3.8_cpu_upload
+          requires:
+          - nightly_binary_macos_wheel_py3.8_cpu
           subfolder: ''
       - binary_linux_conda:
           cu_version: cpu
@@ -875,6 +1001,68 @@ workflows:
           name: nightly_binary_linux_conda_py3.7_cu101_upload
           requires:
           - nightly_binary_linux_conda_py3.7_cu101
+      - binary_linux_conda:
+          cu_version: cpu
+          filters:
+            branches:
+              only: nightly
+          name: nightly_binary_linux_conda_py3.8_cpu
+          python_version: '3.8'
+      - binary_conda_upload:
+          context: org-member
+          filters:
+            branches:
+              only: nightly
+          name: nightly_binary_linux_conda_py3.8_cpu_upload
+          requires:
+          - nightly_binary_linux_conda_py3.8_cpu
+      - binary_linux_conda:
+          cu_version: cu92
+          filters:
+            branches:
+              only: nightly
+          name: nightly_binary_linux_conda_py3.8_cu92
+          python_version: '3.8'
+          wheel_docker_image: pytorch/manylinux-cuda92
+      - binary_conda_upload:
+          context: org-member
+          filters:
+            branches:
+              only: nightly
+          name: nightly_binary_linux_conda_py3.8_cu92_upload
+          requires:
+          - nightly_binary_linux_conda_py3.8_cu92
+      - binary_linux_conda:
+          cu_version: cu100
+          filters:
+            branches:
+              only: nightly
+          name: nightly_binary_linux_conda_py3.8_cu100
+          python_version: '3.8'
+          wheel_docker_image: pytorch/manylinux-cuda100
+      - binary_conda_upload:
+          context: org-member
+          filters:
+            branches:
+              only: nightly
+          name: nightly_binary_linux_conda_py3.8_cu100_upload
+          requires:
+          - nightly_binary_linux_conda_py3.8_cu100
+      - binary_linux_conda:
+          cu_version: cu101
+          filters:
+            branches:
+              only: nightly
+          name: nightly_binary_linux_conda_py3.8_cu101
+          python_version: '3.8'
+      - binary_conda_upload:
+          context: org-member
+          filters:
+            branches:
+              only: nightly
+          name: nightly_binary_linux_conda_py3.8_cu101_upload
+          requires:
+          - nightly_binary_linux_conda_py3.8_cu101
       - binary_macos_conda:
           cu_version: cpu
           filters:
@@ -920,3 +1108,18 @@ workflows:
           name: nightly_binary_macos_conda_py3.7_cpu_upload
           requires:
           - nightly_binary_macos_conda_py3.7_cpu
+      - binary_macos_conda:
+          cu_version: cpu
+          filters:
+            branches:
+              only: nightly
+          name: nightly_binary_macos_conda_py3.8_cpu
+          python_version: '3.8'
+      - binary_conda_upload:
+          context: org-member
+          filters:
+            branches:
+              only: nightly
+          name: nightly_binary_macos_conda_py3.8_cpu_upload
+          requires:
+          - nightly_binary_macos_conda_py3.8_cpu

--- a/.circleci/regenerate.py
+++ b/.circleci/regenerate.py
@@ -23,7 +23,7 @@ def workflows(prefix='', filter_branch=None, upload=False, indentation=6):
     w = []
     for btype in ["wheel", "conda"]:
         for os_type in ["linux", "macos"]:
-            for python_version in ["3.5", "3.6", "3.7"]:
+            for python_version in ["3.5", "3.6", "3.7", "3.8"]:
                 for cu_version in (["cpu", "cu92", "cu100", "cu101"] if os_type == "linux" else ["cpu"]):
                     for unicode in ([False, True] if btype == "wheel" and python_version == "2.7" else [False]):
                         w += workflow_pair(

--- a/packaging/pkg_helpers.bash
+++ b/packaging/pkg_helpers.bash
@@ -165,6 +165,7 @@ setup_wheel_python() {
       3.5) python_abi=cp35-cp35m ;;
       3.6) python_abi=cp36-cp36m ;;
       3.7) python_abi=cp37-cp37m ;;
+      3.8) python_abi=cp38-cp38 ;;
       *)
         echo "Unrecognized PYTHON_VERSION=$PYTHON_VERSION"
         exit 1


### PR DESCRIPTION
Adds python 3.8 to the matrix.

Related PRs:
* https://github.com/pytorch/pytorch/pull/31948
* https://github.com/pytorch/audio/pull/397