### PR TITLE
Faster initialization of Inception family

### DIFF
--- a/torchvision/models/googlenet.py
+++ b/torchvision/models/googlenet.py
@@ -62,11 +62,16 @@ def googlenet(pretrained=False, progress=True, **kwargs):
 class GoogLeNet(nn.Module):
     __constants__ = ['aux_logits', 'transform_input']
 
-    def __init__(self, num_classes=1000, aux_logits=True, transform_input=False, init_weights=True,
+    def __init__(self, num_classes=1000, aux_logits=True, transform_input=False, init_weights=None,
                  blocks=None):
         super(GoogLeNet, self).__init__()
         if blocks is None:
             blocks = [BasicConv2d, Inception, InceptionAux]
+        if init_weights is None:
+            warnings.warn('The default weight initialization of GoogleNet will be changed in future releases of '
+                          'torchvision. If you wish to keep the old behavior (which leads to long initialization times'
+                          ' due to scipy/scipy#11299), please set init_weights=True.', FutureWarning)
+            init_weights = True
         assert len(blocks) == 3
         conv_block = blocks[0]
         inception_block = blocks[1]

--- a/torchvision/models/inception.py
+++ b/torchvision/models/inception.py
@@ -63,13 +63,18 @@ def inception_v3(pretrained=False, progress=True, **kwargs):
 class Inception3(nn.Module):
 
     def __init__(self, num_classes=1000, aux_logits=True, transform_input=False,
-                 inception_blocks=None, init_weights=True):
+                 inception_blocks=None, init_weights=None):
         super(Inception3, self).__init__()
         if inception_blocks is None:
             inception_blocks = [
                 BasicConv2d, InceptionA, InceptionB, InceptionC,
                 InceptionD, InceptionE, InceptionAux
             ]
+        if init_weights is None:
+            warnings.warn('The default weight initialization of inception_v3 will be changed in future releases of '
+                          'torchvision. If you wish to keep the old behavior (which leads to long initialization times'
+                          ' due to scipy/scipy#11299), please set init_weights=True.', FutureWarning)
+            init_weights = True
         assert len(inception_blocks) == 7
         conv_block = inception_blocks[0]
         inception_a = inception_blocks[1]


### PR DESCRIPTION
This PR tries to fix #2166.
It tries to solve the slow object construction for GoogleNet & Inception_v3.
Now, the default argument for `init_weights` is set to `None`. Users have to explicitly set  `init_weights` = `True` or `False` for a new object, else it will raise an exception.