### PR TITLE
Allow passing list to the input argument 'scale' of RandomResizedCrop

### DIFF
--- a/torchvision/transforms/transforms.py
+++ b/torchvision/transforms/transforms.py
@@ -620,7 +620,7 @@ class RandomResizedCrop(object):
     """
 
     def __init__(self, size, scale=(0.08, 1.0), ratio=(3. / 4., 4. / 3.), interpolation=Image.BILINEAR):
-        if isinstance(size, tuple):
+        if isinstance(size, (tuple, list)):
             self.size = size
         else:
             self.size = (size, size)


### PR DESCRIPTION
Summary: Currently the scale argument can only be of type tuple or integer, this diff allows feeding the input argument `scale` with a list.

Differential Revision: D20539466

