### PR TITLE
Add convert_image_dtype to functionals

### DIFF
--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -511,6 +511,11 @@ class Tester(unittest.TestCase):
         self.assertTrue(np.allclose(input_data.numpy(), output.numpy()))
 
     def test_convert_image_dtype(self):
+        def cycle_over(objs):
+            objs = list(objs)
+            for idx, obj in enumerate(objs):
+                yield obj, objs[:idx] + objs[idx + 1:]
+
         dtype_max_value = {
             dtype: 1.0
             for dtype in (torch.float32, torch.float, torch.float64, torch.double, torch.bool,)
@@ -533,11 +538,6 @@ class Tester(unittest.TestCase):
                 )
             }
         )
-
-        def cycle_over(objs):
-            objs = list(objs)
-            for idx, obj in enumerate(objs):
-                yield obj, objs[:idx] + objs[idx + 1:]
 
         for input_dtype, output_dtypes in cycle_over(dtype_max_value.keys()):
             input_image = torch.ones(1, dtype=input_dtype) * dtype_max_value[input_dtype]

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -512,17 +512,17 @@ class Tester(unittest.TestCase):
 
     def test_convert_image_dtype(self):
         dtype_max_value = {
-                dtype: 1.0
-                for dtype in (
-                    torch.float32,
-                    torch.float,
-                    torch.float64,
-                    torch.double,
-                    torch.float16,
-                    torch.half,
-                    torch.bool,
-                )
-            }
+            dtype: 1.0
+            for dtype in (
+                torch.float32,
+                torch.float,
+                torch.float64,
+                torch.double,
+                torch.float16,
+                torch.half,
+                torch.bool,
+            )
+        }
         dtype_max_value.update(
             {
                 dtype: torch.iinfo(dtype).max

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -28,10 +28,12 @@ def cycle_over(objs):
     for idx, obj in enumerate(objs):
         yield obj, objs[:idx] + objs[idx + 1:]
 
+
 def int_dtypes():
     yield from iter(
         (torch.uint8, torch.int8, torch.int16, torch.short, torch.int32, torch.int, torch.int64, torch.long,)
     )
+
 
 def float_dtypes():
     yield from iter((torch.float32, torch.float, torch.float64, torch.double))

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -518,14 +518,14 @@ class Tester(unittest.TestCase):
             torch.double: 1.0,
             torch.float16: 1.0,
             torch.half: 1.0,
-            torch.uint8: 255,
-            torch.int8: 127,
-            torch.int16: 32_767,
-            torch.short: 32_767,
-            torch.int32: 2_147_483_647,
-            torch.int: 2_147_483_647,
-            torch.int64: 9_223_372_036_854_775_807,
-            torch.long: 9_223_372_036_854_775_807,
+            torch.uint8: 2 ** 8 - 1,
+            torch.int8: 2 ** 7 - 1,
+            torch.int16: 2 ** 15 - 1,
+            torch.short: 2 ** 15 - 1,
+            torch.int32: 2 ** 31 - 1,
+            torch.int: 2 ** 31 - 1,
+            torch.int64: 2 ** 63 - 1,
+            torch.long: 2 ** 63 - 1,
             torch.bool: 1,
         }
 
@@ -542,7 +542,9 @@ class Tester(unittest.TestCase):
                 output_image = transform(input_image)
 
                 self.assertEqual(output_image.dtype, output_dtype)
-                self.assertEqual(torch.max(output_image), dtype_max_value[output_dtype])
+                self.assertEqual(
+                    torch.max(output_image).item(), dtype_max_value[output_dtype]
+                )
 
     @unittest.skipIf(accimage is None, 'accimage not available')
     def test_accimage_to_tensor(self):

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -550,11 +550,21 @@ class Tester(unittest.TestCase):
             for output_dtype in output_dtypes:
                 transform = transforms.ConvertImageDtype(output_dtype)
                 output_image = transform(input_image)
-
-                self.assertEqual(output_image.dtype, output_dtype)
-                self.assertAlmostEqual(
-                    torch.max(output_image).item(), dtype_max_value[output_dtype]
+                msg_prefix = "Conversion from {input_dtype} to {output_dtype} resulted in ".format(
+                    input_dtype=input_dtype, output_dtype=output_dtype
                 )
+
+                actual = output_image.dtype
+                desired = output_dtype
+                msg = msg_prefix + "{actual_dtype}.".format(actual_dtype=actual)
+                self.assertEqual(actual, desired, msg=msg)
+
+                actual = torch.max(output_image).item()
+                desired = dtype_max_value[output_dtype]
+                msg = msg_prefix + "{actual_max_value} instead of {desired_max_value}.".format(
+                    actual_max_value=actual, desired_max_value=desired
+                )
+                self.assertAlmostEqual(actual, desired, msg=msg)
 
     @unittest.skipIf(accimage is None, 'accimage not available')
     def test_accimage_to_tensor(self):

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -512,27 +512,37 @@ class Tester(unittest.TestCase):
 
     def test_convert_image_dtype(self):
         dtype_max_value = {
-            torch.float32: 1.0,
-            torch.float: 1.0,
-            torch.float64: 1.0,
-            torch.double: 1.0,
-            torch.float16: 1.0,
-            torch.half: 1.0,
-            torch.uint8: 2 ** 8 - 1,
-            torch.int8: 2 ** 7 - 1,
-            torch.int16: 2 ** 15 - 1,
-            torch.short: 2 ** 15 - 1,
-            torch.int32: 2 ** 31 - 1,
-            torch.int: 2 ** 31 - 1,
-            torch.int64: 2 ** 63 - 1,
-            torch.long: 2 ** 63 - 1,
-            torch.bool: 1,
-        }
+                dtype: 1.0
+                for dtype in (
+                    torch.float32,
+                    torch.float,
+                    torch.float64,
+                    torch.double,
+                    torch.float16,
+                    torch.half,
+                    torch.bool,
+                )
+            }
+        dtype_max_value.update(
+            {
+                dtype: torch.iinfo(dtype).max
+                for dtype in (
+                    torch.uint8,
+                    torch.int8,
+                    torch.int16,
+                    torch.short,
+                    torch.int32,
+                    torch.int,
+                    torch.int64,
+                    torch.long,
+                )
+            }
+        )
 
         def cycle_over(objs):
             objs = list(objs)
             for idx, obj in enumerate(objs):
-                yield obj, objs[:idx] + objs[idx + 1:]
+                yield obj, objs[:idx] + objs[idx + 1 :]
 
         for input_dtype, output_dtypes in cycle_over(dtype_max_value.keys()):
             input_image = torch.ones(1, dtype=input_dtype) * dtype_max_value[input_dtype]
@@ -542,7 +552,7 @@ class Tester(unittest.TestCase):
                 output_image = transform(input_image)
 
                 self.assertEqual(output_image.dtype, output_dtype)
-                self.assertEqual(
+                self.assertAlmostEqual(
                     torch.max(output_image).item(), dtype_max_value[output_dtype]
                 )
 

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -513,15 +513,10 @@ class Tester(unittest.TestCase):
     def test_convert_image_dtype(self):
         dtype_max_value = {
             dtype: 1.0
-            for dtype in (
-                torch.float32,
-                torch.float,
-                torch.float64,
-                torch.double,
-                torch.float16,
-                torch.half,
-                torch.bool,
-            )
+            for dtype in (torch.float32, torch.float, torch.float64, torch.double, torch.bool,)
+            # torch.float16 and torch.half are disabled for now since they do not support torch.max
+            # See https://github.com/pytorch/pytorch/issues/28623#issuecomment-611379051
+            # (torch.float32, torch.float, torch.float64, torch.double, torch.float16, torch.half, torch.bool, )
         }
         dtype_max_value.update(
             {

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -542,7 +542,7 @@ class Tester(unittest.TestCase):
         def cycle_over(objs):
             objs = list(objs)
             for idx, obj in enumerate(objs):
-                yield obj, objs[:idx] + objs[idx + 1 :]
+                yield obj, objs[:idx] + objs[idx + 1:]
 
         for input_dtype, output_dtypes in cycle_over(dtype_max_value.keys()):
             input_image = torch.ones(1, dtype=input_dtype) * dtype_max_value[input_dtype]

--- a/torchvision/transforms/functional.py
+++ b/torchvision/transforms/functional.py
@@ -117,32 +117,16 @@ def convert_image_dtype(
     image: torch.Tensor, dtype: torch.dtype = torch.float
 ) -> torch.Tensor:
     def scale_factor(dtype: torch.dtype) -> float:
-        if dtype in (
-            torch.float32,
-            torch.float,
-            torch.float64,
-            torch.double,
-            torch.float16,
-            torch.half,
-        ):
+        if dtype.is_floating_point:
             return 1.0
+        else:
+            return float(torch.iinfo(dtype))
 
-        num_value_bits = {
-            torch.uint8: 8,
-            torch.int8: 7,
-            torch.int16: 15,
-            torch.short: 15,
-            torch.int32: 31,
-            torch.int: 31,
-            torch.int64: 63,
-            torch.long: 63,
-            torch.bool: 1,
-        }
-        return float(2 ** num_value_bits[dtype] - 1)
-
-    return (
-        image.double().div(scale_factor(image.dtype)).mul(scale_factor(dtype)).to(dtype)
-    )
+    old_dtype = image.dtype
+    image = image.double()
+    image = image / scale_factor(old_dtype)
+    image = image * scale_factor(dtype)
+    return image.to(dtype)
 
 
 def to_pil_image(pic, mode=None):

--- a/torchvision/transforms/functional.py
+++ b/torchvision/transforms/functional.py
@@ -120,7 +120,7 @@ def convert_image_dtype(
         if dtype.is_floating_point or dtype == torch.bool:
             return 1.0
         else:
-            return float(torch.iinfo(dtype))
+            return float(torch.iinfo(dtype).max)
 
     image = image / scale_factor(image.dtype)
     image = image * scale_factor(dtype)

--- a/torchvision/transforms/functional.py
+++ b/torchvision/transforms/functional.py
@@ -116,6 +116,15 @@ def pil_to_tensor(pic):
 def convert_image_dtype(
     image: torch.Tensor, dtype: torch.dtype = torch.float
 ) -> torch.Tensor:
+    """Convert a tensor image to the given ``dtype`` and scale the values accordingly
+
+    Args:
+        image (torch.Tensor): Image to be converted
+        dtype (torch.dtype): Desired data type of the output
+
+    Returns:
+        (torch.Tensor): Converted image
+    """
     def scale_factor(dtype: torch.dtype) -> float:
         if dtype.is_floating_point or dtype == torch.bool:
             return 1.0

--- a/torchvision/transforms/functional.py
+++ b/torchvision/transforms/functional.py
@@ -113,6 +113,38 @@ def pil_to_tensor(pic):
     return img
 
 
+def convert_image_dtype(
+    image: torch.Tensor, dtype: torch.dtype = torch.float
+) -> torch.Tensor:
+    def scale_factor(dtype: torch.dtype) -> float:
+        if dtype in (
+            torch.float32,
+            torch.float,
+            torch.float64,
+            torch.double,
+            torch.float16,
+            torch.half,
+        ):
+            return 1.0
+
+        num_value_bits = {
+            torch.uint8: 8,
+            torch.int8: 7,
+            torch.int16: 15,
+            torch.short: 15,
+            torch.int32: 31,
+            torch.int: 31,
+            torch.int64: 63,
+            torch.long: 63,
+            torch.bool: 1,
+        }
+        return float(2 ** num_value_bits[dtype] - 1)
+
+    return (
+        image.double().div(scale_factor(image.dtype)).mul(scale_factor(dtype)).to(dtype)
+    )
+
+
 def to_pil_image(pic, mode=None):
     """Convert a tensor or an ndarray to PIL Image.
 

--- a/torchvision/transforms/functional.py
+++ b/torchvision/transforms/functional.py
@@ -117,7 +117,7 @@ def convert_image_dtype(
     image: torch.Tensor, dtype: torch.dtype = torch.float
 ) -> torch.Tensor:
     def scale_factor(dtype: torch.dtype) -> float:
-        if dtype.is_floating_point:
+        if dtype.is_floating_point or dtype == torch.bool:
             return 1.0
         else:
             return float(torch.iinfo(dtype))

--- a/torchvision/transforms/functional.py
+++ b/torchvision/transforms/functional.py
@@ -122,9 +122,7 @@ def convert_image_dtype(
         else:
             return float(torch.iinfo(dtype))
 
-    old_dtype = image.dtype
-    image = image.double()
-    image = image / scale_factor(old_dtype)
+    image = image / scale_factor(image.dtype)
     image = image * scale_factor(dtype)
     return image.to(dtype)
 

--- a/torchvision/transforms/transforms.py
+++ b/torchvision/transforms/transforms.py
@@ -121,7 +121,18 @@ class ConvertImageDtype(object):
     Args:
         dtype (torch.dtype): Desired data type of the output
 
+    .. note::
+
+        When converting from a smaller to a larger integer ``dtype`` the maximum values are **not** mapped exactly.
+        If converted back and forth, this mismatch has no effect.
+
+    Raises:
+        RuntimeError: When trying to cast :class:`torch.float32` to :class:`torch.int32` or :class:`torch.int64` as
+            well as for trying to cast :class:`torch.float64` to :class:`torch.int64`. These conversions might lead to
+            overflow errors since the floating point ``dtype`` cannot store consecutive integers over the whole range
+            of the integer ``dtype``.
     """
+
     def __init__(self, dtype: torch.dtype) -> None:
         self.dtype = dtype
 

--- a/torchvision/transforms/transforms.py
+++ b/torchvision/transforms/transforms.py
@@ -15,10 +15,10 @@ import warnings
 from . import functional as F
 
 
-__all__ = ["Compose", "ToTensor", "PILToTensor", "ToPILImage", "Normalize", "Resize", "Scale", "CenterCrop", "Pad",
-           "Lambda", "RandomApply", "RandomChoice", "RandomOrder", "RandomCrop", "RandomHorizontalFlip",
-           "RandomVerticalFlip", "RandomResizedCrop", "RandomSizedCrop", "FiveCrop", "TenCrop", "LinearTransformation",
-           "ColorJitter", "RandomRotation", "RandomAffine", "Grayscale", "RandomGrayscale",
+__all__ = ["Compose", "ToTensor", "PILToTensor", "ConvertImageDtype", "ToPILImage", "Normalize", "Resize", "Scale",
+           "CenterCrop", "Pad", "Lambda", "RandomApply", "RandomChoice", "RandomOrder", "RandomCrop",
+           "RandomHorizontalFlip", "RandomVerticalFlip", "RandomResizedCrop", "RandomSizedCrop", "FiveCrop", "TenCrop",
+           "LinearTransformation", "ColorJitter", "RandomRotation", "RandomAffine", "Grayscale", "RandomGrayscale",
            "RandomPerspective", "RandomErasing"]
 
 _pil_interpolation_to_str = {
@@ -113,6 +113,20 @@ class PILToTensor(object):
 
     def __repr__(self):
         return self.__class__.__name__ + '()'
+
+
+class ConvertImageDtype(object):
+    """Convert a tensor to the given ``dtype`` and scale the values accordingly
+
+    Args:
+        dtype (torch.dtype): Desired data type of the output
+
+    """
+    def __init__(self, dtype: torch.dtype) -> None:
+        self.dtype = dtype
+
+    def __call__(self, image: torch.Tensor) -> torch.Tensor:
+        return F.convert_image_dtype(image, self.dtype)
 
 
 class ToPILImage(object):

--- a/torchvision/transforms/transforms.py
+++ b/torchvision/transforms/transforms.py
@@ -116,7 +116,7 @@ class PILToTensor(object):
 
 
 class ConvertImageDtype(object):
-    """Convert a tensor to the given ``dtype`` and scale the values accordingly
+    """Convert a tensor image to the given ``dtype`` and scale the values accordingly
 
     Args:
         dtype (torch.dtype): Desired data type of the output


### PR DESCRIPTION
This adds a `convert_image_dtype` function as discussed in https://github.com/pytorch/vision/pull/2060#issuecomment-610520844.

Idea behind this function is to first convert the image into the interval `[0.0, 1.0]` and afterwards in the desired interval of the given `dtype`.