### PR TITLE
simplify read_image_file and read_label_file functions

### DIFF
--- a/torchvision/datasets/mnist.py
+++ b/torchvision/datasets/mnist.py
@@ -470,16 +470,14 @@ def read_sn3_pascalvincent_tensor(path, strict=True):
 
 
 def read_label_file(path):
-    with open(path, 'rb') as f:
-        x = read_sn3_pascalvincent_tensor(f, strict=False)
+    x = read_sn3_pascalvincent_tensor(path, strict=False)
     assert(x.dtype == torch.uint8)
     assert(x.ndimension() == 1)
     return x.long()
 
 
 def read_image_file(path):
-    with open(path, 'rb') as f:
-        x = read_sn3_pascalvincent_tensor(f, strict=False)
+    x = read_sn3_pascalvincent_tensor(path, strict=False)
     assert(x.dtype == torch.uint8)
     assert(x.ndimension() == 3)
     return x


### PR DESCRIPTION
Summary: I simplified the read_image_file and read_label_file functions to make it easier to adapt this code to use it with other file systems that aren't compatible with the simple open command.

Differential Revision: D22530585

