### PR TITLE
Updates integer division to use floor division operator

### DIFF
--- a/torchvision/models/detection/rpn.py
+++ b/torchvision/models/detection/rpn.py
@@ -160,8 +160,8 @@ class AnchorGenerator(nn.Module):
         grid_sizes = list([feature_map.shape[-2:] for feature_map in feature_maps])
         image_size = image_list.tensors.shape[-2:]
         dtype, device = feature_maps[0].dtype, feature_maps[0].device
-        strides = [[torch.tensor(image_size[0] / g[0], dtype=torch.int64, device=device),
-                    torch.tensor(image_size[1] / g[1], dtype=torch.int64, device=device)] for g in grid_sizes]
+        strides = [[torch.tensor(image_size[0] // g[0], dtype=torch.int64, device=device),
+                    torch.tensor(image_size[1] // g[1], dtype=torch.int64, device=device)] for g in grid_sizes]
         self.set_cell_anchors(dtype, device)
         anchors_over_all_feature_maps = self.cached_grid_anchors(grid_sizes, strides)
         anchors = torch.jit.annotate(List[List[torch.Tensor]], [])


### PR DESCRIPTION
Integer division using the div operator is deprecated and will throw a RuntimeError in PyTorch 1.6 (and on PyTorch Master very soon). Running a test build with a recent Torchvision commit and integer division using div ('/') disabled revealed this integer division. (see https://circleci.com/api/v1.1/project/github/pytorch/pytorch/5518440/output/104/0?file=true&allocation-id=5ec34242509c7d2f7500a6fb-0-build%2F7440ED7B)

I'll re-run the tests once this is fixed in case it's masking additional issues.