### PR TITLE
Fix DatasetFolder error message

### DIFF
--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -94,7 +94,6 @@ class Tester(unittest.TestCase):
                     root, loader=lambda x: x, is_valid_file=lambda x: False
                 )
 
-
     @mock.patch('torchvision.datasets.mnist.download_and_extract_archive')
     def test_mnist(self, mock_download_extract):
         num_examples = 30

--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -84,6 +84,17 @@ class Tester(unittest.TestCase):
             outputs = sorted([dataset[i] for i in range(len(dataset))])
             self.assertEqual(imgs, outputs)
 
+    def test_imagefolder_empty(self):
+        with get_tmp_dir() as root:
+            with self.assertRaises(RuntimeError):
+                torchvision.datasets.ImageFolder(root, loader=lambda x: x)
+
+            with self.assertRaises(RuntimeError):
+                torchvision.datasets.ImageFolder(
+                    root, loader=lambda x: x, is_valid_file=lambda x: False
+                )
+
+
     @mock.patch('torchvision.datasets.mnist.download_and_extract_archive')
     def test_mnist(self, mock_download_extract):
         num_examples = 30

--- a/torchvision/datasets/folder.py
+++ b/torchvision/datasets/folder.py
@@ -94,8 +94,10 @@ class DatasetFolder(VisionDataset):
         classes, class_to_idx = self._find_classes(self.root)
         samples = make_dataset(self.root, class_to_idx, extensions, is_valid_file)
         if len(samples) == 0:
-            raise (RuntimeError("Found 0 files in subfolders of: " + self.root + "\n"
-                                "Supported extensions are: " + ",".join(extensions)))
+            msg = "Found 0 files in subfolders of: {}\n".format(self.root)
+            if extensions is not None:
+                msg += "Supported extensions are: {}".format(",".join(extensions))
+            raise RuntimeError(msg)
 
         self.loader = loader
         self.extensions = extensions


### PR DESCRIPTION
Fixes #2138 

---

With this the valid `extensions` are only added to the error message if they are available. This arose since the `ImageFolder` dataset only passes `IMG_EXTENSIONS` if no custom `is_valid_file` is used:

https://github.com/pytorch/vision/blob/8df3f29a5ffe875e783474e899e51a0d30b2c17b/torchvision/datasets/folder.py#L201-L206

If one uses a custom `is_valid_file` an no images were found the creation of the error message would raise a `TypeError` which does not reflect the actual problem.