### PR TITLE
Remove constants from DenseNet (#1721)

### DIFF
--- a/torchvision/models/densenet.py
+++ b/torchvision/models/densenet.py
@@ -139,8 +139,6 @@ class DenseNet(nn.Module):
           but slower. Default: *False*. See `"paper" <https://arxiv.org/pdf/1707.06990.pdf>`_
     """
 
-    __constants__ = ['features']
-
     def __init__(self, growth_rate=32, block_config=(6, 12, 24, 16),
                  num_init_features=64, bn_size=4, drop_rate=0, num_classes=1000, memory_efficient=False):
 


### PR DESCRIPTION
Fixes #1721:

`~/python3.7/site-packages/torch/jit/_recursive.py:146: UserWarning: 'features' was found in ScriptModule constants,  but it is a non-constant submodule. Consider removing it.`

@fmassa @eellison #1727
