### PR TITLE
Document origin of preprocessing mean / std

### DIFF
--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -86,14 +86,25 @@ You can use the following transform to normalize::
 An example of such normalization can be found in the imagenet example
 `here <https://github.com/pytorch/examples/blob/42e5b996718797e45c46a25c55b031e6768f8440/imagenet/main.py#L89-L101>`_
 
-The values of `mean` and `std` were obtained by running::
+The process for obtaining the values of `mean` and `std` is roughly equivalent
+to::
 
-    mean = mean([mean(transform(img)) for img in subset(dataset)])
-    std = mean([std(transform(img)) for img in subset(dataset)])
+    import torch
+    from torchvision import datasets, transforms as T
 
-Here `dataset` is the training split of the `ImageNet2012` dataset. The images
-are `transform`ed by resizing them to 256 and subsequently center cropping them
-to 224x224. Unfortunately, the concret `subset` that was used is lost. For more
+    transform = T.Compose([T.Resize(256), T.CenterCrop(224), T.ToTensor])
+    dataset = datasets.ImageNet(".", split="train", transform=transform)
+
+    means = []
+    stds = []
+    for img in subset(dataset):
+        means.append(torch.mean(img))
+        stds.append(torch.std(img))
+
+    mean = torch.mean(torch.tensor(means))
+    std = torch.mean(torch.tensor(stds))
+
+Unfortunately, the concret `subset` that was used is lost. For more
 information see `this discussion <https://github.com/pytorch/vision/issues/1439>`_
 or `these experiments <https://github.com/pytorch/vision/pull/1965>`_.
 

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -86,7 +86,16 @@ You can use the following transform to normalize::
 An example of such normalization can be found in the imagenet example
 `here <https://github.com/pytorch/examples/blob/42e5b996718797e45c46a25c55b031e6768f8440/imagenet/main.py#L89-L101>`_
 
-Shall I document this PR somewhere around here?
+The values of `mean` and `std` were obtained by running::
+
+    mean = mean([mean(transform(img)) for img in subset(dataset)])
+    std = mean([std(transform(img)) for img in subset(dataset)])
+
+Here `dataset` is the training split of the `ImageNet2012` dataset. The images
+are `transform`ed by resizing them to 256 and subsequently center cropping them
+to 224x224. Unfortunately, the concret `subset` that was used is lost. For more
+information see `this discussion <https://github.com/pytorch/vision/issues/1439>`_https://githubc
+or `these experiments <https://github.com/pytorch/vision/pull/1965>`_.
 
 ImageNet 1-crop error rates (224x224)
 

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -92,7 +92,7 @@ to::
     import torch
     from torchvision import datasets, transforms as T
 
-    transform = T.Compose([T.Resize(256), T.CenterCrop(224), T.ToTensor])
+    transform = T.Compose([T.Resize(256), T.CenterCrop(224), T.ToTensor()])
     dataset = datasets.ImageNet(".", split="train", transform=transform)
 
     means = []

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -94,7 +94,7 @@ The values of `mean` and `std` were obtained by running::
 Here `dataset` is the training split of the `ImageNet2012` dataset. The images
 are `transform`ed by resizing them to 256 and subsequently center cropping them
 to 224x224. Unfortunately, the concret `subset` that was used is lost. For more
-information see `this discussion <https://github.com/pytorch/vision/issues/1439>`_https://githubc
+information see `this discussion <https://github.com/pytorch/vision/issues/1439>`_
 or `these experiments <https://github.com/pytorch/vision/pull/1965>`_.
 
 ImageNet 1-crop error rates (224x224)

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -86,6 +86,8 @@ You can use the following transform to normalize::
 An example of such normalization can be found in the imagenet example
 `here <https://github.com/pytorch/examples/blob/42e5b996718797e45c46a25c55b031e6768f8440/imagenet/main.py#L89-L101>`_
 
+Shall I document this PR somewhere around here?
+
 ImageNet 1-crop error rates (224x224)
 
 ================================  =============   =============


### PR DESCRIPTION
I finally came about addressing #1439. Quick recap of the discussion: the origin of the `mean=[0.485, 0.456, 0.406]` and `std=[0.229, 0.224, 0.225]` we use for the normalization transforms on almost every model is only partially known. We know that they were calculated them on a random subset of the `train` split of the `ImageNet2012` dataset. Which images were used or even the sample size as well as the used transformation are unfortunately lost. 

I've tried to reproduce them and found that we probably resized each image to `256` and center cropped it to `224` afterwards. In #1439 my calculated `std`s differed significantly from the values we used. This resulted from the fact that I previously used `sqrt(mean([var(img) for img in dataset]))` while we probably used `mean([std(img) for img in dataset])`. You can find the script I've used for all calculations [here](https://gist.github.com/pmeier/f5e05285cd5987027a98854a5d155e27).

---

Fortunately, varying the `num_samples` with `seed=0` (`python imagenet_normalization.py $IMAGENET_ROOT --num-samples N --seed 0`)

| `num_samples` | `mean`                  | `std`                   |
| ------------- | ----------------------- | ----------------------- |
| `1000`        | `[0.483, 0.454, 0.401]` | `[0.226, 0.223, 0.222]` |
| `2000`        | `[0.482, 0.451, 0.396]` | `[0.225, 0.222, 0.221]` |
| `5000`        | `[0.484, 0.454, 0.401]` | `[0.225, 0.221, 0.221]` |
| `10000`       | `[0.485, 0.454, 0.401]` | `[0.225, 0.221, 0.220]` |
| `20000`       | `[0.484, 0.453, 0.400]` | `[0.224, 0.220, 0.219]` |

as well as varying the `seed` with `num_samples=1000` (`python imagenet_normalization.py $IMAGENET_ROOT --num-samples 1000 --seed S`)

| `seed` | `mean`                  | `std`                   |
| ------ | ----------------------- | ----------------------- |
| `0`    | `[0.483, 0.454, 0.401]` | `[0.226, 0.223, 0.222]` |
| `1`    | `[0.485, 0.455, 0.402]` | `[0.223, 0.218, 0.217]` |
| `27`   | `[0.479, 0.449, 0.398]` | `[0.225, 0.220, 0.219]` |
| `314`  | `[0.480, 0.454, 0.403]` | `[0.223, 0.218, 0.217]` |
| `4669` | `[0.490, 0.458, 0.406]` | `[0.224, 0.219, 0.219]` |

does not change the `mean` and `std` by much. Running on the complete dataset without specific seed (`python imagenet_normalization.py $IMAGENET_ROOT`) results in

```
mean=[0.484, 0.454, 0.403], std=[0.225, 0.220, 0.220]
```

and thus 

```
mean_diff=[1e-3, 2e-3, 3e-3], std_diff=[4e-3, 4e-3, 5e-3] 
```

---

@fmassa How do you want me to document this?