### PR TITLE
Update inception quantized model path

### DIFF
--- a/torchvision/models/quantization/inception.py
+++ b/torchvision/models/quantization/inception.py
@@ -65,6 +65,9 @@ def inception_v3(pretrained=False, progress=True, quantize=False, **kwargs):
 
     if pretrained:
         if quantize:
+            if not original_aux_logits:
+                model.aux_logits = False
+                del model.AuxLogits
             model_url = quant_model_urls['inception_v3_google' + '_' + backend]
         else:
             model_url = inception_module.model_urls['inception_v3_google']
@@ -74,9 +77,10 @@ def inception_v3(pretrained=False, progress=True, quantize=False, **kwargs):
 
         model.load_state_dict(state_dict)
 
-        if not original_aux_logits:
-            model.aux_logits = False
-            del model.AuxLogits
+        if not quantize:
+            if not original_aux_logits:
+                model.aux_logits = False
+                del model.AuxLogits
     return model
 
 

--- a/torchvision/models/quantization/inception.py
+++ b/torchvision/models/quantization/inception.py
@@ -20,7 +20,7 @@ __all__ = [
 quant_model_urls = {
     # fp32 weights ported from TensorFlow, quantized in PyTorch
     "inception_v3_google_fbgemm":
-        "https://download.pytorch.org/models/quantized/inception_v3_google_fbgemm-4f6e4894.pth"
+        "https://download.pytorch.org/models/quantized/inception_v3_google_fbgemm-71447a44.pth"
 }
 
 


### PR DESCRIPTION
Update inception quantized model path. Also remove the auto_logits from model before loading pretrained quantized model.

Tested by running:
python references/classification/train_quantization.py  --data-path='/mnt/fair/imagenet_full_size/' --device='cpu' --backend='fbgemm' --test-only --model='inception_v3'

Got accuracy similar to https://github.com/pytorch/vision/tree/master/references/classification#int8-models:
Acc@1 77.176 Acc@5 93.354
