### PR TITLE
Feat/focal loss faster rcnn

### DIFF
--- a/torchvision/models/detection/faster_rcnn.py
+++ b/torchvision/models/detection/faster_rcnn.py
@@ -159,7 +159,7 @@ class FasterRCNN(GeneralizedRCNN):
                  box_fg_iou_thresh=0.5, box_bg_iou_thresh=0.5,
                  box_batch_size_per_image=512, box_positive_fraction=0.25,
                  bbox_reg_weights=None,
-                 focal_loss = False, focal_loss_gamma = 2):
+                 focal_loss=False, focal_loss_gamma=2):
 
         if not hasattr(backbone, "out_channels"):
             raise ValueError(

--- a/torchvision/models/detection/faster_rcnn.py
+++ b/torchvision/models/detection/faster_rcnn.py
@@ -96,6 +96,8 @@ class FasterRCNN(GeneralizedRCNN):
             of the classification head
         bbox_reg_weights (Tuple[float, float, float, float]): weights for the encoding/decoding of the
             bounding boxes
+        focal_loss (bool): set to true to use focal loss for clasification rather than simple cross entropy
+        focal_loss_gamma (int): adjusts the rate at which easy examples are down-weighted in focal loss
 
     Example::
 

--- a/torchvision/models/detection/faster_rcnn.py
+++ b/torchvision/models/detection/faster_rcnn.py
@@ -156,7 +156,8 @@ class FasterRCNN(GeneralizedRCNN):
                  box_score_thresh=0.05, box_nms_thresh=0.5, box_detections_per_img=100,
                  box_fg_iou_thresh=0.5, box_bg_iou_thresh=0.5,
                  box_batch_size_per_image=512, box_positive_fraction=0.25,
-                 bbox_reg_weights=None):
+                 bbox_reg_weights=None,
+                 focal_loss = False, focal_loss_gamma = 2):
 
         if not hasattr(backbone, "out_channels"):
             raise ValueError(
@@ -222,7 +223,8 @@ class FasterRCNN(GeneralizedRCNN):
             box_fg_iou_thresh, box_bg_iou_thresh,
             box_batch_size_per_image, box_positive_fraction,
             bbox_reg_weights,
-            box_score_thresh, box_nms_thresh, box_detections_per_img)
+            box_score_thresh, box_nms_thresh, box_detections_per_img,
+            focal_loss, focal_loss_gamma)
 
         if image_mean is None:
             image_mean = [0.485, 0.456, 0.406]

--- a/torchvision/models/detection/roi_heads.py
+++ b/torchvision/models/detection/roi_heads.py
@@ -41,7 +41,7 @@ def focal_loss(class_logits, target_tensor, gamma=2, reduction='mean', weight=No
         ((1 - prob) ** gamma) * log_prob,
         target_tensor,
         weight=weight,
-        reduction =reduction
+        reduction=reduction
     )
 
 

--- a/torchvision/models/detection/roi_heads.py
+++ b/torchvision/models/detection/roi_heads.py
@@ -55,6 +55,8 @@ def fastrcnn_loss(class_logits, box_regression, labels, regression_targets, use_
         box_regression (Tensor)
         labels (list[BoxList])
         regression_targets (Tensor)
+        use_focal_loss (bool): set to true to use focal loss for clasification
+        gamma (int): adjusts the rate at which easy examples are down-weighted in focal loss
 
     Returns:
         classification_loss (Tensor)

--- a/torchvision/models/detection/roi_heads.py
+++ b/torchvision/models/detection/roi_heads.py
@@ -12,14 +12,15 @@ from . import _utils as det_utils
 
 from torch.jit.annotations import Optional, List, Dict, Tuple
 
+
 def focal_loss(class_logits, target_tensor, gamma=2, reduction='mean', weight=None):
     """
-    Computes the focal loss for classification head 
+    Computes the focal loss for classification head
     of Faster R-CNN. This variant of focal loss does
     not use alpha balancing. Beecause we can use foreground
-    background sampling paramters instead to tackle 
-    foreground background class imballance. This deals 
-    with class imballance and has similar impact to 
+    background sampling paramters instead to tackle
+    foreground background class imballance. This deals
+    with class imballance and has similar impact to
     hard negative mining.
 
     Arguments:
@@ -40,8 +41,9 @@ def focal_loss(class_logits, target_tensor, gamma=2, reduction='mean', weight=No
         ((1 - prob) ** gamma) * log_prob,
         target_tensor,
         weight=weight,
-        reduction = reduction
+        reduction =reduction
     )
+
 
 def fastrcnn_loss(class_logits, box_regression, labels, regression_targets, use_focal_loss=False, gamma=2):
     # type: (Tensor, Tensor, List[Tensor], List[Tensor]) -> Tuple[Tensor, Tensor]
@@ -576,7 +578,7 @@ class RoIHeads(torch.nn.Module):
         self.keypoint_roi_pool = keypoint_roi_pool
         self.keypoint_head = keypoint_head
         self.keypoint_predictor = keypoint_predictor
-        
+
         self.focal_loss = focal_loss
         self.focal_loss_gamma = focal_loss_gamma
 
@@ -796,7 +798,8 @@ class RoIHeads(torch.nn.Module):
         if self.training:
             assert labels is not None and regression_targets is not None
             loss_classifier, loss_box_reg = fastrcnn_loss(
-                class_logits, box_regression, labels, regression_targets, use_focal_loss=self.focal_loss, gamma= self.focal_loss_gamma)
+                class_logits, box_regression, labels, regression_targets,
+                use_focal_loss=self.focal_loss, gamma=self.focal_loss_gamma)
             losses = {
                 "loss_classifier": loss_classifier,
                 "loss_box_reg": loss_box_reg


### PR DESCRIPTION
This pull request adds focal loss to faster rcnn classification loss computation. Currently cross entropy loss is used to for classification:

CE(pt) =−log(pt)
where pt = softmax probability of correct class

Focal loss as defined [here](https://arxiv.org/pdf/1708.02002.pdf) is:
FL(pt) =−(1−pt)^γ log(pt)

Alpha balancing version of focal loss is:
FL(pt) =−αt(1−pt)^γ log(pt)

We are not using the alpha balancing. Alpha balancing is used to tackle imbalance between foreground and background. Since the two stage network intrinsically handles this, we can use foreground background sampling parameters in faster rcnn to handle this kind of imbalance. But imbalance between foreground object classes is not handled, I have used the version of focal loss without alpha balancing for it. 

Focal loss also has an effect similar to hard negative mining, by reducing the contribution of easy examples to loss. Since we don't have hard negative miner in faster rcnn currently, focal loss becomes handy.

I observed slight improvements in my model performance in imbalanced class problems. Interestingly, it is important to make sure all(most) annotations are correct, since I observed that in cases you have some annotation mistakes focal loss can hurt you by over emphasizing on annotation mistakes. 