### PR TITLE
Fix overflow error for large buffers.

### DIFF
--- a/torchvision/csrc/cpu/video_reader/VideoReader.cpp
+++ b/torchvision/csrc/cpu/video_reader/VideoReader.cpp
@@ -311,7 +311,7 @@ torch::List<torch::Tensor> readVideo(
         videoFrame = torch::zeros(
             {numVideoFrames, outHeight, outWidth, numChannels}, torch::kByte);
         expectedWrittenBytes =
-            numVideoFrames * outHeight * outWidth * numChannels;
+            (size_t)numVideoFrames * outHeight * outWidth * numChannels;
       }
 
       videoFramePts = torch::zeros({numVideoFrames}, torch::kLong);


### PR DESCRIPTION
Summary:
Allow writes of >= 2^32 bytes. High-res video can cross this threshold sometimes.
LHS is `size_t`, but RHS is all `int32`, and will overflow for output tensors >2Gb.

Reviewed By: jsawruk

Differential Revision: D21255664

fbshipit-source-id: 7b4c5da989777297a89e73615aaeee8c7a13186a