### PR TITLE
Added missing header for less dependencies.

### DIFF
--- a/torchvision/csrc/cpu/decoder/audio_sampler.h
+++ b/torchvision/csrc/cpu/decoder/audio_sampler.h
@@ -2,10 +2,6 @@
 
 #include "defs.h"
 
-extern "C" {
-#include <libswresample/swresample.h>
-}
-
 namespace ffmpeg {
 
 /**

--- a/torchvision/csrc/cpu/decoder/defs.h
+++ b/torchvision/csrc/cpu/decoder/defs.h
@@ -7,6 +7,16 @@
 #include <unordered_set>
 #include <vector>
 
+extern "C" {
+#include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+#include <libavformat/avio.h>
+#include <libavutil/avutil.h>
+#include <libavutil/imgutils.h>
+#include <libswresample/swresample.h>
+#include "libswscale/swscale.h"
+}
+
 namespace ffmpeg {
 
 // bit mask of formats, keep them in form 2^n

--- a/torchvision/csrc/cpu/decoder/memory_buffer.cpp
+++ b/torchvision/csrc/cpu/decoder/memory_buffer.cpp
@@ -1,10 +1,6 @@
 #include "memory_buffer.h"
 #include <c10/util/Logging.h>
 
-extern "C" {
-#include <libavformat/avio.h>
-}
-
 namespace ffmpeg {
 
 MemoryBuffer::MemoryBuffer(const uint8_t* buffer, size_t size)

--- a/torchvision/csrc/cpu/decoder/seekable_buffer.cpp
+++ b/torchvision/csrc/cpu/decoder/seekable_buffer.cpp
@@ -3,10 +3,6 @@
 #include <chrono>
 #include "memory_buffer.h"
 
-extern "C" {
-#include <libavformat/avio.h>
-}
-
 namespace ffmpeg {
 
 int SeekableBuffer::init(

--- a/torchvision/csrc/cpu/decoder/stream.h
+++ b/torchvision/csrc/cpu/decoder/stream.h
@@ -4,12 +4,6 @@
 #include "defs.h"
 #include "time_keeper.h"
 
-extern "C" {
-#include <libavformat/avformat.h>
-#include <libavformat/avio.h>
-#include <libavutil/imgutils.h>
-}
-
 namespace ffmpeg {
 
 /**

--- a/torchvision/csrc/cpu/decoder/subtitle_sampler.h
+++ b/torchvision/csrc/cpu/decoder/subtitle_sampler.h
@@ -2,10 +2,6 @@
 
 #include "defs.h"
 
-extern "C" {
-#include <libavcodec/avcodec.h>
-}
-
 namespace ffmpeg {
 
 /**

--- a/torchvision/csrc/cpu/decoder/time_keeper.cpp
+++ b/torchvision/csrc/cpu/decoder/time_keeper.cpp
@@ -1,8 +1,5 @@
 #include "time_keeper.h"
-
-extern "C" {
-#include <libavutil/avutil.h>
-}
+#include "defs.h"
 
 namespace ffmpeg {
 

--- a/torchvision/csrc/cpu/decoder/util.h
+++ b/torchvision/csrc/cpu/decoder/util.h
@@ -2,10 +2,6 @@
 
 #include "defs.h"
 
-extern "C" {
-#include <libavcodec/avcodec.h>
-}
-
 namespace ffmpeg {
 
 /**

--- a/torchvision/csrc/cpu/decoder/video_sampler.cpp
+++ b/torchvision/csrc/cpu/decoder/video_sampler.cpp
@@ -2,10 +2,6 @@
 #include <c10/util/Logging.h>
 #include "util.h"
 
-extern "C" {
-#include <libavutil/imgutils.h>
-}
-
 // www.ffmpeg.org/doxygen/0.5/swscale-example_8c-source.html
 
 namespace ffmpeg {

--- a/torchvision/csrc/cpu/decoder/video_sampler.h
+++ b/torchvision/csrc/cpu/decoder/video_sampler.h
@@ -2,11 +2,6 @@
 
 #include "defs.h"
 
-extern "C" {
-#include <libavformat/avformat.h>
-#include "libswscale/swscale.h"
-}
-
 namespace ffmpeg {
 
 /**


### PR DESCRIPTION
Summary: Include streams/samplers shouldn't depend on decoder headers. Add dependencies directly to the place where they are required.

Differential Revision: D19911404

