### PR TITLE
Changes in docstring example for RCNN based models.

### DIFF
--- a/torchvision/models/detection/faster_rcnn.py
+++ b/torchvision/models/detection/faster_rcnn.py
@@ -126,7 +126,7 @@ class FasterRCNN(GeneralizedRCNN):
         >>> # be [0]. More generally, the backbone should return an
         >>> # OrderedDict[Tensor], and in featmap_names you can choose which
         >>> # feature maps to use.
-        >>> roi_pooler = torchvision.ops.MultiScaleRoIAlign(featmap_names=[0],
+        >>> roi_pooler = torchvision.ops.MultiScaleRoIAlign(featmap_names=['0'],
         >>>                                                 output_size=7,
         >>>                                                 sampling_ratio=2)
         >>>

--- a/torchvision/models/detection/faster_rcnn.py
+++ b/torchvision/models/detection/faster_rcnn.py
@@ -123,7 +123,7 @@ class FasterRCNN(GeneralizedRCNN):
         >>> # use to perform the region of interest cropping, as well as
         >>> # the size of the crop after rescaling.
         >>> # if your backbone returns a Tensor, featmap_names is expected to
-        >>> # be [0]. More generally, the backbone should return an
+        >>> # be ['0']. More generally, the backbone should return an
         >>> # OrderedDict[Tensor], and in featmap_names you can choose which
         >>> # feature maps to use.
         >>> roi_pooler = torchvision.ops.MultiScaleRoIAlign(featmap_names=['0'],

--- a/torchvision/models/detection/keypoint_rcnn.py
+++ b/torchvision/models/detection/keypoint_rcnn.py
@@ -129,14 +129,14 @@ class KeypointRCNN(FasterRCNN):
         >>> # be [0]. More generally, the backbone should return an
         >>> # OrderedDict[Tensor], and in featmap_names you can choose which
         >>> # feature maps to use.
-        >>> roi_pooler = torchvision.ops.MultiScaleRoIAlign(featmap_names=[0],
+        >>> roi_pooler = torchvision.ops.MultiScaleRoIAlign(featmap_names=['0'],
         >>>                                                 output_size=7,
         >>>                                                 sampling_ratio=2)
         >>>
-        >>> keypoint_roi_pooler = torchvision.ops.MultiScaleRoIAlign(featmap_names=[0],
+        >>> keypoint_roi_pooler = torchvision.ops.MultiScaleRoIAlign(featmap_names=['0'],
         >>>                                                          output_size=14,
         >>>                                                          sampling_ratio=2)
-        >>> # put the pieces together inside a FasterRCNN model
+        >>> # put the pieces together inside a KeypointRCNN model
         >>> model = KeypointRCNN(backbone,
         >>>                      num_classes=2,
         >>>                      rpn_anchor_generator=anchor_generator,

--- a/torchvision/models/detection/keypoint_rcnn.py
+++ b/torchvision/models/detection/keypoint_rcnn.py
@@ -102,6 +102,7 @@ class KeypointRCNN(FasterRCNN):
 
     Example::
 
+        >>> import torch
         >>> import torchvision
         >>> from torchvision.models.detection import KeypointRCNN
         >>> from torchvision.models.detection.rpn import AnchorGenerator
@@ -126,7 +127,7 @@ class KeypointRCNN(FasterRCNN):
         >>> # use to perform the region of interest cropping, as well as
         >>> # the size of the crop after rescaling.
         >>> # if your backbone returns a Tensor, featmap_names is expected to
-        >>> # be [0]. More generally, the backbone should return an
+        >>> # be ['0']. More generally, the backbone should return an
         >>> # OrderedDict[Tensor], and in featmap_names you can choose which
         >>> # feature maps to use.
         >>> roi_pooler = torchvision.ops.MultiScaleRoIAlign(featmap_names=['0'],

--- a/torchvision/models/detection/mask_rcnn.py
+++ b/torchvision/models/detection/mask_rcnn.py
@@ -104,6 +104,7 @@ class MaskRCNN(FasterRCNN):
 
     Example::
 
+        >>> import torch
         >>> import torchvision
         >>> from torchvision.models.detection import MaskRCNN
         >>> from torchvision.models.detection.rpn import AnchorGenerator
@@ -128,7 +129,7 @@ class MaskRCNN(FasterRCNN):
         >>> # use to perform the region of interest cropping, as well as
         >>> # the size of the crop after rescaling.
         >>> # if your backbone returns a Tensor, featmap_names is expected to
-        >>> # be [0]. More generally, the backbone should return an
+        >>> # be ['0']. More generally, the backbone should return an
         >>> # OrderedDict[Tensor], and in featmap_names you can choose which
         >>> # feature maps to use.
         >>> roi_pooler = torchvision.ops.MultiScaleRoIAlign(featmap_names=['0'],

--- a/torchvision/models/detection/mask_rcnn.py
+++ b/torchvision/models/detection/mask_rcnn.py
@@ -131,14 +131,14 @@ class MaskRCNN(FasterRCNN):
         >>> # be [0]. More generally, the backbone should return an
         >>> # OrderedDict[Tensor], and in featmap_names you can choose which
         >>> # feature maps to use.
-        >>> roi_pooler = torchvision.ops.MultiScaleRoIAlign(featmap_names=[0],
+        >>> roi_pooler = torchvision.ops.MultiScaleRoIAlign(featmap_names=['0'],
         >>>                                                 output_size=7,
         >>>                                                 sampling_ratio=2)
         >>>
-        >>> mask_roi_pooler = torchvision.ops.MultiScaleRoIAlign(featmap_names=[0],
+        >>> mask_roi_pooler = torchvision.ops.MultiScaleRoIAlign(featmap_names=['0'],
         >>>                                                      output_size=14,
         >>>                                                      sampling_ratio=2)
-        >>> # put the pieces together inside a FasterRCNN model
+        >>> # put the pieces together inside a MaskRCNN model
         >>> model = MaskRCNN(backbone,
         >>>                  num_classes=2,
         >>>                  rpn_anchor_generator=anchor_generator,


### PR DESCRIPTION
This pull request corrects the example shown in the docstring of each RCNN based model.<br>
**Changes:**
- MultiscaleRoiAlign's parameter "featmap_names"  should be a list of strings instead a list of integers.
- torch import added.