### PR TITLE
ci: Remove Python 2.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -297,46 +297,6 @@ workflows:
       - circleci_consistency
       - binary_linux_wheel:
           cu_version: cpu
-          name: binary_linux_wheel_py2.7_cpu
-          python_version: '2.7'
-      - binary_linux_wheel:
-          cu_version: cpu
-          name: binary_linux_wheel_py2.7u_cpu
-          python_version: '2.7'
-          unicode_abi: '1'
-      - binary_linux_wheel:
-          cu_version: cu92
-          name: binary_linux_wheel_py2.7_cu92
-          python_version: '2.7'
-          wheel_docker_image: pytorch/manylinux-cuda92
-      - binary_linux_wheel:
-          cu_version: cu92
-          name: binary_linux_wheel_py2.7u_cu92
-          python_version: '2.7'
-          unicode_abi: '1'
-          wheel_docker_image: pytorch/manylinux-cuda92
-      - binary_linux_wheel:
-          cu_version: cu100
-          name: binary_linux_wheel_py2.7_cu100
-          python_version: '2.7'
-          wheel_docker_image: pytorch/manylinux-cuda100
-      - binary_linux_wheel:
-          cu_version: cu100
-          name: binary_linux_wheel_py2.7u_cu100
-          python_version: '2.7'
-          unicode_abi: '1'
-          wheel_docker_image: pytorch/manylinux-cuda100
-      - binary_linux_wheel:
-          cu_version: cu101
-          name: binary_linux_wheel_py2.7_cu101
-          python_version: '2.7'
-      - binary_linux_wheel:
-          cu_version: cu101
-          name: binary_linux_wheel_py2.7u_cu101
-          python_version: '2.7'
-          unicode_abi: '1'
-      - binary_linux_wheel:
-          cu_version: cpu
           name: binary_linux_wheel_py3.5_cpu
           python_version: '3.5'
       - binary_linux_wheel:
@@ -391,15 +351,6 @@ workflows:
           python_version: '3.7'
       - binary_macos_wheel:
           cu_version: cpu
-          name: binary_macos_wheel_py2.7_cpu
-          python_version: '2.7'
-      - binary_macos_wheel:
-          cu_version: cpu
-          name: binary_macos_wheel_py2.7u_cpu
-          python_version: '2.7'
-          unicode_abi: '1'
-      - binary_macos_wheel:
-          cu_version: cpu
           name: binary_macos_wheel_py3.5_cpu
           python_version: '3.5'
       - binary_macos_wheel:
@@ -410,24 +361,6 @@ workflows:
           cu_version: cpu
           name: binary_macos_wheel_py3.7_cpu
           python_version: '3.7'
-      - binary_linux_conda:
-          cu_version: cpu
-          name: binary_linux_conda_py2.7_cpu
-          python_version: '2.7'
-      - binary_linux_conda:
-          cu_version: cu92
-          name: binary_linux_conda_py2.7_cu92
-          python_version: '2.7'
-          wheel_docker_image: pytorch/manylinux-cuda92
-      - binary_linux_conda:
-          cu_version: cu100
-          name: binary_linux_conda_py2.7_cu100
-          python_version: '2.7'
-          wheel_docker_image: pytorch/manylinux-cuda100
-      - binary_linux_conda:
-          cu_version: cu101
-          name: binary_linux_conda_py2.7_cu101
-          python_version: '2.7'
       - binary_linux_conda:
           cu_version: cpu
           name: binary_linux_conda_py3.5_cpu
@@ -484,10 +417,6 @@ workflows:
           python_version: '3.7'
       - binary_macos_conda:
           cu_version: cpu
-          name: binary_macos_conda_py2.7_cpu
-          python_version: '2.7'
-      - binary_macos_conda:
-          cu_version: cpu
           name: binary_macos_conda_py3.5_cpu
           python_version: '3.5'
       - binary_macos_conda:
@@ -514,142 +443,6 @@ workflows:
   nightly:
     jobs:
       - circleci_consistency
-      - binary_linux_wheel:
-          cu_version: cpu
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_linux_wheel_py2.7_cpu
-          python_version: '2.7'
-      - binary_wheel_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_linux_wheel_py2.7_cpu_upload
-          requires:
-          - nightly_binary_linux_wheel_py2.7_cpu
-          subfolder: cpu/
-      - binary_linux_wheel:
-          cu_version: cpu
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_linux_wheel_py2.7u_cpu
-          python_version: '2.7'
-          unicode_abi: '1'
-      - binary_wheel_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_linux_wheel_py2.7u_cpu_upload
-          requires:
-          - nightly_binary_linux_wheel_py2.7u_cpu
-          subfolder: cpu/
-      - binary_linux_wheel:
-          cu_version: cu92
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_linux_wheel_py2.7_cu92
-          python_version: '2.7'
-          wheel_docker_image: pytorch/manylinux-cuda92
-      - binary_wheel_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_linux_wheel_py2.7_cu92_upload
-          requires:
-          - nightly_binary_linux_wheel_py2.7_cu92
-          subfolder: cu92/
-      - binary_linux_wheel:
-          cu_version: cu92
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_linux_wheel_py2.7u_cu92
-          python_version: '2.7'
-          unicode_abi: '1'
-          wheel_docker_image: pytorch/manylinux-cuda92
-      - binary_wheel_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_linux_wheel_py2.7u_cu92_upload
-          requires:
-          - nightly_binary_linux_wheel_py2.7u_cu92
-          subfolder: cu92/
-      - binary_linux_wheel:
-          cu_version: cu100
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_linux_wheel_py2.7_cu100
-          python_version: '2.7'
-          wheel_docker_image: pytorch/manylinux-cuda100
-      - binary_wheel_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_linux_wheel_py2.7_cu100_upload
-          requires:
-          - nightly_binary_linux_wheel_py2.7_cu100
-          subfolder: cu100/
-      - binary_linux_wheel:
-          cu_version: cu100
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_linux_wheel_py2.7u_cu100
-          python_version: '2.7'
-          unicode_abi: '1'
-          wheel_docker_image: pytorch/manylinux-cuda100
-      - binary_wheel_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_linux_wheel_py2.7u_cu100_upload
-          requires:
-          - nightly_binary_linux_wheel_py2.7u_cu100
-          subfolder: cu100/
-      - binary_linux_wheel:
-          cu_version: cu101
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_linux_wheel_py2.7_cu101
-          python_version: '2.7'
-      - binary_wheel_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_linux_wheel_py2.7_cu101_upload
-          requires:
-          - nightly_binary_linux_wheel_py2.7_cu101
-          subfolder: cu101/
-      - binary_linux_wheel:
-          cu_version: cu101
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_linux_wheel_py2.7u_cu101
-          python_version: '2.7'
-          unicode_abi: '1'
-      - binary_wheel_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_linux_wheel_py2.7u_cu101_upload
-          requires:
-          - nightly_binary_linux_wheel_py2.7u_cu101
-          subfolder: cu101/
       - binary_linux_wheel:
           cu_version: cpu
           filters:
@@ -853,39 +646,6 @@ workflows:
           filters:
             branches:
               only: nightly
-          name: nightly_binary_macos_wheel_py2.7_cpu
-          python_version: '2.7'
-      - binary_wheel_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_macos_wheel_py2.7_cpu_upload
-          requires:
-          - nightly_binary_macos_wheel_py2.7_cpu
-          subfolder: ''
-      - binary_macos_wheel:
-          cu_version: cpu
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_macos_wheel_py2.7u_cpu
-          python_version: '2.7'
-          unicode_abi: '1'
-      - binary_wheel_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_macos_wheel_py2.7u_cpu_upload
-          requires:
-          - nightly_binary_macos_wheel_py2.7u_cpu
-          subfolder: ''
-      - binary_macos_wheel:
-          cu_version: cpu
-          filters:
-            branches:
-              only: nightly
           name: nightly_binary_macos_wheel_py3.5_cpu
           python_version: '3.5'
       - binary_wheel_upload:
@@ -929,68 +689,6 @@ workflows:
           requires:
           - nightly_binary_macos_wheel_py3.7_cpu
           subfolder: ''
-      - binary_linux_conda:
-          cu_version: cpu
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_linux_conda_py2.7_cpu
-          python_version: '2.7'
-      - binary_conda_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_linux_conda_py2.7_cpu_upload
-          requires:
-          - nightly_binary_linux_conda_py2.7_cpu
-      - binary_linux_conda:
-          cu_version: cu92
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_linux_conda_py2.7_cu92
-          python_version: '2.7'
-          wheel_docker_image: pytorch/manylinux-cuda92
-      - binary_conda_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_linux_conda_py2.7_cu92_upload
-          requires:
-          - nightly_binary_linux_conda_py2.7_cu92
-      - binary_linux_conda:
-          cu_version: cu100
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_linux_conda_py2.7_cu100
-          python_version: '2.7'
-          wheel_docker_image: pytorch/manylinux-cuda100
-      - binary_conda_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_linux_conda_py2.7_cu100_upload
-          requires:
-          - nightly_binary_linux_conda_py2.7_cu100
-      - binary_linux_conda:
-          cu_version: cu101
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_linux_conda_py2.7_cu101
-          python_version: '2.7'
-      - binary_conda_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_linux_conda_py2.7_cu101_upload
-          requires:
-          - nightly_binary_linux_conda_py2.7_cu101
       - binary_linux_conda:
           cu_version: cpu
           filters:
@@ -1177,21 +875,6 @@ workflows:
           name: nightly_binary_linux_conda_py3.7_cu101_upload
           requires:
           - nightly_binary_linux_conda_py3.7_cu101
-      - binary_macos_conda:
-          cu_version: cpu
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_macos_conda_py2.7_cpu
-          python_version: '2.7'
-      - binary_conda_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_macos_conda_py2.7_cpu_upload
-          requires:
-          - nightly_binary_macos_conda_py2.7_cpu
       - binary_macos_conda:
           cu_version: cpu
           filters:

--- a/.circleci/regenerate.py
+++ b/.circleci/regenerate.py
@@ -23,7 +23,7 @@ def workflows(prefix='', filter_branch=None, upload=False, indentation=6):
     w = []
     for btype in ["wheel", "conda"]:
         for os_type in ["linux", "macos"]:
-            for python_version in ["2.7", "3.5", "3.6", "3.7"]:
+            for python_version in ["3.5", "3.6", "3.7"]:
                 for cu_version in (["cpu", "cu92", "cu100", "cu101"] if os_type == "linux" else ["cpu"]):
                     for unicode in ([False, True] if btype == "wheel" and python_version == "2.7" else [False]):
                         w += workflow_pair(

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,18 +16,10 @@ matrix:
       install: skip
       script: ./travis-scripts/run-clang-format/run-clang-format.py -r torchvision/csrc
     - env: LINT_CHECK
-      python: "2.7"
-      install: pip install flake8 typing
-      script: flake8 --exclude .circleci
-      after_success: []
-    - env: LINT_CHECK
       python: "3.6"
       install: pip install flake8 typing
       script: flake8 .circleci
       after_success: []
-    - python: "2.7"
-      env: IMAGE_BACKEND=Pillow-SIMD
-    - python: "2.7"
     - python: "3.6"
       env: IMAGE_BACKEND=Pillow-SIMD
     - python: "3.6"


### PR DESCRIPTION
Python 2.7 was EOL on January 1, 2020

The last torchvision release to support Python 2.7 was 0.5.0

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>