### PR TITLE
fix resnet_fpn_backbone docstring, allow backbone to be pluggable

### DIFF
--- a/test/test_backbone_utils.py
+++ b/test/test_backbone_utils.py
@@ -3,6 +3,7 @@ import unittest
 
 import torch
 from torchvision.models.detection.backbone_utils import resnet_fpn_backbone
+from torchvision.models import resnet50
 
 
 class ResnetFPNBackboneTester(unittest.TestCase):
@@ -13,13 +14,43 @@ class ResnetFPNBackboneTester(unittest.TestCase):
     def test_resnet18_fpn_backbone(self):
         device = torch.device('cpu')
         x = torch.rand(1, 3, 300, 300, dtype=self.dtype, device=device)
-        resnet18_fpn = resnet_fpn_backbone(backbone_name='resnet18', pretrained=False)
+        resnet18_fpn = resnet_fpn_backbone(backbone='resnet18', pretrained=False)
         y = resnet18_fpn(x)
         self.assertEqual(list(y.keys()), ['0', '1', '2', '3', 'pool'])
 
     def test_resnet50_fpn_backbone(self):
         device = torch.device('cpu')
         x = torch.rand(1, 3, 300, 300, dtype=self.dtype, device=device)
-        resnet50_fpn = resnet_fpn_backbone(backbone_name='resnet50', pretrained=False)
+        resnet50_fpn = resnet_fpn_backbone(backbone='resnet50', pretrained=False)
         y = resnet50_fpn(x)
         self.assertEqual(list(y.keys()), ['0', '1', '2', '3', 'pool'])
+
+    def test_resnet50_fpn_backbone_with_callable(self):
+        device = torch.device('cpu')
+        x = torch.rand(1, 3, 300, 300, dtype=self.dtype, device=device)
+        resnet50_fpn = resnet_fpn_backbone(backbone=resnet50, pretrained=False)
+        y = resnet50_fpn(x)
+        self.assertEqual(list(y.keys()), ['0', '1', '2', '3', 'pool'])
+
+    def test_resnet101_fpn_backbone(self):
+        device = torch.device('cpu')
+        x = torch.rand(1, 3, 300, 300, dtype=self.dtype, device=device)
+        resnet101_fpn = resnet_fpn_backbone(backbone='resnet101', pretrained=False)
+        y = resnet101_fpn(x)
+        self.assertEqual(list(y.keys()), ['0', '1', '2', '3', 'pool'])
+
+    def test_resnet_fpn_backbone_invalid_backbone_type(self):
+        with self.assertRaises(Exception):
+            resnet_fpn_backbone(backbone=1, pretrained=False)
+
+    def test_resnet_fpn_backbone_invalid_model_name(self):
+        with self.assertRaises(Exception):
+            resnet_fpn_backbone(backbone='resnet20', pretrained=False)
+
+    def test_resnet18_fpn_backbone_invalid_frozen_layers(self):
+        with self.assertRaises(Exception):
+            resnet_fpn_backbone(backbone='resnet18', pretrained=False, trainable_layers=6)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_onnx.py
+++ b/test/test_onnx.py
@@ -5,7 +5,6 @@ from torchvision import models
 from torchvision.models.detection.image_list import ImageList
 from torchvision.models.detection.transform import GeneralizedRCNNTransform
 from torchvision.models.detection.rpn import AnchorGenerator, RPNHead, RegionProposalNetwork
-from torchvision.models.detection.backbone_utils import resnet_fpn_backbone
 from torchvision.models.detection.roi_heads import RoIHeads
 from torchvision.models.detection.faster_rcnn import FastRCNNPredictor, TwoMLPHead
 from torchvision.models.detection.mask_rcnn import MaskRCNNHeads, MaskRCNNPredictor


### PR DESCRIPTION
this PR addresses two issues:

1. fix the docstring position for `resnet_fpn_backbone`
2. allow `resnet_fpn_backbone` to be used with compatible backbones other than the list provided in `resnet` module, e.g. resnext and resnest

the misplaced docstring was added in https://github.com/pytorch/vision/pull/2160.