### PR TITLE
Master version bump 0.6 -> 0.7

### DIFF
--- a/packaging/build_conda.sh
+++ b/packaging/build_conda.sh
@@ -5,7 +5,7 @@ script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 . "$script_dir/pkg_helpers.bash"
 
 export BUILD_TYPE=conda
-setup_env 0.6.0
+setup_env 0.7.0
 export SOURCE_ROOT_DIR="$PWD"
 setup_conda_pytorch_constraint
 setup_conda_cudatoolkit_constraint

--- a/packaging/build_wheel.sh
+++ b/packaging/build_wheel.sh
@@ -5,7 +5,7 @@ script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 . "$script_dir/pkg_helpers.bash"
 
 export BUILD_TYPE=wheel
-setup_env 0.6.0
+setup_env 0.7.0
 setup_wheel_python
 pip_install numpy pyyaml future ninja
 setup_pip_pytorch_version

--- a/packaging/windows/internal/nightly_defaults.bat
+++ b/packaging/windows/internal/nightly_defaults.bat
@@ -144,7 +144,7 @@ if "%CUDA_VERSION%" == "cpu" (
 ::       pytorch-nightly==1.0.0.dev20180908
 ::   or in manylinux like
 ::       torch_nightly-1.0.0.dev20180908-cp27-cp27m-linux_x86_64.whl
-if "%TORCHVISION_BUILD_VERSION%" == "" set TORCHVISION_BUILD_VERSION=0.6.0.dev%NIGHTLIES_DATE_COMPACT%
+if "%TORCHVISION_BUILD_VERSION%" == "" set TORCHVISION_BUILD_VERSION=0.7.0.dev%NIGHTLIES_DATE_COMPACT%
 
 if "%~1" == "Wheels" (
     if not "%CUDA_VERSION%" == "102" (

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ def get_dist(pkgname):
         return None
 
 
-version = '0.6.0a0'
+version = '0.7.0a0'
 sha = 'Unknown'
 package_name = 'torchvision'
 


### PR DESCRIPTION
This PR bumps the version of the nightly version to 0.7.

This should hopefully fix https://github.com/pytorch/vision/issues/2098