### PR TITLE
Check target boxes input on generalized_rcnn.py

### DIFF
--- a/test/test_models.py
+++ b/test/test_models.py
@@ -155,6 +155,24 @@ class ModelTester(TestCase):
         # self.check_script(model, name)
         self.checkModule(model, name, ([x],))
 
+    def _test_detection_model_validation(self, name):
+        set_rng_seed(0)
+        model = models.detection.__dict__[name](num_classes=50, pretrained_backbone=False)
+        input_shape = (1, 3, 300, 300)
+        x = [torch.rand(input_shape)]
+
+        # validate that targets are present in training
+        self.assertRaises(ValueError, model, x)
+
+        # validate type
+        targets = [{'boxes': 0.}]
+        self.assertRaises(ValueError, model, x, targets=targets)
+
+        # validate boxes shape
+        for boxes in (torch.rand((4,)), torch.rand((1, 5))):
+            targets = [{'boxes': boxes}]
+            self.assertRaises(ValueError, model, x, targets=targets)
+
     def _test_video_model(self, name):
         # the default input shape is
         # bs * num_channels * clip_len * h *w
@@ -302,6 +320,11 @@ for model_name in get_available_detection_models():
         self._test_detection_model(model_name)
 
     setattr(ModelTester, "test_" + model_name, do_test)
+
+    def do_validation_test(self, model_name=model_name):
+        self._test_detection_model_validation(model_name)
+
+    setattr(ModelTester, "test_" + model_name + "_validation", do_validation_test)
 
 
 for model_name in get_available_video_models():

--- a/torchvision/models/detection/generalized_rcnn.py
+++ b/torchvision/models/detection/generalized_rcnn.py
@@ -58,14 +58,17 @@ class GeneralizedRCNN(nn.Module):
         if self.training and targets is None:
             raise ValueError("In training mode, targets should be passed")
         if self.training:
-            boxes = targets["boxes"]
-            if isinstance(boxes, torch.Tensor):
-                if len(boxes.shape) != 2 or boxes.shape[-1] != 4:
-                    raise ValueError("Expected target boxes to be a tensor of "
-                                     "shape [N, 4], got {:}.".format(boxes.shape))
-            else:
-                raise ValueError("Expected target boxes to be of type Tensor, "
-                                 "got {:}.".format(type(boxes)))
+            assert targets is not None
+            for target in targets:
+                boxes = target["boxes"]
+                if isinstance(boxes, torch.Tensor):
+                    if len(boxes.shape) != 2 or boxes.shape[-1] != 4:
+                        raise ValueError("Expected target boxes to be a tensor"
+                                         "of shape [N, 4], got {:}.".format(
+                                             boxes.shape))
+                else:
+                    raise ValueError("Expected target boxes to be of type "
+                                     "Tensor, got {:}.".format(type(boxes)))
 
         original_image_sizes = torch.jit.annotate(List[Tuple[int, int]], [])
         for img in images:

--- a/torchvision/models/detection/generalized_rcnn.py
+++ b/torchvision/models/detection/generalized_rcnn.py
@@ -57,6 +57,16 @@ class GeneralizedRCNN(nn.Module):
         """
         if self.training and targets is None:
             raise ValueError("In training mode, targets should be passed")
+        if self.training:
+            boxes = targets["boxes"]
+            if isinstance(boxes, torch.Tensor):
+                if len(boxes.shape) != 2 or boxes.shape[-1] != 4:
+                    raise ValueError("Expected target boxes to be a tensor of "
+                                     "shape [N, 4], got {:}.".format(boxes.shape))
+            else:
+                raise ValueError("Expected target boxes to be of type Tensor, "
+                                 "got {:}.".format(type(boxes)))
+
         original_image_sizes = torch.jit.annotate(List[Tuple[int, int]], [])
         for img in images:
             val = img.shape[-2:]


### PR DESCRIPTION
Solves #2192 with minimal changes, but I can add checks to the `labels` and `scores` fields too. I would also like your opinion on creating a function to make these checks because they can get quite verbose (especially if we check the other fields as well).

Additionally, if we want full validation of the model-specific fields (e.g. `masks` for Mask R-CNN) we need to specify a check function for each child, perhaps by overriding a `_check` method or passing it to the `__init__` method.