### PR TITLE
cmake interface dependency

### DIFF
--- a/cmake/TorchVisionConfig.cmake.in
+++ b/cmake/TorchVisionConfig.cmake.in
@@ -31,7 +31,9 @@ endif()
 if(NOT TARGET Python3::Python)
 find_package(Python3 COMPONENTS Development)
 endif()
-target_link_libraries(TorchVision::TorchVision INTERFACE ${TORCH_LIBRARIES} Python3::Python)
+
+set_target_properties(TorchVision::TorchVision PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_INCLUDEDIR@" INTERFACE_LINK_LIBRARIES "torch;Python3::Python" )
+
 
 if(@WITH_CUDA@)
   target_compile_definitions(TorchVision::TorchVision INTERFACE WITH_CUDA)


### PR DESCRIPTION
I added an INTERFACE dependency to the TorchVision::TorchVision target, which simplifies installing the C++ library to arbitrary locations.