### PR TITLE
Allow passing list to the input argument 'scale' of RandomResizedCrop…

### DIFF
--- a/torchvision/transforms/transforms.py
+++ b/torchvision/transforms/transforms.py
@@ -623,7 +623,7 @@ class RandomResizedCrop(object):
     """
 
     def __init__(self, size, scale=(0.08, 1.0), ratio=(3. / 4., 4. / 3.), interpolation=Image.BILINEAR):
-        if isinstance(size, tuple):
+        if isinstance(size, (tuple, list)):
             self.size = size
         else:
             self.size = (size, size)


### PR DESCRIPTION
… (#1997)

Summary:
Currently the scale argument can only be of type tuple or integer, this diff allows feeding the input argument `scale` with a list.
Pull Request resolved: https://github.com/pytorch/vision/pull/1997

Test Plan:
Without this diff, launching the following classy vision task causes error:
https://our.intern.facebook.com/intern/fblearner/details/175876950/

With this diff, everything works fine:
https://our.intern.facebook.com/intern/fblearner/details/175913768/

Reviewed By: resonatevision

Differential Revision: D20544904

Pulled By: ymao1993

fbshipit-source-id: a95a2e9ceadec77fffe234756fb3b38b1b9c9cb1