### PR TITLE
Added eps attribute to FrozenBatchNorm2d

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -572,8 +572,7 @@ class FrozenBNTester(unittest.TestCase):
         self.assertTrue(torch.allclose(fbn(x), bn(x), atol=1e-6))
 
     def test_frozenbatchnorm2d_n_arg(self):
-        # Ensure a warning is thrown if user try to pass `n` kwarg
-        # Remove this test when support of `n` is dropped
+        # Ensure a warning is thrown when passing `n` kwarg (remove this when support of `n` is dropped)
         self.assertWarns(DeprecationWarning, ops.misc.FrozenBatchNorm2d, 32, eps=1e-5, n=32)
 
 

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -571,6 +571,11 @@ class FrozenBNTester(unittest.TestCase):
         bn.load_state_dict(state_dict)
         self.assertTrue(torch.allclose(fbn(x), bn(x), atol=1e-6))
 
+    def test_frozenbatchnorm2d_n_arg(self):
+        # Ensure a warning is thrown if user try to pass `n` kwarg
+        # Remove this test when support of `n` is dropped
+        self.assertWarns(DeprecationWarning, ops.misc.FrozenBatchNorm2d, 32, eps=1e-5, n=32)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -572,7 +572,8 @@ class FrozenBNTester(unittest.TestCase):
         self.assertTrue(torch.allclose(fbn(x), bn(x), atol=1e-6))
 
     def test_frozenbatchnorm2d_n_arg(self):
-        # Ensure a warning is thrown when passing `n` kwarg (remove this when support of `n` is dropped)
+        """Ensure a warning is thrown when passing `n` kwarg
+        (remove this when support of `n` is dropped)"""
         self.assertWarns(DeprecationWarning, ops.misc.FrozenBatchNorm2d, 32, eps=1e-5, n=32)
 
 

--- a/torchvision/ops/misc.py
+++ b/torchvision/ops/misc.py
@@ -128,7 +128,8 @@ class FrozenBatchNorm2d(torch.nn.Module):
     def __init__(self, num_features, eps=0., n=None):
         # n=None for backward-compatibility
         if n is not None:
-            warnings.warn("`n` argument is deprecated and has been renamed `num_features`")
+            warnings.warn("`n` argument is deprecated and has been renamed `num_features`",
+                          DeprecationWarning)
             num_features = n
         super(FrozenBatchNorm2d, self).__init__()
         self.eps = eps

--- a/torchvision/ops/misc.py
+++ b/torchvision/ops/misc.py
@@ -13,6 +13,7 @@ is implemented
 """
 
 import math
+import warnings
 import torch
 from torchvision.ops import _new_empty_tensor
 from torch.nn import Module, Conv2d
@@ -124,7 +125,11 @@ class FrozenBatchNorm2d(torch.nn.Module):
     are fixed
     """
 
-    def __init__(self, num_features, eps=0.):
+    def __init__(self, num_features, eps=0., n=None):
+        # n=None for backward-compatibility
+        if n is not None:
+            warnings.warn("`n` argument is deprecated and has been renamed `num_features`")
+            num_features = n
         super(FrozenBatchNorm2d, self).__init__()
         self.eps = eps
         self.register_buffer("weight", torch.ones(num_features))

--- a/torchvision/ops/misc.py
+++ b/torchvision/ops/misc.py
@@ -143,12 +143,15 @@ class FrozenBatchNorm2d(torch.nn.Module):
             missing_keys, unexpected_keys, error_msgs)
 
     def forward(self, x):
-        # Scaling factor
-        scale = self.weight * (self.running_var + self.eps).rsqrt()
-        # Bias
-        bias = (self.bias - self.running_mean * scale)
-
-        return x * scale.view(1, -1, 1, 1) + bias.view(1, -1, 1, 1)
+        # move reshapes to the beginning
+        # to make it fuser-friendly
+        w = self.weight.reshape(1, -1, 1, 1)
+        b = self.bias.reshape(1, -1, 1, 1)
+        rv = self.running_var.reshape(1, -1, 1, 1)
+        rm = self.running_mean.reshape(1, -1, 1, 1)
+        scale = w * rv.rsqrt()
+        bias = b - rm * scale
+        return x * scale + bias
 
     def __repr__(self):
         return f"{self.__class__.__name__}({self.weight.shape[0]})"

--- a/torchvision/ops/misc.py
+++ b/torchvision/ops/misc.py
@@ -154,7 +154,7 @@ class FrozenBatchNorm2d(torch.nn.Module):
         b = self.bias.reshape(1, -1, 1, 1)
         rv = self.running_var.reshape(1, -1, 1, 1)
         rm = self.running_mean.reshape(1, -1, 1, 1)
-        scale = w * rv.rsqrt()
+        scale = w * (rv + self.eps).rsqrt()
         bias = b - rm * scale
         return x * scale + bias
 


### PR DESCRIPTION
This PR aims at tackling #2169 by:
- adding a `eps` attribute to  ̀FrozenBatchNorm2d`
- renaming the `n` positional argument of  `FrozenBatchNorm2d` constructor to `num_features`
- adding a unittest to ensure default eps is zero for backward compatibility
- adding a unittest to ensure valid computation when epsilon is higher than zero by comparison with `BatchNorm2d` forward in eval mode.