### PR TITLE
Deprecate Conv2d, ConvTranspose2d and BatchNorm2d

### DIFF
--- a/torchvision/ops/misc.py
+++ b/torchvision/ops/misc.py
@@ -21,22 +21,25 @@ from torchvision.ops import _new_empty_tensor
 class Conv2d(torch.nn.Conv2d):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        warnings.warn("torchvision.ops.misc.Conv2d is deprecated and will be "
-        "removed in future versions, use torch.nn.Conv2d instead.", FutureWarning)
+        warnings.warn(
+            "torchvision.ops.misc.Conv2d is deprecated and will be "
+            "removed in future versions, use torch.nn.Conv2d instead.", FutureWarning)
 
 
 class ConvTranspose2d(torch.nn.ConvTranspose2d):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        warnings.warn("torchvision.ops.misc.ConvTranspose2d is deprecated and will be "
-        "removed in future versions, use torch.nn.ConvTranspose2d instead.", FutureWarning)
+        warnings.warn(
+            "torchvision.ops.misc.ConvTranspose2d is deprecated and will be "
+            "removed in future versions, use torch.nn.ConvTranspose2d instead.", FutureWarning)
 
 
 class BatchNorm2d(torch.nn.BatchNorm2d):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        warnings.warn("torchvision.ops.misc.BatchNorm2d is deprecated and will be "
-        "removed in future versions, use torch.nn.BatchNorm2d instead.", FutureWarning)
+        warnings.warn(
+            "torchvision.ops.misc.BatchNorm2d is deprecated and will be "
+            "removed in future versions, use torch.nn.BatchNorm2d instead.", FutureWarning)
 
 
 def _check_size_scale_factor(dim, size, scale_factor):

--- a/torchvision/ops/misc.py
+++ b/torchvision/ops/misc.py
@@ -18,6 +18,27 @@ import torch
 from torchvision.ops import _new_empty_tensor
 
 
+class Conv2d(torch.nn.Conv2d):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        warnings.warn("torchvision.ops.misc.Conv2d is deprecated and will be "
+        "removed in future versions, use torch.nn.Conv2d instead.", FutureWarning)
+
+
+class ConvTranspose2d(torch.nn.ConvTranspose2d):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        warnings.warn("torchvision.ops.misc.ConvTranspose2d is deprecated and will be "
+        "removed in future versions, use torch.nn.ConvTranspose2d instead.", FutureWarning)
+
+
+class BatchNorm2d(torch.nn.BatchNorm2d):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        warnings.warn("torchvision.ops.misc.BatchNorm2d is deprecated and will be "
+        "removed in future versions, use torch.nn.BatchNorm2d instead.", FutureWarning)
+
+
 def _check_size_scale_factor(dim, size, scale_factor):
     # type: (int, Optional[List[int]], Optional[float]) -> None
     if size is None and scale_factor is None:


### PR DESCRIPTION
PyTorch now natively supports empty batches for `Conv2d`, `ConvTranspose2d` and `BatchNorm2d`, so no need to have our own versions anymore.

Follow-up from #2215 which removed those ops. I'm adding the functions back to avoid breaking BC, but I'm raising a error instead to encourage users to replace those ops in their code.