### PR TITLE
Feat/unfreeze layers fpn backbone

### DIFF
--- a/test/test_models_detection_utils.py
+++ b/test/test_models_detection_utils.py
@@ -1,6 +1,7 @@
 import torch
 from torchvision.models.detection import _utils
 import unittest
+from torchvision.models.detection import fasterrcnn_resnet50_fpn
 
 
 class Tester(unittest.TestCase):
@@ -17,6 +18,21 @@ class Tester(unittest.TestCase):
         self.assertEqual(neg[0].sum(), 3)
         self.assertEqual(neg[0][0:6].sum(), 3)
 
+    def test_fasterrcnn_resnet50_fpn_frozen_layers(self):
+        # we know how many initial layers and parameters of the network should
+        # be frozen for each trainable_backbone_layers paramter value
+        # i.e all 53 params are frozen if trainable_backbone_layers=0
+        # ad first 24 params are frozen if trainable_backbone_layers=2
+        expected_frozen_params = {0:53, 1:43, 2:24, 3:11, 4:1, 5:0}   
+        for train_layers, exp_froz_params in expected_frozen_params.items():
+            model = fasterrcnn_resnet50_fpn(pretrained=True, progress=False,
+                                        num_classes=91, pretrained_backbone=False, 
+                                        trainable_backbone_layers=train_layers)
+            # boolean list that is true if the param at that index is frozen
+            is_frozen = [not parameter.requires_grad for _, parameter in model.named_parameters()]
+            #check that expected initial number of layers are frozen
+            self.assertTrue(all(is_frozen[:exp_froz_params]))
 
+           
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_models_detection_utils.py
+++ b/test/test_models_detection_utils.py
@@ -23,16 +23,16 @@ class Tester(unittest.TestCase):
         # be frozen for each trainable_backbone_layers paramter value
         # i.e all 53 params are frozen if trainable_backbone_layers=0
         # ad first 24 params are frozen if trainable_backbone_layers=2
-        expected_frozen_params = {0:53, 1:43, 2:24, 3:11, 4:1, 5:0}   
+        expected_frozen_params = {0: 53, 1: 43, 2: 24, 3: 11, 4: 1, 5: 0}
         for train_layers, exp_froz_params in expected_frozen_params.items():
             model = fasterrcnn_resnet50_fpn(pretrained=True, progress=False,
-                                        num_classes=91, pretrained_backbone=False, 
-                                        trainable_backbone_layers=train_layers)
+                                            num_classes=91, pretrained_backbone=False,
+                                            trainable_backbone_layers=train_layers)
             # boolean list that is true if the param at that index is frozen
             is_frozen = [not parameter.requires_grad for _, parameter in model.named_parameters()]
-            #check that expected initial number of layers are frozen
+            # check that expected initial number of layers are frozen
             self.assertTrue(all(is_frozen[:exp_froz_params]))
 
-           
+
 if __name__ == '__main__':
     unittest.main()

--- a/torchvision/models/detection/backbone_utils.py
+++ b/torchvision/models/detection/backbone_utils.py
@@ -50,6 +50,7 @@ def resnet_fpn_backbone(backbone_name, pretrained, norm_layer=misc_nn_ops.Frozen
 
     Examples::
 
+        >>> from torchvision.models.detection.backbone_utils import resnet_fpn_backbone
         >>> backbone = resnet_fpn_backbone('resnet50', pretrained=True, trainable_layers=3)
         >>> # get some dummy image
         >>> x = torch.rand(1,3,64,64)
@@ -79,7 +80,7 @@ def resnet_fpn_backbone(backbone_name, pretrained, norm_layer=misc_nn_ops.Frozen
     for name, parameter in backbone.named_parameters():
         if all([layer not in name for layer in layers_to_train]):
             parameter.requires_grad_(False)
-            
+
     return_layers = {'layer1': '0', 'layer2': '1', 'layer3': '2', 'layer4': '3'}
 
     in_channels_stage2 = backbone.inplanes // 8

--- a/torchvision/models/detection/backbone_utils.py
+++ b/torchvision/models/detection/backbone_utils.py
@@ -45,10 +45,11 @@ def resnet_fpn_backbone(backbone_name, pretrained, norm_layer=misc_nn_ops.Frozen
     backbone = resnet.__dict__[backbone_name](
         pretrained=pretrained,
         norm_layer=norm_layer)
-    # freeze layers
-    for name, parameter in backbone.named_parameters():
-        if 'layer2' not in name and 'layer3' not in name and 'layer4' not in name:
-            parameter.requires_grad_(False)
+    # freeze layers only if pretrained backbone is used
+    if pretrained:
+        for name, parameter in backbone.named_parameters():
+            if 'layer2' not in name and 'layer3' not in name and 'layer4' not in name:
+                parameter.requires_grad_(False)
 
     return_layers = {'layer1': '0', 'layer2': '1', 'layer3': '2', 'layer4': '3'}
 

--- a/torchvision/models/detection/backbone_utils.py
+++ b/torchvision/models/detection/backbone_utils.py
@@ -47,11 +47,12 @@ def resnet_fpn_backbone(backbone_name, pretrained, norm_layer=misc_nn_ops.Frozen
         norm_layer=norm_layer)
     
     # select layers that wont be frozen
+    assert trainable_layers<=4 and trainable_layers >=0
     layers_to_train = ['layer4', 'layer3', 'layer2', 'layer1'][:trainable_layers]
     # freeze layers only if pretrained backbone is used
     if pretrained:
         for name, parameter in backbone.named_parameters():
-            if 'layer2' not in name and 'layer3' not in name and 'layer4' not in name:
+            if all([layer not in name for layer in layers_to_train]):
                 parameter.requires_grad_(False)
 
     return_layers = {'layer1': '0', 'layer2': '1', 'layer3': '2', 'layer4': '3'}

--- a/torchvision/models/detection/backbone_utils.py
+++ b/torchvision/models/detection/backbone_utils.py
@@ -41,10 +41,13 @@ class BackboneWithFPN(nn.Module):
         return x
 
 
-def resnet_fpn_backbone(backbone_name, pretrained, norm_layer=misc_nn_ops.FrozenBatchNorm2d):
+def resnet_fpn_backbone(backbone_name, pretrained, norm_layer=misc_nn_ops.FrozenBatchNorm2d, trainable_layers=3):
     backbone = resnet.__dict__[backbone_name](
         pretrained=pretrained,
         norm_layer=norm_layer)
+    
+    # select layers that wont be frozen
+    layers_to_train = ['layer4', 'layer3', 'layer2', 'layer1'][:trainable_layers]
     # freeze layers only if pretrained backbone is used
     if pretrained:
         for name, parameter in backbone.named_parameters():

--- a/torchvision/models/detection/backbone_utils.py
+++ b/torchvision/models/detection/backbone_utils.py
@@ -46,7 +46,7 @@ def resnet_fpn_backbone(backbone_name, pretrained, norm_layer=misc_nn_ops.Frozen
         pretrained=pretrained,
         norm_layer=norm_layer)
     """
-    Constructs a specified ResNet backbone with FPN on top of it. Freezes the specified number of layers in the backbone.
+    Constructs a specified ResNet backbone with FPN on top. Freezes the specified number of layers in the backbone.
 
     Examples::
 
@@ -63,7 +63,7 @@ def resnet_fpn_backbone(backbone_name, pretrained, norm_layer=misc_nn_ops.Frozen
         >>>    ('2', torch.Size([1, 256, 4, 4])),
         >>>    ('3', torch.Size([1, 256, 2, 2])),
         >>>    ('pool', torch.Size([1, 256, 1, 1]))]
-        
+
     Arguments:
         backbone_name (string): resnet architecture. Possible values are 'ResNet', 'resnet18', 'resnet34', 'resnet50',
              'resnet101', 'resnet152', 'resnext50_32x4d', 'resnext101_32x8d', 'wide_resnet50_2', 'wide_resnet101_2'
@@ -74,7 +74,7 @@ def resnet_fpn_backbone(backbone_name, pretrained, norm_layer=misc_nn_ops.Frozen
             Valid values are between 0 and 5, with 5 meaning all backbone layers are trainable.
     """
     # select layers that wont be frozen
-    assert trainable_layers<=5 and trainable_layers >=0
+    assert trainable_layers <= 5 and trainable_layers >= 0
     layers_to_train = ['layer4', 'layer3', 'layer2', 'layer1', 'conv1'][:trainable_layers]
     # freeze layers only if pretrained backbone is used
     for name, parameter in backbone.named_parameters():

--- a/torchvision/models/detection/backbone_utils.py
+++ b/torchvision/models/detection/backbone_utils.py
@@ -44,7 +44,7 @@ class BackboneWithFPN(nn.Module):
 def resnet_fpn_backbone(backbone_name, pretrained, norm_layer=misc_nn_ops.FrozenBatchNorm2d):
     backbone = resnet.__dict__[backbone_name](
         pretrained=pretrained,
-        norm_layer=norm_layer)    
+        norm_layer=norm_layer)
 
     return_layers = {'layer1': '0', 'layer2': '1', 'layer3': '2', 'layer4': '3'}
 

--- a/torchvision/models/detection/backbone_utils.py
+++ b/torchvision/models/detection/backbone_utils.py
@@ -41,19 +41,10 @@ class BackboneWithFPN(nn.Module):
         return x
 
 
-def resnet_fpn_backbone(backbone_name, pretrained, norm_layer=misc_nn_ops.FrozenBatchNorm2d, trainable_layers=3):
+def resnet_fpn_backbone(backbone_name, pretrained, norm_layer=misc_nn_ops.FrozenBatchNorm2d):
     backbone = resnet.__dict__[backbone_name](
         pretrained=pretrained,
-        norm_layer=norm_layer)
-    
-    # select layers that wont be frozen
-    assert trainable_layers<=4 and trainable_layers >=0
-    layers_to_train = ['layer4', 'layer3', 'layer2', 'layer1'][:trainable_layers]
-    # freeze layers only if pretrained backbone is used
-    if pretrained:
-        for name, parameter in backbone.named_parameters():
-            if all([layer not in name for layer in layers_to_train]):
-                parameter.requires_grad_(False)
+        norm_layer=norm_layer)    
 
     return_layers = {'layer1': '0', 'layer2': '1', 'layer3': '2', 'layer4': '3'}
 

--- a/torchvision/models/detection/backbone_utils.py
+++ b/torchvision/models/detection/backbone_utils.py
@@ -45,7 +45,7 @@ def resnet_fpn_backbone(backbone_name, pretrained, norm_layer=misc_nn_ops.Frozen
     backbone = resnet.__dict__[backbone_name](
         pretrained=pretrained,
         norm_layer=norm_layer)
-     """
+    """
     Constructs a specified ResNet backbone with FPN on top of it. Freezes the specified number of layers in the backbone.
 
     Examples::

--- a/torchvision/models/detection/backbone_utils.py
+++ b/torchvision/models/detection/backbone_utils.py
@@ -78,7 +78,7 @@ def resnet_fpn_backbone(backbone_name, pretrained, norm_layer=misc_nn_ops.Frozen
     layers_to_train = ['layer4', 'layer3', 'layer2', 'layer1', 'conv1'][:trainable_layers]
     # freeze layers only if pretrained backbone is used
     for name, parameter in backbone.named_parameters():
-        if all([layer not in name for layer in layers_to_train]):
+        if all([not name.startswith(layer) for layer in layers_to_train]):
             parameter.requires_grad_(False)
 
     return_layers = {'layer1': '0', 'layer2': '1', 'layer3': '2', 'layer4': '3'}

--- a/torchvision/models/detection/backbone_utils.py
+++ b/torchvision/models/detection/backbone_utils.py
@@ -41,11 +41,45 @@ class BackboneWithFPN(nn.Module):
         return x
 
 
-def resnet_fpn_backbone(backbone_name, pretrained, norm_layer=misc_nn_ops.FrozenBatchNorm2d):
+def resnet_fpn_backbone(backbone_name, pretrained, norm_layer=misc_nn_ops.FrozenBatchNorm2d, trainable_layers=3):
     backbone = resnet.__dict__[backbone_name](
         pretrained=pretrained,
         norm_layer=norm_layer)
+     """
+    Constructs a specified ResNet backbone with FPN on top of it. Freezes the specified number of layers in the backbone.
 
+    Examples::
+
+        >>> backbone = resnet_fpn_backbone('resnet50', pretrained=True, trainable_layers=3)
+        >>> # get some dummy image
+        >>> x = torch.rand(1,3,64,64)
+        >>> # compute the output
+        >>> output = backbone(x)
+        >>> print([(k, v.shape) for k, v in output.items()])
+        >>> # returns
+        >>>   [('0', torch.Size([1, 256, 16, 16])),
+        >>>    ('1', torch.Size([1, 256, 8, 8])),
+        >>>    ('2', torch.Size([1, 256, 4, 4])),
+        >>>    ('3', torch.Size([1, 256, 2, 2])),
+        >>>    ('pool', torch.Size([1, 256, 1, 1]))]
+        
+    Arguments:
+        backbone_name (string): resnet architecture. Possible values are 'ResNet', 'resnet18', 'resnet34', 'resnet50',
+             'resnet101', 'resnet152', 'resnext50_32x4d', 'resnext101_32x8d', 'wide_resnet50_2', 'wide_resnet101_2'
+        norm_layer (torchvision.ops): it is recommended to use the default value. For details visit:
+            (https://github.com/facebookresearch/maskrcnn-benchmark/issues/267)
+        pretrained (bool): If True, returns a model with backbone pre-trained on Imagenet
+        trainable_layers (int): number of trainable (not frozen) resnet layers starting from final block.
+            Valid values are between 0 and 5, with 5 meaning all backbone layers are trainable.
+    """
+    # select layers that wont be frozen
+    assert trainable_layers<=5 and trainable_layers >=0
+    layers_to_train = ['layer4', 'layer3', 'layer2', 'layer1', 'conv1'][:trainable_layers]
+    # freeze layers only if pretrained backbone is used
+    for name, parameter in backbone.named_parameters():
+        if all([layer not in name for layer in layers_to_train]):
+            parameter.requires_grad_(False)
+            
     return_layers = {'layer1': '0', 'layer2': '1', 'layer3': '2', 'layer4': '3'}
 
     in_channels_stage2 = backbone.inplanes // 8

--- a/torchvision/models/detection/faster_rcnn.py
+++ b/torchvision/models/detection/faster_rcnn.py
@@ -347,7 +347,7 @@ def fasterrcnn_resnet50_fpn(pretrained=False, progress=True,
         trainable_backbone_layers (int): number of trainable (not frozen) resnet layers starting from final block.
             Valid values are between 0 and 5, with 5 meaning all backbone layers are trainable.
     """
-    assert trainable_backbone_layers<=5 and trainable_backbone_layers >=0
+    assert trainable_backbone_layers <= 5 and trainable_backbone_layers >= 0
     # dont freeze any layers if pretrained model or backbone is not used
     if not (pretrained or pretrained_backbone):
         trainable_backbone_layers = 5

--- a/torchvision/models/detection/faster_rcnn.py
+++ b/torchvision/models/detection/faster_rcnn.py
@@ -350,16 +350,14 @@ def fasterrcnn_resnet50_fpn(pretrained=False, progress=True,
         # no need to download the backbone if pretrained is set
         pretrained_backbone = False
     backbone = resnet_fpn_backbone('resnet50', pretrained_backbone)
-    
     # select layers that wont be frozen
-    assert trainable_backbone_blocks<=4 and trainable_backbone_blocks >=0
+    assert trainable_backbone_blocks <= 4 and trainable_backbone_blocks >= 0
     layers_to_train = ['layer4', 'layer3', 'layer2', 'layer1'][:trainable_backbone_blocks]
     # freeze layers only if pretrained backbone or pretrained model is used
     if pretrained or pretrained_backbone:
         for name, parameter in backbone.named_parameters():
             if 'fpn' not in name and all([layer not in name for layer in layers_to_train]):
                 parameter.requires_grad_(False)
-    
     model = FasterRCNN(backbone, num_classes, **kwargs)
     if pretrained:
         state_dict = load_state_dict_from_url(model_urls['fasterrcnn_resnet50_fpn_coco'],

--- a/torchvision/models/detection/faster_rcnn.py
+++ b/torchvision/models/detection/faster_rcnn.py
@@ -350,7 +350,7 @@ def fasterrcnn_resnet50_fpn(pretrained=False, progress=True,
     assert trainable_backbone_layers<=5 and trainable_backbone_layers >=0
     # dont freeze any layers if pretrained model or backbone is not used
     if not (pretrained or pretrained_backbone):
-        trainable_backbone_blocks = 5
+        trainable_backbone_layers = 5
     if pretrained:
         # no need to download the backbone if pretrained is set
         pretrained_backbone = False

--- a/torchvision/models/detection/faster_rcnn.py
+++ b/torchvision/models/detection/faster_rcnn.py
@@ -289,7 +289,7 @@ model_urls = {
 
 
 def fasterrcnn_resnet50_fpn(pretrained=False, progress=True,
-                            num_classes=91, pretrained_backbone=True, **kwargs):
+                            num_classes=91, pretrained_backbone=True, trainable_backbone_blocks=3, **kwargs):
     """
     Constructs a Faster R-CNN model with a ResNet-50-FPN backbone.
 
@@ -342,11 +342,24 @@ def fasterrcnn_resnet50_fpn(pretrained=False, progress=True,
     Arguments:
         pretrained (bool): If True, returns a model pre-trained on COCO train2017
         progress (bool): If True, displays a progress bar of the download to stderr
+        pretrained_backbone (bool): If True, returns a model with backbone pre-trained on Imagenet
+        num_classes (int): number of output classes of the model (including the background)
+        trainable_backbone_blocks (int): number of trainable (not frozen) resnet blocks starting from final block.
     """
     if pretrained:
         # no need to download the backbone if pretrained is set
         pretrained_backbone = False
     backbone = resnet_fpn_backbone('resnet50', pretrained_backbone)
+    
+    # select layers that wont be frozen
+    assert trainable_backbone_blocks<=4 and trainable_backbone_blocks >=0
+    layers_to_train = ['layer4', 'layer3', 'layer2', 'layer1'][:trainable_backbone_blocks]
+    # freeze layers only if pretrained backbone or pretrained model is used
+    if pretrained or pretrained_backbone:
+        for name, parameter in backbone.named_parameters():
+            if 'fpn' not in name and all([layer not in name for layer in layers_to_train]):
+                parameter.requires_grad_(False)
+    
     model = FasterRCNN(backbone, num_classes, **kwargs)
     if pretrained:
         state_dict = load_state_dict_from_url(model_urls['fasterrcnn_resnet50_fpn_coco'],

--- a/torchvision/models/detection/faster_rcnn.py
+++ b/torchvision/models/detection/faster_rcnn.py
@@ -289,7 +289,7 @@ model_urls = {
 
 
 def fasterrcnn_resnet50_fpn(pretrained=False, progress=True,
-                            num_classes=91, pretrained_backbone=True, trainable_backbone_blocks=3, **kwargs):
+                            num_classes=91, pretrained_backbone=True, trainable_backbone_layers=3, **kwargs):
     """
     Constructs a Faster R-CNN model with a ResNet-50-FPN backbone.
 
@@ -344,20 +344,17 @@ def fasterrcnn_resnet50_fpn(pretrained=False, progress=True,
         progress (bool): If True, displays a progress bar of the download to stderr
         pretrained_backbone (bool): If True, returns a model with backbone pre-trained on Imagenet
         num_classes (int): number of output classes of the model (including the background)
-        trainable_backbone_blocks (int): number of trainable (not frozen) resnet blocks starting from final block.
+        trainable_backbone_layers (int): number of trainable (not frozen) resnet layers starting from final block.
+            Valid values are between 0 and 5, with 5 meaning all backbone layers are trainable.
     """
+    assert trainable_backbone_layers<=5 and trainable_backbone_layers >=0
+    # dont freeze any layers if pretrained model or backbone is not used
+    if not (pretrained or pretrained_backbone):
+        trainable_backbone_blocks = 5
     if pretrained:
         # no need to download the backbone if pretrained is set
         pretrained_backbone = False
-    backbone = resnet_fpn_backbone('resnet50', pretrained_backbone)
-    # select layers that wont be frozen
-    assert trainable_backbone_blocks <= 4 and trainable_backbone_blocks >= 0
-    layers_to_train = ['layer4', 'layer3', 'layer2', 'layer1'][:trainable_backbone_blocks]
-    # freeze layers only if pretrained backbone or pretrained model is used
-    if pretrained or pretrained_backbone:
-        for name, parameter in backbone.named_parameters():
-            if 'fpn' not in name and all([layer not in name for layer in layers_to_train]):
-                parameter.requires_grad_(False)
+    backbone = resnet_fpn_backbone('resnet50', pretrained_backbone, trainable_layers=trainable_backbone_layers)
     model = FasterRCNN(backbone, num_classes, **kwargs)
     if pretrained:
         state_dict = load_state_dict_from_url(model_urls['fasterrcnn_resnet50_fpn_coco'],


### PR DESCRIPTION
Currently, **fasterrcnn_resnet50_fpn** function is used to create a faster rcnn with resnet50 backbone and fpn.  **resnet_fpn_backbone** function is backbone utils is used by this function. This function freezes the backbone layers in resnet apart form layer2, layer3 and layer4. This freezing is hard coded to reflect the faster rcnn paper which frooze the initial layers of pretrained backbone. 

If pretrained backbone is not used and one intends to train the entire network from scratch, no layers should be frozen. Otherwise initial layers will always have randomly initialized weights. I think this can be considered a **bug**, because layer freezing is not even mentioned in the function docs so user are not aware of it.

This resulted in poor AP when we were training faster rcnn with resnet backbone from scratch on Detrac dataset. And it took a while a figure out.

Furthermore, the number of resnet backbone layers that should be frozen is an important hyper parameter in my experience,  and it needs to be tuned for each dataset. So adding an argument to control this enabled me to integrate it in hyper-parameter tuning.

I have created this pull request so that others don't run into the same problem when conducting experiments similar to mine.

I have moved the layer freezing logic to **fasterrcnn_resnet50_fpn** so that layers can be frozen if either a pretrained backbone or pretrained faster rcnn are used, and are not frozen otherwise.