### PR TITLE
check for degenerate boxes (fixes #2240)

### DIFF
--- a/test/test_models.py
+++ b/test/test_models.py
@@ -158,7 +158,7 @@ class ModelTester(TestCase):
     def _test_detection_model_validation(self, name):
         set_rng_seed(0)
         model = models.detection.__dict__[name](num_classes=50, pretrained_backbone=False)
-        input_shape = (1, 3, 300, 300)
+        input_shape = (3, 300, 300)
         x = [torch.rand(input_shape)]
 
         # validate that targets are present in training
@@ -172,6 +172,11 @@ class ModelTester(TestCase):
         for boxes in (torch.rand((4,)), torch.rand((1, 5))):
             targets = [{'boxes': boxes}]
             self.assertRaises(ValueError, model, x, targets=targets)
+
+        # validate that no degenerate boxes are present
+        boxes = torch.tensor([[1, 3, 1, 4], [2, 4, 3, 4]])
+        targets = [{'boxes': boxes}]
+        self.assertRaises(ValueError, model, x, targets=targets)
 
     def _test_video_model(self, name):
         # the default input shape is


### PR DESCRIPTION
This PR fixes issue discussed in #2240 .

Below are some of the key detais for code review:
1. I have added the checking of the shapes after the transformation of image and boxes. This is because of the assumption that some transforation can also generate degenerate boxes. Please suggest if this assumtion is wrong.
2. I found out that the tests was throwing the below error when `input_shape = (1, 3, 300, 300)` was defined at line number 161 in `test/test_models:_test_detection_model_validation`. I have correct the shape. Please let me know if I am right/wrong here.
```python
ValueError: images is expected to be a list of 3d tensors of shape [C, H, W], got torch.Size([1, 3, 300, 300])
```

Please provide feedback, and I'll work upon correcting/improving the code.