### PR TITLE
Remove mock

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ before_install:
     fi
   - pip install future
   - pip install pytest pytest-cov codecov
-  - pip install mock
   - pip install typing
   - |
     if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then

--- a/packaging/torchvision/meta.yaml
+++ b/packaging/torchvision/meta.yaml
@@ -43,7 +43,6 @@ test:
   requires:
     - pytest
     - scipy
-    - mock
     - av
     - ca-certificates
     {{ environ.get('CONDA_TYPING_CONSTRAINT') }}

--- a/packaging/windows/internal/test.bat
+++ b/packaging/windows/internal/test.bat
@@ -8,7 +8,7 @@ set PYTHON_VERSION=%PYTHON_PREFIX:py=cp%
 if "%BUILD_VISION%" == "" (
     pip install future pytest coverage hypothesis protobuf
 ) ELSE (
-    pip install future pytest "pillow>=4.1.1" mock
+    pip install future pytest "pillow>=4.1.1"
 )
 
 for /F "delims=" %%i in ('where /R %SRC_DIR%\output *%MODULE_NAME%*%PYTHON_VERSION%*.whl') do pip install "%%i"

--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -1,7 +1,7 @@
 import sys
 import os
 import unittest
-import mock
+from unittest import mock
 import numpy as np
 import PIL
 from PIL import Image

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -1,5 +1,4 @@
 import os
-import mock
 import torch
 import torchvision.transforms as transforms
 import torchvision.transforms.functional as F


### PR DESCRIPTION
This removes the dependency on [`mock` package](https://pypi.org/project/mock/) since

> `mock` is now part of the Python standard library, available as `unittest.mock` in Python 3.3 onwards.