### PR TITLE
Replaced pytorch cuda by cpu installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_install:
   # Useful for debugging any issues with conda
   - conda info -a
 
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION pytorch scipy -c pytorch-nightly
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION cpuonly pytorch scipy -c pytorch-nightly
   - source activate test-environment
   - |
     if [[ "$IMAGE_BACKEND" == "Pillow-SIMD" ]]; then


### PR DESCRIPTION
Description:

- On Travis CI there is no GPU and thus we can download pytorch cpu only version for tests instead of one with cuda.

Installation times (`conda create -q -n test-environment pytorch ... -c pytorch-nightly`):
- before : 170s
- now : 21s