### PR TITLE
Fix missing compilation files for video-reader

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ install:
     cd -
 
 script:
-  - pytest --cov-config .coveragerc --cov torchvision --cov $TV_INSTALL_PATH -k 'not TestVideoReader and not TestVideoTransforms' test
+  - pytest --cov-config .coveragerc --cov torchvision --cov $TV_INSTALL_PATH -k 'not TestVideoReader and not TestVideoTransforms and not TestIO' test
   - pytest test/test_hub.py
 
 after_success:

--- a/setup.py
+++ b/setup.py
@@ -184,7 +184,9 @@ def get_extensions():
         video_reader_src = glob.glob(os.path.join(video_reader_src_dir, "*.cpp"))
         base_decoder_src_dir = os.path.join(this_dir, 'torchvision', 'csrc', 'cpu', 'decoder')
         base_decoder_src = glob.glob(
-            os.path.join(base_decoder_src_dir, "[!sync_decoder_test,!utils_test]*.cpp"))
+            os.path.join(base_decoder_src_dir, "*.cpp"))
+        # exclude tests
+        base_decoder_src = [x for x in base_decoder_src if '_test.cpp' not in x]
 
         combined_src = video_reader_src + base_decoder_src
 

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -62,7 +62,7 @@ def temp_video(num_frames, height, width, fps, lossless=False, video_codec=None,
 @unittest.skipIf(get_video_backend() != "pyav" and not io._HAS_VIDEO_OPT,
                  "video_reader backend not available")
 @unittest.skipIf(av is None, "PyAV unavailable")
-class Tester(unittest.TestCase):
+class TestIO(unittest.TestCase):
     # compression adds artifacts, thus we add a tolerance of
     # 6 in 0-255 range
     TOLERANCE = 6


### PR DESCRIPTION
Fixes https://github.com/pytorch/vision/issues/2163

The previous glob pattern was not correct, and was removing more files than just the test files.