### PR TITLE
update dead LSUN link (#1626)

### DIFF
--- a/torchvision/datasets/lsun.py
+++ b/torchvision/datasets/lsun.py
@@ -62,7 +62,7 @@ class LSUNClass(VisionDataset):
 
 class LSUN(VisionDataset):
     """
-    `LSUN <http://lsun.cs.princeton.edu>`_ dataset.
+    `LSUN <https://www.yf.io/p/lsun>`_ dataset.
 
     Args:
         root (string): Root directory for the database files.


### PR DESCRIPTION
The current link to the dataset is dead. The change links to the dataset's author's personal page, which describe the dataset and is also referenced at https://github.com/fyu/lsun.