### PR TITLE
fixed typo in docs

### DIFF
--- a/torchvision/datasets/cityscapes.py
+++ b/torchvision/datasets/cityscapes.py
@@ -14,9 +14,9 @@ class Cityscapes(VisionDataset):
     Args:
         root (string): Root directory of dataset where directory ``leftImg8bit``
             and ``gtFine`` or ``gtCoarse`` are located.
-        split (string, optional): The image split to use, ``train``, ``test`` or ``val`` if mode="gtFine"
+        split (string, optional): The image split to use, ``train``, ``test`` or ``val`` if mode="fine"
             otherwise ``train``, ``train_extra`` or ``val``
-        mode (string, optional): The quality mode to use, ``gtFine`` or ``gtCoarse``
+        mode (string, optional): The quality mode to use, ``fine`` or ``coarse``
         target_type (string or list, optional): Type of target to use, ``instance``, ``semantic``, ``polygon``
             or ``color``. Can also be a list to output a tuple with all specified target types.
         transform (callable, optional): A function/transform that takes in a PIL image


### PR DESCRIPTION
input to parameter mode can be 'fine' or 'coarse'. The code internally converts the mode = 'fine' input to 'gtFine' (same for coarse input and gtCoarse), but the docs mention that input to mode should be 'gtFine' or 'gtCoarse' inconsistently.