### PR TITLE
Make _resample_video_idx have a consistent output

### DIFF
--- a/torchvision/datasets/video_utils.py
+++ b/torchvision/datasets/video_utils.py
@@ -265,7 +265,7 @@ class VideoClips(object):
             # optimization: if step is integer, don't need to perform
             # advanced indexing
             step = int(step)
-            return slice(None, None, step)
+            return slice(None, num_frames * step, step)
         idxs = torch.arange(num_frames, dtype=torch.float32) * step
         idxs = idxs.floor().to(torch.int64)
         return idxs


### PR DESCRIPTION
I understand that to do resampling, the original number of frames is needed in `VideoClips._resample_video_idx` and that it's an internal method. However, when the `step` is integer, it returns an unbounded slice, as opposed when it's not that it returns a bounded tensor.

What about setting the same boundary in the slice as in the bounded tensor? This is the change I'm proposing.