### PR TITLE
[BC-breaking] Fix for integer fill value in constant padding

### DIFF
--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -313,7 +313,7 @@ class Tester(unittest.TestCase):
         eps = 1e-5
         self.assertTrue((result[:, :padding, :] - fill_v).abs().max() < eps)
         self.assertTrue((result[:, :, :padding] - fill_v).abs().max() < eps)
-        self.assertRaises(ValueError, transforms.Pad(padding, fill=(1,2)),
+        self.assertRaises(ValueError, transforms.Pad(padding, fill=(1, 2)),
                           transforms.ToPILImage()(img))
 
     def test_pad_with_tuple_of_pad_values(self):

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -309,8 +309,12 @@ class Tester(unittest.TestCase):
         self.assertEqual(result.size(2), width + 2 * padding)
         # check that all elements in the padded region correspond
         # to the pad value
-        self.assertTrue((result[:, :padding, :] == (fill / 255)).all())
-        self.assertTrue((result[:, :, :padding] == (fill / 255)).all())
+        fill_v = fill / 255
+        eps = 1e-5
+        self.assertTrue((result[:, :padding, :] - fill_v).abs().max() < eps)
+        self.assertTrue((result[:, :, :padding] - fill_v).abs().max() < eps)
+        self.assertRaises(ValueError, transforms.Pad(padding, fill=(1,2)),
+                          transforms.ToPILImage()(img))
 
     def test_pad_with_tuple_of_pad_values(self):
         height = random.randint(10, 32) * 2

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -299,13 +299,18 @@ class Tester(unittest.TestCase):
         width = random.randint(10, 32) * 2
         img = torch.ones(3, height, width)
         padding = random.randint(1, 20)
+        fill = random.randint(1, 50)
         result = transforms.Compose([
             transforms.ToPILImage(),
-            transforms.Pad(padding),
+            transforms.Pad(padding, fill=fill),
             transforms.ToTensor(),
         ])(img)
         self.assertEqual(result.size(1), height + 2 * padding)
         self.assertEqual(result.size(2), width + 2 * padding)
+        # check that all elements in the padded region correspond
+        # to the pad value
+        self.assertTrue((result[:, :padding, :] == (fill / 255)).all())
+        self.assertTrue((result[:, :, :padding] == (fill / 255)).all())
 
     def test_pad_with_tuple_of_pad_values(self):
         height = random.randint(10, 32) * 2

--- a/torchvision/transforms/functional.py
+++ b/torchvision/transforms/functional.py
@@ -331,6 +331,10 @@ def pad(img, padding, fill=0, padding_mode='constant'):
     if padding_mode == 'constant':
         if isinstance(fill, numbers.Number):
             fill = (fill,) * len(img.getbands())
+        if len(fill) != len(img.getbands()):
+            raise ValueError('fill should have the same number of elements '
+                             'as the number of channels in the image '
+                             '({}), got {} instead'.format(len(img.getbands()), len(fill)))
         if img.mode == 'P':
             palette = img.getpalette()
             image = ImageOps.expand(img, border=padding, fill=fill)

--- a/torchvision/transforms/functional.py
+++ b/torchvision/transforms/functional.py
@@ -329,6 +329,8 @@ def pad(img, padding, fill=0, padding_mode='constant'):
         'Padding mode should be either constant, edge, reflect or symmetric'
 
     if padding_mode == 'constant':
+        if isinstance(fill, numbers.Number):
+            fill = (fill,) * len(img.getbands())
         if img.mode == 'P':
             palette = img.getpalette()
             image = ImageOps.expand(img, border=padding, fill=fill)


### PR DESCRIPTION
The previous implementation of `pad` with constant fill value had an undesired behavior when a single value was passed.

One would expect that it would fill the whole region with the `(pad, pad, pad)` value, but in fact it was doing `(pad, 0, 0)`, as this is how Pillow handles it.

This is a backwards-incompatible change in torchvision that changes the behavior of the function, but given that most users use a value of 0, this shouldn't be a big issue.