### PR TITLE
packaging: Add BUILD_VERSION as a script_env to pass

### DIFF
--- a/packaging/torchvision/meta.yaml
+++ b/packaging/torchvision/meta.yaml
@@ -30,6 +30,7 @@ build:
     - CUDA_HOME
     - FORCE_CUDA
     - NVCC_FLAGS
+    - BUILD_VERSION
   features:
     {{ environ.get('CONDA_CPUONLY_FEATURE') }}
 


### PR DESCRIPTION
BUILD_VERSION was not getting propagated properly through our conda
packaging, which made release builds look as though they were actually
develpoment builds.

This remedies that by having conda pass the environment variable
BUILD_VERSION through to the "python setup.py install" portion of the
"conda build".

This might have some side effects but I think overall this should be a
fairly harmless change.

closes #2133 

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>