### PR TITLE
Expose WITH_CUDA flag to CPP code.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ option(WITH_CUDA "Enable CUDA support" OFF)
 if(WITH_CUDA)
   enable_language(CUDA)
   add_definitions(-D__CUDA_NO_HALF_OPERATORS__)
+  add_definitions(-DWITH_CUDA)
 endif()
 
 find_package(Python3 COMPONENTS Development)


### PR DESCRIPTION
This PR exposes the definition of the `WITH_CUDA` flag to the CPP code.

It solves: 
https://github.com/pytorch/vision/issues/2575