### PR TITLE
Fixing bug related with trailing slash on UCF-101 dataset.

### DIFF
--- a/torchvision/datasets/ucf101.py
+++ b/torchvision/datasets/ucf101.py
@@ -88,10 +88,10 @@ class UCF101(VisionDataset):
         with open(f, "r") as fid:
             data = fid.readlines()
             data = [x.strip().split(" ") for x in data]
-            data = [x[0] for x in data]
+            data = [os.path.join(self.root, x[0]) for x in data]
             selected_files.extend(data)
         selected_files = set(selected_files)
-        indices = [i for i in range(len(video_list)) if video_list[i][len(self.root) + 1:] in selected_files]
+        indices = [i for i in range(len(video_list)) if video_list[i] in selected_files]
         return indices
 
     def __len__(self):


### PR DESCRIPTION
Now the dataset is not working properly because of this line of code `indices = [i for i in range(len(video_list)) if video_list[i][len(self.root) + 1:] in selected_files]`. 

Performing the `len(self.root) + 1` only make sense if there is no trailing slash to `self.root`.

Here I attach an example of how this operation can remove an extra letter:

```
>>> root = 'data/ucf-101/videos'
>>> video_path = 'data/ucf-101/videos/activity/video.avi'
>>> video_path [len(root ) + 1:] # Works well
'activity/video.avi'
>>> root_with_trailing = 'data/ucf-101/videos/'
>>> video_path [len(root_with_trailing) + 1:] # We remove an extra letter
'ctivity/video.avi'
```

Appending the root path also to the selected files is a simple solution and make the dataset works with and without a trailing slash.