### PR TITLE
Improved error messages for transforms.functional.normalize().

### DIFF
--- a/torchvision/transforms/functional.py
+++ b/torchvision/transforms/functional.py
@@ -209,7 +209,7 @@ def normalize(tensor, mean, std, inplace=False):
     dtype = tensor.dtype
     mean = torch.as_tensor(mean, dtype=dtype, device=tensor.device)
     std = torch.as_tensor(std, dtype=dtype, device=tensor.device)
-    if std == 0:
+    if (std == 0).any():
         raise ValueError('std evaluated to zero after conversion to {}, leading to division by zero.'.format(dtype))
     tensor.sub_(mean[:, None, None]).div_(std[:, None, None])
     return tensor

--- a/torchvision/transforms/functional.py
+++ b/torchvision/transforms/functional.py
@@ -28,10 +28,6 @@ def _is_pil_image(img):
         return isinstance(img, Image.Image)
 
 
-def _is_tensor_image(img):
-    return torch.is_tensor(img) and img.ndimension() == 3
-
-
 def _is_numpy(img):
     return isinstance(img, np.ndarray)
 
@@ -200,8 +196,12 @@ def normalize(tensor, mean, std, inplace=False):
     Returns:
         Tensor: Normalized Tensor image.
     """
-    if not _is_tensor_image(tensor):
-        raise TypeError('tensor is not a torch image.')
+    if not torch.is_tensor(tensor):
+        raise TypeError('tensor should be a torch tensor. Got {}.'.format(type(tensor)))
+    
+    if tensor.ndimension() != 3:
+        raise ValueError('Expected tensor to be a tensor image of size (C, H, W). Got tensor.size() = '
+                         '{}.'.format(tensor.size()))
 
     if not inplace:
         tensor = tensor.clone()

--- a/torchvision/transforms/functional.py
+++ b/torchvision/transforms/functional.py
@@ -209,6 +209,8 @@ def normalize(tensor, mean, std, inplace=False):
     dtype = tensor.dtype
     mean = torch.as_tensor(mean, dtype=dtype, device=tensor.device)
     std = torch.as_tensor(std, dtype=dtype, device=tensor.device)
+    if std == 0:
+        raise ValueError('std evaluated to zero after conversion to {}, leading to division by zero.'.format(dtype))
     tensor.sub_(mean[:, None, None]).div_(std[:, None, None])
     return tensor
 


### PR DESCRIPTION
Split the original TypeError into
1. a TypeError if `tensor` is not a torch.Tensor and 
2. a ValueError if `tensor` does not have the correct dimensionality.

Added more detail to the error for when `tensor` has the wrong dimension to make it easier to diagnose. This is useful when this function isn't called directly by the user (e.g. when the user uses transforms.Normalize and can't directly see this function's doc string).

Deleted the now hanging function `_is_tensor_image()`. It isn't used in this file and isn't used internally anywhere else in torchvision that I can see. (Some users will have used it despite the underscore prefix, but a quick google search for "F._is_tensor_image" suggests this is rare).