### PR TITLE
Remove unintentional -O0 option in setup.py (#1770)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,7 @@ def get_extensions():
         else:
             nvcc_flags = nvcc_flags.split(' ')
         extra_compile_args = {
-            'cxx': ['-O0'],
+            'cxx': [],
             'nvcc': nvcc_flags,
         }
 


### PR DESCRIPTION
Previously, when doing a CUDA build, we would pass -O0 to build cpu
bits. This PR removes that `-O0` (so we build in `-O3` instead.

Test Plan:
- wait for CI