### PR TITLE
Register torchvision ops

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ add_library(${PROJECT_NAME} SHARED ${MODELS_SOURCES} ${OPERATOR_SOURCES})
 target_link_libraries(${PROJECT_NAME} PRIVATE ${TORCH_LIBRARIES} Python3::Python)
 set_target_properties(${PROJECT_NAME} PROPERTIES
   EXPORT_NAME TorchVision
+  INSTALL_RPATH ${TORCH_INSTALL_PREFIX}/lib
 )
 
 include(GNUInstallDirs)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,14 +23,16 @@ file(GLOB MODELS_SOURCES torchvision/csrc/models/*.h torchvision/csrc/models/*.c
 
 add_library(${PROJECT_NAME} SHARED ${MODELS_SOURCES} ${OPERATOR_SOURCES})
 target_link_libraries(${PROJECT_NAME} PRIVATE ${TORCH_LIBRARIES} Python3::Python)
-set_target_properties(${PROJECT_NAME} PROPERTIES EXPORT_NAME TorchVision)
+set_target_properties(${PROJECT_NAME} PROPERTIES
+  EXPORT_NAME TorchVision
+)
+
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
 
 target_include_directories(${PROJECT_NAME} INTERFACE
   $<BUILD_INTERFACE:${HEADERS}>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
-
-include(GNUInstallDirs)
-include(CMakePackageConfigHelpers)
 
 set(TORCHVISION_CMAKECONFIG_INSTALL_DIR "share/cmake/TorchVision" CACHE STRING "install path for TorchVisionConfig.cmake")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ find_package(Python3 COMPONENTS Development)
 find_package(Torch REQUIRED)
 
 file(GLOB HEADERS torchvision/csrc/*.h)
-file(GLOB OPERATOR_SOURCES torchvision/csrc/cpu/*.h torchvision/csrc/cpu/*.cpp torchvision/csrc/*.cpp)
+file(GLOB OPERATOR_SOURCES torchvision/csrc/cpu/*.h torchvision/csrc/cpu/*.cpp torchvision/csrc/ops.cpp)
 if(WITH_CUDA)
   file(GLOB OPERATOR_SOURCES ${OPERATOR_SOURCES} torchvision/csrc/cuda/*.h torchvision/csrc/cuda/*.cu)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ option(WITH_CUDA "Enable CUDA support" OFF)
 
 if(WITH_CUDA)
   enable_language(CUDA)
-  add_definitions(-D__CUDA_NO_HALF_OPERATORS__)
+  add_definitions(-D__CUDA_NO_HALF_OPERATORS__ -DWITH_CUDA)
 endif()
 
 find_package(Python3 COMPONENTS Development)

--- a/README.rst
+++ b/README.rst
@@ -87,6 +87,13 @@ so make sure that it is also available to cmake via the ``CMAKE_PREFIX_PATH``.
 
 For an example setup, take a look at ``examples/cpp/hello_world``.
 
+TorchVision Operators
+---------------------
+In order to get the torchvision operators registered with torch (eg. for the JIT), all you need to do is to ensure that you
+:code:`#include <torchvision/vision.h>` in your project.
+
+Alternatively, you can include :code:`#inclde <torchvision/ops.h>` and call :code:`vision::RegisterOps()` manually.
+
 Documentation
 =============
 You can find the API documentation on the pytorch website: http://pytorch.org/docs/master/torchvision/

--- a/torchvision/csrc/ops.cpp
+++ b/torchvision/csrc/ops.cpp
@@ -25,16 +25,17 @@ int64_t _cuda_version() {
 
 namespace vision {
 int RegisterOps() noexcept {
-  static auto registry = torch::RegisterOperators()
-      .op("torchvision::nms", &nms)
-      .op("torchvision::roi_align(Tensor input, Tensor rois, float spatial_scale, int pooled_height, int pooled_width, int sampling_ratio, bool aligned) -> Tensor",
-          &roi_align)
-      .op("torchvision::roi_pool", &roi_pool)
-      .op("torchvision::_new_empty_tensor_op", &new_empty_tensor)
-      .op("torchvision::ps_roi_align", &ps_roi_align)
-      .op("torchvision::ps_roi_pool", &ps_roi_pool)
-      .op("torchvision::deform_conv2d", &deform_conv2d)
-      .op("torchvision::_cuda_version", &_cuda_version);
+  static auto registry =
+      torch::RegisterOperators()
+          .op("torchvision::nms", &nms)
+          .op("torchvision::roi_align(Tensor input, Tensor rois, float spatial_scale, int pooled_height, int pooled_width, int sampling_ratio, bool aligned) -> Tensor",
+              &roi_align)
+          .op("torchvision::roi_pool", &roi_pool)
+          .op("torchvision::_new_empty_tensor_op", &new_empty_tensor)
+          .op("torchvision::ps_roi_align", &ps_roi_align)
+          .op("torchvision::ps_roi_pool", &ps_roi_pool)
+          .op("torchvision::deform_conv2d", &deform_conv2d)
+          .op("torchvision::_cuda_version", &_cuda_version);
   return 0;
 }
-}
+} // namespace vision

--- a/torchvision/csrc/ops.cpp
+++ b/torchvision/csrc/ops.cpp
@@ -15,7 +15,7 @@
 #include "empty_tensor_op.h"
 #include "nms.h"
 
-int64_t _cuda_version() {
+C10_EXPORT int64_t _cuda_version() {
 #ifdef WITH_CUDA
   return CUDA_VERSION;
 #else

--- a/torchvision/csrc/ops.cpp
+++ b/torchvision/csrc/ops.cpp
@@ -1,0 +1,40 @@
+#include <ATen/core/op_registration/op_registration.h>
+
+#ifdef WITH_CUDA
+#include <cuda.h>
+#endif
+#ifdef WITH_HIP
+#include <hip/hip_runtime.h>
+#endif
+
+#include "DeformConv.h"
+#include "PSROIAlign.h"
+#include "PSROIPool.h"
+#include "ROIAlign.h"
+#include "ROIPool.h"
+#include "empty_tensor_op.h"
+#include "nms.h"
+
+int64_t _cuda_version() {
+#ifdef WITH_CUDA
+  return CUDA_VERSION;
+#else
+  return -1;
+#endif
+}
+
+namespace vision {
+int RegisterOps() noexcept {
+  static auto registry = torch::RegisterOperators()
+      .op("torchvision::nms", &nms)
+      .op("torchvision::roi_align(Tensor input, Tensor rois, float spatial_scale, int pooled_height, int pooled_width, int sampling_ratio, bool aligned) -> Tensor",
+          &roi_align)
+      .op("torchvision::roi_pool", &roi_pool)
+      .op("torchvision::_new_empty_tensor_op", &new_empty_tensor)
+      .op("torchvision::ps_roi_align", &ps_roi_align)
+      .op("torchvision::ps_roi_pool", &ps_roi_pool)
+      .op("torchvision::deform_conv2d", &deform_conv2d)
+      .op("torchvision::_cuda_version", &_cuda_version);
+  return 0;
+}
+}

--- a/torchvision/csrc/ops.h
+++ b/torchvision/csrc/ops.h
@@ -1,8 +1,13 @@
 #ifndef TORCHVISION_OPS_H
 #define TORCHVISION_OPS_H
 
+#include <c10/macros/Export.h>
+#include <cstdint>
+
 namespace vision {
 int RegisterOps() noexcept;
 }
+
+C10_IMPORT int64_t _cuda_version();
 
 #endif // TORCHVISION_OPS_H

--- a/torchvision/csrc/ops.h
+++ b/torchvision/csrc/ops.h
@@ -1,0 +1,8 @@
+#ifndef TORCHVISION_OPS_H
+#define TORCHVISION_OPS_H
+
+namespace vision {
+int RegisterOps() noexcept;
+}
+
+#endif // TORCHVISION_OPS_H

--- a/torchvision/csrc/ops_autoregister.h
+++ b/torchvision/csrc/ops_autoregister.h
@@ -1,0 +1,17 @@
+#include "ops.h"
+
+#if (defined __cpp_inline_variables) || __cplusplus >= 201703L
+#define VISION_INLINE_VARIABLE inline
+#else
+#ifdef _MSC_VER
+#define VISION_INLINE_VARIABLE __declspec(selectany)
+#else
+#define VISION_INLINE_VARIABLE __attribute__((weak))
+#endif
+#endif
+
+namespace vision {
+namespace impl {
+VISION_INLINE_VARIABLE int dummy = RegisterOps();
+}
+} // namespace vision

--- a/torchvision/csrc/vision.cpp
+++ b/torchvision/csrc/vision.cpp
@@ -1,7 +1,7 @@
-#include <Python.h>
-#include <torch/script.h>
+// Autoregister all the torchvision ops.
+#include "ops_autoregister.h"
 
-#include "vision.h"
+#include <Python.h>
 
 // If we are in a Windows environment, we need to define
 // initialization functions for the _C extension

--- a/torchvision/csrc/vision.cpp
+++ b/torchvision/csrc/vision.cpp
@@ -1,4 +1,4 @@
-// Autoregister all the torchvision ops.
+// Autoregister all the torchvision ops (for C++).
 #include "ops_autoregister.h"
 
 #include <Python.h>
@@ -8,14 +8,14 @@
 #ifdef _WIN32
 #if PY_MAJOR_VERSION < 3
 PyMODINIT_FUNC init_C(void) {
-  // No need to do anything.
-  // extension.py will run on load
+  // Register torchvision ops for python.
+  vision::RegisterOps();
   return NULL;
 }
 #else
 PyMODINIT_FUNC PyInit__C(void) {
-  // No need to do anything.
-  // extension.py will run on load
+  // Register torchvision ops for python.
+  vision::RegisterOps();
   return NULL;
 }
 #endif

--- a/torchvision/csrc/vision.cpp
+++ b/torchvision/csrc/vision.cpp
@@ -1,20 +1,7 @@
 #include <Python.h>
 #include <torch/script.h>
 
-#ifdef WITH_CUDA
-#include <cuda.h>
-#endif
-#ifdef WITH_HIP
-#include <hip/hip_runtime.h>
-#endif
-
-#include "DeformConv.h"
-#include "PSROIAlign.h"
-#include "PSROIPool.h"
-#include "ROIAlign.h"
-#include "ROIPool.h"
-#include "empty_tensor_op.h"
-#include "nms.h"
+#include "vision.h"
 
 // If we are in a Windows environment, we need to define
 // initialization functions for the _C extension
@@ -33,23 +20,3 @@ PyMODINIT_FUNC PyInit__C(void) {
 }
 #endif
 #endif
-
-int64_t _cuda_version() {
-#ifdef WITH_CUDA
-  return CUDA_VERSION;
-#else
-  return -1;
-#endif
-}
-
-static auto registry =
-    torch::RegisterOperators()
-        .op("torchvision::nms", &nms)
-        .op("torchvision::roi_align(Tensor input, Tensor rois, float spatial_scale, int pooled_height, int pooled_width, int sampling_ratio, bool aligned) -> Tensor",
-            &roi_align)
-        .op("torchvision::roi_pool", &roi_pool)
-        .op("torchvision::_new_empty_tensor_op", &new_empty_tensor)
-        .op("torchvision::ps_roi_align", &ps_roi_align)
-        .op("torchvision::ps_roi_pool", &ps_roi_pool)
-        .op("torchvision::deform_conv2d", &deform_conv2d)
-        .op("torchvision::_cuda_version", &_cuda_version);

--- a/torchvision/csrc/vision.h
+++ b/torchvision/csrc/vision.h
@@ -2,22 +2,6 @@
 #define VISION_H
 
 #include "models/models.h"
-#include "ops.h"
-
-#if (defined __cpp_inline_variables) || __cplusplus >= 201703L
-#define VISION_INLINE_VARIABLE inline
-#else
-#ifdef _MSC_VER
-#define VISION_INLINE_VARIABLE __declspec(selectany)
-#else
-#define VISION_INLINE_VARIABLE __attribute__((weak))
-#endif
-#endif
-
-namespace vision {
-namespace impl {
-VISION_INLINE_VARIABLE int dummy = RegisterOps();
-}
-} // namespace vision
+#include "ops_autoregister.h"
 
 #endif // VISION_H

--- a/torchvision/csrc/vision.h
+++ b/torchvision/csrc/vision.h
@@ -1,9 +1,8 @@
 #ifndef VISION_H
 #define VISION_H
 
-#include "ops.h"
 #include "models/models.h"
-
+#include "ops.h"
 
 #if (defined __cpp_inline_variables) || __cplusplus >= 201703L
 #define VISION_INLINE_VARIABLE inline
@@ -19,6 +18,6 @@ namespace vision {
 namespace impl {
 VISION_INLINE_VARIABLE int dummy = RegisterOps();
 }
-}
+} // namespace vision
 
 #endif // VISION_H

--- a/torchvision/csrc/vision.h
+++ b/torchvision/csrc/vision.h
@@ -1,8 +1,8 @@
 #ifndef VISION_H
 #define VISION_H
 
-#include <torchvision/ops.h>
-#include <torchvision/models/models.h>
+#include "ops.h"
+#include "models/models.h"
 
 
 #if (defined __cpp_inline_variables) || __cplusplus >= 201703L

--- a/torchvision/csrc/vision.h
+++ b/torchvision/csrc/vision.h
@@ -1,6 +1,24 @@
 #ifndef VISION_H
 #define VISION_H
 
+#include <torchvision/ops.h>
 #include <torchvision/models/models.h>
+
+
+#if (defined __cpp_inline_variables) || __cplusplus >= 201703L
+#define VISION_INLINE_VARIABLE inline
+#else
+#ifdef _MSC_VER
+#define VISION_INLINE_VARIABLE __declspec(selectany)
+#else
+#define VISION_INLINE_VARIABLE __attribute__((weak))
+#endif
+#endif
+
+namespace vision {
+namespace impl {
+VISION_INLINE_VARIABLE int dummy = RegisterOps();
+}
+}
 
 #endif // VISION_H


### PR DESCRIPTION
This changes the way that the ops are registered with torch. Instead of relying on a static initializer that might not get run based on the linker's mood, we add a RegisterOps function that is automatically run whenever the user includes vision.h exploiting weak symbols.
This way, the user doesn't have to reference any torchvision symbols for the registration to happen.

I have purposely left it flexible enough so that users could just include ops.h and manually call the function with the minimal compile-time overhead.

I had to fix some issues with CMakeLists.txt along the way. Also I have noticed that the functions in the operators headers are not marked inline, which could spell ODR trouble if the users include them themselves, but that's for another PR.

Closes #2134