### PR TITLE
extend decoder to support new video_max_dimension argument

### DIFF
--- a/test/test_video_reader.py
+++ b/test/test_video_reader.py
@@ -395,7 +395,7 @@ class TestVideoReader(unittest.TestCase):
     def test_stress_test_read_video_from_file(self):
         num_iter = 10000
         # video related
-        width, height, min_dimension = 0, 0, 0
+        width, height, min_dimension, max_dimension = 0, 0, 0, 0
         video_start_pts, video_end_pts = 0, -1
         video_timebase_num, video_timebase_den = 0, 1
         # audio related
@@ -416,6 +416,7 @@ class TestVideoReader(unittest.TestCase):
                     width,
                     height,
                     min_dimension,
+                    max_dimension,
                     video_start_pts,
                     video_end_pts,
                     video_timebase_num,
@@ -434,7 +435,7 @@ class TestVideoReader(unittest.TestCase):
         Test the case when decoder starts with a video file to decode frames.
         """
         # video related
-        width, height, min_dimension = 0, 0, 0
+        width, height, min_dimension, max_dimension = 0, 0, 0, 0
         video_start_pts, video_end_pts = 0, -1
         video_timebase_num, video_timebase_den = 0, 1
         # audio related
@@ -454,6 +455,7 @@ class TestVideoReader(unittest.TestCase):
                 width,
                 height,
                 min_dimension,
+                max_dimension,
                 video_start_pts,
                 video_end_pts,
                 video_timebase_num,
@@ -479,7 +481,7 @@ class TestVideoReader(unittest.TestCase):
         only reads video stream and ignores audio stream
         """
         # video related
-        width, height, min_dimension = 0, 0, 0
+        width, height, min_dimension, max_dimension = 0, 0, 0, 0
         video_start_pts, video_end_pts = 0, -1
         video_timebase_num, video_timebase_den = 0, 1
         # audio related
@@ -499,6 +501,7 @@ class TestVideoReader(unittest.TestCase):
                     width,
                     height,
                     min_dimension,
+                    max_dimension,
                     video_start_pts,
                     video_end_pts,
                     video_timebase_num,
@@ -536,7 +539,7 @@ class TestVideoReader(unittest.TestCase):
         video min dimension between height and width is set.
         """
         # video related
-        width, height, min_dimension = 0, 0, 128
+        width, height, min_dimension, max_dimension = 0, 0, 128, 0
         video_start_pts, video_end_pts = 0, -1
         video_timebase_num, video_timebase_den = 0, 1
         # audio related
@@ -555,6 +558,7 @@ class TestVideoReader(unittest.TestCase):
                 width,
                 height,
                 min_dimension,
+                max_dimension,
                 video_start_pts,
                 video_end_pts,
                 video_timebase_num,
@@ -571,13 +575,13 @@ class TestVideoReader(unittest.TestCase):
                 min_dimension, min(tv_result[0].size(1), tv_result[0].size(2))
             )
 
-    def test_read_video_from_file_rescale_width(self):
+    def test_read_video_from_file_rescale_max_dimension(self):
         """
         Test the case when decoder starts with a video file to decode frames, and
-        video width is set.
+        video min dimension between height and width is set.
         """
         # video related
-        width, height, min_dimension = 256, 0, 0
+        width, height, min_dimension, max_dimension = 0, 0, 0, 85
         video_start_pts, video_end_pts = 0, -1
         video_timebase_num, video_timebase_den = 0, 1
         # audio related
@@ -596,6 +600,94 @@ class TestVideoReader(unittest.TestCase):
                 width,
                 height,
                 min_dimension,
+                max_dimension,
+                video_start_pts,
+                video_end_pts,
+                video_timebase_num,
+                video_timebase_den,
+                1,  # readAudioStream
+                samples,
+                channels,
+                audio_start_pts,
+                audio_end_pts,
+                audio_timebase_num,
+                audio_timebase_den,
+            )
+            self.assertEqual(
+                max_dimension, max(tv_result[0].size(1), tv_result[0].size(2))
+            )
+
+    def test_read_video_from_file_rescale_both_min_max_dimension(self):
+        """
+        Test the case when decoder starts with a video file to decode frames, and
+        video min dimension between height and width is set.
+        """
+        # video related
+        width, height, min_dimension, max_dimension = 0, 0, 64, 85
+        video_start_pts, video_end_pts = 0, -1
+        video_timebase_num, video_timebase_den = 0, 1
+        # audio related
+        samples, channels = 0, 0
+        audio_start_pts, audio_end_pts = 0, -1
+        audio_timebase_num, audio_timebase_den = 0, 1
+
+        for test_video, _config in test_videos.items():
+            full_path = os.path.join(VIDEO_DIR, test_video)
+
+            tv_result = torch.ops.video_reader.read_video_from_file(
+                full_path,
+                seek_frame_margin,
+                0,  # getPtsOnly
+                1,  # readVideoStream
+                width,
+                height,
+                min_dimension,
+                max_dimension,
+                video_start_pts,
+                video_end_pts,
+                video_timebase_num,
+                video_timebase_den,
+                1,  # readAudioStream
+                samples,
+                channels,
+                audio_start_pts,
+                audio_end_pts,
+                audio_timebase_num,
+                audio_timebase_den,
+            )
+            self.assertEqual(
+                min_dimension, min(tv_result[0].size(1), tv_result[0].size(2))
+            )
+            self.assertEqual(
+                max_dimension, max(tv_result[0].size(1), tv_result[0].size(2))
+            )
+
+    def test_read_video_from_file_rescale_width(self):
+        """
+        Test the case when decoder starts with a video file to decode frames, and
+        video width is set.
+        """
+        # video related
+        width, height, min_dimension, max_dimension = 256, 0, 0, 0
+        video_start_pts, video_end_pts = 0, -1
+        video_timebase_num, video_timebase_den = 0, 1
+        # audio related
+        samples, channels = 0, 0
+        audio_start_pts, audio_end_pts = 0, -1
+        audio_timebase_num, audio_timebase_den = 0, 1
+
+        for test_video, _config in test_videos.items():
+            full_path = os.path.join(VIDEO_DIR, test_video)
+
+            tv_result = torch.ops.video_reader.read_video_from_file(
+                full_path,
+                seek_frame_margin,
+                0,  # getPtsOnly
+                1,  # readVideoStream
+                width,
+                height,
+                min_dimension,
+                max_dimension,
                 video_start_pts,
                 video_end_pts,
                 video_timebase_num,
@@ -616,7 +708,7 @@ class TestVideoReader(unittest.TestCase):
         video height is set.
         """
         # video related
-        width, height, min_dimension = 0, 224, 0
+        width, height, min_dimension, max_dimension = 0, 224, 0, 0
         video_start_pts, video_end_pts = 0, -1
         video_timebase_num, video_timebase_den = 0, 1
         # audio related
@@ -635,6 +727,7 @@ class TestVideoReader(unittest.TestCase):
                 width,
                 height,
                 min_dimension,
+                max_dimension,
                 video_start_pts,
                 video_end_pts,
                 video_timebase_num,
@@ -655,7 +748,7 @@ class TestVideoReader(unittest.TestCase):
         both video height and width are set.
         """
         # video related
-        width, height, min_dimension = 320, 240, 0
+        width, height, min_dimension, max_dimension = 320, 240, 0, 0
         video_start_pts, video_end_pts = 0, -1
         video_timebase_num, video_timebase_den = 0, 1
         # audio related
@@ -674,6 +767,7 @@ class TestVideoReader(unittest.TestCase):
                 width,
                 height,
                 min_dimension,
+                max_dimension,
                 video_start_pts,
                 video_end_pts,
                 video_timebase_num,
@@ -697,7 +791,7 @@ class TestVideoReader(unittest.TestCase):
 
         for samples in [9600, 96000]:  # downsampling  # upsampling
             # video related
-            width, height, min_dimension = 0, 0, 0
+            width, height, min_dimension, max_dimension = 0, 0, 0, 0
             video_start_pts, video_end_pts = 0, -1
             video_timebase_num, video_timebase_den = 0, 1
             # audio related
@@ -716,6 +810,7 @@ class TestVideoReader(unittest.TestCase):
                     width,
                     height,
                     min_dimension,
+                    max_dimension,
                     video_start_pts,
                     video_end_pts,
                     video_timebase_num,
@@ -752,7 +847,7 @@ class TestVideoReader(unittest.TestCase):
         Test the case when video is already in memory, and decoder reads data in memory
         """
         # video related
-        width, height, min_dimension = 0, 0, 0
+        width, height, min_dimension, max_dimension = 0, 0, 0, 0
         video_start_pts, video_end_pts = 0, -1
         video_timebase_num, video_timebase_den = 0, 1
         # audio related
@@ -772,6 +867,7 @@ class TestVideoReader(unittest.TestCase):
                 width,
                 height,
                 min_dimension,
+                max_dimension,
                 video_start_pts,
                 video_end_pts,
                 video_timebase_num,
@@ -794,6 +890,7 @@ class TestVideoReader(unittest.TestCase):
                 width,
                 height,
                 min_dimension,
+                max_dimension,
                 video_start_pts,
                 video_end_pts,
                 video_timebase_num,
@@ -816,7 +913,7 @@ class TestVideoReader(unittest.TestCase):
         Test the case when video is already in memory, and decoder reads data in memory
         """
         # video related
-        width, height, min_dimension = 0, 0, 0
+        width, height, min_dimension, max_dimension = 0, 0, 0, 0
         video_start_pts, video_end_pts = 0, -1
         video_timebase_num, video_timebase_den = 0, 1
         # audio related
@@ -836,6 +933,7 @@ class TestVideoReader(unittest.TestCase):
                 width,
                 height,
                 min_dimension,
+                max_dimension,
                 video_start_pts,
                 video_end_pts,
                 video_timebase_num,
@@ -861,7 +959,7 @@ class TestVideoReader(unittest.TestCase):
         for both pts and frame data
         """
         # video related
-        width, height, min_dimension = 0, 0, 0
+        width, height, min_dimension, max_dimension = 0, 0, 0, 0
         video_start_pts, video_end_pts = 0, -1
         video_timebase_num, video_timebase_den = 0, 1
         # audio related
@@ -881,6 +979,7 @@ class TestVideoReader(unittest.TestCase):
                 width,
                 height,
                 min_dimension,
+                max_dimension,
                 video_start_pts,
                 video_end_pts,
                 video_timebase_num,
@@ -904,6 +1003,7 @@ class TestVideoReader(unittest.TestCase):
                 width,
                 height,
                 min_dimension,
+                max_dimension,
                 video_start_pts,
                 video_end_pts,
                 video_timebase_num,
@@ -930,7 +1030,7 @@ class TestVideoReader(unittest.TestCase):
         for test_video, config in test_videos.items():
             full_path, video_tensor = _get_video_tensor(VIDEO_DIR, test_video)
             # video related
-            width, height, min_dimension = 0, 0, 0
+            width, height, min_dimension, max_dimension = 0, 0, 0, 0
             video_start_pts, video_end_pts = 0, -1
             video_timebase_num, video_timebase_den = 0, 1
             # audio related
@@ -946,6 +1046,7 @@ class TestVideoReader(unittest.TestCase):
                 width,
                 height,
                 min_dimension,
+                max_dimension,
                 video_start_pts,
                 video_end_pts,
                 video_timebase_num,
@@ -1000,6 +1101,7 @@ class TestVideoReader(unittest.TestCase):
                     width,
                     height,
                     min_dimension,
+                    max_dimension,
                     video_start_pts,
                     video_end_pts,
                     video_timebase_num,
@@ -1099,7 +1201,7 @@ class TestVideoReader(unittest.TestCase):
         Test the case when video is already in memory, and decoder reads data in memory
         """
         # video related
-        width, height, min_dimension = 0, 0, 0
+        width, height, min_dimension, max_dimension = 0, 0, 0, 0
         video_start_pts, video_end_pts = 0, -1
         video_timebase_num, video_timebase_den = 0, 1
         # audio related
@@ -1121,6 +1223,7 @@ class TestVideoReader(unittest.TestCase):
                 width,
                 height,
                 min_dimension,
+                max_dimension,
                 [video_start_pts, video_end_pts],
                 video_timebase_num,
                 video_timebase_den,

--- a/torchvision/csrc/cpu/decoder/defs.h
+++ b/torchvision/csrc/cpu/decoder/defs.h
@@ -49,11 +49,29 @@ struct VideoFormat {
   bool operator==(const VideoFormat& x) const {
     return x.format == format && x.width == width && x.height == height;
   }
-
+  /*
+  When width = 0, height = 0, minDimension = 0, and maxDimension = 0,
+    keep the orignal frame resolution
+  When width = 0, height = 0, minDimension != 0, and maxDimension = 0,
+    keep the aspect ratio and resize the frame so that shorter edge size is minDimension
+  When width = 0, height = 0, minDimension = 0, and maxDimension != 0,
+    keep the aspect ratio and resize the frame so that longer edge size is maxDimension
+  When width = 0, height = 0, minDimension != 0, and maxDimension != 0,
+    resize the frame so that shorter edge size is minDimension, and
+    longer edge size is maxDimension. The aspect ratio may not be preserved
+  When width = 0, height != 0, minDimension = 0, and maxDimension = 0,
+    keep the aspect ratio and resize the frame so that frame height is $height
+  When width != 0, height = 0, minDimension = 0, and maxDimension = 0,
+    keep the aspect ratio and resize the frame so that frame width is $width
+  When width != 0, height != 0, minDimension = 0, and maxDimension = 0,
+    resize the frame so that frame width and  height are set to $width and $height,
+    respectively
+  */
   size_t width{0}; // width in pixels
   size_t height{0}; // height in pixels
   long format{-1}; // AVPixelFormat, auto AV_PIX_FMT_NONE
   size_t minDimension{0}; // choose min dimension and rescale accordingly
+  size_t maxDimension{0}; // choose max dimension and rescale accordingly
   size_t cropImage{0}; // request image crop
   // -- alignment 40 bytes
 };

--- a/torchvision/csrc/cpu/decoder/util.h
+++ b/torchvision/csrc/cpu/decoder/util.h
@@ -21,6 +21,7 @@ void setFormatDimensions(
     size_t srcW,
     size_t srcH,
     size_t minDimension,
+    size_t maxDimension,
     size_t cropImage);
 bool validateVideoFormat(const VideoFormat& format);
 } // namespace Util

--- a/torchvision/csrc/cpu/decoder/video_sampler.cpp
+++ b/torchvision/csrc/cpu/decoder/video_sampler.cpp
@@ -87,6 +87,7 @@ bool VideoSampler::init(const SamplerParameters& params) {
         params.in.video.width,
         params.in.video.height,
         0,
+        0,
         1);
 
     if (!(scaleFormat_ == params_.out.video)) { // crop required

--- a/torchvision/csrc/cpu/decoder/video_stream.cpp
+++ b/torchvision/csrc/cpu/decoder/video_stream.cpp
@@ -68,6 +68,7 @@ int VideoStream::initFormat() {
       codecCtx_->width,
       codecCtx_->height,
       format_.format.video.minDimension,
+      format_.format.video.maxDimension,
       0);
 
   if (format_.format.video.format == AV_PIX_FMT_NONE) {

--- a/torchvision/csrc/cpu/video_reader/VideoReader.cpp
+++ b/torchvision/csrc/cpu/video_reader/VideoReader.cpp
@@ -44,6 +44,7 @@ DecoderParameters getDecoderParams(
     int videoWidth,
     int videoHeight,
     int videoMinDimension,
+    int videoMaxDimension,
     int64_t readAudioStream,
     int audioSamples,
     int audioChannels) {
@@ -62,6 +63,7 @@ DecoderParameters getDecoderParams(
     videoFormat.format.video.width = videoWidth;
     videoFormat.format.video.height = videoHeight;
     videoFormat.format.video.minDimension = videoMinDimension;
+    videoFormat.format.video.maxDimension = videoMaxDimension;
     params.formats.insert(videoFormat);
   }
 
@@ -190,6 +192,7 @@ torch::List<torch::Tensor> readVideo(
     int64_t width,
     int64_t height,
     int64_t minDimension,
+    int64_t maxDimension,
     int64_t videoStartPts,
     int64_t videoEndPts,
     int64_t videoTimeBaseNum,
@@ -227,6 +230,7 @@ torch::List<torch::Tensor> readVideo(
       width, // width
       height, // height
       minDimension, // minDimension
+      maxDimension, // maxDimension
       readAudioStream, // readAudioStream
       audioSamples, // audioSamples
       audioChannels // audioChannels
@@ -429,6 +433,7 @@ torch::List<torch::Tensor> readVideoFromMemory(
     int64_t width,
     int64_t height,
     int64_t minDimension,
+    int64_t maxDimension,
     int64_t videoStartPts,
     int64_t videoEndPts,
     int64_t videoTimeBaseNum,
@@ -450,6 +455,7 @@ torch::List<torch::Tensor> readVideoFromMemory(
       width,
       height,
       minDimension,
+      maxDimension,
       videoStartPts,
       videoEndPts,
       videoTimeBaseNum,
@@ -471,6 +477,7 @@ torch::List<torch::Tensor> readVideoFromFile(
     int64_t width,
     int64_t height,
     int64_t minDimension,
+    int64_t maxDimension,
     int64_t videoStartPts,
     int64_t videoEndPts,
     int64_t videoTimeBaseNum,
@@ -493,6 +500,7 @@ torch::List<torch::Tensor> readVideoFromFile(
       width,
       height,
       minDimension,
+      maxDimension,
       videoStartPts,
       videoEndPts,
       videoTimeBaseNum,
@@ -519,6 +527,7 @@ torch::List<torch::Tensor> probeVideo(
       0, // width
       0, // height
       0, // minDimension
+      0, // maxDimension
       1, // readAudioStream
       0, // audioSamples
       0 // audioChannels

--- a/torchvision/datasets/video_utils.py
+++ b/torchvision/datasets/video_utils.py
@@ -98,6 +98,7 @@ class VideoClips(object):
         _video_width=0,
         _video_height=0,
         _video_min_dimension=0,
+        _video_max_dimension=0,
         _audio_samples=0,
         _audio_channels=0,
     ):
@@ -109,6 +110,7 @@ class VideoClips(object):
         self._video_width = _video_width
         self._video_height = _video_height
         self._video_min_dimension = _video_min_dimension
+        self._video_max_dimension = _video_max_dimension
         self._audio_samples = _audio_samples
         self._audio_channels = _audio_channels
 
@@ -182,6 +184,7 @@ class VideoClips(object):
             _video_width=self._video_width,
             _video_height=self._video_height,
             _video_min_dimension=self._video_min_dimension,
+            _video_max_dimension=self._video_max_dimension,
             _audio_samples=self._audio_samples,
             _audio_channels=self._audio_channels,
         )
@@ -302,6 +305,10 @@ class VideoClips(object):
                 raise ValueError(
                     "pyav backend doesn't support _video_min_dimension != 0"
                 )
+            if self._video_max_dimension != 0:
+                raise ValueError(
+                    "pyav backend doesn't support _video_max_dimension != 0"
+                )
             if self._audio_samples != 0:
                 raise ValueError("pyav backend doesn't support _audio_samples != 0")
 
@@ -338,6 +345,7 @@ class VideoClips(object):
                 video_width=self._video_width,
                 video_height=self._video_height,
                 video_min_dimension=self._video_min_dimension,
+                video_max_dimension=self._video_max_dimension,
                 video_pts_range=(video_start_pts, video_end_pts),
                 video_timebase=video_timebase,
                 audio_samples=self._audio_samples,

--- a/torchvision/io/_video_opt.py
+++ b/torchvision/io/_video_opt.py
@@ -138,6 +138,7 @@ def _read_video_from_file(
     video_width=0,
     video_height=0,
     video_min_dimension=0,
+    video_max_dimension=0,
     video_pts_range=(0, -1),
     video_timebase=default_timebase,
     read_audio_stream=True,
@@ -155,21 +156,34 @@ def _read_video_from_file(
     filename : str
         path to the video file
     seek_frame_margin: double, optional
-        seeking frame in the stream is imprecise. Thus, when video_start_pts is specified,
-        we seek the pts earlier by seek_frame_margin seconds
+        seeking frame in the stream is imprecise. Thus, when video_start_pts
+        is specified, we seek the pts earlier by seek_frame_margin seconds
     read_video_stream: int, optional
         whether read video stream. If yes, set to 1. Otherwise, 0
-    video_width/video_height/video_min_dimension: int
+    video_width/video_height/video_min_dimension/video_max_dimension: int
         together decide the size of decoded frames
-        - when video_width = 0, video_height = 0, and video_min_dimension = 0, keep the orignal frame resolution
-        - when video_width = 0, video_height = 0, and video_min_dimension != 0, keep the aspect ratio and resize
-            the frame so that shorter edge size is video_min_dimension
-        - When video_width = 0, and video_height != 0, keep the aspect ratio and resize the frame
-            so that frame video_height is $video_height
-        - When video_width != 0, and video_height == 0, keep the aspect ratio and resize the frame
-            so that frame video_height is $video_width
-        - When video_width != 0, and video_height != 0, resize the frame so that frame video_width and video_height
-            are set to $video_width and $video_height, respectively
+        - When video_width = 0, video_height = 0, video_min_dimension = 0,
+            and video_max_dimension = 0, keep the orignal frame resolution
+        - When video_width = 0, video_height = 0, video_min_dimension != 0,
+            and video_max_dimension = 0, keep the aspect ratio and resize the
+            frame so that shorter edge size is video_min_dimension
+        - When video_width = 0, video_height = 0, video_min_dimension = 0,
+            and video_max_dimension != 0, keep the aspect ratio and resize
+            the frame so that longer edge size is video_max_dimension
+        - When video_width = 0, video_height = 0, video_min_dimension != 0,
+            and video_max_dimension != 0, resize the frame so that shorter
+            edge size is video_min_dimension, and longer edge size is
+            video_max_dimension. The aspect ratio may not be preserved
+        - When video_width = 0, video_height != 0, video_min_dimension = 0,
+            and video_max_dimension = 0, keep the aspect ratio and resize
+            the frame so that frame video_height is $video_height
+        - When video_width != 0, video_height == 0, video_min_dimension = 0,
+            and video_max_dimension = 0, keep the aspect ratio and resize
+            the frame so that frame video_width is $video_width
+        - When video_width != 0, video_height != 0, video_min_dimension = 0,
+            and video_max_dimension = 0, resize the frame so that frame
+            video_width and  video_height are set to $video_width and
+            $video_height, respectively
     video_pts_range : list(int), optional
         the start and end presentation timestamp of video stream
     video_timebase: Fraction, optional
@@ -207,6 +221,7 @@ def _read_video_from_file(
         video_width,
         video_height,
         video_min_dimension,
+        video_max_dimension,
         video_pts_range[0],
         video_pts_range[1],
         video_timebase.numerator,
@@ -244,6 +259,7 @@ def _read_video_timestamps_from_file(filename):
         0,  # video_width
         0,  # video_height
         0,  # video_min_dimension
+        0,  # video_max_dimension
         0,  # video_start_pts
         -1,  # video_end_pts
         0,  # video_timebase_num
@@ -282,6 +298,7 @@ def _read_video_from_memory(
     video_width=0,  # type: int
     video_height=0,  # type: int
     video_min_dimension=0,  # type: int
+    video_max_dimension=0,  # type: int
     video_pts_range=(0, -1),  # type: List[int]
     video_timebase_numerator=0,  # type: int
     video_timebase_denominator=1,  # type: int
@@ -307,17 +324,30 @@ def _read_video_from_memory(
         we seek the pts earlier by seek_frame_margin seconds
     read_video_stream: int, optional
         whether read video stream. If yes, set to 1. Otherwise, 0
-    video_width/video_height/video_min_dimension: int
+    video_width/video_height/video_min_dimension/video_max_dimension: int
         together decide the size of decoded frames
-        - when video_width = 0, video_height = 0, and video_min_dimension = 0, keep the orignal frame resolution
-        - when video_width = 0, video_height = 0, and video_min_dimension != 0, keep the aspect ratio and resize
-            the frame so that shorter edge size is video_min_dimension
-        - When video_width = 0, and video_height != 0, keep the aspect ratio and resize the frame
-            so that frame video_height is $video_height
-        - When video_width != 0, and video_height == 0, keep the aspect ratio and resize the frame
-            so that frame video_height is $video_width
-        - When video_width != 0, and video_height != 0, resize the frame so that frame video_width and video_height
-            are set to $video_width and $video_height, respectively
+        - When video_width = 0, video_height = 0, video_min_dimension = 0,
+            and video_max_dimension = 0, keep the orignal frame resolution
+        - When video_width = 0, video_height = 0, video_min_dimension != 0,
+            and video_max_dimension = 0, keep the aspect ratio and resize the
+            frame so that shorter edge size is video_min_dimension
+        - When video_width = 0, video_height = 0, video_min_dimension = 0,
+            and video_max_dimension != 0, keep the aspect ratio and resize
+            the frame so that longer edge size is video_max_dimension
+        - When video_width = 0, video_height = 0, video_min_dimension != 0,
+            and video_max_dimension != 0, resize the frame so that shorter
+            edge size is video_min_dimension, and longer edge size is
+            video_max_dimension. The aspect ratio may not be preserved
+        - When video_width = 0, video_height != 0, video_min_dimension = 0,
+            and video_max_dimension = 0, keep the aspect ratio and resize
+            the frame so that frame video_height is $video_height
+        - When video_width != 0, video_height == 0, video_min_dimension = 0,
+            and video_max_dimension = 0, keep the aspect ratio and resize
+            the frame so that frame video_width is $video_width
+        - When video_width != 0, video_height != 0, video_min_dimension = 0,
+            and video_max_dimension = 0, resize the frame so that frame
+            video_width and  video_height are set to $video_width and
+            $video_height, respectively
     video_pts_range : list(int), optional
         the start and end presentation timestamp of video stream
     video_timebase_numerator / video_timebase_denominator: optional
@@ -353,6 +383,7 @@ def _read_video_from_memory(
         video_width,
         video_height,
         video_min_dimension,
+        video_max_dimension,
         video_pts_range[0],
         video_pts_range[1],
         video_timebase_numerator,
@@ -394,6 +425,7 @@ def _read_video_timestamps_from_memory(video_data):
         0,  # video_width
         0,  # video_height
         0,  # video_min_dimension
+        0,  # video_max_dimension
         0,  # video_start_pts
         -1,  # video_end_pts
         0,  # video_timebase_num

--- a/torchvision/io/video.py
+++ b/torchvision/io/video.py
@@ -370,6 +370,7 @@ def read_video_from_memory(
     audio_pts_range=(0, -1),  # type: List[int]
     audio_timebase_numerator=0,  # type: int
     audio_timebase_denominator=1,  # type: int
+    video_max_dimension=0,  # type: int
 ):
     # type: (...) -> Tuple[torch.Tensor, torch.Tensor]
     return _video_opt._read_video_from_memory(
@@ -379,6 +380,7 @@ def read_video_from_memory(
         video_width,
         video_height,
         video_min_dimension,
+        video_max_dimension,
         video_pts_range,
         video_timebase_numerator,
         video_timebase_denominator,


### PR DESCRIPTION
Summary:
Extend `video reader` decoder python API in Torchvision to support a new argument `video_max_dimension`. This enables the new video decoding use cases. When setting `video_width=0`, `video_height=0`, `video_min_dimension != 0`, and `video_max_dimension != 0`, we can rescale the video clips so that its spatial resolution (height, width) becomes
 - (video_min_dimension, video_max_dimension) if original height < original width
 - (video_max_dimension, video_min_dimension) if original height >= original width

This is useful at video model testing stage, where we perform fully convolution evaluation and take entire video frames without cropping as input. Previously, for instance we can only set `video_width=0`, `video_height=0`, `video_min_dimension = 128`, which will preserve aspect ratio. In production dataset, there are a small number of videos where aspect ratio is either extremely large or small, and when the shorter edge is rescaled to 128, the longer edge is still large. This will easily cause GPU memory OOM when we sample multiple video clips, and put them in a single minibatch.

Now, we can set (for instance) `video_width=0`, `video_height=0`, `video_min_dimension = 128` and `video_max_dimension = 171` so that the rescale resolution is either (128, 171) or (171, 128) depending on whether original height is larger than original width.

Differential Revision: D20182529

