### PR TITLE
Replace 2 transpose with 1 permute

### DIFF
--- a/torchvision/transforms/functional.py
+++ b/torchvision/transforms/functional.py
@@ -84,8 +84,7 @@ def to_tensor(pic):
 
     img = img.view(pic.size[1], pic.size[0], len(pic.getbands()))
     # put it from HWC to CHW format
-    # yikes, this transpose takes 80% of the loading time/CPU
-    img = img.transpose(0, 1).transpose(0, 2).contiguous()
+    img = img.permute((2, 0, 1)).contiguous()
     if isinstance(img, torch.ByteTensor):
         return img.float().div(255)
     else:


### PR DESCRIPTION
Changing image's channel format using permute is almost twice faster than using transposes. Is there a good reason we're using 2 transposes instead of permute to change channel format?