### PR TITLE
Fixed resize to only match the smaller edge when an int is given

### DIFF
--- a/test/test_functional_tensor.py
+++ b/test/test_functional_tensor.py
@@ -337,7 +337,7 @@ class Tester(unittest.TestCase):
             if dt is not None:
                 # This is a trivial cast to float of uint8 data to test all cases
                 tensor = tensor.to(dt)
-            for size in [32, [32, ], [32, 32], (32, 32), ]:
+            for size in [32, 26, [32, ], [32, 32], (32, 32), [26, 35]]:
                 for interpolation in [BILINEAR, BICUBIC, NEAREST]:
                     resized_tensor = F_t.resize(tensor, size=size, interpolation=interpolation)
                     resized_pil_img = F_pil.resize(pil_img, size=size, interpolation=interpolation)

--- a/test/test_transforms_tensor.py
+++ b/test/test_transforms_tensor.py
@@ -226,7 +226,7 @@ class Tester(unittest.TestCase):
             if dt is not None:
                 # This is a trivial cast to float of uint8 data to test all cases
                 tensor = tensor.to(dt)
-            for size in [32, [32, ], [32, 32], (32, 32), ]:
+            for size in [32, 34, [32, ], [32, 32], (32, 32), [34, 35]]:
                 for interpolation in [BILINEAR, BICUBIC, NEAREST]:
 
                     resized_tensor = F.resize(tensor, size=size, interpolation=interpolation)
@@ -250,7 +250,7 @@ class Tester(unittest.TestCase):
 
         for scale in [(0.7, 1.2), [0.7, 1.2]]:
             for ratio in [(0.75, 1.333), [0.75, 1.333]]:
-                for size in [(32, ), [32, ], [32, 32], (32, 32)]:
+                for size in [(32, ), [44, ], [32, ], [32, 32], (32, 32), [44, 55]]:
                     for interpolation in [NEAREST, BILINEAR, BICUBIC]:
                         transform = T.RandomResizedCrop(
                             size=size, scale=scale, ratio=ratio, interpolation=interpolation

--- a/torchvision/transforms/functional_tensor.py
+++ b/torchvision/transforms/functional_tensor.py
@@ -586,8 +586,8 @@ def resize(img: Tensor, size: List[int], interpolation: int = 2) -> Tensor:
         else:
             size_w = int(size_h * w / h)
 
-    if (w <= h and w == size_w) or (h <= w and h == size_h):
-        return img
+        if (w <= h and w == size_w) or (h <= w and h == size_h):
+            return img
 
     # make image NCHW
     need_squeeze = False


### PR DESCRIPTION
The smaller edge should be matched and the aspect ratio should be kept the same *only* when one int or a list of one element is given. When an explicit tuple of (h,w) is given, the image should always be resized to the requested size

This fixes #2517 