### PR TITLE
Fix for rotate fill with Images of type F

### DIFF
--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -1078,7 +1078,7 @@ class Tester(unittest.TestCase):
     def test_rotate_fill(self):
         img = F.to_pil_image(np.ones((100, 100, 3), dtype=np.uint8) * 255, "RGB")
 
-        modes = ("L", "RGB")
+        modes = ("L", "RGB", "F")
         nums_bands = [len(mode) for mode in modes]
         fill = 127
 

--- a/torchvision/transforms/functional.py
+++ b/torchvision/transforms/functional.py
@@ -725,9 +725,9 @@ def rotate(img, angle, resample=False, expand=False, center=None, fill=None):
 
         if fill is None:
             fill = 0
-        if isinstance(fill, (int, float)):
+        if isinstance(fill, (int, float)) and num_bands > 1:
             fill = tuple([fill] * num_bands)
-        if len(fill) != num_bands:
+        if not isinstance(fill, (int, float)) and len(fill) != num_bands:
             msg = ("The number of elements in 'fill' does not match the number of "
                    "bands of the image ({} != {})")
             raise ValueError(msg.format(len(fill), num_bands))


### PR DESCRIPTION
Bugfix which was introduced in #1760.

It turns out that whenever the image is of type `F` we can't pass a tuple of one element for `fill` but instead we need indeed to pass it as a number.

cc @pmeier 