### PR TITLE
Temporarily re-add Python-2 support for clang-format lint

### DIFF
--- a/travis-scripts/run-clang-format/run-clang-format.py
+++ b/travis-scripts/run-clang-format/run-clang-format.py
@@ -8,6 +8,8 @@ A diff output is produced and a sensible exit code is returned.
 
 """
 
+from __future__ import print_function, unicode_literals
+
 import argparse
 import codecs
 import difflib
@@ -127,6 +129,11 @@ def run_clang_format_diff(args, file):
     #   > Each translation completely replaces the format string
     #   > for the diagnostic.
     #   > -- http://clang.llvm.org/docs/InternalsManual.html#internals-diag-translation
+    #
+    # It's not pretty, due to Python 2 & 3 compatibility.
+    encoding_py3 = {}
+    if sys.version_info[0] >= 3:
+        encoding_py3['encoding'] = 'utf-8'
 
     try:
         proc = subprocess.Popen(
@@ -134,7 +141,7 @@ def run_clang_format_diff(args, file):
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             universal_newlines=True,
-            encoding='utf-8')
+            **encoding_py3)
     except OSError as exc:
         raise DiffError(
             "Command '{}' failed to start: {}".format(
@@ -143,7 +150,12 @@ def run_clang_format_diff(args, file):
         )
     proc_stdout = proc.stdout
     proc_stderr = proc.stderr
-
+    if sys.version_info[0] < 3:
+        # make the pipes compatible with Python 3,
+        # reading lines should output unicode
+        encoding = 'utf-8'
+        proc_stdout = codecs.getreader(encoding)(proc_stdout)
+        proc_stderr = codecs.getreader(encoding)(proc_stderr)
     # hopefully the stderr pipe won't get full and block the process
     outs = list(proc_stdout.readlines())
     errs = list(proc_stderr.readlines())
@@ -191,7 +203,10 @@ def colorize(diff_lines):
 def print_diff(diff_lines, use_color):
     if use_color:
         diff_lines = colorize(diff_lines)
-    sys.stdout.writelines(diff_lines)
+    if sys.version_info[0] < 3:
+        sys.stdout.writelines((l.encode('utf-8') for l in diff_lines))
+    else:
+        sys.stdout.writelines(diff_lines)
 
 
 def print_trouble(prog, message, use_colors):


### PR DESCRIPTION
This re-adds Python2 support for this CI script, as some of our CI is still using (incorrectly, and should be fixed in the near future) python 2

cc @pmeier 