### PR TITLE
Remove Python 3.5 from CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -385,26 +385,6 @@ workflows:
       - circleci_consistency
       - binary_linux_wheel:
           cu_version: cpu
-          name: binary_linux_wheel_py3.5_cpu
-          python_version: '3.5'
-          wheel_docker_image: pytorch/manylinux-cuda102
-      - binary_linux_wheel:
-          cu_version: cu92
-          name: binary_linux_wheel_py3.5_cu92
-          python_version: '3.5'
-          wheel_docker_image: pytorch/manylinux-cuda92
-      - binary_linux_wheel:
-          cu_version: cu101
-          name: binary_linux_wheel_py3.5_cu101
-          python_version: '3.5'
-          wheel_docker_image: pytorch/manylinux-cuda101
-      - binary_linux_wheel:
-          cu_version: cu102
-          name: binary_linux_wheel_py3.5_cu102
-          python_version: '3.5'
-          wheel_docker_image: pytorch/manylinux-cuda102
-      - binary_linux_wheel:
-          cu_version: cpu
           name: binary_linux_wheel_py3.6_cpu
           python_version: '3.6'
           wheel_docker_image: pytorch/manylinux-cuda102
@@ -465,11 +445,6 @@ workflows:
           wheel_docker_image: pytorch/manylinux-cuda102
       - binary_macos_wheel:
           cu_version: cpu
-          name: binary_macos_wheel_py3.5_cpu
-          python_version: '3.5'
-          wheel_docker_image: pytorch/manylinux-cuda102
-      - binary_macos_wheel:
-          cu_version: cpu
           name: binary_macos_wheel_py3.6_cpu
           python_version: '3.6'
           wheel_docker_image: pytorch/manylinux-cuda102
@@ -483,34 +458,6 @@ workflows:
           name: binary_macos_wheel_py3.8_cpu
           python_version: '3.8'
           wheel_docker_image: pytorch/manylinux-cuda102
-      - binary_win_wheel_release:
-          cu_version: cpu
-          filters:
-            branches:
-              only: master
-          name: binary_win_wheel_py3.5_cpu
-          python_version: '3.5'
-      - binary_win_wheel_release:
-          cu_version: '92'
-          filters:
-            branches:
-              only: master
-          name: binary_win_wheel_py3.5_cu92
-          python_version: '3.5'
-      - binary_win_wheel_release:
-          cu_version: '101'
-          filters:
-            branches:
-              only: master
-          name: binary_win_wheel_py3.5_cu101
-          python_version: '3.5'
-      - binary_win_wheel_release:
-          cu_version: '102'
-          filters:
-            branches:
-              only: master
-          name: binary_win_wheel_py3.5_cu102
-          python_version: '3.5'
       - binary_win_wheel_release:
           cu_version: cpu
           filters:
@@ -591,26 +538,6 @@ workflows:
           python_version: '3.8'
       - binary_linux_conda:
           cu_version: cpu
-          name: binary_linux_conda_py3.5_cpu
-          python_version: '3.5'
-          wheel_docker_image: pytorch/manylinux-cuda102
-      - binary_linux_conda:
-          cu_version: cu92
-          name: binary_linux_conda_py3.5_cu92
-          python_version: '3.5'
-          wheel_docker_image: pytorch/manylinux-cuda92
-      - binary_linux_conda:
-          cu_version: cu101
-          name: binary_linux_conda_py3.5_cu101
-          python_version: '3.5'
-          wheel_docker_image: pytorch/manylinux-cuda101
-      - binary_linux_conda:
-          cu_version: cu102
-          name: binary_linux_conda_py3.5_cu102
-          python_version: '3.5'
-          wheel_docker_image: pytorch/manylinux-cuda102
-      - binary_linux_conda:
-          cu_version: cpu
           name: binary_linux_conda_py3.6_cpu
           python_version: '3.6'
           wheel_docker_image: pytorch/manylinux-cuda102
@@ -671,11 +598,6 @@ workflows:
           wheel_docker_image: pytorch/manylinux-cuda102
       - binary_macos_conda:
           cu_version: cpu
-          name: binary_macos_conda_py3.5_cpu
-          python_version: '3.5'
-          wheel_docker_image: pytorch/manylinux-cuda102
-      - binary_macos_conda:
-          cu_version: cpu
           name: binary_macos_conda_py3.6_cpu
           python_version: '3.6'
           wheel_docker_image: pytorch/manylinux-cuda102
@@ -689,34 +611,6 @@ workflows:
           name: binary_macos_conda_py3.8_cpu
           python_version: '3.8'
           wheel_docker_image: pytorch/manylinux-cuda102
-      - binary_win_conda_release:
-          cu_version: cpu
-          filters:
-            branches:
-              only: master
-          name: binary_win_conda_py3.5_cpu
-          python_version: '3.5'
-      - binary_win_conda_release:
-          cu_version: '92'
-          filters:
-            branches:
-              only: master
-          name: binary_win_conda_py3.5_cu92
-          python_version: '3.5'
-      - binary_win_conda_release:
-          cu_version: '101'
-          filters:
-            branches:
-              only: master
-          name: binary_win_conda_py3.5_cu101
-          python_version: '3.5'
-      - binary_win_conda_release:
-          cu_version: '102'
-          filters:
-            branches:
-              only: master
-          name: binary_win_conda_py3.5_cu102
-          python_version: '3.5'
       - binary_win_conda_release:
           cu_version: cpu
           filters:
@@ -815,74 +709,6 @@ workflows:
       - circleci_consistency
       - python_lint
       - clang_format
-      - binary_linux_wheel:
-          cu_version: cpu
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_linux_wheel_py3.5_cpu
-          python_version: '3.5'
-          wheel_docker_image: pytorch/manylinux-cuda102
-      - binary_wheel_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_linux_wheel_py3.5_cpu_upload
-          requires:
-          - nightly_binary_linux_wheel_py3.5_cpu
-          subfolder: cpu/
-      - binary_linux_wheel:
-          cu_version: cu92
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_linux_wheel_py3.5_cu92
-          python_version: '3.5'
-          wheel_docker_image: pytorch/manylinux-cuda92
-      - binary_wheel_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_linux_wheel_py3.5_cu92_upload
-          requires:
-          - nightly_binary_linux_wheel_py3.5_cu92
-          subfolder: cu92/
-      - binary_linux_wheel:
-          cu_version: cu101
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_linux_wheel_py3.5_cu101
-          python_version: '3.5'
-          wheel_docker_image: pytorch/manylinux-cuda101
-      - binary_wheel_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_linux_wheel_py3.5_cu101_upload
-          requires:
-          - nightly_binary_linux_wheel_py3.5_cu101
-          subfolder: cu101/
-      - binary_linux_wheel:
-          cu_version: cu102
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_linux_wheel_py3.5_cu102
-          python_version: '3.5'
-          wheel_docker_image: pytorch/manylinux-cuda102
-      - binary_wheel_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_linux_wheel_py3.5_cu102_upload
-          requires:
-          - nightly_binary_linux_wheel_py3.5_cu102
-          subfolder: cu102/
       - binary_linux_wheel:
           cu_version: cpu
           filters:
@@ -1092,23 +918,6 @@ workflows:
           filters:
             branches:
               only: nightly
-          name: nightly_binary_macos_wheel_py3.5_cpu
-          python_version: '3.5'
-          wheel_docker_image: pytorch/manylinux-cuda102
-      - binary_wheel_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_macos_wheel_py3.5_cpu_upload
-          requires:
-          - nightly_binary_macos_wheel_py3.5_cpu
-          subfolder: ''
-      - binary_macos_wheel:
-          cu_version: cpu
-          filters:
-            branches:
-              only: nightly
           name: nightly_binary_macos_wheel_py3.6_cpu
           python_version: '3.6'
           wheel_docker_image: pytorch/manylinux-cuda102
@@ -1155,70 +964,6 @@ workflows:
           requires:
           - nightly_binary_macos_wheel_py3.8_cpu
           subfolder: ''
-      - binary_win_wheel_release:
-          cu_version: cpu
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_win_wheel_py3.5_cpu
-          python_version: '3.5'
-      - binary_wheel_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_win_wheel_py3.5_cpu_upload
-          requires:
-          - nightly_binary_win_wheel_py3.5_cpu
-          subfolder: cpu/
-      - binary_win_wheel_release:
-          cu_version: '92'
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_win_wheel_py3.5_cu92
-          python_version: '3.5'
-      - binary_wheel_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_win_wheel_py3.5_cu92_upload
-          requires:
-          - nightly_binary_win_wheel_py3.5_cu92
-          subfolder: cu92/
-      - binary_win_wheel_release:
-          cu_version: '101'
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_win_wheel_py3.5_cu101
-          python_version: '3.5'
-      - binary_wheel_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_win_wheel_py3.5_cu101_upload
-          requires:
-          - nightly_binary_win_wheel_py3.5_cu101
-          subfolder: cu101/
-      - binary_win_wheel_release:
-          cu_version: '102'
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_win_wheel_py3.5_cu102
-          python_version: '3.5'
-      - binary_wheel_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_win_wheel_py3.5_cu102_upload
-          requires:
-          - nightly_binary_win_wheel_py3.5_cu102
-          subfolder: cu102/
       - binary_win_wheel_release:
           cu_version: cpu
           filters:
@@ -1416,70 +1161,6 @@ workflows:
           filters:
             branches:
               only: nightly
-          name: nightly_binary_linux_conda_py3.5_cpu
-          python_version: '3.5'
-          wheel_docker_image: pytorch/manylinux-cuda102
-      - binary_conda_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_linux_conda_py3.5_cpu_upload
-          requires:
-          - nightly_binary_linux_conda_py3.5_cpu
-      - binary_linux_conda:
-          cu_version: cu92
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_linux_conda_py3.5_cu92
-          python_version: '3.5'
-          wheel_docker_image: pytorch/manylinux-cuda92
-      - binary_conda_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_linux_conda_py3.5_cu92_upload
-          requires:
-          - nightly_binary_linux_conda_py3.5_cu92
-      - binary_linux_conda:
-          cu_version: cu101
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_linux_conda_py3.5_cu101
-          python_version: '3.5'
-          wheel_docker_image: pytorch/manylinux-cuda101
-      - binary_conda_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_linux_conda_py3.5_cu101_upload
-          requires:
-          - nightly_binary_linux_conda_py3.5_cu101
-      - binary_linux_conda:
-          cu_version: cu102
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_linux_conda_py3.5_cu102
-          python_version: '3.5'
-          wheel_docker_image: pytorch/manylinux-cuda102
-      - binary_conda_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_linux_conda_py3.5_cu102_upload
-          requires:
-          - nightly_binary_linux_conda_py3.5_cu102
-      - binary_linux_conda:
-          cu_version: cpu
-          filters:
-            branches:
-              only: nightly
           name: nightly_binary_linux_conda_py3.6_cpu
           python_version: '3.6'
           wheel_docker_image: pytorch/manylinux-cuda102
@@ -1672,22 +1353,6 @@ workflows:
           filters:
             branches:
               only: nightly
-          name: nightly_binary_macos_conda_py3.5_cpu
-          python_version: '3.5'
-          wheel_docker_image: pytorch/manylinux-cuda102
-      - binary_conda_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_macos_conda_py3.5_cpu_upload
-          requires:
-          - nightly_binary_macos_conda_py3.5_cpu
-      - binary_macos_conda:
-          cu_version: cpu
-          filters:
-            branches:
-              only: nightly
           name: nightly_binary_macos_conda_py3.6_cpu
           python_version: '3.6'
           wheel_docker_image: pytorch/manylinux-cuda102
@@ -1731,66 +1396,6 @@ workflows:
           name: nightly_binary_macos_conda_py3.8_cpu_upload
           requires:
           - nightly_binary_macos_conda_py3.8_cpu
-      - binary_win_conda_release:
-          cu_version: cpu
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_win_conda_py3.5_cpu
-          python_version: '3.5'
-      - binary_conda_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_win_conda_py3.5_cpu_upload
-          requires:
-          - nightly_binary_win_conda_py3.5_cpu
-      - binary_win_conda_release:
-          cu_version: '92'
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_win_conda_py3.5_cu92
-          python_version: '3.5'
-      - binary_conda_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_win_conda_py3.5_cu92_upload
-          requires:
-          - nightly_binary_win_conda_py3.5_cu92
-      - binary_win_conda_release:
-          cu_version: '101'
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_win_conda_py3.5_cu101
-          python_version: '3.5'
-      - binary_conda_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_win_conda_py3.5_cu101_upload
-          requires:
-          - nightly_binary_win_conda_py3.5_cu101
-      - binary_win_conda_release:
-          cu_version: '102'
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_win_conda_py3.5_cu102
-          python_version: '3.5'
-      - binary_conda_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-          name: nightly_binary_win_conda_py3.5_cu102_upload
-          requires:
-          - nightly_binary_win_conda_py3.5_cu102
       - binary_win_conda_release:
           cu_version: cpu
           filters:

--- a/.circleci/regenerate.py
+++ b/.circleci/regenerate.py
@@ -23,7 +23,7 @@ def workflows(prefix='', filter_branch=None, upload=False, indentation=6, window
     w = []
     for btype in ["wheel", "conda"]:
         for os_type in ["linux", "macos", "win"]:
-            python_versions = ["3.5", "3.6", "3.7", "3.8"]
+            python_versions = ["3.6", "3.7", "3.8"]
             cu_versions = (["cpu", "cu92", "cu101", "cu102"] if os_type == "linux" or os_type == "win" else ["cpu"])
             for python_version in python_versions:
                 for cu_version in cu_versions:


### PR DESCRIPTION
PyTorch doesn't provide nightlies for Python 3.5 anymore.