### PR TITLE
Skip inception v3 in test/test_quantized_models

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,6 +105,8 @@ jobs:
           root: /opt/conda/conda-bld/linux-64
           paths:
             - "*"
+      - store_test_results:
+          path: build_results/
 
   binary_linux_conda_cuda:
     <<: *binary_common
@@ -190,6 +192,8 @@ jobs:
             conda install -yq conda-build "conda-package-handling!=1.5.0"
             bash packaging/build_conda.sh
           shell: powershell.exe
+      - store_test_results:
+          path: build_results/
 
   binary_win_conda_cuda:
     <<: *binary_common
@@ -246,6 +250,8 @@ jobs:
           root: /Users/distiller/miniconda3/conda-bld/osx-64
           paths:
             - "*"
+      - store_test_results:
+          path: build_results/
 
   # Requires org-member context
   binary_conda_upload:

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -105,6 +105,8 @@ jobs:
           root: /opt/conda/conda-bld/linux-64
           paths:
             - "*"
+      - store_test_results:
+          path: build_results/
 
   binary_linux_conda_cuda:
     <<: *binary_common
@@ -190,6 +192,8 @@ jobs:
             conda install -yq conda-build "conda-package-handling!=1.5.0"
             bash packaging/build_conda.sh
           shell: powershell.exe
+      - store_test_results:
+          path: build_results/
 
   binary_win_conda_cuda:
     <<: *binary_common
@@ -246,6 +250,8 @@ jobs:
           root: /Users/distiller/miniconda3/conda-bld/osx-64
           paths:
             - "*"
+      - store_test_results:
+          path: build_results/
 
   # Requires org-member context
   binary_conda_upload:

--- a/packaging/build_conda.sh
+++ b/packaging/build_conda.sh
@@ -10,4 +10,5 @@ export SOURCE_ROOT_DIR="$PWD"
 setup_conda_pytorch_constraint
 setup_conda_cudatoolkit_constraint
 setup_visual_studio_constraint
+setup_junit_results_folder
 conda build $CONDA_CHANNEL_FLAGS -c defaults -c conda-forge --no-anaconda-upload --python "$PYTHON_VERSION" packaging/torchvision

--- a/packaging/pkg_helpers.bash
+++ b/packaging/pkg_helpers.bash
@@ -270,3 +270,9 @@ setup_visual_studio_constraint() {
       cp packaging/$VSTOOLCHAIN_PACKAGE/conda_build_config.yaml packaging/torchvision/conda_build_config.yaml
   fi
 }
+
+setup_junit_results_folder() {
+  if [[ "$CI" == "true" ]]; then
+    export CONDA_PYTORCH_BUILD_RESULTS_DIRECTORY="${SOURCE_ROOT_DIR}/build_results/results.xml"
+  fi
+}

--- a/packaging/torchvision/meta.yaml
+++ b/packaging/torchvision/meta.yaml
@@ -49,7 +49,7 @@ test:
     - ca-certificates
     {{ environ.get('CONDA_TYPING_CONSTRAINT') }}
   commands:
-    pytest .
+    pytest . --verbose --junitxml={{ environ.get("CONDA_PYTORCH_BUILD_RESULTS_DIRECTORY", "build/test_results.xml" )}}
 
 
 about:

--- a/test/test_quantized_models.py
+++ b/test/test_quantized_models.py
@@ -83,7 +83,10 @@ for model_name in get_available_quantizable_models():
             input_shape = (1, 3, 299, 299)
         self._test_classification_model(model_name, input_shape)
 
-    setattr(ModelTester, "test_" + model_name, do_test)
+    # inception_v3 was causing timeouts on circleci
+    # See https://github.com/pytorch/vision/issues/1857
+    if model_name not in ['inception_v3']:
+        setattr(ModelTester, "test_" + model_name, do_test)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Based off of #1880 

Basically just skips `test_inception_v3` in `test/test_quantized_models.py`.

Relates to:
* #1857 