### PR TITLE
Use consistent symbols in the doc of Normalize to avoid confusion

### DIFF
--- a/torchvision/transforms/transforms.py
+++ b/torchvision/transforms/transforms.py
@@ -136,8 +136,9 @@ class ToPILImage(object):
 
 class Normalize(object):
     """Normalize a tensor image with mean and standard deviation.
-    Given mean: ``(M1,...,Mn)`` and std: ``(S1,..,Sn)`` for ``n`` channels, this transform
-    will normalize each channel of the input ``torch.*Tensor`` i.e.
+    Given mean: ``(mean[1],...,mean[n])`` and std: ``(std[1],..,std[n])`` for ``n``
+    channels, this transform will normalize each channel of the input
+    ``torch.*Tensor`` i.e.,
     ``output[channel] = (input[channel] - mean[channel]) / std[channel]``
 
     .. note::


### PR DESCRIPTION
`Mn`, `Sn` are used as mean and std, but their suddenly turned to be
`mean[n]` and `std[n]` in about 10 words later.