### PR TITLE
Fixed typo in comments

### DIFF
--- a/torchvision/transforms/transforms.py
+++ b/torchvision/transforms/transforms.py
@@ -147,7 +147,7 @@ class Normalize(object):
     """Normalize a tensor image with mean and standard deviation.
     Given mean: ``(M1,...,Mn)`` and std: ``(S1,..,Sn)`` for ``n`` channels, this transform
     will normalize each channel of the input ``torch.*Tensor`` i.e.
-    ``input[channel] = (input[channel] - mean[channel]) / std[channel]``
+    ``output[channel] = (input[channel] - mean[channel]) / std[channel]``
 
     .. note::
         This transform acts out of place, i.e., it does not mutates the input tensor.


### PR DESCRIPTION
I have fixed a typo that was persent in the Normalize class changed line 150 from     ``input[channel] = (input[channel] - mean[channel]) / std[channel]`` to     ``output[channel] = (input[channel] - mean[channel]) / std[channel]``
This is follow up to https://github.com/pytorch/pytorch/issues/32279