### PR TITLE
replaced mean on dimensions 2,3 by adaptive_avg_pooling2d 

### DIFF
--- a/torchvision/models/mobilenet.py
+++ b/torchvision/models/mobilenet.py
@@ -1,3 +1,4 @@
+import torch
 from torch import nn
 from .utils import load_state_dict_from_url
 
@@ -151,7 +152,7 @@ class MobileNetV2(nn.Module):
         # This exists since TorchScript doesn't support inheritance, so the superclass method
         # (this one) needs to have a name other than `forward` that can be accessed in a subclass
         x = self.features(x)
-        x = nn.functional.adaptive_avg_pool2d(x, 1).reshape(x.shape[0], -1)
+        x = torch.squeeze(nn.functional.adaptive_avg_pool2d(x, 1))
         x = self.classifier(x)
         return x
 

--- a/torchvision/models/mobilenet.py
+++ b/torchvision/models/mobilenet.py
@@ -1,4 +1,3 @@
-import torch
 from torch import nn
 from .utils import load_state_dict_from_url
 

--- a/torchvision/models/mobilenet.py
+++ b/torchvision/models/mobilenet.py
@@ -152,7 +152,8 @@ class MobileNetV2(nn.Module):
         # This exists since TorchScript doesn't support inheritance, so the superclass method
         # (this one) needs to have a name other than `forward` that can be accessed in a subclass
         x = self.features(x)
-        x = torch.squeeze(nn.functional.adaptive_avg_pool2d(x, 1))
+        # Cannot use "squeeze" as batch-size can be 1 => must use reshape with x.shape[0]
+        x = nn.functional.adaptive_avg_pool2d(x, 1).reshape(x.shape[0], -1)
         x = self.classifier(x)
         return x
 

--- a/torchvision/models/mobilenet.py
+++ b/torchvision/models/mobilenet.py
@@ -151,7 +151,7 @@ class MobileNetV2(nn.Module):
         # This exists since TorchScript doesn't support inheritance, so the superclass method
         # (this one) needs to have a name other than `forward` that can be accessed in a subclass
         x = self.features(x)
-        x = x.mean([2, 3])
+        x = nn.functional.adaptive_avg_pool2d(x, 1).reshape(x.shape[0], -1)
         x = self.classifier(x)
         return x
 


### PR DESCRIPTION
with destination of 1 (which is a Pytorch way to implement GlobalAvgPooling2D), to remove hardcoded dimension ordering