### PR TITLE
Propagate WITH_CUDA macro to target consumers

### DIFF
--- a/cmake/TorchVisionConfig.cmake.in
+++ b/cmake/TorchVisionConfig.cmake.in
@@ -33,5 +33,9 @@ find_package(pybind11 REQUIRED)
 endif()
 target_link_libraries(TorchVision::TorchVision INTERFACE ${TORCH_LIBRARIES} pybind11::pybind11)
 
+if(@WITH_CUDA@)
+  target_compile_definitions(TorchVision::TorchVision INTERFACE WITH_CUDA)
+endif()
+
 endif()
 endif()


### PR DESCRIPTION
Currently we have to manually specify `add_compile_definitions(WITH_CUDA)` in the CMakeLists.txt file of the project that wants to consume the TorchVision target (see #1849).
This updates the CMakeConfig file to automatically propagate the `WITH_CUDA` macro to the target consumers if torchvision was built with cuda support.