### PR TITLE
Adapted functional tensor tests on CPU/CUDA

### DIFF
--- a/test/test_functional_tensor.py
+++ b/test/test_functional_tensor.py
@@ -52,7 +52,7 @@ class Tester(unittest.TestCase):
     @run_on_cpu_and_cuda
     def test_vflip(self, device):
         script_vflip = torch.jit.script(F_t.vflip)
-        img_tensor = torch.randn(3, 16, 16).to(device=device)
+        img_tensor = torch.randn(3, 16, 16, device=device)
         img_tensor_clone = img_tensor.clone()
         vflipped_img = F_t.vflip(img_tensor)
         vflipped_img_again = F_t.vflip(vflipped_img)
@@ -66,7 +66,7 @@ class Tester(unittest.TestCase):
     @run_on_cpu_and_cuda
     def test_hflip(self, device):
         script_hflip = torch.jit.script(F_t.hflip)
-        img_tensor = torch.randn(3, 16, 16).to(device)
+        img_tensor = torch.randn(3, 16, 16, device=device)
         img_tensor_clone = img_tensor.clone()
         hflipped_img = F_t.hflip(img_tensor)
         hflipped_img_again = F_t.hflip(hflipped_img)

--- a/test/test_functional_tensor.py
+++ b/test/test_functional_tensor.py
@@ -227,7 +227,9 @@ class Tester(unittest.TestCase):
         self.assertTrue(torch.equal(cropped_script, cropped_tensor))
 
     def test_five_crop(self):
+        script_five_crop = torch.jit.script(F_t.five_crop)
         img_tensor = torch.randint(0, 255, (1, 32, 32), dtype=torch.uint8)
+        img_tensor_clone = img_tensor.clone()
         cropped_tensor = F_t.five_crop(img_tensor, [10, 10])
         cropped_pil_image = F.five_crop(transforms.ToPILImage()(img_tensor), [10, 10])
         self.assertTrue(torch.equal(cropped_tensor[0],
@@ -240,6 +242,11 @@ class Tester(unittest.TestCase):
                                     (transforms.ToTensor()(cropped_pil_image[3]) * 255).to(torch.uint8)))
         self.assertTrue(torch.equal(cropped_tensor[4],
                                     (transforms.ToTensor()(cropped_pil_image[4]) * 255).to(torch.uint8)))
+        self.assertTrue(torch.equal(img_tensor, img_tensor_clone))
+        # scriptable function test
+        cropped_script = script_five_crop(img_tensor, [10, 10])
+        for cropped_script_img, cropped_tensor_img in zip(cropped_script, cropped_tensor):
+            self.assertTrue(torch.equal(cropped_script_img, cropped_tensor_img))
 
     def test_ten_crop(self):
         script_ten_crop = torch.jit.script(F_t.ten_crop)

--- a/torchvision/transforms/functional.py
+++ b/torchvision/transforms/functional.py
@@ -223,12 +223,10 @@ def to_pil_image(pic, mode=None):
             pic = np.expand_dims(pic, 2)
 
     npimg = pic
-    if pic.is_floating_point() and mode != 'F':
-        pic = pic.mul(255).byte()
     if isinstance(pic, torch.Tensor):
-        if pic.device != torch.device("cpu"):
-            pic = pic.cpu()
-        npimg = np.transpose(pic.numpy(), (1, 2, 0))
+        if pic.is_floating_point() and mode != 'F':
+            pic = pic.mul(255).byte()
+        npimg = np.transpose(pic.cpu().numpy(), (1, 2, 0))
 
     if not isinstance(npimg, np.ndarray):
         raise TypeError('Input pic must be a torch.Tensor or NumPy ndarray, ' +

--- a/torchvision/transforms/functional.py
+++ b/torchvision/transforms/functional.py
@@ -223,9 +223,11 @@ def to_pil_image(pic, mode=None):
             pic = np.expand_dims(pic, 2)
 
     npimg = pic
-    if isinstance(pic, torch.FloatTensor) and mode != 'F':
+    if pic.is_floating_point() and mode != 'F':
         pic = pic.mul(255).byte()
     if isinstance(pic, torch.Tensor):
+        if pic.device != torch.device("cpu"):
+            pic = pic.cpu()
         npimg = np.transpose(pic.numpy(), (1, 2, 0))
 
     if not isinstance(npimg, np.ndarray):

--- a/torchvision/transforms/functional_tensor.py
+++ b/torchvision/transforms/functional_tensor.py
@@ -659,6 +659,9 @@ def _apply_grid_transform(img: Tensor, grid: Tensor, mode: str) -> Tensor:
         need_cast = True
         img = img.to(torch.float32)
 
+    if grid.device.type != img.device.type:
+        grid = grid.to(img)
+
     img = grid_sample(img, grid, mode=mode, padding_mode="zeros", align_corners=False)
 
     if need_squeeze:


### PR DESCRIPTION
Related to https://github.com/pytorch/vision/issues/2292#issuecomment-665557690

Description:

- fixed bug with transforms using generated grid
- remains `*_crop`, blocked by #2568 -> done

TODO: 
- [x] Adapt test_adjustments
- [ ] Adapt test_rgb_to_grayscale