### PR TITLE
Remove 'downsample' constants (#1721)

### DIFF
--- a/torchvision/models/resnet.py
+++ b/torchvision/models/resnet.py
@@ -34,7 +34,6 @@ def conv1x1(in_planes, out_planes, stride=1):
 
 class BasicBlock(nn.Module):
     expansion = 1
-    __constants__ = ['downsample']
 
     def __init__(self, inplanes, planes, stride=1, downsample=None, groups=1,
                  base_width=64, dilation=1, norm_layer=None):
@@ -75,7 +74,6 @@ class BasicBlock(nn.Module):
 
 class Bottleneck(nn.Module):
     expansion = 4
-    __constants__ = ['downsample']
 
     def __init__(self, inplanes, planes, stride=1, downsample=None, groups=1,
                  base_width=64, dilation=1, norm_layer=None):

--- a/torchvision/models/video/resnet.py
+++ b/torchvision/models/video/resnet.py
@@ -81,7 +81,6 @@ class Conv3DNoTemporal(nn.Conv3d):
 
 class BasicBlock(nn.Module):
 
-    __constants__ = ['downsample']
     expansion = 1
 
     def __init__(self, inplanes, planes, conv_builder, stride=1, downsample=None):


### PR DESCRIPTION
Fixes #1721:

`~/pytorch/lib/python3.7/site-packages/torch/jit/_recursive.py:146: UserWarning: 'downsample' was found in ScriptModule constants,  but it is a non-constant submodule. Consider removing it.
  " but it is a non-constant {}. Consider removing it.".format(name, hint))`

@fmassa @eellison #1727 #1907