### PR TITLE
Make ceil_div __host__ __device__

### DIFF
--- a/torchvision/csrc/cuda/cuda_helpers.h
+++ b/torchvision/csrc/cuda/cuda_helpers.h
@@ -5,6 +5,6 @@
        i += (blockDim.x * gridDim.x))
 
 template <typename integer>
-constexpr inline integer ceil_div(integer n, integer m) {
+constexpr __host__ __device__ inline integer ceil_div(integer n, integer m) {
   return (n + m - 1) / m;
 }


### PR DESCRIPTION
Fixes https://github.com/pytorch/vision/issues/2214

I don't know why the building is not working with `--expt-relaxed-constexpr` flag set, but it is generally a good idea to declare this as `__host__ __device__`