### PR TITLE
Remove Python2.x code for os.makedirs

### DIFF
--- a/torchvision/datasets/caltech.py
+++ b/torchvision/datasets/caltech.py
@@ -4,7 +4,7 @@ import os
 import os.path
 
 from .vision import VisionDataset
-from .utils import download_and_extract_archive, makedir_exist_ok, verify_str_arg
+from .utils import download_and_extract_archive, verify_str_arg
 
 
 class Caltech101(VisionDataset):
@@ -35,7 +35,7 @@ class Caltech101(VisionDataset):
         super(Caltech101, self).__init__(os.path.join(root, 'caltech101'),
                                          transform=transform,
                                          target_transform=target_transform)
-        makedir_exist_ok(self.root)
+        os.makedirs(self.root, exist_ok=True)
         if not isinstance(target_type, list):
             target_type = [target_type]
         self.target_type = [verify_str_arg(t, "target_type", ("category", "annotation"))
@@ -148,7 +148,7 @@ class Caltech256(VisionDataset):
         super(Caltech256, self).__init__(os.path.join(root, 'caltech256'),
                                          transform=transform,
                                          target_transform=target_transform)
-        makedir_exist_ok(self.root)
+        os.makedirs(self.root, exist_ok=True)
 
         if download:
             self.download()

--- a/torchvision/datasets/mnist.py
+++ b/torchvision/datasets/mnist.py
@@ -9,7 +9,7 @@ import torch
 import codecs
 import string
 from .utils import download_url, download_and_extract_archive, extract_archive, \
-    makedir_exist_ok, verify_str_arg
+    verify_str_arg
 
 
 class MNIST(VisionDataset):
@@ -129,8 +129,8 @@ class MNIST(VisionDataset):
         if self._check_exists():
             return
 
-        makedir_exist_ok(self.raw_folder)
-        makedir_exist_ok(self.processed_folder)
+        os.makedirs(self.raw_folder, exist_ok=True)
+        os.makedirs(self.processed_folder, exist_ok=True)
 
         # download files
         for url, md5 in self.resources:
@@ -274,8 +274,8 @@ class EMNIST(MNIST):
         if self._check_exists():
             return
 
-        makedir_exist_ok(self.raw_folder)
-        makedir_exist_ok(self.processed_folder)
+        os.makedirs(self.raw_folder, exist_ok=True)
+        os.makedirs(self.processed_folder, exist_ok=True)
 
         # download files
         print('Downloading and extracting zip archive')
@@ -377,8 +377,8 @@ class QMNIST(MNIST):
         """
         if self._check_exists():
             return
-        makedir_exist_ok(self.raw_folder)
-        makedir_exist_ok(self.processed_folder)
+        os.makedirs(self.raw_folder, exist_ok=True)
+        os.makedirs(self.processed_folder, exist_ok=True)
         split = self.resources[self.subsets[self.what]]
         files = []
 

--- a/torchvision/datasets/utils.py
+++ b/torchvision/datasets/utils.py
@@ -43,19 +43,6 @@ def check_integrity(fpath, md5=None):
     return check_md5(fpath, md5)
 
 
-def makedir_exist_ok(dirpath):
-    """
-    Python2 support for os.makedirs(.., exist_ok=True)
-    """
-    try:
-        os.makedirs(dirpath)
-    except OSError as e:
-        if e.errno == errno.EEXIST:
-            pass
-        else:
-            raise
-
-
 def download_url(url, root, filename=None, md5=None):
     """Download a file from a url and place it in root.
 
@@ -72,7 +59,7 @@ def download_url(url, root, filename=None, md5=None):
         filename = os.path.basename(url)
     fpath = os.path.join(root, filename)
 
-    makedir_exist_ok(root)
+    os.makedirs(root, exist_ok=True)
 
     # check if file is already present locally
     if check_integrity(fpath, md5):
@@ -164,7 +151,7 @@ def download_file_from_google_drive(file_id, root, filename=None, md5=None):
         filename = file_id
     fpath = os.path.join(root, filename)
 
-    makedir_exist_ok(root)
+    os.makedirs(root, exist_ok=True)
 
     if os.path.isfile(fpath) and check_integrity(fpath, md5):
         print('Using downloaded and verified file: ' + fpath)


### PR DESCRIPTION
Walking through the code, I found out some extra lines support for Python 2.x. Deleted awkward custom function call for creating directories with direct call to `os.makedirs`.