### PR TITLE
conda build only needs typing if python is 3.5

### DIFF
--- a/packaging/conda/build_vision.sh
+++ b/packaging/conda/build_vision.sh
@@ -157,6 +157,12 @@ for py_ver in "${DESIRED_PYTHON[@]}"; do
     rm -rf "$output_folder"
     mkdir "$output_folder"
 
+    if [[ "$py_ver" == 3.5 ]]; then
+	export CONDA_TYPING_CONSTRAINT="- typing"
+    else
+	export CONDA_TYPING_CONSTRAINT=""
+    fi
+
     export VSTOOLCHAIN_PACKAGE=vs2017
 
     # We need to build the compiler activation scripts first on Windows

--- a/packaging/pkg_helpers.bash
+++ b/packaging/pkg_helpers.bash
@@ -115,6 +115,15 @@ setup_macos() {
   fi
 }
 
+# set variable to determine whether the typing library needs to be built in
+setup_typing() {
+  if [[ "$PYTHON_VERSION" == 3.5 ]]; then
+    export CONDA_TYPING_CONSTRAINT="- typing"
+  else
+    export CONDA_TYPING_CONSTRAINT=""
+  fi
+}
+
 # Top-level entry point for things every package will need to do
 #
 # Usage: setup_env 0.2.0
@@ -122,6 +131,7 @@ setup_env() {
   setup_cuda
   setup_build_version "$1"
   setup_macos
+  setup_typing
 }
 
 # Function to retry functions that sometimes timeout or have flaky failures

--- a/packaging/torchvision/meta.yaml
+++ b/packaging/torchvision/meta.yaml
@@ -47,7 +47,7 @@ test:
     - mock
     - av
     - ca-certificates
-    - typing
+    {{ environ.get('CONDA_TYPING_CONSTRAINT') }}
   commands:
     pytest .
 


### PR DESCRIPTION
As part of a wider effort to get the build working on Python 3.8, see https://github.com/pytorch/vision/pull/1731, it will be useful to not depend on the `typing` library, which is only useful for Python 3.5 and older.