### PR TITLE
Format torchvision/utils.py signatures with black

### DIFF
--- a/torchvision/utils.py
+++ b/torchvision/utils.py
@@ -6,10 +6,15 @@ import math
 irange = range
 
 
-def make_grid(tensor: Union[torch.Tensor, Sequence[torch.Tensor]], nrow: int = 8,
-              padding: int = 2, normalize: bool = False,
-              range: Optional[Tuple[int, int]] = None, scale_each: bool = False,
-              pad_value: int = 0) -> torch.Tensor:
+def make_grid(
+    tensor: Union[torch.Tensor, Sequence[torch.Tensor]],
+    nrow: int = 8,
+    padding: int = 2,
+    normalize: bool = False,
+    range: Optional[Tuple[int, int]] = None,
+    scale_each: bool = False,
+    pad_value: int = 0,
+) -> torch.Tensor:
     """Make a grid of images.
 
     Args:
@@ -93,9 +98,17 @@ def make_grid(tensor: Union[torch.Tensor, Sequence[torch.Tensor]], nrow: int = 8
     return grid
 
 
-def save_image(tensor: Union[torch.Tensor, Sequence[torch.Tensor]], fp: Union[Text, pathlib.Path, BinaryIO],
-               nrow: int = 8, padding: int = 2, normalize: bool = False, range: Optional[Tuple[int, int]] = None,
-               scale_each: bool = False, pad_value: int = 0, format: Optional[str] = None) -> None:
+def save_image(
+    tensor: Union[torch.Tensor, Sequence[torch.Tensor]],
+    fp: Union[Text, pathlib.Path, BinaryIO],
+    nrow: int = 8,
+    padding: int = 2,
+    normalize: bool = False,
+    range: Optional[Tuple[int, int]] = None,
+    scale_each: bool = False,
+    pad_value: int = 0,
+    format: Optional[str] = None,
+) -> None:
     """Save a given Tensor into an image file.
 
     Args:


### PR DESCRIPTION
Addendum to #2034. This formats the signatures with [`black`](/psf/black) as discussed in #2025.