### PR TITLE
.circleci: Switch to use token for conda uploads

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -264,12 +264,8 @@ jobs:
           command: |
             # Prevent credential from leaking
             conda install -yq anaconda-client
-            set +x
-            anaconda login \
-                --username "$PYTORCH_BINARY_PJH5_CONDA_USERNAME" \
-                --password "$PYTORCH_BINARY_PJH5_CONDA_PASSWORD"
             set -x
-            anaconda upload ~/workspace/*.tar.bz2 -u pytorch-nightly --label main --no-progress --force
+            anaconda  -t "${CONDA_PYTORCHBOT_TOKEN}" upload ~/workspace/*.tar.bz2 -u pytorch-nightly --label main --no-progress --force
 
   # Requires org-member context
   binary_wheel_upload:

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -264,12 +264,8 @@ jobs:
           command: |
             # Prevent credential from leaking
             conda install -yq anaconda-client
-            set +x
-            anaconda login \
-                --username "$PYTORCH_BINARY_PJH5_CONDA_USERNAME" \
-                --password "$PYTORCH_BINARY_PJH5_CONDA_PASSWORD"
             set -x
-            anaconda upload ~/workspace/*.tar.bz2 -u pytorch-nightly --label main --no-progress --force
+            anaconda  -t "${CONDA_PYTORCHBOT_TOKEN}" upload ~/workspace/*.tar.bz2 -u pytorch-nightly --label main --no-progress --force
 
   # Requires org-member context
   binary_wheel_upload:


### PR DESCRIPTION
pjh5 is a former employee so we should switch over to using a bot token.

Should resolve nightly pipeline failing on upload.

Relates to users experiencing issues installing the latest nightlies of both `torchvision` and `pytorch` as experienced in #1956 

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>