### PR TITLE
remove reduntant target send to device

### DIFF
--- a/references/detection/engine.py
+++ b/references/detection/engine.py
@@ -83,7 +83,6 @@ def evaluate(model, data_loader, device):
 
     for images, targets in metric_logger.log_every(data_loader, 100, header):
         images = list(img.to(device) for img in images)
-        targets = [{k: v.to(device) for k, v in t.items()} for t in targets]
 
         torch.cuda.synchronize()
         model_time = time.time()


### PR DESCRIPTION
It seems to be redundant sending to the device of targets during the evaluation 
#2502 