### PR TITLE
Fix mask-rcnn region proposal netowrk onnx exporting(issue1741)

### DIFF
--- a/torchvision/models/detection/rpn.py
+++ b/torchvision/models/detection/rpn.py
@@ -30,7 +30,7 @@ def _onnx_get_num_anchors_and_pre_nms_top_n(ob, orig_pre_nms_top_n):
 
 @torch.jit.unused
 def _onnx_get_grid_image_sizes(feature_maps, image_list_tensors):
-    # type: (List[Tensor], Tensor) -> Tuple[List[Tensor], Tensor]
+    # type: (List[Tensor], Tensor) -> Tuple[List[List[int]], List[int]]
     from torch.onnx import operators
     grid_sizes = list([operators.shape_as_tensor(feature_map)[-2:] for feature_map in feature_maps])
     image_size = operators.shape_as_tensor(image_list_tensors)[-2:]
@@ -70,9 +70,9 @@ def _onnx_clip_boxes_to_image(boxes, size):
 
 @torch.jit.unused
 def _onnx_get_num_anchors_per_level(objectness):
-    # type: (List(Tensor)) -> (List[Tensor])
+    # type: (List(Tensor)) -> Tuple[List[int]]
     """
-    Number of anchors per level needs to be tensor for onnx exporting.
+    num_anchors_per_level needs to be a list of Tensor for onnx exporting.
     """
     from torch.onnx.operators import shape_as_tensor
     num_anchors_per_level_shape_tensors = [shape_as_tensor(o[0]) for o in objectness]

--- a/torchvision/models/detection/rpn.py
+++ b/torchvision/models/detection/rpn.py
@@ -29,7 +29,7 @@ def _onnx_get_num_anchors_and_pre_nms_top_n(ob, orig_pre_nms_top_n):
 
 @torch.jit.unused
 def _onnx_get_grid_image_sizes(feature_maps, image_list_tensors):
-    # type: (List[Tensor], Tensor) -> Tuple(List[Tensor], Tensor)
+    # type: (List[Tensor], Tensor) -> Tuple[List[Tensor], Tensor]
     from torch.onnx import operators
     grid_sizes = list([operators.shape_as_tensor(feature_map)[-2:] for feature_map in feature_maps])
     image_size = operators.shape_as_tensor(image_list_tensors)[-2:]


### PR DESCRIPTION
Related isssue: #1741

1. Change `strides` from int -> tensor
   `strides` in AnchorGenerator's forward needs to be a tensor for onnx exporting
2. Change `torch.clip` -> `torch.min/max`
    torch.clip is used in box_ops.clip_boxes_to_image. Its arguments are always traced as constants. Use torch.min/max to WAR
3. split -> index
  ` torch.split`'s split_size is traced as constant, Use index to WAR

- The `images_sizes` in the `image_list` are intialized as `List(Tuple(int64, int64))`. We should use tensor instead. 
- Above fixes are only for dynamic_axes in H,W dimension. N dimension is not considered yet.