### PR TITLE
remove redundant condition in resnet.py

### DIFF
--- a/torchvision/models/resnet.py
+++ b/torchvision/models/resnet.py
@@ -175,7 +175,7 @@ class ResNet(nn.Module):
         if dilate:
             self.dilation *= stride
             stride = 1
-        if stride != 1 or self.inplanes != planes * block.expansion:
+        if self.inplanes != planes * block.expansion:
             downsample = nn.Sequential(
                 conv1x1(self.inplanes, planes * block.expansion, stride),
                 norm_layer(planes * block.expansion),


### PR DESCRIPTION
The "stride != 1" condition [here ](https://github.com/pytorch/vision/blob/b70e333ac5be307d2d5e38c1653b755907a09f04/torchvision/models/resnet.py#L178)in `resnet.py` appears to be redundant.

```python
def _make_layer(self, block, planes, blocks, stride=1, dilate=False):
        ...
        if stride != 1 or self.inplanes != planes * block.expansion:
            downsample = nn.Sequential(
                conv1x1(self.inplanes, planes * block.expansion, stride),
                norm_layer(planes * block.expansion),
            )
        ...
```
 Apparently the `if` statement here is used to decide whether to apply a "downsampling". It seems that this statement is considering two conditions:
1. the feature map's size(WxH) has changed. (`stride != 1`)
2. the number of channels has expanded.(`self.inplanes != planes * block.expansion`)

I try to explain that the Condition 2 is a **strict superset** of Condition 1 below.
- In all the models from ResNet18 to ResNet152 and their variants, the expansion of channels takes place whenever feature map’s size reduces. This matches the descriptions in the original paper:
> if the feature map size is halved, the number of filters is doubled so as to preserve the time complexity per layer.
- the opposite is not true. There is one single case where the channels expand without reduction of feature map’s size: when the input goes through the first Bottleneck of first layer, e.g. in ResNet101, its channels expand(from 64 to 256) while its feature maps remain the same size.

It only makes sense to use “stride != 1” if there exists a case where the feature map’s size shrinks but the channels remain the same. But such a situation doesn’t exist in any implementation of all standard ResNet models. 
Therefore, I think the `stride != 1` condition should be omitted for tidiness and readability.