### PR TITLE
Fix corner case in interpolate

### DIFF
--- a/torchvision/ops/misc.py
+++ b/torchvision/ops/misc.py
@@ -113,7 +113,7 @@ def interpolate(input, size=None, scale_factor=None, mode="nearest", align_corne
         )
 
     output_shape = _output_size(2, input, size, scale_factor)
-    output_shape = list(input.shape[:-2]) + output_shape
+    output_shape = list(input.shape[:-2]) + list(output_shape)
     return _new_empty_tensor(input, output_shape)
 
 


### PR DESCRIPTION
If the user specify the size as a tuple instead of a list, and the image is empty, we might end up with errors like
```
TypeError: can only concatenate list (not "tuple") to list
```
This is a workaround fix for it.
We should move support for empty tensors in interpolate into PyTorch, so that we don't need to handle it ourselves.

cc @szagoruyko 