### PR TITLE
Fixed Pillow version check for Pillow >= 10

### DIFF
--- a/torchvision/transforms/functional.py
+++ b/torchvision/transforms/functional.py
@@ -437,7 +437,9 @@ def _parse_fill(fill, img, min_pil_version):
     Returns:
         dict: kwarg for ``fillcolor``
     """
-    if PILLOW_VERSION < min_pil_version:
+    major_found, minor_found = (int(v) for v in PILLOW_VERSION.split('.')[:2])
+    major_required, minor_required = (int(v) for v in min_pil_version.split('.')[:2])
+    if major_found < major_required or (major_found == major_required and minor_found < minor_required):
         if fill is None:
             return {}
         else:
@@ -853,7 +855,7 @@ def affine(img, angle, translate, scale, shear, resample=0, fillcolor=None):
     output_size = img.size
     center = (img.size[0] * 0.5 + 0.5, img.size[1] * 0.5 + 0.5)
     matrix = _get_inverse_affine_matrix(center, angle, translate, scale, shear)
-    kwargs = {"fillcolor": fillcolor} if PILLOW_VERSION[0] >= '5' else {}
+    kwargs = {"fillcolor": fillcolor} if int(PILLOW_VERSION.split('.')[0]) >= 5 else {}
     return img.transform(output_size, Image.AFFINE, matrix, resample, **kwargs)
 
 


### PR DESCRIPTION
The check for the Pillow version compares strings, which works fine for the moment. However, this will stop working when Pillow reaches version 10 in a few years.

```
>>> '7.0.0' > '5.0.0'
True
>>> '10.0.0' > '5.0.0'
False
```