### PR TITLE
replaced mean on dimensions 2,3 by adaptive_avg_pooling2d  (#1838)

### DIFF
--- a/torchvision/models/mobilenet.py
+++ b/torchvision/models/mobilenet.py
@@ -151,7 +151,8 @@ class MobileNetV2(nn.Module):
         # This exists since TorchScript doesn't support inheritance, so the superclass method
         # (this one) needs to have a name other than `forward` that can be accessed in a subclass
         x = self.features(x)
-        x = x.mean([2, 3])
+        # Cannot use "squeeze" as batch-size can be 1 => must use reshape with x.shape[0]
+        x = nn.functional.adaptive_avg_pool2d(x, 1).reshape(x.shape[0], -1)
         x = self.classifier(x)
         return x
 


### PR DESCRIPTION
* replaced mean on dimensions 2,3 by adaptive_avg_pooling2d with destination of 1, to remove hardcoded dimension ordering

* replaced reshape command by torch.squeeze after global_avg_pool2d, which is cleaner

* reshape rather than squeeze for BS=1

* remove import torch