### PR TITLE
add missing CelebA in docs

### DIFF
--- a/docs/source/datasets.rst
+++ b/docs/source/datasets.rst
@@ -224,3 +224,10 @@ UCF101
 .. autoclass:: UCF101
   :members: __getitem__
   :special-members:
+
+CelebA
+~~~~~~
+
+.. autoclass:: CelebA
+  :members: __getitem__
+  :special-members:


### PR DESCRIPTION
this PR add to docs the reference to CelebA dataset in torchvision.
code is here: https://github.com/pytorch/vision/blob/master/torchvision/datasets/celeba.py

but no reference for some reason