### PR TITLE
Remove unnecessary ResNet/ResNext shortcut conditions

### DIFF
--- a/torchvision/models/resnet.py
+++ b/torchvision/models/resnet.py
@@ -181,7 +181,7 @@ class ResNet(nn.Module):
         if dilate:
             self.dilation *= stride
             stride = 1
-        if stride != 1 or self.inplanes != planes * block.expansion:
+        if self.inplanes != planes * block.expansion:
             downsample = nn.Sequential(
                 conv1x1(self.inplanes, planes * block.expansion, stride),
                 norm_layer(planes * block.expansion),


### PR DESCRIPTION
From Deep Residual Learning for Image Recognition arXiv:1512.03385v1

> When dimensions increase, we consider two options....

So I think it is not necessary to determine stride !=1 when determining if shortcut needs to be downsampled or not, This stride condition may be confusing to beginners like me.

I wrote a piece of code to test the difference between the two and found that the output of the model was identical for all resnet families

```
def compare(model1, model2):
    for (name_1, value_1), (name_2, value_2) in zip(model1.named_parameters(), model2.named_parameters()):
        if name_1 == name_2 and value_1.size() == value_1.size() and name_2 == name_2 and value_2.size() == value_2.size():
            continue
        else:
            return False

    return True

if compare(resnext101_32x8d(), my_resnext101_32x8d()):
    print("True")
else:
    print("False")
```