### PR TITLE
Re-enable one torchvision CUDA CI for tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -497,6 +497,10 @@ workflows:
           name: binary_macos_conda_py3.8_cpu
           python_version: '3.8'
           wheel_docker_image: pytorch/manylinux-cuda102
+      - binary_linux_conda_cuda:
+          name: torchvision_linux_py3.8_cu102_cuda
+          python_version: "3.8"
+          cu_version: "cu102"
       - binary_win_conda:
           name: torchvision_win_py3.6_cpu
           python_version: "3.6"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -498,9 +498,9 @@ workflows:
           python_version: '3.8'
           wheel_docker_image: pytorch/manylinux-cuda102
       - binary_linux_conda_cuda:
-          name: torchvision_linux_py3.8_cu102_cuda
-          python_version: "3.8"
-          cu_version: "cu102"
+          name: torchvision_linux_py3.6_cu92_cuda
+          python_version: "3.6"
+          cu_version: "cu92"
       - binary_win_conda:
           name: torchvision_win_py3.6_cpu
           python_version: "3.6"

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -299,6 +299,10 @@ workflows:
     jobs:
       - circleci_consistency
       {{ workflows() }}
+      - binary_linux_conda_cuda:
+          name: torchvision_linux_py3.8_cu102_cuda
+          python_version: "3.8"
+          cu_version: "cu102"
       - binary_win_conda:
           name: torchvision_win_py3.6_cpu
           python_version: "3.6"

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -300,9 +300,9 @@ workflows:
       - circleci_consistency
       {{ workflows() }}
       - binary_linux_conda_cuda:
-          name: torchvision_linux_py3.8_cu102_cuda
-          python_version: "3.8"
-          cu_version: "cu102"
+          name: torchvision_linux_py3.6_cu92_cuda
+          python_version: "3.6"
+          cu_version: "cu92"
       - binary_win_conda:
           name: torchvision_win_py3.6_cpu
           python_version: "3.6"


### PR DESCRIPTION
It seems to have been disabled in https://github.com/pytorch/vision/pull/1980

Note that the only test that effectively uses GPUs for linux are those which calls into `binary_linux_conda_cuda`, which was not applied anymore.

This should be more consistent overall, but TBD if we want to have all cuda jobs that build torchvision to use GPUs