### PR TITLE
Update Windows CI for nightly builds

### DIFF
--- a/packaging/conda/build_vision.sh
+++ b/packaging/conda/build_vision.sh
@@ -104,7 +104,9 @@ if [[ "$desired_cuda" == 'cpu' ]]; then
 else
     export CONDA_CPUONLY_FEATURE=""
     . ./switch_cuda_version.sh $desired_cuda
-    if [[ "$desired_cuda" == "10.1" ]]; then
+    if [[ "$desired_cuda" == "10.2" ]]; then
+        export CONDA_CUDATOOLKIT_CONSTRAINT="- cudatoolkit >=10.2,<10.3 # [not osx]"
+    elif [[ "$desired_cuda" == "10.1" ]]; then
         export CONDA_CUDATOOLKIT_CONSTRAINT="- cudatoolkit >=10.1,<10.2 # [not osx]"
     elif [[ "$desired_cuda" == "10.0" ]]; then
         export CONDA_CUDATOOLKIT_CONSTRAINT="- cudatoolkit >=10.0,<10.1 # [not osx]"

--- a/packaging/torchvision/bld.bat
+++ b/packaging/torchvision/bld.bat
@@ -19,6 +19,7 @@ if "%desired_cuda%" == "9.0" set NVCC_FLAGS=%NVCC_FLAGS% -gencode=arch=compute_3
 if "%desired_cuda%" == "9.2" set NVCC_FLAGS=%NVCC_FLAGS% -gencode=arch=compute_35,code=sm_35 -gencode=arch=compute_50,code=sm_50 -gencode=arch=compute_60,code=sm_60 -gencode=arch=compute_61,code=sm_61 -gencode=arch=compute_70,code=sm_70 -gencode=arch=compute_50,code=compute_50
 if "%desired_cuda%" == "10.0" set NVCC_FLAGS=%NVCC_FLAGS% -gencode=arch=compute_35,code=sm_35 -gencode=arch=compute_50,code=sm_50 -gencode=arch=compute_60,code=sm_60 -gencode=arch=compute_70,code=sm_70 -gencode=arch=compute_75,code=sm_75 -gencode=arch=compute_50,code=compute_50
 if "%desired_cuda%" == "10.1" set NVCC_FLAGS=%NVCC_FLAGS% -gencode=arch=compute_35,code=sm_35 -gencode=arch=compute_50,code=sm_50 -gencode=arch=compute_60,code=sm_60 -gencode=arch=compute_70,code=sm_70 -gencode=arch=compute_75,code=sm_75 -gencode=arch=compute_50,code=compute_50
+if "%desired_cuda%" == "10.2" set NVCC_FLAGS=%NVCC_FLAGS% -gencode=arch=compute_35,code=sm_35 -gencode=arch=compute_50,code=sm_50 -gencode=arch=compute_60,code=sm_60 -gencode=arch=compute_70,code=sm_70 -gencode=arch=compute_75,code=sm_75 -gencode=arch=compute_50,code=compute_50
 
 :cuda_flags_end
 

--- a/packaging/windows/cuda102.bat
+++ b/packaging/windows/cuda102.bat
@@ -1,0 +1,59 @@
+@echo off
+
+IF NOT "%BUILD_VISION%" == "" (
+    set MODULE_NAME=vision
+) ELSE (
+    set MODULE_NAME=pytorch
+)
+
+IF NOT EXIST "setup.py" IF NOT EXIST "%MODULE_NAME%" (
+    call internal\clone.bat
+    cd ..
+    IF ERRORLEVEL 1 goto eof
+) ELSE (
+    call internal\clean.bat
+)
+
+call internal\check_deps.bat
+IF ERRORLEVEL 1 goto eof
+
+REM Check for optional components
+
+set NO_CUDA=
+set CMAKE_GENERATOR=Visual Studio 15 2017 Win64
+
+IF "%NVTOOLSEXT_PATH%"=="" (
+    echo NVTX ^(Visual Studio Extension ^for CUDA^) ^not installed, failing
+    exit /b 1
+    goto optcheck
+)
+
+IF "%CUDA_PATH_V10_2%"=="" (
+    echo CUDA 10.2 not found, failing
+    exit /b 1
+) ELSE (
+    IF "%BUILD_VISION%" == "" (
+        set TORCH_CUDA_ARCH_LIST=3.5;5.0+PTX;6.0;6.1;7.0;7.5
+        set TORCH_NVCC_FLAGS=-Xfatbin -compress-all
+    ) ELSE (
+        set NVCC_FLAGS=-D__CUDA_NO_HALF_OPERATORS__ --expt-relaxed-constexpr -gencode=arch=compute_35,code=sm_35 -gencode=arch=compute_50,code=sm_50 -gencode=arch=compute_60,code=sm_60 -gencode=arch=compute_70,code=sm_70 -gencode=arch=compute_75,code=sm_75 -gencode=arch=compute_50,code=compute_50
+    )
+
+    set "CUDA_PATH=%CUDA_PATH_V10_2%"
+    set "PATH=%CUDA_PATH_V10_2%\bin;%PATH%"
+)
+
+:optcheck
+
+IF "%BUILD_VISION%" == "" (
+    call internal\check_opts.bat
+    IF ERRORLEVEL 1 goto eof
+
+    call internal\copy.bat
+    IF ERRORLEVEL 1 goto eof
+)
+
+call internal\setup.bat
+IF ERRORLEVEL 1 goto eof
+
+:eof

--- a/packaging/windows/internal/cuda_install.bat
+++ b/packaging/windows/internal/cuda_install.bat
@@ -17,6 +17,7 @@ set CUDA_VERSION_STR=%CUDA_VER_MAJOR%.%CUDA_VER_MINOR%
 if %CUDA_VER% EQU 92 goto cuda92
 if %CUDA_VER% EQU 100 goto cuda100
 if %CUDA_VER% EQU 101 goto cuda101
+if %CUDA_VER% EQU 102 goto cuda102
 
 echo CUDA %CUDA_VERSION_STR% is not supported
 exit /b 1

--- a/packaging/windows/internal/cuda_install.bat
+++ b/packaging/windows/internal/cuda_install.bat
@@ -71,6 +71,23 @@ if not exist "%SRC_DIR%\temp_build\cudnn-10.1-windows10-x64-v7.6.4.38.zip" (
 
 goto cuda_common
 
+:cuda102
+
+if not exist "%SRC_DIR%\temp_build\cuda_10.2.89_441.22_win10.exe" (
+    curl -k -L https://ossci-windows.s3.amazonaws.com/cuda_10.2.89_441.22_win10.exe --output "%SRC_DIR%\temp_build\cuda_10.2.89_441.22_win10.exe"
+    if errorlevel 1 exit /b 1
+    set "CUDA_SETUP_FILE=%SRC_DIR%\temp_build\cuda_10.2.89_441.22_win10.exe"
+    set "ARGS=nvcc_10.2 cuobjdump_10.2 nvprune_10.2 cupti_10.2 cublas_10.2 cublas_dev_10.2 cudart_10.2 cufft_10.2 cufft_dev_10.2 curand_10.2 curand_dev_10.2 cusolver_10.2 cusolver_dev_10.2 cusparse_10.2 cusparse_dev_10.2 nvgraph_10.2 nvgraph_dev_10.2 npp_10.2 npp_dev_10.2 nvrtc_10.2 nvrtc_dev_10.2 nvml_dev_10.2"
+)
+
+if not exist "%SRC_DIR%\temp_build\cudnn-10.2-windows10-x64-v7.6.5.32.zip" (
+    curl -k -L https://ossci-windows.s3.amazonaws.com/cudnn-10.1-windows10-x64-v7.6.4.38.zip --output "%SRC_DIR%\temp_build\cudnn-10.2-windows10-x64-v7.6.5.32.zip"
+    if errorlevel 1 exit /b 1
+    set "CUDNN_SETUP_FILE=%SRC_DIR%\temp_build\cudnn-10.2-windows10-x64-v7.6.5.32.zip"
+)
+
+goto cuda_common
+
 :cuda_common
 
 if not exist "%SRC_DIR%\temp_build\NvToolsExt.7z" (

--- a/packaging/windows/internal/vs_install.bat
+++ b/packaging/windows/internal/vs_install.bat
@@ -1,11 +1,14 @@
 @echo off
 
-set VS_INSTALLER=C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installer.exe
+set VS_DOWNLOAD_LINK=https://aka.ms/vs/15/release/vs_enterprise.exe
 set VS_INSTALL_PATH=C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise
 set VS_INSTALL_ARGS=--nocache --quiet --wait --add Microsoft.VisualStudio.Component.VC.Tools.14.11
 set VSDEVCMD_ARGS=-vcvars_ver=14.11
 
-start /wait "%VS_INSTALLER%" modify --installPath "%VS_INSTALL_PATH%" %VS_INSTALL_ARGS%
+curl -k -L %VS_DOWNLOAD_LINK% --output vs_installer.exe
+if errorlevel 1 exit /b 1
+
+start /wait vs_installer.exe modify --installPath "%VS_INSTALL_PATH%" %VS_INSTALL_ARGS%
 if not errorlevel 0 exit /b 1
 if errorlevel 1 if not errorlevel 3010 exit /b 1
 if errorlevel 3011 exit /b 1

--- a/packaging/windows/internal/vs_install.bat
+++ b/packaging/windows/internal/vs_install.bat
@@ -1,28 +1,14 @@
 @echo off
 
-set VS_DOWNLOAD_LINK=https://aka.ms/vs/15/release/vs_buildtools.exe
-REM IF "%VS_LATEST%" == "1" (
-REM    set VS_INSTALL_ARGS= --nocache --norestart --quiet --wait --add Microsoft.VisualStudio.Workload.VCTools
-REM    set VSDEVCMD_ARGS=
-REM ) ELSE (
-set VS_INSTALL_ARGS=--nocache --quiet --wait --add Microsoft.VisualStudio.Workload.VCTools ^
-                                             --add Microsoft.VisualStudio.Component.VC.Tools.14.11 ^
-                                             --add Microsoft.Component.MSBuild ^
-                                             --add Microsoft.VisualStudio.Component.Roslyn.Compiler ^
-                                             --add Microsoft.VisualStudio.Component.TextTemplating ^
-                                             --add Microsoft.VisualStudio.Component.VC.CoreIde ^
-                                             --add Microsoft.VisualStudio.Component.VC.Redist.14.Latest ^
-                                             --add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Core ^
-                                             --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 ^
-                                             --add Microsoft.VisualStudio.Component.VC.Tools.14.11 ^
-                                             --add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Win81
+set VS_INSTALLER=C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installer.exe
+set VS_INSTALL_PATH=C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise
+set VS_INSTALL_ARGS=--nocache --quiet --wait --add Microsoft.VisualStudio.Component.VC.Tools.14.11
 set VSDEVCMD_ARGS=-vcvars_ver=14.11
-REM )
 
 curl -k -L %VS_DOWNLOAD_LINK% --output vs_installer.exe
 if errorlevel 1 exit /b 1
 
-start /wait .\vs_installer.exe %VS_INSTALL_ARGS%
+start /wait "%VS_INSTALLER%" modify --installPath "%VS_INSTALL_PATH%" %VS_INSTALL_ARGS%
 if not errorlevel 0 exit /b 1
 if errorlevel 1 if not errorlevel 3010 exit /b 1
 if errorlevel 3011 exit /b 1

--- a/packaging/windows/internal/vs_install.bat
+++ b/packaging/windows/internal/vs_install.bat
@@ -5,9 +5,6 @@ set VS_INSTALL_PATH=C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterpri
 set VS_INSTALL_ARGS=--nocache --quiet --wait --add Microsoft.VisualStudio.Component.VC.Tools.14.11
 set VSDEVCMD_ARGS=-vcvars_ver=14.11
 
-curl -k -L %VS_DOWNLOAD_LINK% --output vs_installer.exe
-if errorlevel 1 exit /b 1
-
 start /wait "%VS_INSTALLER%" modify --installPath "%VS_INSTALL_PATH%" %VS_INSTALL_ARGS%
 if not errorlevel 0 exit /b 1
 if errorlevel 1 if not errorlevel 3010 exit /b 1

--- a/packaging/windows/templates/auth_task.yml
+++ b/packaging/windows/templates/auth_task.yml
@@ -6,7 +6,7 @@ jobs:
   - group: 'peterjc-vsts-token'
 
   pool:
-    vmImage: 'win1803'
+    vmImage: 'vs2017-win2016'
 
   steps:
   - checkout: self

--- a/packaging/windows/templates/build_task.yml
+++ b/packaging/windows/templates/build_task.yml
@@ -133,23 +133,23 @@ jobs:
         msagent: ${{ parameters.msagent }}
 
   # If you want to upload binaries to S3 & Anaconda Cloud, please uncomment this section.
-  # - ${{ if and(eq(parameters.package, 'Wheels'), eq(parameters.spec, 'CPU')) }}:
-  #   - template: upload_to_s3.yml
-  #     parameters:
-  #       cuVer: '$(CUDA_VERSION)'
-  #       cudaVer: '$(CUDA_VERSION)'
+  - ${{ if and(eq(parameters.package, 'Wheels'), eq(parameters.spec, 'CPU')) }}:
+    - template: upload_to_s3.yml
+      parameters:
+        cuVer: '$(CUDA_VERSION)'
+        cudaVer: '$(CUDA_VERSION)'
 
-  # - ${{ if and(eq(parameters.package, 'Wheels'), ne(parameters.spec, 'CPU')) }}:
-  #   - template: upload_to_s3.yml
-  #     parameters:
-  #       cuVer: 'cu$(CUDA_VERSION)'
-  #       cudaVer: 'cuda$(CUDA_VERSION)'
+  - ${{ if and(eq(parameters.package, 'Wheels'), ne(parameters.spec, 'CPU')) }}:
+    - template: upload_to_s3.yml
+      parameters:
+        cuVer: 'cu$(CUDA_VERSION)'
+        cudaVer: 'cuda$(CUDA_VERSION)'
 
-  # - ${{ if eq(parameters.package, 'Conda') }}:
-  #   - template: upload_to_conda.yml
-  #     parameters:
-  #       user: $(peterjc_conda_username)
-  #       pass: $(peterjc_conda_password)
+  - ${{ if eq(parameters.package, 'Conda') }}:
+    - template: upload_to_conda.yml
+      parameters:
+        user: $(peterjc_conda_username)
+        pass: $(peterjc_conda_password)
 
   # If you want to upload binaries to Azure Git, please uncomment this section.
   # - ${{ if or(eq(parameters.package, 'Wheels'), eq(parameters.package, 'Conda')) }}:

--- a/packaging/windows/templates/build_task.yml
+++ b/packaging/windows/templates/build_task.yml
@@ -86,7 +86,7 @@ jobs:
 
   pool:
     ${{ if eq(parameters.msagent, 'true') }}:
-      vmImage: 'win1803'
+      vmImage: 'vs2017-win2016'
     ${{ if eq(parameters.msagent, 'false') }}:
       name: 'release'
 
@@ -121,23 +121,23 @@ jobs:
         msagent: ${{ parameters.msagent }}
 
   # If you want to upload binaries to S3 & Anaconda Cloud, please uncomment this section.
-  - ${{ if and(eq(parameters.package, 'Wheels'), eq(parameters.spec, 'CPU')) }}:
-    - template: upload_to_s3.yml
-      parameters:
-        cuVer: '$(CUDA_VERSION)'
-        cudaVer: '$(CUDA_VERSION)'
+  # - ${{ if and(eq(parameters.package, 'Wheels'), eq(parameters.spec, 'CPU')) }}:
+  #   - template: upload_to_s3.yml
+  #     parameters:
+  #       cuVer: '$(CUDA_VERSION)'
+  #       cudaVer: '$(CUDA_VERSION)'
 
-  - ${{ if and(eq(parameters.package, 'Wheels'), ne(parameters.spec, 'CPU')) }}:
-    - template: upload_to_s3.yml
-      parameters:
-        cuVer: 'cu$(CUDA_VERSION)'
-        cudaVer: 'cuda$(CUDA_VERSION)'
+  # - ${{ if and(eq(parameters.package, 'Wheels'), ne(parameters.spec, 'CPU')) }}:
+  #   - template: upload_to_s3.yml
+  #     parameters:
+  #       cuVer: 'cu$(CUDA_VERSION)'
+  #       cudaVer: 'cuda$(CUDA_VERSION)'
 
-  - ${{ if eq(parameters.package, 'Conda') }}:
-    - template: upload_to_conda.yml
-      parameters:
-        user: $(peterjc_conda_username)
-        pass: $(peterjc_conda_password)
+  # - ${{ if eq(parameters.package, 'Conda') }}:
+  #   - template: upload_to_conda.yml
+  #     parameters:
+  #       user: $(peterjc_conda_username)
+  #       pass: $(peterjc_conda_password)
 
   # If you want to upload binaries to Azure Git, please uncomment this section.
   # - ${{ if or(eq(parameters.package, 'Wheels'), eq(parameters.package, 'Conda')) }}:

--- a/packaging/windows/templates/build_task.yml
+++ b/packaging/windows/templates/build_task.yml
@@ -83,6 +83,18 @@ jobs:
         PY3.8_101:
           DESIRED_PYTHON: 3.8
           CUDA_VERSION: 101
+        PY3.5_102:
+          DESIRED_PYTHON: 3.5
+          CUDA_VERSION: 102
+        PY3.6_102:
+          DESIRED_PYTHON: 3.6
+          CUDA_VERSION: 102
+        PY3.7_102:
+          DESIRED_PYTHON: 3.7
+          CUDA_VERSION: 102
+        PY3.8_102:
+          DESIRED_PYTHON: 3.8
+          CUDA_VERSION: 102
 
   pool:
     ${{ if eq(parameters.msagent, 'true') }}:


### PR DESCRIPTION
1. According to https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops#use-a-microsoft-hosted-agent, `win1803` will be removed soon. Use `vs2017-win2016` instead.
2. Add CUDA 10.2 jobs.
