### PR TITLE
Updates integer division to use floor division operator

### DIFF
--- a/torchvision/models/detection/roi_heads.py
+++ b/torchvision/models/detection/roi_heads.py
@@ -182,7 +182,7 @@ def _onnx_heatmaps_to_keypoints(maps, maps_i, roi_map_width, roi_map_height,
     pos = roi_map.reshape(num_keypoints, -1).argmax(dim=1)
 
     x_int = (pos % w)
-    y_int = ((pos - x_int) / w)
+    y_int = ((pos - x_int) // w)
 
     x = (torch.tensor(0.5, dtype=torch.float32) + x_int.to(dtype=torch.float32)) * \
         width_correction.to(dtype=torch.float32)


### PR DESCRIPTION
Another instance of integer division using the division operator. In this case line 266 already shows the correct formulation, so line 185 only needs the update.

There may still be additional instances of floor division. I'll see if I can run the test identifying them locally to catch them faster. 

Update: I was able to verify locally that this this should be the final needed fix to get the PyTorch OSS CI passing. 