### PR TITLE
[release/0.7] .circleci: Remove CUDA 9.2 for windows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -475,15 +475,6 @@ workflows:
           name: binary_win_wheel_py3.6_cpu
           python_version: '3.6'
       - binary_win_wheel_release:
-          cu_version: cu92
-          filters:
-            branches:
-              only: master
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: binary_win_wheel_py3.6_cu92
-          python_version: '3.6'
-      - binary_win_wheel_release:
           cu_version: cu101
           filters:
             branches:
@@ -511,15 +502,6 @@ workflows:
           name: binary_win_wheel_py3.7_cpu
           python_version: '3.7'
       - binary_win_wheel_release:
-          cu_version: cu92
-          filters:
-            branches:
-              only: master
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: binary_win_wheel_py3.7_cu92
-          python_version: '3.7'
-      - binary_win_wheel_release:
           cu_version: cu101
           filters:
             branches:
@@ -540,15 +522,6 @@ workflows:
       - binary_win_wheel_release:
           cu_version: cpu
           name: binary_win_wheel_py3.8_cpu
-          python_version: '3.8'
-      - binary_win_wheel_release:
-          cu_version: cu92
-          filters:
-            branches:
-              only: master
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: binary_win_wheel_py3.8_cu92
           python_version: '3.8'
       - binary_win_wheel_release:
           cu_version: cu101
@@ -648,15 +621,6 @@ workflows:
           name: binary_win_conda_py3.6_cpu
           python_version: '3.6'
       - binary_win_conda_release:
-          cu_version: cu92
-          filters:
-            branches:
-              only: master
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: binary_win_conda_py3.6_cu92
-          python_version: '3.6'
-      - binary_win_conda_release:
           cu_version: cu101
           filters:
             branches:
@@ -684,15 +648,6 @@ workflows:
           name: binary_win_conda_py3.7_cpu
           python_version: '3.7'
       - binary_win_conda_release:
-          cu_version: cu92
-          filters:
-            branches:
-              only: master
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: binary_win_conda_py3.7_cu92
-          python_version: '3.7'
-      - binary_win_conda_release:
           cu_version: cu101
           filters:
             branches:
@@ -713,15 +668,6 @@ workflows:
       - binary_win_conda_release:
           cu_version: cpu
           name: binary_win_conda_py3.8_cpu
-          python_version: '3.8'
-      - binary_win_conda_release:
-          cu_version: cu92
-          filters:
-            branches:
-              only: master
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: binary_win_conda_py3.8_cu92
           python_version: '3.8'
       - binary_win_conda_release:
           cu_version: cu101
@@ -1094,26 +1040,6 @@ workflows:
           - nightly_binary_win_wheel_py3.6_cpu
           subfolder: cpu/
       - binary_win_wheel_release:
-          cu_version: cu92
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_win_wheel_py3.6_cu92
-          python_version: '3.6'
-      - binary_wheel_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_win_wheel_py3.6_cu92_upload
-          requires:
-          - nightly_binary_win_wheel_py3.6_cu92
-          subfolder: cu92/
-      - binary_win_wheel_release:
           cu_version: cu101
           filters:
             branches:
@@ -1174,26 +1100,6 @@ workflows:
           - nightly_binary_win_wheel_py3.7_cpu
           subfolder: cpu/
       - binary_win_wheel_release:
-          cu_version: cu92
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_win_wheel_py3.7_cu92
-          python_version: '3.7'
-      - binary_wheel_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_win_wheel_py3.7_cu92_upload
-          requires:
-          - nightly_binary_win_wheel_py3.7_cu92
-          subfolder: cu92/
-      - binary_win_wheel_release:
           cu_version: cu101
           filters:
             branches:
@@ -1253,26 +1159,6 @@ workflows:
           requires:
           - nightly_binary_win_wheel_py3.8_cpu
           subfolder: cpu/
-      - binary_win_wheel_release:
-          cu_version: cu92
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_win_wheel_py3.8_cu92
-          python_version: '3.8'
-      - binary_wheel_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_win_wheel_py3.8_cu92_upload
-          requires:
-          - nightly_binary_win_wheel_py3.8_cu92
-          subfolder: cu92/
       - binary_win_wheel_release:
           cu_version: cu101
           filters:
@@ -1633,25 +1519,6 @@ workflows:
           requires:
           - nightly_binary_win_conda_py3.6_cpu
       - binary_win_conda_release:
-          cu_version: cu92
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_win_conda_py3.6_cu92
-          python_version: '3.6'
-      - binary_conda_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_win_conda_py3.6_cu92_upload
-          requires:
-          - nightly_binary_win_conda_py3.6_cu92
-      - binary_win_conda_release:
           cu_version: cu101
           filters:
             branches:
@@ -1709,25 +1576,6 @@ workflows:
           requires:
           - nightly_binary_win_conda_py3.7_cpu
       - binary_win_conda_release:
-          cu_version: cu92
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_win_conda_py3.7_cu92
-          python_version: '3.7'
-      - binary_conda_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_win_conda_py3.7_cu92_upload
-          requires:
-          - nightly_binary_win_conda_py3.7_cu92
-      - binary_win_conda_release:
           cu_version: cu101
           filters:
             branches:
@@ -1784,25 +1632,6 @@ workflows:
           name: nightly_binary_win_conda_py3.8_cpu_upload
           requires:
           - nightly_binary_win_conda_py3.8_cpu
-      - binary_win_conda_release:
-          cu_version: cu92
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_win_conda_py3.8_cu92
-          python_version: '3.8'
-      - binary_conda_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_win_conda_py3.8_cu92_upload
-          requires:
-          - nightly_binary_win_conda_py3.8_cu92
       - binary_win_conda_release:
           cu_version: cu101
           filters:

--- a/.circleci/regenerate.py
+++ b/.circleci/regenerate.py
@@ -28,6 +28,8 @@ def workflows(prefix='', filter_branch=None, upload=False, indentation=6, window
             for python_version in python_versions:
                 for cu_version in cu_versions:
                     for unicode in ([False, True] if btype == "wheel" and python_version == "2.7" else [False]):
+                        if os_type == "win" and cu_version == "cu92":
+                            continue
                         fb = filter_branch
                         if windows_latest_only and os_type == "win" and filter_branch is None and \
                             (python_version != python_versions[-1] or


### PR DESCRIPTION
There is an outstanding issue with JIT for pytorch binaries compiled
with Visual Studio 2014.

Since CUDA 9.2 is only compilable with Visual Studio 2014 we have
decided to drop it altogether.

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>