### PR TITLE
Use include_directories, to help packaging of C++.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,10 +33,7 @@ target_link_libraries(${PROJECT_NAME} PRIVATE ${TORCH_LIBRARIES} ${PNG_LIBRARY} 
 # target_link_libraries(${PROJECT_NAME} PRIVATE ${PNG_LIBRARY} Python3::Python)
 set_target_properties(${PROJECT_NAME} PROPERTIES EXPORT_NAME TorchVision)
 
-target_include_directories(${PROJECT_NAME} INTERFACE
-  $<BUILD_INTERFACE:${HEADERS}:${PNG_INCLUDE_DIR}:${JPEG_INCLUDE_DIRS}>
-  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
-
+include_directories(torchvision/csrc)
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 


### PR DESCRIPTION
This PR helps packaging the C++ library of torchvision, making its build non dependent of the machine that packaged the library.

The problem is due to the usage of `INTERFACE_INCLUDE_DIRECTORIES` in the CMakeLists file, _since it is not advisable to populate the_ `INSTALL_INTERFACE` _of the_ `INTERFACE_INCLUDE_DIRECTORIES` _of a target with paths for dependencies. That would hard-code into installed packages the include directory paths for dependencies as found on the machine the package was made on_ [[source](https://cmake.org/cmake/help/v3.2/prop_tgt/INTERFACE_INCLUDE_DIRECTORIES.html)].

Follow up of pull request:
https://github.com/pytorch/vision/pull/2446