### PR TITLE
improve consistency among box IoU calculations

### DIFF
--- a/torchvision/csrc/cuda/nms_cuda.cu
+++ b/torchvision/csrc/cuda/nms_cuda.cu
@@ -18,7 +18,7 @@ __device__ inline bool devIoU(T const* const a, T const* const b, const float th
   T interS = width * height;
   T Sa = (a[2] - a[0]) * (a[3] - a[1]);
   T Sb = (b[2] - b[0]) * (b[3] - b[1]);
-  return interS > threshold * (Sa + Sb - interS);
+  return (interS / (Sa + Sb - interS)) > threshold;
 }
 
 template <typename T>


### PR DESCRIPTION
Torchvision includes at least 3 bits of code that calculate
box Intersection over Union values (and usually compare to
a threshold):

- box_iou in torchvision/ops/boxes.py
- devIoU in torchvision/csrc/cuda/nms_cuda.cu
- nms_cpu_kernel in torchvision/csrc/cpu/nms_cpu.cpp

The calculations were performed slightly differently between
those, leading to occasional differences in results.

Update devIoU to use the same method as the others for better
consistency.

This change improves agreement between the CPU and CUDA
calculations but the results can still differ slightly.
Setting NVCC_FLAGS to include "--fmad=true" would provide
still better agreement, but with likely cost to performance.