### PR TITLE
Update README to reflect strict dependency on torch==1.4.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ The torchvision package consists of popular datasets, model architectures, and c
 Installation
 ============
 
-TorchVision requires PyTorch 1.2 or newer.
+TorchVision requires PyTorch 1.4.
 
 Anaconda:
 

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ The torchvision package consists of popular datasets, model architectures, and c
 Installation
 ============
 
-TorchVision requires PyTorch 1.4.
+TorchVision requires PyTorch 1.4 or newer.
 
 Anaconda:
 


### PR DESCRIPTION
This PR addresses #1762, where we found that the README (as of `vision==0.5.0`) was out-of-date with respect to the required `torch` version.