### PR TITLE
Fix missing include for OSX in video decoder

### DIFF
--- a/torchvision/csrc/cpu/decoder/defs.h
+++ b/torchvision/csrc/cpu/decoder/defs.h
@@ -1,12 +1,12 @@
 #pragma once
 
+#include <array>
 #include <functional>
 #include <memory>
 #include <set>
 #include <string>
 #include <unordered_set>
 #include <vector>
-#include <array>
 
 extern "C" {
 #include <libavcodec/avcodec.h>

--- a/torchvision/csrc/cpu/decoder/defs.h
+++ b/torchvision/csrc/cpu/decoder/defs.h
@@ -6,6 +6,7 @@
 #include <string>
 #include <unordered_set>
 #include <vector>
+#include <array>
 
 extern "C" {
 #include <libavcodec/avcodec.h>


### PR DESCRIPTION
Fixes https://github.com/pytorch/vision/issues/2220

Looks like for OSX we need to explicitly include `array`, while for Linux it worked just fine without.