### PR TITLE
Add test channels for pytorch version functions

### DIFF
--- a/packaging/pkg_helpers.bash
+++ b/packaging/pkg_helpers.bash
@@ -214,6 +214,7 @@ setup_pip_pytorch_version() {
   else
     pip_install "torch==$PYTORCH_VERSION$PYTORCH_VERSION_SUFFIX" \
       -f https://download.pytorch.org/whl/torch_stable.html \
+      -f https://download.pytorch.org/whl/test/torch_test.html
       -f https://download.pytorch.org/whl/nightly/torch_nightly.html
   fi
 }
@@ -239,7 +240,7 @@ setup_conda_pytorch_constraint() {
       exit 1
     fi
   else
-    export CONDA_CHANNEL_FLAGS="-c pytorch -c pytorch-nightly"
+    export CONDA_CHANNEL_FLAGS="-c pytorch -c pytorch-nightly -c pytorch-test"
   fi
   if [[ "$CU_VERSION" == cpu ]]; then
     export CONDA_PYTORCH_BUILD_CONSTRAINT="- pytorch==$PYTORCH_VERSION${PYTORCH_VERSION_SUFFIX}"


### PR DESCRIPTION
This is a follow up to my previous PR #2204 

This should make it so we automatically grab any pytorch release
candidates that are put in the test channel.

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>