### PR TITLE
Fix interpolate when no scale_factor is passed

### DIFF
--- a/torchvision/ops/misc.py
+++ b/torchvision/ops/misc.py
@@ -77,7 +77,8 @@ def _check_size_scale_factor(dim, size, scale_factor):
         raise ValueError("either size or scale_factor should be defined")
     if size is not None and scale_factor is not None:
         raise ValueError("only one of size or scale_factor should be defined")
-    if not (scale_factor is not None and len(scale_factor) != dim):
+    if scale_factor is not None and isinstance(scale_factor, tuple)\
+            and len(scale_factor) != dim:
         raise ValueError(
             "scale_factor shape must match input shape. "
             "Input is {}D, scale_factor size is {}".format(dim, len(scale_factor))


### PR DESCRIPTION
Reported by @alcinos

This was introduced in #1407, let's see if torchscript supports `isinstance(..., tuple)`, or else we might need to find another workaround (or remove this last check altogether)