### PR TITLE
Add vision.cpp in libtorchvision.so

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,10 +34,6 @@ include(CMakePackageConfigHelpers)
 
 set(TORCHVISION_CMAKECONFIG_INSTALL_DIR "share/cmake/TorchVision" CACHE STRING "install path for TorchVisionConfig.cmake")
 
-if(NOT CMAKE_INSTALL_LIBDIR)
-  set(CMAKE_INSTALL_LIBDIR lib)
-endif()
-
 configure_package_config_file(cmake/TorchVisionConfig.cmake.in
   "${CMAKE_CURRENT_BINARY_DIR}/TorchVisionConfig.cmake"
   INSTALL_DESTINATION ${TORCHVISION_CMAKECONFIG_INSTALL_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ find_package(Torch REQUIRED)
 find_package(pybind11 REQUIRED)
 
 file(GLOB HEADERS torchvision/csrc/*.h)
-file(GLOB OPERATOR_SOURCES torchvision/csrc/cpu/*.h torchvision/csrc/cpu/*.cpp)
+file(GLOB OPERATOR_SOURCES torchvision/csrc/cpu/*.h torchvision/csrc/cpu/*.cpp torchvision/csrc/*.cpp)
 if(WITH_CUDA)
   file(GLOB OPERATOR_SOURCES ${OPERATOR_SOURCES} torchvision/csrc/cuda/*.h torchvision/csrc/cuda/*.cu)
 endif()
@@ -34,6 +34,14 @@ include(CMakePackageConfigHelpers)
 
 set(TORCHVISION_CMAKECONFIG_INSTALL_DIR "share/cmake/TorchVision" CACHE STRING "install path for TorchVisionConfig.cmake")
 
+if(NOT TORCHVISION_INSTALL_LIBRARY_DIR)
+  set(TORCHVISION_INSTALL_LIBRARY_DIR lib)
+endif()
+
+if(NOT TORCHVISION_INSTALL_ARCHIVE_DIR)
+  set(TORCHVISION_INSTALL_ARCHIVE_DIR lib)
+endif()
+
 configure_package_config_file(cmake/TorchVisionConfig.cmake.in
   "${CMAKE_CURRENT_BINARY_DIR}/TorchVisionConfig.cmake"
   INSTALL_DESTINATION ${TORCHVISION_CMAKECONFIG_INSTALL_DIR})
@@ -47,7 +55,10 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/TorchVisionConfig.cmake
   DESTINATION ${TORCHVISION_CMAKECONFIG_INSTALL_DIR})
 
 install(TARGETS ${PROJECT_NAME}
-  EXPORT TorchVisionTargets)
+  EXPORT TorchVisionTargets
+  LIBRARY DESTINATION ${TORCHVISION_INSTALL_LIBRARY_DIR}
+  ARCHIVE DESTINATION ${TORCHVISION_INSTALL_ARCHIVE_DIR}
+  )
 
 install(EXPORT TorchVisionTargets
   NAMESPACE TorchVision::

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,12 +34,8 @@ include(CMakePackageConfigHelpers)
 
 set(TORCHVISION_CMAKECONFIG_INSTALL_DIR "share/cmake/TorchVision" CACHE STRING "install path for TorchVisionConfig.cmake")
 
-if(NOT TORCHVISION_INSTALL_LIBRARY_DIR)
-  set(TORCHVISION_INSTALL_LIBRARY_DIR lib)
-endif()
-
-if(NOT TORCHVISION_INSTALL_ARCHIVE_DIR)
-  set(TORCHVISION_INSTALL_ARCHIVE_DIR lib)
+if(NOT CMAKE_INSTALL_LIBDIR)
+  set(CMAKE_INSTALL_LIBDIR lib)
 endif()
 
 configure_package_config_file(cmake/TorchVisionConfig.cmake.in
@@ -56,8 +52,7 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/TorchVisionConfig.cmake
 
 install(TARGETS ${PROJECT_NAME}
   EXPORT TorchVisionTargets
-  LIBRARY DESTINATION ${TORCHVISION_INSTALL_LIBRARY_DIR}
-  ARCHIVE DESTINATION ${TORCHVISION_INSTALL_ARCHIVE_DIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   )
 
 install(EXPORT TorchVisionTargets


### PR DESCRIPTION
Could you include vision.cpp in libtorchvision.so not to register ops by user's code?

When we use maskrcnn in c++, we need to register some ops explicitly.
https://github.com/pytorch/vision/issues/1730
(python's module already includes the registration.)

By this pr, the registration is done automatically.
And c++ user does not need torchvison's include-headers.

In addition to the ops, this pr fixes following cmake's error.

```
$ cmake --version
cmake version 3.13.4
$ cmake ..
CMake Error at CMakeLists.txt:49 (install):
  install TARGETS given no LIBRARY DESTINATION for shared library target
  "torchvision".
```
