### PR TITLE
Update torchvision ops in doc

### DIFF
--- a/docs/source/ops.rst
+++ b/docs/source/ops.rst
@@ -11,9 +11,15 @@ torchvision.ops
 
 .. autofunction:: nms
 .. autofunction:: roi_align
+.. autofunction:: ps_roi_align
 .. autofunction:: roi_pool
+.. autofunction:: ps_roi_pool
 .. autofunction:: deform_conv2d
 
 .. autoclass:: RoIAlign
+.. autoclass:: PSRoIAlign
 .. autoclass:: RoIPool
+.. autoclass:: PSRoIPool
 .. autoclass:: DeformConv2d
+.. autoclass:: MultiScaleRoIAlign
+.. autoclass:: FeaturePyramidNetwork

--- a/docs/source/ops.rst
+++ b/docs/source/ops.rst
@@ -12,6 +12,8 @@ torchvision.ops
 .. autofunction:: nms
 .. autofunction:: roi_align
 .. autofunction:: roi_pool
+.. autofunction:: deform_conv2d
 
 .. autoclass:: RoIAlign
 .. autoclass:: RoIPool
+.. autoclass:: DeformConv2d


### PR DESCRIPTION
Noticed in #1586 , the `deform_conv2d`, `PSPOIPool` was not updated in Doc, so added in this PR.

And, the operator [`batched_nms`](https://github.com/pytorch/vision/blob/42aa9b263eaea3553369ff39268cfe295c7a57b0/torchvision/ops/boxes.py#L45) is useful in many cases, would it be considered to be added in this pull request?