### PR TITLE
Use autocast's built-in cast-helper functions

### DIFF
--- a/torchvision/csrc/ROIAlign.h
+++ b/torchvision/csrc/ROIAlign.h
@@ -49,8 +49,8 @@ at::Tensor ROIAlign_autocast(
     const bool aligned) {
   c10::impl::ExcludeDispatchKeyGuard no_autocast(c10::DispatchKey::Autocast);
   return roi_align(
-             autocast::_cast(at::kFloat, input),
-             autocast::_cast(at::kFloat, rois),
+             at::autocast::cached_cast(at::kFloat, input),
+             at::autocast::cached_cast(at::kFloat, rois),
              spatial_scale,
              pooled_height,
              pooled_width,

--- a/torchvision/csrc/autocast.h
+++ b/torchvision/csrc/autocast.h
@@ -1,28 +1,5 @@
 #pragma once
 
 #if defined(WITH_CUDA) || defined(WITH_HIP)
-namespace autocast {
-
-inline bool is_eligible(const at::Tensor& arg) {
-  return (
-      arg.is_cuda() && arg.is_floating_point() &&
-      (arg.scalar_type() != at::kDouble));
-}
-
-// Overload to catch Tensor args
-inline at::Tensor _cast(at::ScalarType to_type, const at::Tensor& arg) {
-  if (is_eligible(arg) && (arg.scalar_type() != to_type)) {
-    return arg.to(to_type);
-  } else {
-    return arg;
-  }
-}
-
-// Template to catch non-Tensor args
-template <typename T>
-inline T _cast(at::ScalarType to_type, T arg) {
-  return arg;
-}
-
-} // namespace autocast
+#include <ATen/autocast_mode.h>
 #endif

--- a/torchvision/csrc/nms.h
+++ b/torchvision/csrc/nms.h
@@ -28,8 +28,8 @@ at::Tensor nms_autocast(
     const double iou_threshold) {
   c10::impl::ExcludeDispatchKeyGuard no_autocast(c10::DispatchKey::Autocast);
   return nms(
-      autocast::_cast(at::kFloat, dets),
-      autocast::_cast(at::kFloat, scores),
+      at::autocast::cached_cast(at::kFloat, dets),
+      at::autocast::cached_cast(at::kFloat, scores),
       iou_threshold);
 }
 #endif


### PR DESCRIPTION
Changes `roi_align` and `nms` to use autocast's native cast-helper functions, which https://github.com/pytorch/pytorch/pull/42385 made available to external C++ libs (as shown in the [Autocast ](https://pytorch.org/tutorials/advanced/dispatcher.html#autocast) section of the dispatcher tutorial).

`roi_align` and `nms` are kept as fp32list ops, but if you think they're fine in fp16 or fp32, making them promotelist ops (that run in the widest type among inputs) would be a one-line addition (also shown in the tutorial).