### PR TITLE
Add eps in FrozenBatchNorm2d

### DIFF
--- a/torchvision/ops/misc.py
+++ b/torchvision/ops/misc.py
@@ -124,12 +124,13 @@ class FrozenBatchNorm2d(torch.nn.Module):
     are fixed
     """
 
-    def __init__(self, n):
+    def __init__(self, n, eps=1e-5):
         super(FrozenBatchNorm2d, self).__init__()
         self.register_buffer("weight", torch.ones(n))
         self.register_buffer("bias", torch.zeros(n))
         self.register_buffer("running_mean", torch.zeros(n))
         self.register_buffer("running_var", torch.ones(n))
+        self.eps = eps
 
     def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict,
                               missing_keys, unexpected_keys, error_msgs):
@@ -148,6 +149,6 @@ class FrozenBatchNorm2d(torch.nn.Module):
         b = self.bias.reshape(1, -1, 1, 1)
         rv = self.running_var.reshape(1, -1, 1, 1)
         rm = self.running_mean.reshape(1, -1, 1, 1)
-        scale = w * rv.rsqrt()
+        scale = w * (rv + self.eps).rsqrt()
         bias = b - rm * scale
         return x * scale + bias


### PR DESCRIPTION
works without eps with pretrained ResNet, but WRN and ResNeXt explode, thus this fix. Not sure about BC, trained ResNet models will slightly change.