### PR TITLE
Remove interpolate in favor of PyTorch's implementation

### DIFF
--- a/torchvision/models/detection/keypoint_rcnn.py
+++ b/torchvision/models/detection/keypoint_rcnn.py
@@ -1,8 +1,6 @@
 import torch
 from torch import nn
 
-from torchvision.ops import misc as misc_nn_ops
-
 from torchvision.ops import MultiScaleRoIAlign
 
 from ..utils import load_state_dict_from_url
@@ -253,7 +251,7 @@ class KeypointRCNNPredictor(nn.Module):
 
     def forward(self, x):
         x = self.kps_score_lowres(x)
-        x = misc_nn_ops.interpolate(
+        x = torch.nn.functional.interpolate(
             x, scale_factor=float(self.up_scale), mode="bilinear", align_corners=False
         )
         return x

--- a/torchvision/models/detection/roi_heads.py
+++ b/torchvision/models/detection/roi_heads.py
@@ -175,7 +175,7 @@ def _onnx_heatmaps_to_keypoints(maps, maps_i, roi_map_width, roi_map_height,
     height_correction = heights_i / roi_map_height
 
     roi_map = F.interpolate(
-        maps_i[None], size=(int(roi_map_height), int(roi_map_width)), mode='bicubic', align_corners=False)[0]
+        maps_i[:, None], size=(int(roi_map_height), int(roi_map_width)), mode='bicubic', align_corners=False)[:, 0]
 
     w = torch.scalar_tensor(roi_map.size(2), dtype=torch.int64)
     pos = roi_map.reshape(num_keypoints, -1).argmax(dim=1)
@@ -256,7 +256,7 @@ def heatmaps_to_keypoints(maps, rois):
         width_correction = widths[i] / roi_map_width
         height_correction = heights[i] / roi_map_height
         roi_map = F.interpolate(
-            maps[i][None], size=(roi_map_height, roi_map_width), mode='bicubic', align_corners=False)[0]
+            maps[i][:, None], size=(roi_map_height, roi_map_width), mode='bicubic', align_corners=False)[:, 0]
         # roi_map_probs = scores_to_probs(roi_map.copy())
         w = roi_map.shape[2]
         pos = roi_map.reshape(num_keypoints, -1).argmax(dim=1)

--- a/torchvision/models/detection/roi_heads.py
+++ b/torchvision/models/detection/roi_heads.py
@@ -5,7 +5,6 @@ import torch.nn.functional as F
 from torch import nn, Tensor
 
 from torchvision.ops import boxes as box_ops
-from torchvision.ops import misc as misc_nn_ops
 
 from torchvision.ops import roi_align
 
@@ -175,7 +174,7 @@ def _onnx_heatmaps_to_keypoints(maps, maps_i, roi_map_width, roi_map_height,
     width_correction = widths_i / roi_map_width
     height_correction = heights_i / roi_map_height
 
-    roi_map = torch.nn.functional.interpolate(
+    roi_map = F.interpolate(
         maps_i[None], size=(int(roi_map_height), int(roi_map_width)), mode='bicubic', align_corners=False)[0]
 
     w = torch.scalar_tensor(roi_map.size(2), dtype=torch.int64)
@@ -256,7 +255,7 @@ def heatmaps_to_keypoints(maps, rois):
         roi_map_height = int(heights_ceil[i].item())
         width_correction = widths[i] / roi_map_width
         height_correction = heights[i] / roi_map_height
-        roi_map = torch.nn.functional.interpolate(
+        roi_map = F.interpolate(
             maps[i][None], size=(roi_map_height, roi_map_width), mode='bicubic', align_corners=False)[0]
         # roi_map_probs = scores_to_probs(roi_map.copy())
         w = roi_map.shape[2]
@@ -392,7 +391,7 @@ def paste_mask_in_image(mask, box, im_h, im_w):
     mask = mask.expand((1, 1, -1, -1))
 
     # Resize mask
-    mask = misc_nn_ops.interpolate(mask, size=(h, w), mode='bilinear', align_corners=False)
+    mask = F.interpolate(mask, size=(h, w), mode='bilinear', align_corners=False)
     mask = mask[0][0]
 
     im_mask = torch.zeros((im_h, im_w), dtype=mask.dtype, device=mask.device)
@@ -420,7 +419,7 @@ def _onnx_paste_mask_in_image(mask, box, im_h, im_w):
     mask = mask.expand((1, 1, mask.size(0), mask.size(1)))
 
     # Resize mask
-    mask = torch.nn.functional.interpolate(mask, size=(int(h), int(w)), mode='bilinear', align_corners=False)
+    mask = F.interpolate(mask, size=(int(h), int(w)), mode='bilinear', align_corners=False)
     mask = mask[0][0]
 
     x_0 = torch.max(torch.cat((box[0].unsqueeze(0), zero)))

--- a/torchvision/models/detection/transform.py
+++ b/torchvision/models/detection/transform.py
@@ -50,7 +50,7 @@ def _resize_image_and_masks(image, self_min_size, self_max_size, target):
 
     if "masks" in target:
         mask = target["masks"]
-        mask = F.interpolate(mask[None].float(), scale_factor=scale_factor)[0].byte()
+        mask = F.interpolate(mask[:, None].float(), scale_factor=scale_factor)[:, 0].byte()
         target["masks"] = mask
     return image, target
 

--- a/torchvision/models/detection/transform.py
+++ b/torchvision/models/detection/transform.py
@@ -2,10 +2,10 @@ import random
 import math
 import torch
 from torch import nn, Tensor
+from torch.nn import functional as F
 import torchvision
 from torch.jit.annotations import List, Tuple, Dict, Optional
 
-from torchvision.ops import misc as misc_nn_ops
 from .image_list import ImageList
 from .roi_heads import paste_masks_in_image
 
@@ -28,7 +28,7 @@ def _resize_image_and_masks_onnx(image, self_min_size, self_max_size, target):
 
     if "masks" in target:
         mask = target["masks"]
-        mask = misc_nn_ops.interpolate(mask[None].float(), scale_factor=scale_factor)[0].byte()
+        mask = F.interpolate(mask[None].float(), scale_factor=scale_factor)[0].byte()
         target["masks"] = mask
     return image, target
 
@@ -50,7 +50,7 @@ def _resize_image_and_masks(image, self_min_size, self_max_size, target):
 
     if "masks" in target:
         mask = target["masks"]
-        mask = misc_nn_ops.interpolate(mask[None].float(), scale_factor=scale_factor)[0].byte()
+        mask = F.interpolate(mask[None].float(), scale_factor=scale_factor)[0].byte()
         target["masks"] = mask
     return image, target
 

--- a/torchvision/models/detection/transform.py
+++ b/torchvision/models/detection/transform.py
@@ -28,7 +28,7 @@ def _resize_image_and_masks_onnx(image, self_min_size, self_max_size, target):
 
     if "masks" in target:
         mask = target["masks"]
-        mask = F.interpolate(mask[None].float(), scale_factor=scale_factor)[0].byte()
+        mask = F.interpolate(mask[:, None].float(), scale_factor=scale_factor)[:, 0].byte()
         target["masks"] = mask
     return image, target
 


### PR DESCRIPTION
It is natively supported in PyTorch now, so this workaround implementation can be removed.

We can also remove `_new_empty_tensor`, but I'll leave this to a follow-up PR.