### PR TITLE
Fixed missing new line in the crop docstring

### DIFF
--- a/torchvision/transforms/functional.py
+++ b/torchvision/transforms/functional.py
@@ -348,6 +348,7 @@ def pad(img, padding, fill=0, padding_mode='constant'):
 
 def crop(img, top, left, height, width):
     """Crop the given PIL Image.
+    
     Args:
         img (PIL Image): Image to be cropped. (0,0) denotes the top left corner of the image.
         top (int): Vertical component of the top left corner of the crop box.


### PR DESCRIPTION
Just added a new line before `Args:` to improve visualization.
This is a fix for issue: [https://github.com/pytorch/vision/issues/1921](https://github.com/pytorch/vision/issues/1921)