### PR TITLE
Update cmake target name in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,12 +75,12 @@ Installation From source:
     make 
     make install
 
-Once installed, the library can be accessed in cmake (after properly configuring ``CMAKE_PREFIX_PATH``) via the :code:`TorchVision::Vision` target:
+Once installed, the library can be accessed in cmake (after properly configuring ``CMAKE_PREFIX_PATH``) via the :code:`TorchVision::TorchVision` target:
 
 .. code:: rest
 
 	find_package(TorchVision REQUIRED)
-	target_link_libraries(my-target TorchVision::Vision)
+	target_link_libraries(my-target PUBLIC TorchVision::TorchVision)
 
 The ``TorchVision`` package will also automatically look for the ``Torch`` and ``pybind11`` packages and add them as dependencies to ``my-target``,
 so make sure that they are also available to cmake via the ``CMAKE_PREFIX_PATH``.


### PR DESCRIPTION
I had forgotten to update the README after the cmake target renaming, this addresses it.
