### PR TITLE
Add Unsupervised ImageFolder

### DIFF
--- a/torchvision/datasets/__init__.py
+++ b/torchvision/datasets/__init__.py
@@ -1,5 +1,6 @@
 from .lsun import LSUN, LSUNClass
 from .folder import ImageFolder, DatasetFolder
+from .folder import UnsupervisedImageFolder, UnsupervisedDatasetFolder
 from .coco import CocoCaptions, CocoDetection
 from .cifar import CIFAR10, CIFAR100
 from .stl10 import STL10

--- a/torchvision/datasets/folder.py
+++ b/torchvision/datasets/folder.py
@@ -146,6 +146,81 @@ class DatasetFolder(VisionDataset):
     def __len__(self):
         return len(self.samples)
 
+class UnsupervisedDatasetFolder(VisionDataset):
+    """A generic data loader where the samples are arranged in this way: ::
+
+        root/xxx.ext
+        root/xxy.ext
+        root/xxz.ext
+
+    Args:
+        root (string): Root directory path.
+        loader (callable): A function to load a sample given its path.
+        extensions (tuple[string]): A list of allowed extensions.
+            both extensions and is_valid_file should not be passed.
+        transform (callable, optional): A function/transform that takes in
+            a sample and returns a transformed version.
+            E.g, ``transforms.RandomCrop`` for images.
+        is_valid_file (callable, optional): A function that takes path of a file
+            and check if the file is a valid file (used to check of corrupt files)
+            both extensions and is_valid_file should not be passed.
+
+     Attributes:
+        samples (list): List of paths to samples
+    """
+
+    def __init__(self, root, loader, extensions=None, transform=None,
+                 is_valid_file=None):
+        super().__init__(root, transform=transform)
+        self.loader = loader
+        self.extensions = extensions
+
+        self.samples = self._make_samples_only_dataset(extensions, is_valid_file)
+        if len(self.samples) == 0:
+            raise (RuntimeError("Found 0 files in subfolders of: " + self.root + "\n"
+                                "Supported extensions are: " + ",".join(extensions)))
+
+    def _make_samples_only_dataset(self, extensions=None, is_valid_file=None):
+        """
+        Returns all file paths according to passed extensions or is_valid_file arguments
+
+        Args:
+            extensions (tuple of strings, optional): tuple of allowed extensions (lowercase)
+            is_valid_file (callable, optional): A function that takes path of a file
+                and check if the file is a valid file (used to check of corrupt files)
+            Only one of the [extensions, is_valid_file] should be passed
+
+        Returns:
+            list: path to a valid file declared by extensions/is_valid_file argument
+        """
+        dir = os.path.expanduser(self.root)
+        if not ((extensions is None) ^ (is_valid_file is None)):
+            raise ValueError("Both extensions and is_valid_file cannot be None or not None "
+                             "at the same time")
+        if extensions is not None:
+            def is_valid_file(x):
+                return has_file_allowed_extension(x, extensions)
+
+        samples = [os.path.join(dir, fname) for fname in os.listdir(dir)
+                   if is_valid_file(fname)]
+        return samples
+
+    def __getitem__(self, index):
+        """
+        Args:
+            index (int): Index
+
+        Returns:
+            torch.Tensor: sample
+        """
+        path = self.samples[index]
+        sample = self.loader(path)
+        if self.transform is not None:
+            sample = self.transform(sample)
+        return sample
+
+    def __len__(self):
+        return len(self.samples)
 
 IMG_EXTENSIONS = ('.jpg', '.jpeg', '.png', '.ppm', '.bmp', '.pgm', '.tif', '.tiff', '.webp')
 
@@ -172,6 +247,33 @@ def default_loader(path):
         return accimage_loader(path)
     else:
         return pil_loader(path)
+
+
+class UnsupervisedImageFolder(UnsupervisedDatasetFolder):
+    """A generic data loader where the images are arranged in this way: ::
+
+        root/xxx.png
+        root/xxy.png
+        root/xxz.png
+
+    Args:
+        root (string): Root directory path.
+        transform (callable, optional): A function/transform that  takes in an PIL image
+            and returns a transformed version. E.g, ``transforms.RandomCrop``
+        loader (callable, optional): A function to load an image given its path.
+        is_valid_file (callable, optional): A function that takes path of an Image file
+            and check if the file is a valid file (used to check of corrupt files)
+
+     Attributes:
+        imgs (list): List of image_paths
+    """
+    def __init__(self, root, transform=None, target_transform=None,
+                 loader=default_loader, is_valid_file=None):
+        super(UnsupervisedImageFolder, self).__init__(root, loader,
+                                                      IMG_EXTENSIONS if is_valid_file is None else None,
+                                                      transform=transform,
+                                                      is_valid_file=is_valid_file)
+        self.imgs = self.samples
 
 
 class ImageFolder(DatasetFolder):
@@ -203,7 +305,8 @@ class ImageFolder(DatasetFolder):
 
     def __init__(self, root, transform=None, target_transform=None,
                  loader=default_loader, is_valid_file=None):
-        super(ImageFolder, self).__init__(root, loader, IMG_EXTENSIONS if is_valid_file is None else None,
+        super(ImageFolder, self).__init__(root, loader,
+                                          IMG_EXTENSIONS if is_valid_file is None else None,
                                           transform=transform,
                                           target_transform=target_transform,
                                           is_valid_file=is_valid_file)


### PR DESCRIPTION
Right now (correct me if i wrong) i can't think of better way of using ImageFolder with unlabeled datasets (e.g. "root/*.png") other than moving directory with samples into another folder and just ignore the fictional labels. So i thought it would be good to have a class that represents such types of datasets.