### PR TITLE
Add return statement

### DIFF
--- a/references/detection/engine.py
+++ b/references/detection/engine.py
@@ -52,6 +52,8 @@ def train_one_epoch(model, optimizer, data_loader, device, epoch, print_freq):
         metric_logger.update(loss=losses_reduced, **loss_dict_reduced)
         metric_logger.update(lr=optimizer.param_groups[0]["lr"])
 
+    return metric_logger
+
 
 def _get_iou_types(model):
     model_without_ddp = model


### PR DESCRIPTION
Adding simple 'return' statement to the train_one_epoch() function.

Fyi, we (Microsoft) are using the references/detection folder as-is in our Computer Vision Best Practices repository. All our Jupyter notebooks and higher-level functionality for Object Detection is based fully on torchvision.

See these notebooks:
https://github.com/microsoft/computervision-recipes/tree/master/scenarios/detection

And Torchvision's reference folder is copy & pasted here:
https://github.com/microsoft/computervision-recipes/tree/master/utils_cv/detection/references