### PR TITLE
Add commands used to train `fcn_resnet50` and `deeplabv3_resnet50`

### DIFF
--- a/references/segmentation/README.md
+++ b/references/segmentation/README.md
@@ -6,9 +6,19 @@ training and evaluation scripts to quickly bootstrap research.
 
 All models have been trained on 8x V100 GPUs.
 
+## fcn_resnet50
+```
+python -m torch.distributed.launch --nproc_per_node=8 --use_env train.py --lr 0.02 --dataset coco -b 4 --model fcn_resnet50 --aux-loss
+```
+
 ## fcn_resnet101
 ```
 python -m torch.distributed.launch --nproc_per_node=8 --use_env train.py --lr 0.02 --dataset coco -b 4 --model fcn_resnet101 --aux-loss
+```
+
+## deeplabv3_resnet50
+```
+python -m torch.distributed.launch --nproc_per_node=8 --use_env train.py --lr 0.02 --dataset coco -b 4 --model deeplabv3_resnet50 --aux-loss
 ```
 
 ## deeplabv3_resnet101


### PR DESCRIPTION
Followup of #2086 
This adds the command I used for training `fcn_resnet50` and `deeplabv3_resnet50` in README.