### PR TITLE
Fix some deprecated warnings in nms

### DIFF
--- a/torchvision/csrc/cpu/nms_cpu.cpp
+++ b/torchvision/csrc/cpu/nms_cpu.cpp
@@ -5,10 +5,10 @@ at::Tensor nms_cpu_kernel(
     const at::Tensor& dets,
     const at::Tensor& scores,
     const float iou_threshold) {
-  AT_ASSERTM(!dets.type().is_cuda(), "dets must be a CPU tensor");
-  AT_ASSERTM(!scores.type().is_cuda(), "scores must be a CPU tensor");
+  AT_ASSERTM(!dets.options().device().is_cuda(), "dets must be a CPU tensor");
+  AT_ASSERTM(!scores.options().device().is_cuda(), "scores must be a CPU tensor");
   AT_ASSERTM(
-      dets.type() == scores.type(), "dets should have the same type as scores");
+      dets.scalar_type() == scores.scalar_type(), "dets should have the same type as scores");
 
   if (dets.numel() == 0)
     return at::empty({0}, dets.options().dtype(at::kLong));
@@ -74,7 +74,7 @@ at::Tensor nms_cpu(
     const float iou_threshold) {
   auto result = at::empty({0}, dets.options());
 
-  AT_DISPATCH_FLOATING_TYPES(dets.type(), "nms", [&] {
+  AT_DISPATCH_FLOATING_TYPES(dets.scalar_type(), "nms", [&] {
     result = nms_cpu_kernel<scalar_t>(dets, scores, iou_threshold);
   });
   return result;


### PR DESCRIPTION
Currently not able to test it tbh, so I hope you have some unit tests in place ;)

Anyhow, I was getting these warnings while building this:
```
_nms_cpu.cpp:13:16: warning: ‘at::DeprecatedTypeProperties& at::Tensor::type() const’ is deprecated: Tensor.type() is deprecated. Instead use Tensor.options(), which in many cases (e.g. in a constructor) is a drop-in replacement. If you were using data from type(), that is now available from Tensor itself, so instead of tensor.type().scalar_type(), use tensor.scalar_type() instead and instead of tensor.type().backend() use tensor.device(). [-Wdeprecated-declarations]
       dets.type() == scores.type(), "dets should have the same type as scores");
```
So I changed the calls to use the options()