### PR TITLE
Set Pillow to 6.2.2 on requirements, as 7 breaks it

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ requirements = [
     pytorch_dep,
 ]
 
-pillow_ver = ' >= 4.1.1'
+pillow_ver = ' ==6.2.2'
 pillow_req = 'pillow-simd' if get_dist('pillow-simd') is not None else 'pillow'
 requirements.append(pillow_req + pillow_ver)
 


### PR DESCRIPTION
Set Pillow to 6.2.2 on requirements, as pillow 7 breaks it and makes it impossible to import torchvision.