### PR TITLE
Places365 dataset

### DIFF
--- a/docs/source/datasets.rst
+++ b/docs/source/datasets.rst
@@ -166,6 +166,13 @@ PhotoTour
   :members: __getitem__
   :special-members:
 
+Places365
+~~~~~~~~~
+
+.. autoclass:: Places365
+  :members: __getitem__
+  :special-members:
+
 QMNIST
 ~~~~~~
 

--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -361,6 +361,18 @@ class Tester(unittest.TestCase):
 
                     assert all(os.path.exists(item[0]) for item in dataset.imgs)
 
+    def test_places365_images_download_preexisting(self):
+        split = "train-standard"
+        small = False
+        images_dir = "train_large_places365standard"
+
+        with places365_root(split=split, small=small) as places365:
+            root, data = places365
+            os.mkdir(os.path.join(root, images_dir))
+
+            with self.assertRaises(RuntimeError):
+                torchvision.datasets.Places365(root, split=split, small=small, download=True)
+
     def test_places365_repr_smoke(self):
         with places365_root(extract_images=False) as places365:
             root, data = places365

--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -369,5 +369,6 @@ class Tester(unittest.TestCase):
             dataset = torchvision.datasets.Places365(root, download=True)
             self.assertIsInstance(repr(dataset), str)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -9,8 +9,11 @@ from torch._utils_internal import get_file_path_2
 import torchvision
 from common_utils import get_tmp_dir
 from fakedata_generation import mnist_root, cifar_root, imagenet_root, \
-    cityscapes_root, svhn_root, voc_root, ucf101_root
+    cityscapes_root, svhn_root, voc_root, ucf101_root, places365_root
 import xml.etree.ElementTree as ET
+from urllib.parse import urljoin
+from urllib.request import Request, urlopen
+import itertools
 
 
 try:
@@ -280,6 +283,91 @@ class Tester(unittest.TestCase):
                         self.assertEqual(audio.numel(), 0)
                         self.assertEqual(label, 1)
 
+    def test_places365(self):
+        for split, small in itertools.product(("train-standard", "train-challenge", "val", "test"), (False, True)):
+            with places365_root(split=split, small=small) as places365:
+                root, data = places365
+
+                dataset = torchvision.datasets.Places365(root, split=split, small=small, download=True)
+                self.generic_classification_dataset_test(dataset, num_images=len(data["imgs"]))
+
+    def test_places365_transforms(self):
+        expected_image = "image"
+        expected_target = "target"
+
+        def transform(image):
+            return expected_image
+
+        def target_transform(target):
+            return expected_target
+
+        with places365_root() as places365:
+            root, data = places365
+
+            dataset = torchvision.datasets.Places365(
+                root, transform=transform, target_transform=target_transform, download=True
+            )
+            actual_image, actual_target = dataset[0]
+
+            self.assertEqual(actual_image, expected_image)
+            self.assertEqual(actual_target, expected_target)
+
+    @mock.patch("torchvision.datasets.utils.download_url")
+    def test_places365_downloadable(self, download_url):
+        for split, small in itertools.product(("train-standard", "train-challenge", "val", "test"), (False, True)):
+            with places365_root(split=split, small=small) as places365:
+                root, data = places365
+
+                torchvision.datasets.Places365(root, split=split, small=small, download=True)
+
+        urls = {call_args[0][0] for call_args in download_url.call_args_list}
+        for url in urls:
+            with self.subTest(url=url):
+                response = urlopen(Request(url, method="HEAD"))
+                assert response.code == 200, f"Server returned status code {response.code} for {url}."
+
+    def test_places365_devkit_download(self):
+        for split in ("train-standard", "train-challenge", "val", "test"):
+            with self.subTest(split=split):
+                with places365_root(split=split) as places365:
+                    root, data = places365
+
+                    dataset = torchvision.datasets.Places365(root, split=split, download=True)
+
+                    with self.subTest("classes"):
+                        self.assertSequenceEqual(dataset.classes, data["classes"])
+
+                    with self.subTest("class_to_idx"):
+                        self.assertDictEqual(dataset.class_to_idx, data["class_to_idx"])
+
+                    with self.subTest("imgs"):
+                        self.assertSequenceEqual(dataset.imgs, data["imgs"])
+
+    def test_places365_devkit_no_download(self):
+        for split in ("train-standard", "train-challenge", "val", "test"):
+            with self.subTest(split=split):
+                with places365_root(split=split, extract_images=False) as places365:
+                    root, data = places365
+
+                    with self.assertRaises(RuntimeError):
+                        torchvision.datasets.Places365(root, split=split, download=False)
+
+    def test_places365_images_download(self):
+        for split, small in itertools.product(("train-standard", "train-challenge", "val", "test"), (False, True)):
+            with self.subTest(split=split, small=small):
+                with places365_root(split=split, small=small) as places365:
+                    root, data = places365
+
+                    dataset = torchvision.datasets.Places365(root, split=split, small=small, download=True)
+
+                    assert all(os.path.exists(item[0]) for item in dataset.imgs)
+
+    def test_places365_repr_smoke(self):
+        with places365_root(extract_images=False) as places365:
+            root, data = places365
+
+            dataset = torchvision.datasets.Places365(root, download=True)
+            self.assertIsInstance(repr(dataset), str)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -11,7 +11,6 @@ from common_utils import get_tmp_dir
 from fakedata_generation import mnist_root, cifar_root, imagenet_root, \
     cityscapes_root, svhn_root, voc_root, ucf101_root, places365_root
 import xml.etree.ElementTree as ET
-from urllib.parse import urljoin
 from urllib.request import Request, urlopen
 import itertools
 

--- a/torchvision/datasets/__init__.py
+++ b/torchvision/datasets/__init__.py
@@ -22,6 +22,7 @@ from .usps import USPS
 from .kinetics import Kinetics400
 from .hmdb51 import HMDB51
 from .ucf101 import UCF101
+from .places365 import Places365
 
 __all__ = ('LSUN', 'LSUNClass',
            'ImageFolder', 'DatasetFolder', 'FakeData',
@@ -31,4 +32,4 @@ __all__ = ('LSUN', 'LSUNClass',
            'Omniglot', 'SBU', 'Flickr8k', 'Flickr30k',
            'VOCSegmentation', 'VOCDetection', 'Cityscapes', 'ImageNet',
            'Caltech101', 'Caltech256', 'CelebA', 'SBDataset', 'VisionDataset',
-           'USPS', 'Kinetics400', 'HMDB51', 'UCF101')
+           'USPS', 'Kinetics400', 'HMDB51', 'UCF101', 'Places365')

--- a/torchvision/datasets/places365.py
+++ b/torchvision/datasets/places365.py
@@ -15,7 +15,8 @@ class Places365(VisionDataset):
         root (string): Root directory of the Places365 dataset.
         split (string, optional): The dataset split. Can be one of ``train-standard`` (default), ``train-challendge``,
             ``val``, and ``test``.
-        small (bool, optional):
+        small (bool, optional): If ``True``, uses the small images, i. e. resized to 256 x 256 pixels, instead of the
+            high resolution ones.
         download (bool, optional): If ``True``, downloads the dataset components and places them in ``root``. Already
             downloaded archives are not downloaded again.
         transform (callable, optional): A function/transform that  takes in an PIL image

--- a/torchvision/datasets/places365.py
+++ b/torchvision/datasets/places365.py
@@ -9,6 +9,30 @@ from .vision import VisionDataset
 
 
 class Places365(VisionDataset):
+    r"""`Places365 <http://places2.csail.mit.edu/index.html>`_ classification dataset.
+
+    Args:
+        root (string): Root directory of the Places365 dataset.
+        split (string, optional): The dataset split. Can be one of ``train-standard`` (default), ``train-challendge``,
+            ``val``, and ``test``.
+        small (bool, optional):
+        download (bool, optional): If ``True``, downloads the dataset components and places them in ``root``. Already
+            downloaded archives are not downloaded again.
+        transform (callable, optional): A function/transform that  takes in an PIL image
+            and returns a transformed version. E.g, ``transforms.RandomCrop``
+        target_transform (callable, optional): A function/transform that takes in the
+            target and transforms it.
+        loader (callable, optional): A function to load an image given its path.
+
+     Attributes:
+        classes (list): List of the class names.
+        class_to_idx (dict): Dict with items (class_name, class_index).
+        imgs (list): List of (image path, class_index) tuples
+        targets (list): The class_index value for each image in the dataset
+
+    Raises:
+        RuntimeError: If ``download is False`` and the meta files, i. e. the devkit, are not present or corrupted.
+    """
     _SPLITS = ("train-standard", "train-challenge", "val", "test")
     _BASE_URL = "http://data.csail.mit.edu/places/places365/"
     # {variant: (archive, md5)}

--- a/torchvision/datasets/places365.py
+++ b/torchvision/datasets/places365.py
@@ -113,7 +113,7 @@ class Places365(VisionDataset):
             images = [process(line) for line in fh]
 
         _, targets = zip(*images)
-        return images, targets
+        return images, list(targets)
 
     def download_devkit(self) -> None:
         file, md5 = self._DEVKIT_META["challenge" if self.split == "train-challenge" else "standard"]

--- a/torchvision/datasets/places365.py
+++ b/torchvision/datasets/places365.py
@@ -32,6 +32,7 @@ class Places365(VisionDataset):
 
     Raises:
         RuntimeError: If ``download is False`` and the meta files, i. e. the devkit, are not present or corrupted.
+        RuntimeError: If ``download is True`` and the image archive is already extracted.
     """
     _SPLITS = ("train-standard", "train-challenge", "val", "test")
     _BASE_URL = "http://data.csail.mit.edu/places/places365/"
@@ -145,6 +146,12 @@ class Places365(VisionDataset):
         download_and_extract_archive(urljoin(self._BASE_URL, file), self.root, md5=md5)
 
     def download_images(self) -> None:
+        if path.exists(self.images_dir):
+            raise RuntimeError(
+                f"The directory {self.images_dir} already exists. If you want to re-download or re-extract the images, "
+                f"delete the directory."
+            )
+
         file, md5 = self._IMAGES_META[(self.split, self.small)]
         download_and_extract_archive(urljoin(self._BASE_URL, file), self.root, extract_root=self.images_dir, md5=md5)
 

--- a/torchvision/datasets/places365.py
+++ b/torchvision/datasets/places365.py
@@ -119,8 +119,10 @@ class Places365(VisionDataset):
 
     def load_file_list(self, download: bool = True) -> Tuple[List[Tuple[str, int]], List[int]]:
         def fix_path(path: str) -> str:
-            if path[0] == "/":
-                path = path[1:]
+            if not path.startswith("/"):
+                return path
+
+            path = path[1:]
 
             if os.sep == "/":
                 return path

--- a/torchvision/datasets/places365.py
+++ b/torchvision/datasets/places365.py
@@ -1,0 +1,89 @@
+from os import path
+from typing import Any, Tuple
+from urllib.parse import urljoin
+
+from .folder import ImageFolder
+from .utils import verify_str_arg
+
+
+class Places365(ImageFolder):
+    _BASE_URL = "http://data.csail.mit.edu/places/places365/"
+    # {variant: (archive, md5)}
+    _DEVKIT_META = {
+        "standard": ("filelist_places365-standard.tar", "35a0585fee1fa656440f3ab298f8479c"),
+        "challenge": ("filelist_places365-standard.tar", ""),
+    }
+    # {(split, high_res): (archive, md5)}
+    _IMAGE_ARCHIVE_META = {
+        ("train-standard", True): ("train_large_places365standard.tar", "67e186b496a84c929568076ed01a8aa1"),
+        ("train-challenge", True): ("train_large_places365challenge.tar", "605f18e68e510c82b958664ea134545f"),
+        ("val", True): ("val_large.tar", "9b71c4993ad89d2d8bcbdc4aef38042f"),
+        ("test", True): ("test_large.tar", "41a4b6b724b1d2cd862fb3871ed59913"),
+        ("train-standard", False): ("train_256_places365standard.tar", "53ca1c756c3d1e7809517cc47c5561c5"),
+        ("train-challenge", False): ("train_256_places365challenge.tar", "741915038a5e3471ec7332404dfb64ef"),
+        ("val", False): ("val_256.tar", "e27b17d8d44f4af9a78502beb927f808"),
+        ("test", False): ("test_256.tar", "f532f6ad7b582262a2ec8009075e186b"),
+    }
+    _SPLITS = ("train-standard", "train-challenge", "val", "test")
+
+    def __init__(
+        self, root: str, split: str = "train-standard", high_res: bool = True, download: bool = False, **kwargs: Any
+    ) -> None:
+        self.root = root = path.abspath(path.expanduser(root))
+        self.split = self._verify_split(split)
+        self.high_res = high_res
+
+        if download:
+            self.download()
+
+        super().__init__(root, **kwargs)
+        self.root = root
+
+    def _verify_split(self, split: str) -> str:
+        return verify_str_arg(split, "split", self._SPLITS)
+
+    @property
+    def variant(self) -> str:
+        return 'challenge' if self.split == 'train_challenge' else 'standard'
+
+    @property
+    def _archive_meta(self) -> Tuple[str, str]:
+        return self._IMAGE_ARCHIVE_META[(self.split, self.high_res)]
+
+    @property
+    def archive(self) -> str:
+        return self._archive_meta[0]
+
+    @property
+    def md5(self) -> str:
+        return self._archive_meta[1]
+
+    @property
+    def url(self) -> str:
+        return urljoin(self._BASE_URL, self.archive)
+
+    @property
+    def split_dir(self) -> str:
+        return path.join(self.root, path.splitext(self.archive)[0])
+
+    @property
+    def meta_file(self) -> str:
+        return path.join(self.root, f"meta-{self.variant}.bin")
+
+    def download(self):
+        if not path.exists(self.meta_file):
+            self._parse_devkit()
+
+        # fail if split dir is already present
+
+        self._load_meta()
+
+    def _parse_devkit(self):
+        print("Downloading and parsing the devkit. This is only needed for the first run.")
+
+    def _load_meta(self):
+        # fail if not present
+        pass
+
+    def extra_repr(self) -> str:
+        return "\n".join(("Split: {split}", "High resolution: {high_res}", "Variant: {variant}")).format(**self.__dict__)

--- a/torchvision/datasets/places365.py
+++ b/torchvision/datasets/places365.py
@@ -62,10 +62,11 @@ class Places365(VisionDataset):
     def __getitem__(self, index: int) -> Tuple[Any, Any]:
         file, target = self.imgs[index]
         image = self.loader(file)
-        if self.transforms is None:
-            return image, target
 
-        return self.transforms(image, target)
+        if self.transforms is not None:
+            image, target = self.transforms(image, target)
+
+        return image, target
 
     def __len__(self) -> int:
         return len(self.imgs)


### PR DESCRIPTION
This adds the [Places365 dataset](http://places2.csail.mit.edu/download.html). As the name implies it comprises 365 categories of "places". It is structured in 4 different splits:

- `training-standard` (~ `1.8e6` images)
- `training-challenge` (~ `8e6` images)
- `val` (~ `18e3` images)
- `test` (~ `330e3` images)

With the flag `small` the user can switch between high resolution and small (`256 x 256`) images.