### PR TITLE
Fix torchscript issue in ConvTranspose2d

### DIFF
--- a/torchvision/ops/misc.py
+++ b/torchvision/ops/misc.py
@@ -42,7 +42,7 @@ class ConvTranspose2d(torch.nn.ConvTranspose2d):
                 list(self.output_padding),
             )
         ]
-        output_shape = [x.shape[0], self.bias.shape[0]] + output_shape
+        output_shape = [x.shape[0], self.out_channels] + output_shape
         return _new_empty_tensor(x, output_shape)
 
     def super_forward(self, input, output_size=None):


### PR DESCRIPTION
Tests have been failing recently with
```
RuntimeError:  Tried to access nonexistent attribute or method 'shape' of type 'Optional[Tensor]'.:   File "/opt/conda/conda-bld/torchvision_1582614418949/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placeh/lib/python3.5/site-packages/torchvision/ops/misc.py", line 45             )         ]         output_shape = [x.shape[0], self.bias.shape[0]] + output_shape                                     ~~~~~~~~~~~~~~~ <--- HERE         return _new_empty_tensor(x, output_shape)
```
most probably due to some changes in torchscript.

This fixes it.