### PR TITLE
Added reference to the Computer Vision Best Practices repository

### DIFF
--- a/references/detection/README.md
+++ b/references/detection/README.md
@@ -29,3 +29,10 @@ python -m torch.distributed.launch --nproc_per_node=8 --use_env train.py\
     --lr-steps 36 43 --aspect-ratio-group-factor 3
 ```
 
+# External repositories
+
+For further examples and explanations on how to use the object detection code in this folder, see Microsoft's [Computer Vision Best Practices](https://github.com/microsoft/computervision-recipes/tree/master/scenarios/detection) repository. The repository contains multiple notebooks with functionality to help with e.g. training on a custom dataset, model evaluation, parameters selection, etc., to more advanced topics such as hard-negative mining or model deployment.
+
+<p align="center">
+  <img src="https://cvbp.blob.core.windows.net/public/images/cvbp_notebooks.jpg" width="700" alt="CVBP notebooks"/>
+</p>


### PR DESCRIPTION
The Computer Vision Best Practices repository (2,500 stars on Github, by Microsoft) implements various notebooks which are helpful for somebody who wants to use Torchvision for object detection. 

Currently, the references folder lacks a bit with regards to e.g. explanations or being beginner-friendly, hence proposing this PR. Not sure what Tochvision's policy in this regard is.

Note that the CV repository only adds functionality and explanations on top of the original torchvision code. See the url below, which contains a un-edited copy of Torchvision's "references/detection/" folder:
https://github.com/microsoft/computervision-recipes/tree/master/utils_cv/detection/references

