### PR TITLE
Fixing samplers initialization

### DIFF
--- a/torchvision/csrc/cpu/decoder/audio_stream.cpp
+++ b/torchvision/csrc/cpu/decoder/audio_stream.cpp
@@ -79,6 +79,7 @@ int AudioStream::copyFrameBytes(ByteStorage* out, bool flush) {
     SamplerParameters params;
     params.type = format_.type;
     params.out = format_.format;
+    params.in = FormatUnion();
     flush ? toAudioFormat(params.in.audio, *codecCtx_)
           : toAudioFormat(params.in.audio, *frame_);
     if (!sampler_->init(params)) {

--- a/torchvision/csrc/cpu/decoder/video_stream.cpp
+++ b/torchvision/csrc/cpu/decoder/video_stream.cpp
@@ -92,6 +92,7 @@ int VideoStream::copyFrameBytes(ByteStorage* out, bool flush) {
     SamplerParameters params;
     params.type = format_.type;
     params.out = format_.format;
+    params.in = FormatUnion(0);
     flush ? toVideoFormat(params.in.video, *codecCtx_)
           : toVideoFormat(params.in.video, *frame_);
     if (!sampler_->init(params)) {


### PR DESCRIPTION
Summary: No-ops for torchvision diff, which fixes samplers.

Differential Revision: D20397218

