### PR TITLE
add comments for the modified implementation of ResNet

### DIFF
--- a/torchvision/models/resnet.py
+++ b/torchvision/models/resnet.py
@@ -73,6 +73,12 @@ class BasicBlock(nn.Module):
 
 
 class Bottleneck(nn.Module):
+    # Bottleneck in torchvision places the stride for downsampling at 3x3 convolution(self.conv2)
+    # while original implementation places the stride at the first 1x1 convolution(self.conv1)
+    # according to "Deep residual learning for image recognition"https://arxiv.org/abs/1512.03385.
+    # This variant is also known as ResNet V1.5 and improves accuracy according to
+    # https://ngc.nvidia.com/catalog/model-scripts/nvidia:resnet_50_v1_5_for_pytorch.
+
     expansion = 4
 
     def __init__(self, inplanes, planes, stride=1, downsample=None, groups=1,


### PR DESCRIPTION
In reference to https://github.com/pytorch/vision/issues/191 added comments to clarify the differences between torchvision's implementation of ResNet and the one in original paper.

Not sure if it's the proper place to insert such comments and if I have explained the situation clear enough.

Please let me know if further modifications are needed. @fmassa 