### PR TITLE
Add `fcn_resnet50` and `deeplabv3_resnet50` pretrained models.

### DIFF
--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -258,8 +258,8 @@ Semantic Segmentation
 The models subpackage contains definitions for the following model
 architectures for semantic segmentation:
 
-- `FCN ResNet101 <https://arxiv.org/abs/1411.4038>`_
-- `DeepLabV3 ResNet101 <https://arxiv.org/abs/1706.05587>`_
+- `FCN ResNet50, ResNet101 <https://arxiv.org/abs/1411.4038>`_
+- `DeepLabV3 ResNet50, ResNet101 <https://arxiv.org/abs/1706.05587>`_
 
 As with image classification models, all pre-trained models expect input images normalized in the same way.
 The images have to be loaded in to a range of ``[0, 1]`` and then normalized using
@@ -282,7 +282,9 @@ The accuracies of the pre-trained models evaluated on COCO val2017 are as follow
 ================================  =============  ====================
 Network                           mean IoU       global pixelwise acc
 ================================  =============  ====================
+FCN ResNet50                      60.5           91.4
 FCN ResNet101                     63.7           91.9
+DeepLabV3 ResNet50                66.4           92.4
 DeepLabV3 ResNet101               67.4           92.4
 ================================  =============  ====================
 

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -42,9 +42,11 @@ def get_available_video_models():
 # before they are compared to the eager model outputs. This is useful if the
 # model outputs are different between TorchScript / Eager mode
 script_test_models = {
+    'deeplabv3_resnet50': {},
     'deeplabv3_resnet101': {},
     'mobilenet_v2': {},
     'resnext50_32x4d': {},
+    'fcn_resnet50': {},
     'fcn_resnet101': {},
     'googlenet': {
         'unwrapper': lambda x: x.logits

--- a/torchvision/models/segmentation/segmentation.py
+++ b/torchvision/models/segmentation/segmentation.py
@@ -9,9 +9,9 @@ __all__ = ['fcn_resnet50', 'fcn_resnet101', 'deeplabv3_resnet50', 'deeplabv3_res
 
 
 model_urls = {
-    'fcn_resnet50_coco': None,
+    'fcn_resnet50_coco': 'https://download.pytorch.org/models/fcn_resnet50_coco-1167a1af.pth',
     'fcn_resnet101_coco': 'https://download.pytorch.org/models/fcn_resnet101_coco-7ecb50ca.pth',
-    'deeplabv3_resnet50_coco': None,
+    'deeplabv3_resnet50_coco': 'https://download.pytorch.org/models/deeplabv3_resnet50_coco-cd0a2569.pth',
     'deeplabv3_resnet101_coco': 'https://download.pytorch.org/models/deeplabv3_resnet101_coco-586e9e4e.pth',
 }
 


### PR DESCRIPTION
This PR adds pre-trained models for FCN ResNet 50 and DeepLabV3 ResNet 50.

```
$ python -c 'import torchvision;torchvision.models.segmentation.fcn_resnet50(pretrained=True)'
Downloading: "https://download.pytorch.org/models/fcn_resnet50_coco-1167a1af.pth" to /home/moto/.cache/torch/checkpoints/fcn_resnet50_coco-1167a1af.pth
100.0%
```

```
$python -c 'import torchvision;torchvision.models.segmentation.deeplabv3_resnet50(pretrained=True)'
Downloading: "https://download.pytorch.org/models/deeplabv3_resnet50_coco-cd0a2569.pth" to /home/moto/.cache/torch/checkpoints/deeplabv3_resnet50_coco-cd0a2569.pth
100.0%
```

Closes #1853
cc @isalirezag 