### PR TITLE
.circleci: Bump xcode workers to 9.4.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -212,7 +212,7 @@ jobs:
   binary_macos_wheel:
     <<: *binary_common
     macos:
-      xcode: "9.0"
+      xcode: "9.4.1"
     steps:
       - checkout_merge
       - run:
@@ -234,7 +234,7 @@ jobs:
   binary_macos_conda:
     <<: *binary_common
     macos:
-      xcode: "9.0"
+      xcode: "9.4.1"
     steps:
       - checkout_merge
       - run:

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -212,7 +212,7 @@ jobs:
   binary_macos_wheel:
     <<: *binary_common
     macos:
-      xcode: "9.0"
+      xcode: "9.4.1"
     steps:
       - checkout_merge
       - run:
@@ -234,7 +234,7 @@ jobs:
   binary_macos_conda:
     <<: *binary_common
     macos:
-      xcode: "9.0"
+      xcode: "9.4.1"
     steps:
       - checkout_merge
       - run:


### PR DESCRIPTION
Upstream is on 9.4.1 and we were experiencing issues when conda-build
was attempting to check for overlinking and failed out due to some files
not existing in xcode 9.0

Similar to https://github.com/pytorch/csprng/pull/74

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>