### PR TITLE
.cirlceci: Bump NVIDIA driver, CUDA version, Python Version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,7 +152,7 @@ jobs:
           sudo apt-get update && sudo apt-get install -y nvidia-container-toolkit=${NVIDIA_CONTAINER_VERSION}
           sudo systemctl restart docker
 
-          DRIVER_FN="NVIDIA-Linux-x86_64-410.104.run"
+          DRIVER_FN="NVIDIA-Linux-x86_64-440.59.run"
           wget "https://s3.amazonaws.com/ossci-linux/nvidia_driver/$DRIVER_FN"
           sudo /bin/bash "$DRIVER_FN" -s --no-drm || (sudo cat /var/log/nvidia-installer.log && false)
           nvidia-smi
@@ -498,9 +498,9 @@ workflows:
           python_version: '3.8'
           wheel_docker_image: pytorch/manylinux-cuda102
       - binary_linux_conda_cuda:
-          name: torchvision_linux_py3.6_cu92_cuda
-          python_version: "3.6"
-          cu_version: "cu92"
+          name: torchvision_linux_py3.8_cu102_cuda
+          python_version: "3.8"
+          cu_version: "cu102"
       - binary_win_conda:
           name: torchvision_win_py3.6_cpu
           python_version: "3.6"

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -152,7 +152,7 @@ jobs:
           sudo apt-get update && sudo apt-get install -y nvidia-container-toolkit=${NVIDIA_CONTAINER_VERSION}
           sudo systemctl restart docker
 
-          DRIVER_FN="NVIDIA-Linux-x86_64-410.104.run"
+          DRIVER_FN="NVIDIA-Linux-x86_64-440.59.run"
           wget "https://s3.amazonaws.com/ossci-linux/nvidia_driver/$DRIVER_FN"
           sudo /bin/bash "$DRIVER_FN" -s --no-drm || (sudo cat /var/log/nvidia-installer.log && false)
           nvidia-smi
@@ -300,9 +300,9 @@ workflows:
       - circleci_consistency
       {{ workflows() }}
       - binary_linux_conda_cuda:
-          name: torchvision_linux_py3.6_cu92_cuda
-          python_version: "3.6"
-          cu_version: "cu92"
+          name: torchvision_linux_py3.8_cu102_cuda
+          python_version: "3.8"
+          cu_version: "cu102"
       - binary_win_conda:
           name: torchvision_win_py3.6_cpu
           python_version: "3.6"


### PR DESCRIPTION
CUDA 10.2 is compatible with Nvidia drivers >= 440

We should also be testing against the latest version of python wherever
possible.

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>