### PR TITLE
Only pull keys from db in lsun for faster cache.

### DIFF
--- a/torchvision/datasets/lsun.py
+++ b/torchvision/datasets/lsun.py
@@ -24,7 +24,7 @@ class LSUNClass(VisionDataset):
             self.keys = pickle.load(open(cache_file, "rb"))
         else:
             with self.env.begin(write=False) as txn:
-                self.keys = [key for key, _ in txn.cursor()]
+                self.keys = [key for key in txn.cursor().iternext(keys=True, values=False)]
             pickle.dump(self.keys, open(cache_file, "wb"))
 
     def __getitem__(self, index):

--- a/torchvision/datasets/lsun.py
+++ b/torchvision/datasets/lsun.py
@@ -103,10 +103,10 @@ class LSUN(VisionDataset):
                 raise ValueError(msg.format(type(classes)))
 
             classes = list(classes)
-            msg_fmtstr = ("Expected type str for elements in argument classes, "
+            msg_fmtstr_type = ("Expected type str for elements in argument classes, "
                           "but got type {}.")
             for c in classes:
-                verify_str_arg(c, custom_msg=msg_fmtstr.format(type(c)))
+                verify_str_arg(c, custom_msg=msg_fmtstr_type.format(type(c)))
                 c_short = c.split('_')
                 category, dset_opt = '_'.join(c_short[:-1]), c_short[-1]
 

--- a/torchvision/datasets/lsun.py
+++ b/torchvision/datasets/lsun.py
@@ -104,7 +104,7 @@ class LSUN(VisionDataset):
 
             classes = list(classes)
             msg_fmtstr_type = ("Expected type str for elements in argument classes, "
-                          "but got type {}.")
+                               "but got type {}.")
             for c in classes:
                 verify_str_arg(c, custom_msg=msg_fmtstr_type.format(type(c)))
                 c_short = c.split('_')


### PR DESCRIPTION
This pull request inhances the speed of the cache creation for lsun dataset. For the "kitchen_train" the speed was getting slow with cache creation taking more then two hours. This speeds up to cache creation in within minutes. The issue was pulling the large image values each time and dropping them.



For more details on this please refer this issue https://github.com/jnwatson/py-lmdb/issues/195.

Also fixes a bug when using multiple categories in lsun dataset