### PR TITLE
Fixed torch randint incoherent sampling (compatible to random.randint)

### DIFF
--- a/torchvision/transforms/transforms.py
+++ b/torchvision/transforms/transforms.py
@@ -510,8 +510,8 @@ class RandomCrop(torch.nn.Module):
         if w == tw and h == th:
             return 0, 0, h, w
 
-        i = torch.randint(0, h - th, size=(1, )).item()
-        j = torch.randint(0, w - tw, size=(1, )).item()
+        i = torch.randint(0, h - th + 1, size=(1, )).item()
+        j = torch.randint(0, w - tw + 1, size=(1, )).item()
         return i, j, th, tw
 
     def __init__(self, size, padding=None, pad_if_needed=False, fill=0, padding_mode="constant"):
@@ -1433,8 +1433,8 @@ class RandomErasing(torch.nn.Module):
             else:
                 v = torch.tensor(value)[:, None, None]
 
-            i = torch.randint(0, img_h - h, size=(1, )).item()
-            j = torch.randint(0, img_w - w, size=(1, )).item()
+            i = torch.randint(0, img_h - h + 1, size=(1, )).item()
+            j = torch.randint(0, img_w - w + 1, size=(1, )).item()
             return i, j, h, w, v
 
         # Return original image


### PR DESCRIPTION
Description:
- Fixed torch randint incoherent sampling (compatible to `random.randint`)

Code with `random.randint`:
- https://github.com/pytorch/vision/pull/2342/files#diff-549cc9d2872b8748db818d9a51e34708L508

```python
i = random.randint(0, h - th)
j = random.randint(0, w - tw)
```

- https://github.com/pytorch/vision/pull/2386/files#diff-549cc9d2872b8748db818d9a51e34708L1410

```python
i = random.randint(0, img_h - h)
j = random.randint(0, img_w - w)
```