### PR TITLE
Add tests for negative samples for Mask R-CNN and Keypoint R-CNN

### DIFF
--- a/test/test_models_detection_negative_samples.py
+++ b/test/test_models_detection_negative_samples.py
@@ -128,5 +128,6 @@ class Tester(unittest.TestCase):
         self.assertEqual(loss_dict["loss_rpn_box_reg"], torch.tensor(0.))
         self.assertEqual(loss_dict["loss_keypoint"], torch.tensor(0.))
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/torchvision/ops/misc.py
+++ b/torchvision/ops/misc.py
@@ -113,7 +113,7 @@ def interpolate(input, size=None, scale_factor=None, mode="nearest", align_corne
         )
 
     output_shape = _output_size(2, input, size, scale_factor)
-    output_shape = input.shape[:-2] + output_shape
+    output_shape = list(input.shape[:-2]) + output_shape
     return _new_empty_tensor(input, output_shape)
 
 


### PR DESCRIPTION
Follow-up of https://github.com/pytorch/vision/pull/1911 adding tests for Mask R-CNN and Keypoint R-CNN