### PR TITLE
Check JPEG_FOUND macro in jpeg common definitions

### DIFF
--- a/torchvision/csrc/cpu/image/jpegcommon.cpp
+++ b/torchvision/csrc/cpu/image/jpegcommon.cpp
@@ -1,6 +1,7 @@
 #include "jpegcommon.h"
 #include <string>
 
+#if JPEG_FOUND
 void torch_jpeg_error_exit(j_common_ptr cinfo) {
   /* cinfo->err really points to a torch_jpeg_error_mgr struct, so coerce
    * pointer */
@@ -15,3 +16,4 @@ void torch_jpeg_error_exit(j_common_ptr cinfo) {
   /* Return control to the setjmp point */
   longjmp(myerr->setjmp_buffer, 1);
 }
+#endif

--- a/torchvision/csrc/cpu/image/jpegcommon.h
+++ b/torchvision/csrc/cpu/image/jpegcommon.h
@@ -4,6 +4,8 @@
 #include <cstdio>
 #include <cstddef>
 // clang-format on
+
+#if JPEG_FOUND
 #include <jpeglib.h>
 #include <setjmp.h>
 #include <string>
@@ -17,3 +19,5 @@ struct torch_jpeg_error_mgr {
 
 typedef struct torch_jpeg_error_mgr* torch_jpeg_error_ptr;
 void torch_jpeg_error_exit(j_common_ptr cinfo);
+
+#endif


### PR DESCRIPTION
This PR prevents further compilation errors when libjepg/turbo is not found

Fixes https://github.com/pytorch/vision/issues/2724

