### PR TITLE
Add pil_to_tensor to functionals

### DIFF
--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -516,7 +516,6 @@ class Tester(unittest.TestCase):
         test_channels = [1, 3, 4]
         height, width = 4, 4
         trans = transforms.PILToTensor()
-        trans_noswap = transforms.PILToTensor(swap_to_channelsfirst=False)
 
         with self.assertRaises(TypeError):
             trans(np.random.rand(1, height, width).tolist())
@@ -528,33 +527,16 @@ class Tester(unittest.TestCase):
             output = trans(img)
             self.assertTrue(np.allclose(input_data.numpy(), output.numpy()))
 
-            input_data = torch.ByteTensor(channels, height, width).random_(0, 255)
-            img = transforms.ToPILImage()(input_data)  # CHW -> HWC
-            output = trans_noswap(img).permute(2, 0, 1)  # HWC -> CHW
-            self.assertTrue(np.allclose(input_data.numpy(), output.numpy()))
-
             input_data = np.random.randint(low=0, high=255, size=(height, width, channels)).astype(np.uint8)
             img = transforms.ToPILImage()(input_data)
             output = trans(img)
             expected_output = input_data.transpose((2, 0, 1))
             self.assertTrue(np.allclose(output.numpy(), expected_output))
 
-            input_data = np.random.randint(low=0, high=255, size=(height, width, channels)).astype(np.uint8)
-            img = transforms.ToPILImage()(input_data)
-            output = trans_noswap(img)
-            expected_output = input_data
-            self.assertTrue(np.allclose(output.numpy(), expected_output))
-
             input_data = torch.as_tensor(np.random.rand(channels, height, width).astype(np.float32))
             img = transforms.ToPILImage()(input_data)  # CHW -> HWC and (* 255).byte()
             output = trans(img)  # HWC -> CHW
             expected_output = (input_data * 255).byte()
-            self.assertTrue(np.allclose(output.numpy(), expected_output.numpy()))
-
-            input_data = torch.as_tensor(np.random.rand(channels, height, width).astype(np.float32))
-            img = transforms.ToPILImage()(input_data)  # CHW -> HWC
-            output = trans_noswap(img)  # HWC -> HWC
-            expected_output = (input_data.permute(1, 2, 0) * 255).byte()  # CHW -> HWC
             self.assertTrue(np.allclose(output.numpy(), expected_output.numpy()))
 
         # separate test for mode '1' PIL images

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -530,7 +530,7 @@ class Tester(unittest.TestCase):
 
             input_data = torch.ByteTensor(channels, height, width).random_(0, 255)
             img = transforms.ToPILImage()(input_data)  # HWC
-            output = trans_noswap(img).transpose((2, 0, 1))  # HWC -> CHW 
+            output = trans_noswap(img).transpose((2, 0, 1))  # HWC -> CHW
             self.assertTrue(np.allclose(input_data.numpy(), output.numpy()))
 
             input_data = np.random.randint(low=0, high=255, size=(height, width, channels)).astype(np.uint8)

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -530,7 +530,7 @@ class Tester(unittest.TestCase):
 
             input_data = torch.ByteTensor(channels, height, width).random_(0, 255)
             img = transforms.ToPILImage()(input_data)  # HWC
-            output = trans_noswap(img).transpose((2, 0, 1))  # HWC -> CHW
+            output = trans_noswap(img).permute(2, 0, 1)  # HWC -> CHW
             self.assertTrue(np.allclose(input_data.numpy(), output.numpy()))
 
             input_data = np.random.randint(low=0, high=255, size=(height, width, channels)).astype(np.uint8)

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -546,15 +546,15 @@ class Tester(unittest.TestCase):
             self.assertTrue(np.allclose(output.numpy(), expected_output))
 
             input_data = torch.as_tensor(np.random.rand(channels, height, width).astype(np.float32))
-            img = transforms.ToPILImage()(input_data)  # CHW -> HWC
+            img = transforms.ToPILImage()(input_data)  # CHW -> HWC and (* 255).byte()
             output = trans(img)  # HWC -> CHW
-            expected_output = input_data
+            expected_output = (input_data * 255).byte()
             self.assertTrue(np.allclose(output.numpy(), expected_output.numpy()))
 
             input_data = torch.as_tensor(np.random.rand(channels, height, width).astype(np.float32))
             img = transforms.ToPILImage()(input_data)  # CHW -> HWC
             output = trans_noswap(img)  # HWC -> HWC
-            expected_output = input_data.permute(1, 2, 0)  # CHW -> HWC
+            expected_output = (input_data.permute(1, 2, 0) * 255).byte()  # CHW -> HWC
             self.assertTrue(np.allclose(output.numpy(), expected_output.numpy()))
 
         # separate test for mode '1' PIL images

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -527,6 +527,9 @@ class Tester(unittest.TestCase):
             img = transforms.ToPILImage()(input_data)
             output = trans(img)
             self.assertTrue(np.allclose(input_data.numpy(), output.numpy()))
+
+            input_data = torch.ByteTensor(channels, height, width).random_(0, 255)
+            img = transforms.ToPILImage()(input_data)
             output = trans_noswap(img)
             self.assertTrue(np.allclose(input_data.numpy(), output.numpy()))
 
@@ -535,6 +538,9 @@ class Tester(unittest.TestCase):
             output = trans(img)
             expected_output = input_data.transpose((2, 0, 1))
             self.assertTrue(np.allclose(output.numpy(), expected_output))
+
+            input_data = np.random.randint(low=0, high=255, size=(height, width, channels)).astype(np.uint8)
+            img = transforms.ToPILImage()(input_data)
             output = trans_noswap(img)
             expected_output = input_data
             self.assertTrue(np.allclose(output.numpy(), expected_output))
@@ -544,6 +550,10 @@ class Tester(unittest.TestCase):
             output = trans(img)
             expected_output = input_data.transpose((2, 0, 1))
             self.assertTrue(np.allclose(output.numpy(), expected_output))
+            input_data = np.random.rand(height, width, channels).astype(np.float32)
+
+            input_data = np.random.rand(height, width, channels).astype(np.float32)
+            img = transforms.ToPILImage()(input_data)
             output = trans_noswap(img)
             expected_output = input_data
             self.assertTrue(np.allclose(output.numpy(), expected_output))

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -546,14 +546,13 @@ class Tester(unittest.TestCase):
             self.assertTrue(np.allclose(output.numpy(), expected_output))
 
             input_data = np.random.rand(height, width, channels).astype(np.float32)
-            img = transforms.ToPILImage()(input_data)
+            img = transforms.ToPILImage(mode='F')(input_data)
             output = trans(img)
             expected_output = input_data.transpose((2, 0, 1))
             self.assertTrue(np.allclose(output.numpy(), expected_output))
-            input_data = np.random.rand(height, width, channels).astype(np.float32)
 
             input_data = np.random.rand(height, width, channels).astype(np.float32)
-            img = transforms.ToPILImage()(input_data)
+            img = transforms.ToPILImage(mode='F')(input_data)
             output = trans_noswap(img)
             expected_output = input_data
             self.assertTrue(np.allclose(output.numpy(), expected_output))

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -529,7 +529,7 @@ class Tester(unittest.TestCase):
             self.assertTrue(np.allclose(input_data.numpy(), output.numpy()))
 
             input_data = torch.ByteTensor(channels, height, width).random_(0, 255)
-            img = transforms.ToPILImage()(input_data)  # HWC
+            img = transforms.ToPILImage()(input_data)  # CHW -> HWC
             output = trans_noswap(img).permute(2, 0, 1)  # HWC -> CHW
             self.assertTrue(np.allclose(input_data.numpy(), output.numpy()))
 
@@ -545,17 +545,17 @@ class Tester(unittest.TestCase):
             expected_output = input_data
             self.assertTrue(np.allclose(output.numpy(), expected_output))
 
-            input_data = np.random.rand(height, width, channels).astype(np.float32)
-            img = transforms.ToPILImage(mode='F')(input_data)
-            output = trans(img)
-            expected_output = input_data.transpose((2, 0, 1))
-            self.assertTrue(np.allclose(output.numpy(), expected_output))
-
-            input_data = np.random.rand(height, width, channels).astype(np.float32)
-            img = transforms.ToPILImage(mode='F')(input_data)
-            output = trans_noswap(img)
+            input_data = torch.as_tensor(np.random.rand(channels, height, width).astype(np.float32))
+            img = transforms.ToPILImage()(input_data)  # CHW -> HWC
+            output = trans(img)  # HWC -> CHW
             expected_output = input_data
-            self.assertTrue(np.allclose(output.numpy(), expected_output))
+            self.assertTrue(np.allclose(output.numpy(), expected_output.numpy()))
+
+            input_data = torch.as_tensor(np.random.rand(channels, height, width).astype(np.float32))
+            img = transforms.ToPILImage()(input_data)  # CHW -> HWC
+            output = trans_noswap(img)  # HWC -> HWC
+            expected_output = input_data.permute(1, 2, 0)  # CHW -> HWC
+            self.assertTrue(np.allclose(output.numpy(), expected_output.numpy()))
 
         # separate test for mode '1' PIL images
         input_data = torch.ByteTensor(1, height, width).bernoulli_()

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -529,8 +529,8 @@ class Tester(unittest.TestCase):
             self.assertTrue(np.allclose(input_data.numpy(), output.numpy()))
 
             input_data = torch.ByteTensor(channels, height, width).random_(0, 255)
-            img = transforms.ToPILImage()(input_data)
-            output = trans_noswap(img)
+            img = transforms.ToPILImage()(input_data) #HWC
+            output = trans_noswap(img).transpose((2, 0, 1)) #HWC -> CHW 
             self.assertTrue(np.allclose(input_data.numpy(), output.numpy()))
 
             input_data = np.random.randint(low=0, high=255, size=(height, width, channels)).astype(np.uint8)

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -529,8 +529,8 @@ class Tester(unittest.TestCase):
             self.assertTrue(np.allclose(input_data.numpy(), output.numpy()))
 
             input_data = torch.ByteTensor(channels, height, width).random_(0, 255)
-            img = transforms.ToPILImage()(input_data) #HWC
-            output = trans_noswap(img).transpose((2, 0, 1)) #HWC -> CHW 
+            img = transforms.ToPILImage()(input_data)  # HWC
+            output = trans_noswap(img).transpose((2, 0, 1))  # HWC -> CHW 
             self.assertTrue(np.allclose(input_data.numpy(), output.numpy()))
 
             input_data = np.random.randint(low=0, high=255, size=(height, width, channels)).astype(np.uint8)

--- a/torchvision/transforms/functional.py
+++ b/torchvision/transforms/functional.py
@@ -81,6 +81,7 @@ def to_tensor(pic):
     else:
         return img
 
+
 def as_tensor(pic):
     """Convert a ``PIL Image`` or ``numpy.ndarray`` to tensor of same type.
 

--- a/torchvision/transforms/functional.py
+++ b/torchvision/transforms/functional.py
@@ -118,7 +118,7 @@ def as_tensor(pic):
         img = torch.from_numpy(np.array(pic, np.int16, copy=False))
     elif pic.mode == 'F':
         img = torch.from_numpy(np.array(pic, np.float32, copy=False))
-    elif pic.mode == '1' or pic.mode == 'L':
+    elif pic.mode == '1':
         img = torch.from_numpy(np.array(pic, np.uint8, copy=False))
     else:
         img = torch.ByteTensor(torch.ByteStorage.from_buffer(pic.tobytes()))

--- a/torchvision/transforms/functional.py
+++ b/torchvision/transforms/functional.py
@@ -104,29 +104,20 @@ def as_tensor(pic):
         if pic.ndim == 2:
             pic = pic[:, :, None]
 
-        img = torch.from_numpy(pic.transpose((2, 0, 1)))
+        img = torch.as_tensor(pic.transpose((2, 0, 1)))
         return img
 
     if accimage is not None and isinstance(pic, accimage.Image):
         nppic = np.zeros([pic.channels, pic.height, pic.width], dtype=np.float32)
         pic.copyto(nppic)
-        return torch.from_numpy(nppic)
+        return torch.as_tensor(nppic)
 
     # handle PIL Image
-    if pic.mode == 'I':
-        img = torch.from_numpy(np.array(pic, np.int32, copy=False))
-    elif pic.mode == 'I;16':
-        img = torch.from_numpy(np.array(pic, np.int16, copy=False))
-    elif pic.mode == 'F':
-        img = torch.from_numpy(np.array(pic, np.float32, copy=False))
-    elif pic.mode == '1':
-        img = torch.from_numpy(np.array(pic, np.uint8, copy=False))
-    else:
-        img = torch.ByteTensor(torch.ByteStorage.from_buffer(pic.tobytes()))
+    img = torch.as_tensor(np.asarray(pic))
 
     img = img.view(pic.size[1], pic.size[0], len(pic.getbands()))
     # put it from HWC to CHW format
-    img = img.permute((2, 0, 1)).contiguous()
+    img = img.permute((2, 0, 1))
     return img
 
 

--- a/torchvision/transforms/functional.py
+++ b/torchvision/transforms/functional.py
@@ -104,9 +104,9 @@ def pil_to_tensor(pic, swap_to_channelsfirst=True):
 
     # handle PIL Image
     img = torch.as_tensor(np.asarray(pic))
+    img = img.view(pic.size[1], pic.size[0], len(pic.getbands()))
 
     if swap_to_channelsfirst:
-        img = img.view(pic.size[1], pic.size[0], len(pic.getbands()))
         # put it from HWC to CHW format
         img = img.permute((2, 0, 1))
     return img

--- a/torchvision/transforms/functional.py
+++ b/torchvision/transforms/functional.py
@@ -82,14 +82,13 @@ def to_tensor(pic):
         return img
 
 
-def pil_to_tensor(pic, swap_to_channelsfirst=True):
+def pil_to_tensor(pic):
     """Convert a ``PIL Image`` to a tensor of the same type.
 
     See ``AsTensor`` for more details.
 
     Args:
         pic (PIL Image): Image to be converted to tensor.
-        swap_to_channelsfirst (bool): Boolean indicator to convert to CHW format.
 
     Returns:
         Tensor: Converted image.
@@ -105,10 +104,8 @@ def pil_to_tensor(pic, swap_to_channelsfirst=True):
     # handle PIL Image
     img = torch.as_tensor(np.asarray(pic))
     img = img.view(pic.size[1], pic.size[0], len(pic.getbands()))
-
-    if swap_to_channelsfirst:
-        # put it from HWC to CHW format
-        img = img.permute((2, 0, 1))
+    # put it from HWC to CHW format
+    img = img.permute((2, 0, 1))
     return img
 
 

--- a/torchvision/transforms/functional.py
+++ b/torchvision/transforms/functional.py
@@ -82,30 +82,20 @@ def to_tensor(pic):
         return img
 
 
-def as_tensor(pic):
-    """Convert a ``PIL Image`` or ``numpy.ndarray`` to tensor of same type.
+def pil_to_tensor(pic, swap_to_channelsfirst=True):
+    """Convert a ``PIL Image`` to a tensor of the same type.
 
     See ``AsTensor`` for more details.
 
     Args:
-        pic (PIL Image or numpy.ndarray): Image to be converted to tensor.
+        pic (PIL Image): Image to be converted to tensor.
+        swap_to_channelsfirst (bool): Boolean indicator to convert to CHW format.
 
     Returns:
         Tensor: Converted image.
     """
-    if not(_is_pil_image(pic) or _is_numpy(pic)):
-        raise TypeError('pic should be PIL Image or ndarray. Got {}'.format(type(pic)))
-
-    if _is_numpy(pic) and not _is_numpy_image(pic):
-        raise ValueError('pic should be 2/3 dimensional. Got {} dimensions.'.format(pic.ndim))
-
-    if isinstance(pic, np.ndarray):
-        # handle numpy array
-        if pic.ndim == 2:
-            pic = pic[:, :, None]
-
-        img = torch.as_tensor(pic.transpose((2, 0, 1)))
-        return img
+    if not(_is_pil_image(pic)):
+        raise TypeError('pic should be PIL Image. Got {}'.format(type(pic)))
 
     if accimage is not None and isinstance(pic, accimage.Image):
         nppic = np.zeros([pic.channels, pic.height, pic.width], dtype=np.float32)
@@ -115,9 +105,10 @@ def as_tensor(pic):
     # handle PIL Image
     img = torch.as_tensor(np.asarray(pic))
 
-    img = img.view(pic.size[1], pic.size[0], len(pic.getbands()))
-    # put it from HWC to CHW format
-    img = img.permute((2, 0, 1))
+    if swap_to_channelsfirst:
+        img = img.view(pic.size[1], pic.size[0], len(pic.getbands()))
+        # put it from HWC to CHW format
+        img = img.permute((2, 0, 1))
     return img
 
 

--- a/torchvision/transforms/transforms.py
+++ b/torchvision/transforms/transforms.py
@@ -15,7 +15,7 @@ import warnings
 from . import functional as F
 
 
-__all__ = ["Compose", "ToTensor", "ToPILImage", "Normalize", "Resize", "Scale", "CenterCrop", "Pad",
+__all__ = ["Compose", "ToTensor", "AsTensor", "ToPILImage", "Normalize", "Resize", "Scale", "CenterCrop", "Pad",
            "Lambda", "RandomApply", "RandomChoice", "RandomOrder", "RandomCrop", "RandomHorizontalFlip",
            "RandomVerticalFlip", "RandomResizedCrop", "RandomSizedCrop", "FiveCrop", "TenCrop", "LinearTransformation",
            "ColorJitter", "RandomRotation", "RandomAffine", "Grayscale", "RandomGrayscale",
@@ -90,6 +90,28 @@ class ToTensor(object):
             Tensor: Converted image.
         """
         return F.to_tensor(pic)
+
+    def __repr__(self):
+        return self.__class__.__name__ + '()'
+
+
+class AsTensor(object):
+    """Convert a ``PIL Image`` or ``numpy.ndarray`` to tensor of the same type.
+
+    Converts a PIL Image or numpy.ndarray (H x W x C) to a torch.Tensor of shape (C x H x W)
+    if the PIL Image belongs to one of the modes (L, LA, P, I, F, RGB, YCbCr, RGBA, CMYK, 1)
+    or if the numpy.ndarray has dtype = np.uint8
+    """
+
+    def __call__(self, pic):
+        """
+        Args:
+            pic (PIL Image or numpy.ndarray): Image to be converted to tensor.
+
+        Returns:
+            Tensor: Converted image.
+        """
+        return F.as_tensor(pic)
 
     def __repr__(self):
         return self.__class__.__name__ + '()'

--- a/torchvision/transforms/transforms.py
+++ b/torchvision/transforms/transforms.py
@@ -15,7 +15,7 @@ import warnings
 from . import functional as F
 
 
-__all__ = ["Compose", "ToTensor", "AsTensor", "ToPILImage", "Normalize", "Resize", "Scale", "CenterCrop", "Pad",
+__all__ = ["Compose", "ToTensor", "PILToTensor", "ToPILImage", "Normalize", "Resize", "Scale", "CenterCrop", "Pad",
            "Lambda", "RandomApply", "RandomChoice", "RandomOrder", "RandomCrop", "RandomHorizontalFlip",
            "RandomVerticalFlip", "RandomResizedCrop", "RandomSizedCrop", "FiveCrop", "TenCrop", "LinearTransformation",
            "ColorJitter", "RandomRotation", "RandomAffine", "Grayscale", "RandomGrayscale",
@@ -95,23 +95,24 @@ class ToTensor(object):
         return self.__class__.__name__ + '()'
 
 
-class AsTensor(object):
-    """Convert a ``PIL Image`` or ``numpy.ndarray`` to tensor of the same type.
+class PILToTensor(object):
+    """Convert a ``PIL Image`` to a tensor of the same type.
 
-    Converts a PIL Image or numpy.ndarray (H x W x C) to a torch.Tensor of shape (C x H x W)
-    if the PIL Image belongs to one of the modes (L, LA, P, I, F, RGB, YCbCr, RGBA, CMYK, 1)
-    or if the numpy.ndarray has dtype = np.uint8
+    Converts a PIL Image (H x W x C) to a torch.Tensor. If swap_to_channelsfirst is True
+    the returned shape will be (C x H x W) otherwise the shape will remain unchanged.
     """
 
-    def __call__(self, pic):
+    def __call__(self, pic, swap_to_channelsfirst=True):
         """
         Args:
-            pic (PIL Image or numpy.ndarray): Image to be converted to tensor.
+            pic (PIL Image): Image to be converted to tensor.
+            swap_to_channelsfirst (bool): Boolean indicator to swap to channels first format. 
+                Defaults to True.
 
         Returns:
             Tensor: Converted image.
         """
-        return F.as_tensor(pic)
+        return F.pil_to_tensor(pic)
 
     def __repr__(self):
         return self.__class__.__name__ + '()'

--- a/torchvision/transforms/transforms.py
+++ b/torchvision/transforms/transforms.py
@@ -101,8 +101,10 @@ class PILToTensor(object):
     Converts a PIL Image (H x W x C) to a torch.Tensor. If swap_to_channelsfirst is True
     the returned shape will be (C x H x W) otherwise the shape will remain unchanged.
     """
+    def __init__(self, swap_to_channelsfirst=True):
+        self.swap_to_channelsfirst = swap_to_channelsfirst
 
-    def __call__(self, pic, swap_to_channelsfirst=True):
+    def __call__(self, pic):
         """
         Args:
             pic (PIL Image): Image to be converted to tensor.
@@ -112,7 +114,7 @@ class PILToTensor(object):
         Returns:
             Tensor: Converted image.
         """
-        return F.pil_to_tensor(pic)
+        return F.pil_to_tensor(pic, self.swap_to_channelsfirst)
 
     def __repr__(self):
         return self.__class__.__name__ + '()'

--- a/torchvision/transforms/transforms.py
+++ b/torchvision/transforms/transforms.py
@@ -98,23 +98,18 @@ class ToTensor(object):
 class PILToTensor(object):
     """Convert a ``PIL Image`` to a tensor of the same type.
 
-    Converts a PIL Image (H x W x C) to a torch.Tensor. If swap_to_channelsfirst is True
-    the returned shape will be (C x H x W) otherwise the shape will remain unchanged.
+    Converts a PIL Image (H x W x C) to a torch.Tensor of shape (C x H x W).
     """
-    def __init__(self, swap_to_channelsfirst=True):
-        self.swap_to_channelsfirst = swap_to_channelsfirst
 
     def __call__(self, pic):
         """
         Args:
             pic (PIL Image): Image to be converted to tensor.
-            swap_to_channelsfirst (bool): Boolean indicator to swap to channels first format.
-                Defaults to True.
 
         Returns:
             Tensor: Converted image.
         """
-        return F.pil_to_tensor(pic, self.swap_to_channelsfirst)
+        return F.pil_to_tensor(pic)
 
     def __repr__(self):
         return self.__class__.__name__ + '()'

--- a/torchvision/transforms/transforms.py
+++ b/torchvision/transforms/transforms.py
@@ -108,7 +108,7 @@ class PILToTensor(object):
         """
         Args:
             pic (PIL Image): Image to be converted to tensor.
-            swap_to_channelsfirst (bool): Boolean indicator to swap to channels first format. 
+            swap_to_channelsfirst (bool): Boolean indicator to swap to channels first format.
                 Defaults to True.
 
         Returns:


### PR DESCRIPTION
This adds an as_tensor function as discussed in https://github.com/pytorch/vision/pull/2060#issuecomment-610520844.

The idea behind this function is to first convert the image into a torch.Tensor of the same dtype as the inputted image.

I do not know have an example TIFF image to test out if this issue https://github.com/pytorch/vision/issues/856#issue-433759349 is addressed or not.  Please instruct me on how to proceed. Thanks