### PR TITLE
For std::min and std::max cast to like data types

### DIFF
--- a/torchvision/csrc/cpu/decoder/seekable_buffer.cpp
+++ b/torchvision/csrc/cpu/decoder/seekable_buffer.cpp
@@ -55,7 +55,7 @@ bool SeekableBuffer::readBytes(
     size_t maxBytes,
     uint64_t timeoutMs) {
   // Resize to th minimum 4K page or less
-  buffer_.resize(std::min(maxBytes, 4 * 1024UL));
+  buffer_.resize(std::min(maxBytes, size_t(4 * 1024UL)));
   end_ = 0;
   eof_ = false;
 
@@ -72,7 +72,7 @@ bool SeekableBuffer::readBytes(
     if (res > 0) {
       end_ += res;
       if (end_ == buffer_.size()) {
-        buffer_.resize(std::min(end_ * 4UL, maxBytes));
+        buffer_.resize(std::min(size_t(end_ * 4UL), maxBytes));
       }
     } else if (res == 0) {
       eof_ = true;

--- a/torchvision/csrc/cpu/decoder/util.cpp
+++ b/torchvision/csrc/cpu/decoder/util.cpp
@@ -395,8 +395,8 @@ void setFormatDimensions(
     }
   }
   // prevent zeros
-  destW = std::max(destW, 1UL);
-  destH = std::max(destH, 1UL);
+  destW = std::max(destW, size_t(1UL));
+  destH = std::max(destH, size_t(1UL));
 }
 } // namespace Util
 } // namespace ffmpeg


### PR DESCRIPTION
Casting to size_t to comply with std library min and max template requirements that the types should match instead of relying on the compiler to figure it out. 

Since size_t can be many data types, depending on the architecture and compiler, this change should hopefully ensure it is correct.