### PR TITLE
Add namespace to avoid conflict with ATen version of channel_shuffle().

### DIFF
--- a/torchvision/csrc/models/shufflenetv2.cpp
+++ b/torchvision/csrc/models/shufflenetv2.cpp
@@ -80,7 +80,7 @@ struct ShuffleNetV2InvertedResidualImpl : torch::nn::Module {
     } else
       out = torch::cat({branch1->forward(x), branch2->forward(x)}, 1);
 
-    out = channel_shuffle(out, 2);
+    out = ::vision::models::channel_shuffle(out, 2);
     return out;
   }
 };


### PR DESCRIPTION
Fix https://github.com/pytorch/vision/issues/2193.