### PR TITLE
remove script annotations / eager compilation

### DIFF
--- a/torchvision/io/_video_opt.py
+++ b/torchvision/io/_video_opt.py
@@ -34,7 +34,6 @@ default_timebase = Fraction(0, 1)
 
 # simple class for torch scripting
 # the complex Fraction class from fractions module is not scriptable
-@torch.jit.script
 class Timebase(object):
     __annotations__ = {"numerator": int, "denominator": int}
     __slots__ = ["numerator", "denominator"]
@@ -49,7 +48,6 @@ class Timebase(object):
         self.denominator = denominator
 
 
-@torch.jit.script
 class VideoMetaData(object):
     __annotations__ = {
         "has_video": bool,

--- a/torchvision/models/detection/_utils.py
+++ b/torchvision/models/detection/_utils.py
@@ -13,7 +13,6 @@ def zeros_like(tensor, dtype):
                             device=tensor.device, pin_memory=tensor.is_pinned())
 
 
-@torch.jit.script
 class BalancedPositiveNegativeSampler(object):
     """
     This class samples batches, ensuring that they contain a fixed proportion of positives
@@ -131,7 +130,6 @@ def encode_boxes(reference_boxes, proposals, weights):
     return targets
 
 
-@torch.jit.script
 class BoxCoder(object):
     """
     This class encodes and decodes a set of bounding boxes into
@@ -226,7 +224,6 @@ class BoxCoder(object):
         return pred_boxes
 
 
-@torch.jit.script
 class Matcher(object):
     """
     This class assigns to each predicted "element" (e.g., a box) a ground-truth

--- a/torchvision/models/detection/image_list.py
+++ b/torchvision/models/detection/image_list.py
@@ -4,7 +4,6 @@ from torch.jit.annotations import List, Tuple
 from torch import Tensor
 
 
-@torch.jit.script
 class ImageList(object):
     """
     Structure that holds a list of images (of possibly

--- a/torchvision/ops/poolers.py
+++ b/torchvision/ops/poolers.py
@@ -37,7 +37,6 @@ def initLevelMapper(k_min, k_max, canonical_scale=224, canonical_level=4, eps=1e
     return LevelMapper(k_min, k_max, canonical_scale, canonical_level, eps)
 
 
-@torch.jit.script
 class LevelMapper(object):
     """Determine which FPN level each RoI in a set of RoIs should map to based
     on the heuristic in the FPN paper.


### PR DESCRIPTION
After https://github.com/pytorch/pytorch/pull/38050, classes compile recursively so there is no longer any need to annotation them. And we can use `_script_if_tracing` to not eagerly compile the script functions but still compile them when we trace.

I'm hoping this resolves https://github.com/pytorch/vision/issues/2132

Edit looks like #38050 hasnt made its way to nightly yet