### PR TITLE
Remove warning about deprecated

### DIFF
--- a/torchvision/csrc/DeformConv.h
+++ b/torchvision/csrc/DeformConv.h
@@ -19,7 +19,7 @@ at::Tensor DeformConv2d_forward(
     const std::pair<int, int>& dilation,
     const int groups,
     const int offset_groups) {
-  if (input.type().is_cuda()) {
+  if (input.is_cuda()) {
 #if defined(WITH_CUDA) || defined(WITH_HIP)
     return DeformConv2d_forward_cuda(
         input.contiguous(),
@@ -58,7 +58,7 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor> DeformConv2d_backward
     const std::pair<int, int>& dilation,
     const int groups,
     const int offset_groups) {
-  if (grad.type().is_cuda()) {
+  if (grad.is_cuda()) {
 #if defined(WITH_CUDA) || defined(WITH_HIP)
     return DeformConv2d_backward_cuda(
         grad.contiguous(),

--- a/torchvision/csrc/PSROIAlign.h
+++ b/torchvision/csrc/PSROIAlign.h
@@ -18,7 +18,7 @@ std::tuple<at::Tensor, at::Tensor> PSROIAlign_forward(
     const int pooled_height,
     const int pooled_width,
     const int sampling_ratio) {
-  if (input.type().is_cuda()) {
+  if (input.is_cuda()) {
 #if defined(WITH_CUDA) || defined(WITH_HIP)
     return PSROIAlign_forward_cuda(
         input,
@@ -47,7 +47,7 @@ at::Tensor PSROIAlign_backward(
     const int channels,
     const int height,
     const int width) {
-  if (grad.type().is_cuda()) {
+  if (grad.is_cuda()) {
 #if defined(WITH_CUDA) || defined(WITH_HIP)
     return PSROIAlign_backward_cuda(
         grad,

--- a/torchvision/csrc/PSROIPool.h
+++ b/torchvision/csrc/PSROIPool.h
@@ -15,7 +15,7 @@ std::tuple<at::Tensor, at::Tensor> PSROIPool_forward(
     const float spatial_scale,
     const int pooled_height,
     const int pooled_width) {
-  if (input.type().is_cuda()) {
+  if (input.is_cuda()) {
 #if defined(WITH_CUDA) || defined(WITH_HIP)
     return PSROIPool_forward_cuda(
         input, rois, spatial_scale, pooled_height, pooled_width);
@@ -38,7 +38,7 @@ at::Tensor PSROIPool_backward(
     const int channels,
     const int height,
     const int width) {
-  if (grad.type().is_cuda()) {
+  if (grad.is_cuda()) {
 #if defined(WITH_CUDA) || defined(WITH_HIP)
     return PSROIPool_backward_cuda(
         grad,

--- a/torchvision/csrc/ROIAlign.h
+++ b/torchvision/csrc/ROIAlign.h
@@ -21,7 +21,7 @@ at::Tensor ROIAlign_forward(
     const bool aligned) // The flag for pixel shift
 // along each axis.
 {
-  if (input.type().is_cuda()) {
+  if (input.is_cuda()) {
 #if defined(WITH_CUDA) || defined(WITH_HIP)
     return ROIAlign_forward_cuda(
         input,
@@ -57,7 +57,7 @@ at::Tensor ROIAlign_backward(
     const int width,
     const int sampling_ratio,
     const bool aligned) {
-  if (grad.type().is_cuda()) {
+  if (grad.is_cuda()) {
 #if defined(WITH_CUDA) || defined(WITH_HIP)
     return ROIAlign_backward_cuda(
         grad,

--- a/torchvision/csrc/ROIPool.h
+++ b/torchvision/csrc/ROIPool.h
@@ -15,7 +15,7 @@ std::tuple<at::Tensor, at::Tensor> ROIPool_forward(
     const double spatial_scale,
     const int64_t pooled_height,
     const int64_t pooled_width) {
-  if (input.type().is_cuda()) {
+  if (input.is_cuda()) {
 #if defined(WITH_CUDA) || defined(WITH_HIP)
     return ROIPool_forward_cuda(
         input, rois, spatial_scale, pooled_height, pooled_width);
@@ -38,7 +38,7 @@ at::Tensor ROIPool_backward(
     const int channels,
     const int height,
     const int width) {
-  if (grad.type().is_cuda()) {
+  if (grad.is_cuda()) {
 #if defined(WITH_CUDA) || defined(WITH_HIP)
     return ROIPool_backward_cuda(
         grad,

--- a/torchvision/csrc/cpu/ROIAlign_cpu.cpp
+++ b/torchvision/csrc/cpu/ROIAlign_cpu.cpp
@@ -408,21 +408,21 @@ at::Tensor ROIAlign_forward_cpu(
     return output;
 
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-    input.scalar_type(), "ROIAlign_forward", [&] {
-      ROIAlignForward<scalar_t>(
-          output_size,
-          input.contiguous().data_ptr<scalar_t>(),
-          spatial_scale,
-          channels,
-          height,
-          width,
-          pooled_height,
-          pooled_width,
-          sampling_ratio,
-          aligned,
-          rois.contiguous().data_ptr<scalar_t>(),
-          output.data_ptr<scalar_t>());
-  });
+      input.scalar_type(), "ROIAlign_forward", [&] {
+        ROIAlignForward<scalar_t>(
+            output_size,
+            input.contiguous().data_ptr<scalar_t>(),
+            spatial_scale,
+            channels,
+            height,
+            width,
+            pooled_height,
+            pooled_width,
+            sampling_ratio,
+            aligned,
+            rois.contiguous().data_ptr<scalar_t>(),
+            output.data_ptr<scalar_t>());
+      });
   return output;
 }
 
@@ -461,24 +461,24 @@ at::Tensor ROIAlign_backward_cpu(
   int w_stride = grad.stride(3);
 
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-    grad.scalar_type(), "ROIAlign_forward", [&] {
-      ROIAlignBackward<scalar_t>(
-          grad.numel(),
-          grad.data_ptr<scalar_t>(),
-          spatial_scale,
-          channels,
-          height,
-          width,
-          pooled_height,
-          pooled_width,
-          sampling_ratio,
-          aligned,
-          grad_input.data_ptr<scalar_t>(),
-          rois.contiguous().data_ptr<scalar_t>(),
-          n_stride,
-          c_stride,
-          h_stride,
-          w_stride);
-  });
+      grad.scalar_type(), "ROIAlign_forward", [&] {
+        ROIAlignBackward<scalar_t>(
+            grad.numel(),
+            grad.data_ptr<scalar_t>(),
+            spatial_scale,
+            channels,
+            height,
+            width,
+            pooled_height,
+            pooled_width,
+            sampling_ratio,
+            aligned,
+            grad_input.data_ptr<scalar_t>(),
+            rois.contiguous().data_ptr<scalar_t>(),
+            n_stride,
+            c_stride,
+            h_stride,
+            w_stride);
+      });
   return grad_input;
 }

--- a/torchvision/csrc/cpu/ROIAlign_cpu.cpp
+++ b/torchvision/csrc/cpu/ROIAlign_cpu.cpp
@@ -407,20 +407,21 @@ at::Tensor ROIAlign_forward_cpu(
   if (output.numel() == 0)
     return output;
 
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(), "ROIAlign_forward", [&] {
-    ROIAlignForward<scalar_t>(
-        output_size,
-        input.contiguous().data_ptr<scalar_t>(),
-        spatial_scale,
-        channels,
-        height,
-        width,
-        pooled_height,
-        pooled_width,
-        sampling_ratio,
-        aligned,
-        rois.contiguous().data_ptr<scalar_t>(),
-        output.data_ptr<scalar_t>());
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(
+    input.scalar_type(), "ROIAlign_forward", [&] {
+      ROIAlignForward<scalar_t>(
+          output_size,
+          input.contiguous().data_ptr<scalar_t>(),
+          spatial_scale,
+          channels,
+          height,
+          width,
+          pooled_height,
+          pooled_width,
+          sampling_ratio,
+          aligned,
+          rois.contiguous().data_ptr<scalar_t>(),
+          output.data_ptr<scalar_t>());
   });
   return output;
 }
@@ -459,24 +460,25 @@ at::Tensor ROIAlign_backward_cpu(
   int h_stride = grad.stride(2);
   int w_stride = grad.stride(3);
 
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(grad.scalar_type(), "ROIAlign_forward", [&] {
-    ROIAlignBackward<scalar_t>(
-        grad.numel(),
-        grad.data_ptr<scalar_t>(),
-        spatial_scale,
-        channels,
-        height,
-        width,
-        pooled_height,
-        pooled_width,
-        sampling_ratio,
-        aligned,
-        grad_input.data_ptr<scalar_t>(),
-        rois.contiguous().data_ptr<scalar_t>(),
-        n_stride,
-        c_stride,
-        h_stride,
-        w_stride);
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(
+    grad.scalar_type(), "ROIAlign_forward", [&] {
+      ROIAlignBackward<scalar_t>(
+          grad.numel(),
+          grad.data_ptr<scalar_t>(),
+          spatial_scale,
+          channels,
+          height,
+          width,
+          pooled_height,
+          pooled_width,
+          sampling_ratio,
+          aligned,
+          grad_input.data_ptr<scalar_t>(),
+          rois.contiguous().data_ptr<scalar_t>(),
+          n_stride,
+          c_stride,
+          h_stride,
+          w_stride);
   });
   return grad_input;
 }

--- a/torchvision/csrc/cpu/ROIAlign_cpu.cpp
+++ b/torchvision/csrc/cpu/ROIAlign_cpu.cpp
@@ -407,7 +407,7 @@ at::Tensor ROIAlign_forward_cpu(
   if (output.numel() == 0)
     return output;
 
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.type(), "ROIAlign_forward", [&] {
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(), "ROIAlign_forward", [&] {
     ROIAlignForward<scalar_t>(
         output_size,
         input.contiguous().data_ptr<scalar_t>(),
@@ -459,7 +459,7 @@ at::Tensor ROIAlign_backward_cpu(
   int h_stride = grad.stride(2);
   int w_stride = grad.stride(3);
 
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(grad.type(), "ROIAlign_forward", [&] {
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(grad.scalar_type(), "ROIAlign_forward", [&] {
     ROIAlignBackward<scalar_t>(
         grad.numel(),
         grad.data_ptr<scalar_t>(),

--- a/torchvision/csrc/cpu/ROIPool_cpu.cpp
+++ b/torchvision/csrc/cpu/ROIPool_cpu.cpp
@@ -149,7 +149,7 @@ std::tuple<at::Tensor, at::Tensor> ROIPool_forward_cpu(
     return std::make_tuple(output, argmax);
   }
 
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.type(), "ROIPool_forward", [&] {
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(), "ROIPool_forward", [&] {
     RoIPoolForward<scalar_t>(
         input.contiguous().data_ptr<scalar_t>(),
         spatial_scale,
@@ -203,7 +203,7 @@ at::Tensor ROIPool_backward_cpu(
   int h_stride = grad.stride(2);
   int w_stride = grad.stride(3);
 
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(grad.type(), "ROIPool_backward", [&] {
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(grad.scalar_type(), "ROIPool_backward", [&] {
     RoIPoolBackward<scalar_t>(
         grad.data_ptr<scalar_t>(),
         argmax.data_ptr<int>(),

--- a/torchvision/csrc/cpu/ROIPool_cpu.cpp
+++ b/torchvision/csrc/cpu/ROIPool_cpu.cpp
@@ -149,19 +149,20 @@ std::tuple<at::Tensor, at::Tensor> ROIPool_forward_cpu(
     return std::make_tuple(output, argmax);
   }
 
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(), "ROIPool_forward", [&] {
-    RoIPoolForward<scalar_t>(
-        input.contiguous().data_ptr<scalar_t>(),
-        spatial_scale,
-        channels,
-        height,
-        width,
-        pooled_height,
-        pooled_width,
-        rois.contiguous().data_ptr<scalar_t>(),
-        num_rois,
-        output.data_ptr<scalar_t>(),
-        argmax.data_ptr<int>());
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(
+    input.scalar_type(), "ROIPool_forward", [&] {
+      RoIPoolForward<scalar_t>(
+          input.contiguous().data_ptr<scalar_t>(),
+          spatial_scale,
+          channels,
+          height,
+          width,
+          pooled_height,
+          pooled_width,
+          rois.contiguous().data_ptr<scalar_t>(),
+          num_rois,
+          output.data_ptr<scalar_t>(),
+          argmax.data_ptr<int>());
   });
   return std::make_tuple(output, argmax);
 }
@@ -203,22 +204,23 @@ at::Tensor ROIPool_backward_cpu(
   int h_stride = grad.stride(2);
   int w_stride = grad.stride(3);
 
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(grad.scalar_type(), "ROIPool_backward", [&] {
-    RoIPoolBackward<scalar_t>(
-        grad.data_ptr<scalar_t>(),
-        argmax.data_ptr<int>(),
-        num_rois,
-        channels,
-        height,
-        width,
-        pooled_height,
-        pooled_width,
-        grad_input.data_ptr<scalar_t>(),
-        rois.contiguous().data_ptr<scalar_t>(),
-        n_stride,
-        c_stride,
-        h_stride,
-        w_stride);
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(
+    grad.scalar_type(), "ROIPool_backward", [&] {
+      RoIPoolBackward<scalar_t>(
+          grad.data_ptr<scalar_t>(),
+          argmax.data_ptr<int>(),
+          num_rois,
+          channels,
+          height,
+          width,
+          pooled_height,
+          pooled_width,
+          grad_input.data_ptr<scalar_t>(),
+          rois.contiguous().data_ptr<scalar_t>(),
+          n_stride,
+          c_stride,
+          h_stride,
+          w_stride);
   });
   return grad_input;
 }

--- a/torchvision/csrc/cpu/ROIPool_cpu.cpp
+++ b/torchvision/csrc/cpu/ROIPool_cpu.cpp
@@ -150,20 +150,20 @@ std::tuple<at::Tensor, at::Tensor> ROIPool_forward_cpu(
   }
 
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-    input.scalar_type(), "ROIPool_forward", [&] {
-      RoIPoolForward<scalar_t>(
-          input.contiguous().data_ptr<scalar_t>(),
-          spatial_scale,
-          channels,
-          height,
-          width,
-          pooled_height,
-          pooled_width,
-          rois.contiguous().data_ptr<scalar_t>(),
-          num_rois,
-          output.data_ptr<scalar_t>(),
-          argmax.data_ptr<int>());
-  });
+      input.scalar_type(), "ROIPool_forward", [&] {
+        RoIPoolForward<scalar_t>(
+            input.contiguous().data_ptr<scalar_t>(),
+            spatial_scale,
+            channels,
+            height,
+            width,
+            pooled_height,
+            pooled_width,
+            rois.contiguous().data_ptr<scalar_t>(),
+            num_rois,
+            output.data_ptr<scalar_t>(),
+            argmax.data_ptr<int>());
+      });
   return std::make_tuple(output, argmax);
 }
 
@@ -205,22 +205,22 @@ at::Tensor ROIPool_backward_cpu(
   int w_stride = grad.stride(3);
 
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-    grad.scalar_type(), "ROIPool_backward", [&] {
-      RoIPoolBackward<scalar_t>(
-          grad.data_ptr<scalar_t>(),
-          argmax.data_ptr<int>(),
-          num_rois,
-          channels,
-          height,
-          width,
-          pooled_height,
-          pooled_width,
-          grad_input.data_ptr<scalar_t>(),
-          rois.contiguous().data_ptr<scalar_t>(),
-          n_stride,
-          c_stride,
-          h_stride,
-          w_stride);
-  });
+      grad.scalar_type(), "ROIPool_backward", [&] {
+        RoIPoolBackward<scalar_t>(
+            grad.data_ptr<scalar_t>(),
+            argmax.data_ptr<int>(),
+            num_rois,
+            channels,
+            height,
+            width,
+            pooled_height,
+            pooled_width,
+            grad_input.data_ptr<scalar_t>(),
+            rois.contiguous().data_ptr<scalar_t>(),
+            n_stride,
+            c_stride,
+            h_stride,
+            w_stride);
+      });
   return grad_input;
 }

--- a/torchvision/csrc/cpu/nms_cpu.cpp
+++ b/torchvision/csrc/cpu/nms_cpu.cpp
@@ -75,9 +75,8 @@ at::Tensor nms_cpu(
     const float iou_threshold) {
   auto result = at::empty({0}, dets.options());
 
-  AT_DISPATCH_FLOATING_TYPES(
-    dets.scalar_type(), "nms", [&] {
-      result = nms_cpu_kernel<scalar_t>(dets, scores, iou_threshold);
+  AT_DISPATCH_FLOATING_TYPES(dets.scalar_type(), "nms", [&] {
+    result = nms_cpu_kernel<scalar_t>(dets, scores, iou_threshold);
   });
   return result;
 }

--- a/torchvision/csrc/cpu/nms_cpu.cpp
+++ b/torchvision/csrc/cpu/nms_cpu.cpp
@@ -6,8 +6,7 @@ at::Tensor nms_cpu_kernel(
     const at::Tensor& scores,
     const float iou_threshold) {
   AT_ASSERTM(!dets.is_cuda(), "dets must be a CPU tensor");
-  AT_ASSERTM(
-      !scores.is_cuda(), "scores must be a CPU tensor");
+  AT_ASSERTM(!scores.is_cuda(), "scores must be a CPU tensor");
   AT_ASSERTM(
       dets.scalar_type() == scores.scalar_type(),
       "dets should have the same type as scores");
@@ -76,8 +75,9 @@ at::Tensor nms_cpu(
     const float iou_threshold) {
   auto result = at::empty({0}, dets.options());
 
-  AT_DISPATCH_FLOATING_TYPES(dets.scalar_type(), "nms", [&] {
-    result = nms_cpu_kernel<scalar_t>(dets, scores, iou_threshold);
+  AT_DISPATCH_FLOATING_TYPES(
+    dets.scalar_type(), "nms", [&] {
+      result = nms_cpu_kernel<scalar_t>(dets, scores, iou_threshold);
   });
   return result;
 }

--- a/torchvision/csrc/cpu/nms_cpu.cpp
+++ b/torchvision/csrc/cpu/nms_cpu.cpp
@@ -5,9 +5,9 @@ at::Tensor nms_cpu_kernel(
     const at::Tensor& dets,
     const at::Tensor& scores,
     const float iou_threshold) {
-  AT_ASSERTM(!dets.options().device().is_cuda(), "dets must be a CPU tensor");
+  AT_ASSERTM(!dets.is_cuda(), "dets must be a CPU tensor");
   AT_ASSERTM(
-      !scores.options().device().is_cuda(), "scores must be a CPU tensor");
+      !scores.is_cuda(), "scores must be a CPU tensor");
   AT_ASSERTM(
       dets.scalar_type() == scores.scalar_type(),
       "dets should have the same type as scores");

--- a/torchvision/csrc/cuda/DeformConv_cuda.cu
+++ b/torchvision/csrc/cuda/DeformConv_cuda.cu
@@ -267,7 +267,7 @@ at::Tensor DeformConv2d_forward_cuda(
   TORCH_CHECK(input.is_contiguous());
   TORCH_CHECK(offset.is_contiguous());
   TORCH_CHECK(weight.is_contiguous());
-  TORCH_CHECK(input.device().is_cuda(), "input must be a CUDA tensor");
+  TORCH_CHECK(input.is_cuda(), "input must be a CUDA tensor");
 
   at::DeviceGuard guard(input.device());
 
@@ -411,7 +411,7 @@ at::Tensor DeformConv2d_forward_cuda(
                           .view_as(out_buf[b][g]);
     }
     columns = columns.view(
-        {columns.size(0) * columns.size(1), columns.size(2)});    
+        {columns.size(0) * columns.size(1), columns.size(2)});
   }
 
   out_buf = out_buf.view({batch_sz / n_parallel_imgs,
@@ -776,7 +776,7 @@ static std::tuple<at::Tensor, at::Tensor> deform_conv_backward_input_cuda(
                            weight.size(1),
                            weight.size(2),
                            weight.size(3)});
-  
+
   columns = columns.view(
       {n_weight_grps, columns.size(0) / n_weight_grps, columns.size(1)});
   for (int elt = 0; elt < batch_sz / n_parallel_imgs; elt++) {

--- a/torchvision/csrc/cuda/PSROIAlign_cuda.cu
+++ b/torchvision/csrc/cuda/PSROIAlign_cuda.cu
@@ -302,8 +302,8 @@ std::tuple<at::Tensor, at::Tensor> PSROIAlign_forward_cuda(
     const int pooled_width,
     const int sampling_ratio) {
   // Check if input tensors are CUDA tensors
-  AT_ASSERTM(input.type().is_cuda(), "input must be a CUDA tensor");
-  AT_ASSERTM(rois.type().is_cuda(), "rois must be a CUDA tensor");
+  AT_ASSERTM(input.is_cuda(), "input must be a CUDA tensor");
+  AT_ASSERTM(rois.is_cuda(), "rois must be a CUDA tensor");
 
   at::TensorArg input_t{input, "input", 1}, rois_t{rois, "rois", 2};
 
@@ -377,10 +377,10 @@ at::Tensor PSROIAlign_backward_cuda(
     const int height,
     const int width) {
   // Check if input tensors are CUDA tensors
-  AT_ASSERTM(grad.type().is_cuda(), "grad must be a CUDA tensor");
-  AT_ASSERTM(rois.type().is_cuda(), "rois must be a CUDA tensor");
+  AT_ASSERTM(grad.is_cuda(), "grad must be a CUDA tensor");
+  AT_ASSERTM(rois.is_cuda(), "rois must be a CUDA tensor");
   AT_ASSERTM(
-      channel_mapping.type().is_cuda(),
+      channel_mapping.is_cuda(),
       "channel_mapping must be a CUDA tensor");
 
   at::TensorArg grad_t{grad, "grad", 1}, rois_t{rois, "rois", 2},

--- a/torchvision/csrc/cuda/PSROIPool_cuda.cu
+++ b/torchvision/csrc/cuda/PSROIPool_cuda.cu
@@ -139,8 +139,8 @@ std::tuple<at::Tensor, at::Tensor> PSROIPool_forward_cuda(
     const int pooled_height,
     const int pooled_width) {
   // Check if input tensors are CUDA tensors
-  AT_ASSERTM(input.type().is_cuda(), "input must be a CUDA tensor");
-  AT_ASSERTM(rois.type().is_cuda(), "rois must be a CUDA tensor");
+  AT_ASSERTM(input.is_cuda(), "input must be a CUDA tensor");
+  AT_ASSERTM(rois.is_cuda(), "rois must be a CUDA tensor");
 
   at::TensorArg input_t{input, "input", 1}, rois_t{rois, "rois", 2};
 
@@ -211,10 +211,10 @@ at::Tensor PSROIPool_backward_cuda(
     const int height,
     const int width) {
   // Check if input tensors are CUDA tensors
-  AT_ASSERTM(grad.type().is_cuda(), "grad must be a CUDA tensor");
-  AT_ASSERTM(rois.type().is_cuda(), "rois must be a CUDA tensor");
+  AT_ASSERTM(grad.is_cuda(), "grad must be a CUDA tensor");
+  AT_ASSERTM(rois.is_cuda(), "rois must be a CUDA tensor");
   AT_ASSERTM(
-      channel_mapping.type().is_cuda(),
+      channel_mapping.is_cuda(),
       "channel_mapping must be a CUDA tensor");
 
   at::TensorArg grad_t{grad, "grad", 1}, rois_t{rois, "rois", 2},

--- a/torchvision/csrc/cuda/ROIAlign_cuda.cu
+++ b/torchvision/csrc/cuda/ROIAlign_cuda.cu
@@ -345,7 +345,7 @@ at::Tensor ROIAlign_forward_cuda(
     return output;
   }
 
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.type(), "ROIAlign_forward", [&] {
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(), "ROIAlign_forward", [&] {
     RoIAlignForward<scalar_t><<<grid, block, 0, stream>>>(
         output_size,
         input.contiguous().data_ptr<scalar_t>(),
@@ -409,7 +409,7 @@ at::Tensor ROIAlign_backward_cuda(
   int h_stride = grad.stride(2);
   int w_stride = grad.stride(3);
 
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(grad.type(), "ROIAlign_backward", [&] {
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(grad.scalar_type(), "ROIAlign_backward", [&] {
     RoIAlignBackward<scalar_t><<<grid, block, 0, stream>>>(
         grad.numel(),
         grad.data_ptr<scalar_t>(),

--- a/torchvision/csrc/cuda/ROIAlign_cuda.cu
+++ b/torchvision/csrc/cuda/ROIAlign_cuda.cu
@@ -312,8 +312,8 @@ at::Tensor ROIAlign_forward_cuda(
     const int pooled_width,
     const int sampling_ratio,
     const bool aligned) {
-  AT_ASSERTM(input.device().is_cuda(), "input must be a CUDA tensor");
-  AT_ASSERTM(rois.device().is_cuda(), "rois must be a CUDA tensor");
+  AT_ASSERTM(input.is_cuda(), "input must be a CUDA tensor");
+  AT_ASSERTM(rois.is_cuda(), "rois must be a CUDA tensor");
 
   at::TensorArg input_t{input, "input", 1}, rois_t{rois, "rois", 2};
 
@@ -376,8 +376,8 @@ at::Tensor ROIAlign_backward_cuda(
     const int width,
     const int sampling_ratio,
     const bool aligned) {
-  AT_ASSERTM(grad.device().is_cuda(), "grad must be a CUDA tensor");
-  AT_ASSERTM(rois.device().is_cuda(), "rois must be a CUDA tensor");
+  AT_ASSERTM(grad.is_cuda(), "grad must be a CUDA tensor");
+  AT_ASSERTM(rois.is_cuda(), "rois must be a CUDA tensor");
 
   at::TensorArg grad_t{grad, "grad", 1}, rois_t{rois, "rois", 2};
 

--- a/torchvision/csrc/cuda/ROIPool_cuda.cu
+++ b/torchvision/csrc/cuda/ROIPool_cuda.cu
@@ -157,7 +157,7 @@ std::tuple<at::Tensor, at::Tensor> ROIPool_forward_cuda(
     return std::make_tuple(output, argmax);
   }
 
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.type(), "ROIPool_forward", [&] {
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(), "ROIPool_forward", [&] {
     RoIPoolForward<scalar_t><<<grid, block, 0, stream>>>(
         output_size,
         input.contiguous().data_ptr<scalar_t>(),
@@ -224,7 +224,7 @@ at::Tensor ROIPool_backward_cuda(
   int h_stride = grad.stride(2);
   int w_stride = grad.stride(3);
 
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(grad.type(), "ROIPool_backward", [&] {
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(grad.scalar_type(), "ROIPool_backward", [&] {
     RoIPoolBackward<scalar_t><<<grid, block, 0, stream>>>(
         grad.numel(),
         grad.data_ptr<scalar_t>(),

--- a/torchvision/csrc/cuda/ROIPool_cuda.cu
+++ b/torchvision/csrc/cuda/ROIPool_cuda.cu
@@ -121,8 +121,8 @@ std::tuple<at::Tensor, at::Tensor> ROIPool_forward_cuda(
     const float spatial_scale,
     const int pooled_height,
     const int pooled_width) {
-  AT_ASSERTM(input.device().is_cuda(), "input must be a CUDA tensor");
-  AT_ASSERTM(rois.device().is_cuda(), "rois must be a CUDA tensor");
+  AT_ASSERTM(input.is_cuda(), "input must be a CUDA tensor");
+  AT_ASSERTM(rois.is_cuda(), "rois must be a CUDA tensor");
 
   at::TensorArg input_t{input, "input", 1}, rois_t{rois, "rois", 2};
 
@@ -187,9 +187,9 @@ at::Tensor ROIPool_backward_cuda(
     const int height,
     const int width) {
   // Check if input tensors are CUDA tensors
-  AT_ASSERTM(grad.device().is_cuda(), "grad must be a CUDA tensor");
-  AT_ASSERTM(rois.device().is_cuda(), "rois must be a CUDA tensor");
-  AT_ASSERTM(argmax.device().is_cuda(), "argmax must be a CUDA tensor");
+  AT_ASSERTM(grad.is_cuda(), "grad must be a CUDA tensor");
+  AT_ASSERTM(rois.is_cuda(), "rois must be a CUDA tensor");
+  AT_ASSERTM(argmax.is_cuda(), "argmax must be a CUDA tensor");
 
   at::TensorArg grad_t{grad, "grad", 1}, rois_t{rois, "rois", 2},
       argmax_t{argmax, "argmax", 3};

--- a/torchvision/csrc/cuda/nms_cuda.cu
+++ b/torchvision/csrc/cuda/nms_cuda.cu
@@ -91,7 +91,7 @@ at::Tensor nms_cuda(const at::Tensor& dets,
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-      dets_sorted.type(), "nms_kernel_cuda", [&] {
+      dets_sorted.scalar_type(), "nms_kernel_cuda", [&] {
         nms_kernel<scalar_t><<<blocks, threads, 0, stream>>>(
             dets_num,
             iou_threshold,

--- a/torchvision/csrc/cuda/nms_cuda.cu
+++ b/torchvision/csrc/cuda/nms_cuda.cu
@@ -72,8 +72,8 @@ __global__ void nms_kernel(
 at::Tensor nms_cuda(const at::Tensor& dets,
     const at::Tensor& scores,
     float iou_threshold) {
-  AT_ASSERTM(dets.type().is_cuda(), "dets must be a CUDA tensor");
-  AT_ASSERTM(scores.type().is_cuda(), "scores must be a CUDA tensor");
+  AT_ASSERTM(dets.is_cuda(), "dets must be a CUDA tensor");
+  AT_ASSERTM(scores.is_cuda(), "scores must be a CUDA tensor");
   at::cuda::CUDAGuard device_guard(dets.device());
 
   auto order_t = std::get<1>(scores.sort(0, /* descending=*/true));

--- a/torchvision/csrc/nms.h
+++ b/torchvision/csrc/nms.h
@@ -12,7 +12,7 @@ at::Tensor nms(
     const at::Tensor& dets,
     const at::Tensor& scores,
     const double iou_threshold) {
-  if (dets.device().is_cuda()) {
+  if (dets.is_cuda()) {
 #if defined(WITH_CUDA)
     if (dets.numel() == 0) {
       at::cuda::CUDAGuard device_guard(dets.device());


### PR DESCRIPTION
changed `is_cuda` and `type` methods.

### Error examples

```
/home/user/vision/torchvision/csrc/ROIPool.h:41:17: warning: ‘at::DeprecatedTypeProperties& at::Tensor::type() const’ is deprecated: Tensor.type() is deprecated. Instead use Tensor.options(), which in many cases (e.g. in a constructor) is a drop-in replacement. If you were using data from type(), that is now available from Tensor itself, so instead of tensor.type().scalar_type(), use tensor.scalar_type() instead and instead of tensor.type().backend() use tensor.device(). [-Wdeprecated-declarations]
   if (grad.type().is_cuda()) {
```

```
/home/user/vision/torchvision/csrc/cpu/ROIAlign_cpu.cpp:410:50: warning: ‘at::DeprecatedTypeProperties& at::Tensor::type() const’ is deprecated: Tensor.type() is deprecated. Instead use Tensor.options(), which in many cases (e.g. in a constructor) is a drop-in replacement. If you were using data from type(), that is now available from Tensor itself, so instead of tensor.type().scalar_type(), use tensor.scalar_type() instead and instead of tensor.type().backend() use tensor.device(). [-Wdeprecated-declarations]
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.type(), "ROIAlign_forward", [&] {
```