### PR TITLE
video.py read_video_timestamps calculate pts without storing full frames

### DIFF
--- a/torchvision/io/video.py
+++ b/torchvision/io/video.py
@@ -318,6 +318,7 @@ def read_video_timestamps(filename, pts_unit="pts"):
     _check_av_available()
 
     video_fps = None
+    pts = []
 
     try:
         container = av.open(filename, metadata_errors="ignore")
@@ -335,6 +336,8 @@ def read_video_timestamps(filename, pts_unit="pts"):
                 pts = [x.pts for x in container.decode(video=0) if x.pts is not None]
             video_fps = float(video_stream.average_rate)
         container.close()
+
+    pts.sort()
 
     if pts_unit == "sec":
         pts = [x * video_time_base for x in pts]

--- a/torchvision/io/video.py
+++ b/torchvision/io/video.py
@@ -331,17 +331,11 @@ def read_video_timestamps(filename, pts_unit="pts"):
             video_time_base = video_stream.time_base
             if _can_read_timestamps_from_packets(container):
                 # fast path
-                video_frames = [
-                    x for x in container.demux(video=0) if x.pts is not None
-                ]
+                pts = [x.pts for x in container.demux(video=0) if x.pts is not None]
             else:
-                video_frames = _read_from_stream(
-                    container, 0, float("inf"), pts_unit, video_stream, {"video": 0}
-                )
+                pts = [x.pts for x in container.decode(video=0) if x.pts is not None]
             video_fps = float(video_stream.average_rate)
         container.close()
-
-    pts = [x.pts for x in video_frames]
 
     if pts_unit == "sec":
         pts = [x * video_time_base for x in pts]

--- a/torchvision/io/video.py
+++ b/torchvision/io/video.py
@@ -317,7 +317,6 @@ def read_video_timestamps(filename, pts_unit="pts"):
 
     _check_av_available()
 
-    video_frames = []
     video_fps = None
 
     try:


### PR DESCRIPTION
To calculate the PTS the function is storing the full frame objects on memory. This makes it crash for longer videos as it can't fill everything. PTS can be calculated directly.

With this fix we don't call `_read_from_stream`. That's ok as most of the code deals with seeking which is not needed in this case, but video decoding is surrounded by a try/except that we're not doing here. I'm not sure if a try/except av.AVError should be added too as it's not done in the demux either. Also, do we really want to mute this exception?