### PR TITLE
add @torch.jit.script to ImageList

### DIFF
--- a/torchvision/models/detection/image_list.py
+++ b/torchvision/models/detection/image_list.py
@@ -6,6 +6,7 @@ from torch.jit.annotations import List, Tuple
 from torch import Tensor
 
 
+@torch.jit.script
 class ImageList(object):
     """
     Structure that holds a list of images (of possibly


### PR DESCRIPTION
Torchscript model exported from torchvision.models.detection.transform.GeneralizedRCNNTransform can not be used. The error is that ImageList can not convert to a c++ object from a python object.
I guess the reason is that torchscipt can not find ImageList definition in python.