### PR TITLE
PR: Remove linux distribution detection, search first on local paths for libraries

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -254,7 +254,6 @@ def get_extensions():
 
     build_prefix = os.environ.get('BUILD_PREFIX', None)
     is_conda_build = build_prefix is not None
-    running_under_conda = is_conda or is_conda_build
 
     # Locating libPNG
     libpng = distutils.spawn.find_executable('libpng-config')
@@ -275,7 +274,7 @@ def get_extensions():
                 png_lib = subprocess.run([libpng, '--libdir'],
                                          stdout=subprocess.PIPE)
                 png_lib = png_lib.stdout.strip().decode('utf-8')
-                if not png_lib.contains('disabled'):
+                if 'disabled' not in png_lib:
                     image_library += [png_lib]
                 png_include = subprocess.run([libpng, '--I_opts'],
                                              stdout=subprocess.PIPE)

--- a/setup.py
+++ b/setup.py
@@ -88,72 +88,53 @@ def find_library(name, vision_include):
     include_folder = None
     library_header = '{0}.h'.format(name)
 
-    print('Running build on conda-build: {0}'.format(is_conda_build))
-    if is_conda_build:
-        # Add conda headers/libraries
-        if os.name == 'nt':
-            build_prefix = os.path.join(build_prefix, 'Library')
-        include_folder = os.path.join(build_prefix, 'include')
-        lib_folder = os.path.join(build_prefix, 'lib')
-        library_header_path = os.path.join(
-            include_folder, library_header)
-        library_found = os.path.isfile(library_header_path)
-        conda_installed = library_found
-    else:
-        # Check if using Anaconda to produce wheels
-        conda = distutils.spawn.find_executable('conda')
-        is_conda = conda is not None
-        print('Running build on conda: {0}'.format(is_conda))
-        if is_conda:
-            python_executable = sys.executable
-            py_folder = os.path.dirname(python_executable)
+    # Lookup in TORCHVISION_INCLUDE or in the package file
+    package_path = [os.path.join(this_dir, 'torchvision')]
+    for folder in vision_include + package_path:
+        candidate_path = os.path.join(folder, library_header)
+        library_found = os.path.exists(candidate_path)
+        if library_found:
+            break
+
+    if not library_found:
+        print('Running build on conda-build: {0}'.format(is_conda_build))
+        if is_conda_build:
+            # Add conda headers/libraries
             if os.name == 'nt':
-                env_path = os.path.join(py_folder, 'Library')
-            else:
-                env_path = os.path.dirname(py_folder)
-            lib_folder = os.path.join(env_path, 'lib')
-            include_folder = os.path.join(env_path, 'include')
+                build_prefix = os.path.join(build_prefix, 'Library')
+            include_folder = os.path.join(build_prefix, 'include')
+            lib_folder = os.path.join(build_prefix, 'lib')
             library_header_path = os.path.join(
                 include_folder, library_header)
             library_found = os.path.isfile(library_header_path)
             conda_installed = library_found
-
-    if not library_found:
-        if sys.platform == 'linux':
-            library_found = os.path.exists('/usr/include/{0}'.format(
-                library_header))
-            library_found = library_found or os.path.exists(
-                '/usr/local/include/{0}'.format(library_header))
         else:
-            # Lookup in TORCHVISION_INCLUDE or in the package file
-            package_path = [os.path.join(this_dir, 'torchvision')]
-            for folder in vision_include + package_path:
-                candidate_path = os.path.join(folder, library_header)
-                library_found = os.path.exists(candidate_path)
-                if library_found:
-                    break
+            # Check if using Anaconda to produce wheels
+            conda = distutils.spawn.find_executable('conda')
+            is_conda = conda is not None
+            print('Running build on conda: {0}'.format(is_conda))
+            if is_conda:
+                python_executable = sys.executable
+                py_folder = os.path.dirname(python_executable)
+                if os.name == 'nt':
+                    env_path = os.path.join(py_folder, 'Library')
+                else:
+                    env_path = os.path.dirname(py_folder)
+                lib_folder = os.path.join(env_path, 'lib')
+                include_folder = os.path.join(env_path, 'include')
+                library_header_path = os.path.join(
+                    include_folder, library_header)
+                library_found = os.path.isfile(library_header_path)
+                conda_installed = library_found
+
+        if not library_found:
+            if sys.platform == 'linux':
+                library_found = os.path.exists('/usr/include/{0}'.format(
+                    library_header))
+                library_found = library_found or os.path.exists(
+                    '/usr/local/include/{0}'.format(library_header))
 
     return library_found, conda_installed, include_folder, lib_folder
-
-
-def get_linux_distribution():
-    release_data = {}
-    with open("/etc/os-release") as f:
-        reader = csv.reader(f, delimiter="=")
-        for row in reader:
-            if row:
-                release_data[row[0]] = row[1]
-    if release_data["ID"] in ["debian", "raspbian"]:
-        with open("/etc/debian_version") as f:
-            debian_version = f.readline().strip()
-        major_version = debian_version.split(".")[0]
-        version_split = release_data["VERSION"].split(" ", maxsplit=1)
-        if version_split[0] == major_version:
-            # Just major version shown, replace it with the full version
-            release_data["VERSION"] = " ".join(
-                [debian_version] + version_split[1:])
-    print("{} {}".format(release_data["NAME"], release_data["VERSION"]))
-    return release_data
 
 
 def get_extensions():
@@ -291,20 +272,10 @@ def get_extensions():
             png_version = parse_version(png_version)
             if png_version >= parse_version("1.6.0"):
                 print('Building torchvision with PNG image support')
-                linux = sys.platform == 'linux'
-                not_debian = False
-                libpng_on_conda = False
-                if linux:
-                    bin_folder = os.path.dirname(sys.executable)
-                    png_bin_folder = os.path.dirname(libpng)
-                    libpng_on_conda = (
-                        running_under_conda and bin_folder == png_bin_folder)
-                    release_info = get_linux_distribution()
-                    not_debian = release_info["NAME"] not in {'Ubuntu', 'Debian'}
-                if not linux or libpng_on_conda or not_debian:
-                    png_lib = subprocess.run([libpng, '--libdir'],
-                                             stdout=subprocess.PIPE)
-                    png_lib = png_lib.stdout.strip().decode('utf-8')
+                png_lib = subprocess.run([libpng, '--libdir'],
+                                         stdout=subprocess.PIPE)
+                png_lib = png_lib.stdout.strip().decode('utf-8')
+                if not png_lib.contains('disabled'):
                     image_library += [png_lib]
                 png_include = subprocess.run([libpng, '--I_opts'],
                                              stdout=subprocess.PIPE)

--- a/setup.py
+++ b/setup.py
@@ -248,13 +248,6 @@ def get_extensions():
     image_library = []
     image_link_flags = []
 
-    # Detect if build is running under conda/conda-build
-    conda = distutils.spawn.find_executable('conda')
-    is_conda = conda is not None
-
-    build_prefix = os.environ.get('BUILD_PREFIX', None)
-    is_conda_build = build_prefix is not None
-
     # Locating libPNG
     libpng = distutils.spawn.find_executable('libpng-config')
     pngfix = distutils.spawn.find_executable('pngfix')


### PR DESCRIPTION
See https://github.com/pytorch/vision/pull/2398#issuecomment-656245966

This PR removes the need for checking which Linux distribution is being used, additionally it modifies the discovery order of the external libraries, so that `TORCHVISION_INCLUDE` come first, then conda and finally the standard paths