### PR TITLE
Issue 2350 - support of all padding modes with tensors

### DIFF
--- a/test/test_functional_tensor.py
+++ b/test/test_functional_tensor.py
@@ -14,8 +14,7 @@ from PIL import Image
 class Tester(unittest.TestCase):
 
     def _create_data(self, height=3, width=3, channels=3):
-        # tensor = torch.randint(0, 255, (channels, height, width), dtype=torch.uint8)
-        tensor = torch.arange(0, channels * height * width,  dtype=torch.uint8).reshape(channels, height, width)
+        tensor = torch.randint(0, 255, (channels, height, width), dtype=torch.uint8)
         pil_img = Image.fromarray(tensor.permute(1, 2, 0).contiguous().numpy())
         return tensor, pil_img
 
@@ -261,7 +260,6 @@ class Tester(unittest.TestCase):
                     {"padding_mode": "constant", "fill": 20},
                     {"padding_mode": "edge"},
                     {"padding_mode": "reflect"},
-                    # {"padding_mode": "symmetric"},
                 ]
                 for kwargs in configs:
                     pad_tensor = F_t.pad(tensor, pad, **kwargs)

--- a/test/test_functional_tensor.py
+++ b/test/test_functional_tensor.py
@@ -248,17 +248,21 @@ class Tester(unittest.TestCase):
         script_fn = torch.jit.script(F_t.pad)
         tensor, pil_img = self._create_data(7, 8)
         for pad in [1, [1, ], [0, 1], (2, 2), [1, 0, 1, 2]]:
-            padding_mode = "constant"
-            for fill in [0, 10, 20]:
-                pad_tensor = F_t.pad(tensor, pad, fill=fill, padding_mode=padding_mode)
-                pad_pil_img = F_pil.pad(pil_img, pad, fill=fill, padding_mode=padding_mode)
-                self.compareTensorToPIL(pad_tensor, pad_pil_img, msg="{}, {}".format(pad, fill))
+            configs = [
+                {"padding_mode": "constant", "fill": 0},
+                {"padding_mode": "constant", "fill": 10},
+                {"padding_mode": "constant", "fill": 20},
+            ]
+            for kwargs in configs:
+                pad_tensor = F_t.pad(tensor, pad, **kwargs)
+                pad_pil_img = F_pil.pad(pil_img, pad, **kwargs)
+                self.compareTensorToPIL(pad_tensor, pad_pil_img, msg="{}, {}".format(pad, kwargs))
                 if isinstance(pad, int):
                     script_pad = [pad, ]
                 else:
                     script_pad = pad
-                pad_tensor_script = script_fn(tensor, script_pad, fill=fill, padding_mode=padding_mode)
-                self.assertTrue(pad_tensor.equal(pad_tensor_script), msg="{}, {}".format(pad, fill))
+                pad_tensor_script = script_fn(tensor, script_pad, **kwargs)
+                self.assertTrue(pad_tensor.equal(pad_tensor_script), msg="{}, {}".format(pad, kwargs))
 
 
 if __name__ == '__main__':

--- a/torchvision/transforms/functional_tensor.py
+++ b/torchvision/transforms/functional_tensor.py
@@ -417,7 +417,7 @@ def pad(img: Tensor, padding: List[int], fill: int = 0, padding_mode: str = "con
 
     out_dtype = img.dtype
     need_cast = False
-    if img.dtype not in (torch.float32, torch.float64):
+    if (padding_mode != "constant") and img.dtype not in (torch.float32, torch.float64):
         # Here we temporary cast input tensor to float
         # until pytorch issue is resolved :
         # https://github.com/pytorch/pytorch/issues/40763

--- a/torchvision/transforms/functional_tensor.py
+++ b/torchvision/transforms/functional_tensor.py
@@ -359,6 +359,13 @@ def pad(img: Tensor, padding: List[int], fill: int, padding_mode: str = "constan
 
             - constant: pads with a constant value, this value is specified with fill
 
+            - edge: pads with the last value on the edge of the image
+
+            - reflect: pads with reflection of image (without repeating the last value on the edge)
+
+                       padding [1, 2, 3, 4] with 2 elements on both sides in reflect mode
+                       will result in [3, 2, 1, 2, 3, 4, 3, 2]
+
     Returns:
         Tensor: Padded image.
     """
@@ -379,8 +386,8 @@ def pad(img: Tensor, padding: List[int], fill: int, padding_mode: str = "constan
         raise ValueError("Padding must be an int or a 1, 2, or 4 element tuple, not a " +
                          "{} element tuple".format(len(padding)))
 
-    if padding_mode not in ["constant", ]:
-        raise ValueError("Only constant padding_mode supported for torch tensors")
+    if padding_mode not in ["constant", "edge", "reflect"]:
+        raise ValueError("Padding mode should be either constant, edge, reflect")
 
     if isinstance(padding, int):
         if torch.jit.is_scripting():

--- a/torchvision/transforms/functional_tensor.py
+++ b/torchvision/transforms/functional_tensor.py
@@ -366,11 +366,6 @@ def pad(img: Tensor, padding: List[int], fill: int = 0, padding_mode: str = "con
                        padding [1, 2, 3, 4] with 2 elements on both sides in reflect mode
                        will result in [3, 2, 1, 2, 3, 4, 3, 2]
 
-            - symmetric: pads with reflection of image (repeating the last value on the edge)
-
-                         padding [1, 2, 3, 4] with 2 elements on both sides in symmetric mode
-                         will result in [2, 1, 1, 2, 3, 4, 4, 3]
-
     Returns:
         Tensor: Padded image.
     """
@@ -391,8 +386,8 @@ def pad(img: Tensor, padding: List[int], fill: int = 0, padding_mode: str = "con
         raise ValueError("Padding must be an int or a 1, 2, or 4 element tuple, not a " +
                          "{} element tuple".format(len(padding)))
 
-    if padding_mode not in ["constant", "edge", "reflect", "symmetric"]:
-        raise ValueError("Padding mode should be either constant, edge, reflect or symmetric")
+    if padding_mode not in ["constant", "edge", "reflect"]:
+        raise ValueError("Padding mode should be either constant, edge or reflect")
 
     if isinstance(padding, int):
         if torch.jit.is_scripting():
@@ -423,6 +418,9 @@ def pad(img: Tensor, padding: List[int], fill: int = 0, padding_mode: str = "con
     out_dtype = img.dtype
     need_cast = False
     if img.dtype not in (torch.float32, torch.float64):
+        # Here we temporary cast input tensor to float
+        # until pytorch issue is resolved :
+        # https://github.com/pytorch/pytorch/issues/40763
         need_cast = True
         img = img.to(torch.float32)
 


### PR DESCRIPTION
Fixes #2350

Description:

- [x] Added code to support "edge", "reflect" padding modes with `functional_tensor.pad`
- [x] Added tests
- [x] Updated docs