### PR TITLE
Clarify scaling of ToTensor transform for target masks in the documentation

### DIFF
--- a/torchvision/transforms/transforms.py
+++ b/torchvision/transforms/transforms.py
@@ -76,7 +76,9 @@ class ToTensor(object):
 
     .. note::
         Because the input image is scaled to [0.0, 1.0], this transformation should not be used when
-        transforming target image masks. See the references for implementing the transforms for image masks.
+        transforming target image masks. See the `references`_ for implementing the transforms for image masks.
+
+    .. _references: https://github.com/pytorch/vision/tree/master/references/segmentation
     """
 
     def __call__(self, pic):

--- a/torchvision/transforms/transforms.py
+++ b/torchvision/transforms/transforms.py
@@ -73,6 +73,10 @@ class ToTensor(object):
     or if the numpy.ndarray has dtype = np.uint8
 
     In the other cases, tensors are returned without scaling.
+
+    .. note::
+        Because the input image is scaled to [0.0, 1.0], this transformation should not be used when
+        transforming target image masks. See the references for implementing the transforms for image masks.
     """
 
     def __call__(self, pic):


### PR DESCRIPTION
As discussed in #2497 this should clarify that the scope of ToTensor() does not include target image masks, but only input images, because masks will be subject to the [0,1] scaling which is not desired.

I was not sure if I should add a link to the references (https://github.com/pytorch/vision/tree/master/references) and what the format in the documentation should be (absolute/relative link?).