### PR TITLE
Set should_buffer to True by default in _read_from_stream video.py

### DIFF
--- a/torchvision/io/video.py
+++ b/torchvision/io/video.py
@@ -106,7 +106,7 @@ def _read_from_stream(
         )
 
     frames = {}
-    should_buffer = False
+    should_buffer = True
     max_buffer_size = 5
     if stream.type == "video":
         # DivX-style packed B-frames can have out-of-order pts (2 frames in a single pkt)


### PR DESCRIPTION
Following the discussion, fixes #1884 

I used VideoClips and the following code to test the drop in performance on `_read_from_stream`:
```python
vc = VideoClips(["video.mp4"])
s = time.time()
for i in tqdm(range(vc.num_clips())):
    _ = vc.get_clip(i)
print(f"Get {vc.num_clips()} clips: {time.time()-s}")
```

In my local machine, with a 2:30s video (3577 clips) and after several iterations the mean times where `997s` for the current code and `1050s` for the version with `should_buffer` enabled. This accounts for an increase of ~0,015s per clip.

The default VideoClips length is 16 frames and the buffer size is 5 frames on each side. The drop in performance should be less noticeable with a bigger length.

The code related to DivX might still disable the `should_buffer` if it's not necessary on DivX cases:
https://github.com/pytorch/vision/blob/85b8fbfd31e9324e64e24ca25410284ef238bcb3/torchvision/io/video.py#L112-L127
I don't know if that part should be removed or if it's better to keep it.