### PR TITLE
Add read_file

### DIFF
--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -18,40 +18,6 @@ import numpy as np
 from PIL import Image
 
 
-# allows to remove readonly files on Windows
-# see https://bugs.python.org/issue26660
-# took the implementation from that has been added in Python master
-# in https://github.com/python/cpython/pull/10320
-def _rmtree(name):
-    def onerror(func, path, exc_info):
-        if issubclass(exc_info[0], PermissionError):
-            def resetperms(path):
-                try:
-                    os.chflags(path, 0)
-                except AttributeError:
-                    pass
-                os.chmod(path, 0o700)
-
-            try:
-                if path != name:
-                    resetperms(os.path.dirname(path))
-                resetperms(path)
-
-                try:
-                    os.unlink(path)
-                # PermissionError is raised on FreeBSD for directories
-                except (IsADirectoryError, PermissionError):
-                    # _rmtree(path)
-                    pass
-            except FileNotFoundError:
-                pass
-        elif issubclass(exc_info[0], FileNotFoundError):
-            pass
-        else:
-            raise
-    shutil.rmtree(name, onerror=onerror)
-
-
 @contextlib.contextmanager
 def get_tmp_dir(src=None, **kwargs):
     tmp_dir = tempfile.mkdtemp(**kwargs)
@@ -61,7 +27,7 @@ def get_tmp_dir(src=None, **kwargs):
     try:
         yield tmp_dir
     finally:
-        _rmtree(tmp_dir)
+        shutil.rmtree(tmp_dir)
 
 
 ACCEPT = os.getenv('EXPECTTEST_ACCEPT')

--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -41,7 +41,8 @@ def _rmtree(name):
                     os.unlink(path)
                 # PermissionError is raised on FreeBSD for directories
                 except (IsADirectoryError, PermissionError):
-                    _rmtree(path)
+                    #_rmtree(path)
+                    pass
             except FileNotFoundError:
                 pass
         elif issubclass(exc_info[0], FileNotFoundError):

--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -1,4 +1,5 @@
 import os
+import stat
 import shutil
 import tempfile
 import contextlib
@@ -18,6 +19,13 @@ import numpy as np
 from PIL import Image
 
 
+# allows to remove readonly files on Windows
+# see https://bugs.python.org/issue26660
+def remove_readonly(func, path, _):
+    "Clear the readonly bit and reattempt the removal"
+    os.chmod(path, stat.S_IWRITE)
+    func(path)
+
 @contextlib.contextmanager
 def get_tmp_dir(src=None, **kwargs):
     tmp_dir = tempfile.mkdtemp(**kwargs)
@@ -27,7 +35,7 @@ def get_tmp_dir(src=None, **kwargs):
     try:
         yield tmp_dir
     finally:
-        shutil.rmtree(tmp_dir)
+        shutil.rmtree(tmp_dir, onerror=remove_readonly)
 
 
 ACCEPT = os.getenv('EXPECTTEST_ACCEPT')

--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -1,5 +1,4 @@
 import os
-import stat
 import shutil
 import tempfile
 import contextlib
@@ -21,10 +20,35 @@ from PIL import Image
 
 # allows to remove readonly files on Windows
 # see https://bugs.python.org/issue26660
-def remove_readonly(func, path, _):
-    "Clear the readonly bit and reattempt the removal"
-    os.chmod(path, stat.S_IWRITE)
-    func(path)
+# took the implementation from that has been added in Python master
+# in https://github.com/python/cpython/pull/10320
+def _rmtree(name):
+    def onerror(func, path, exc_info):
+        if issubclass(exc_info[0], PermissionError):
+            def resetperms(path):
+                try:
+                    os.chflags(path, 0)
+                except AttributeError:
+                    pass
+                os.chmod(path, 0o700)
+
+            try:
+                if path != name:
+                    resetperms(_os.path.dirname(path))
+                resetperms(path)
+
+                try:
+                    os.unlink(path)
+                # PermissionError is raised on FreeBSD for directories
+                except (IsADirectoryError, PermissionError):
+                    _rmtree(path)
+            except FileNotFoundError:
+                pass
+        elif issubclass(exc_info[0], FileNotFoundError):
+            pass
+        else:
+            raise
+    shutil.rmtree(name, onerror=onerror)
 
 
 @contextlib.contextmanager
@@ -36,7 +60,7 @@ def get_tmp_dir(src=None, **kwargs):
     try:
         yield tmp_dir
     finally:
-        shutil.rmtree(tmp_dir, onerror=remove_readonly)
+        _rmtree(tmp_dir)
 
 
 ACCEPT = os.getenv('EXPECTTEST_ACCEPT')

--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -34,7 +34,7 @@ def _rmtree(name):
 
             try:
                 if path != name:
-                    resetperms(_os.path.dirname(path))
+                    resetperms(os.path.dirname(path))
                 resetperms(path)
 
                 try:

--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -26,6 +26,7 @@ def remove_readonly(func, path, _):
     os.chmod(path, stat.S_IWRITE)
     func(path)
 
+
 @contextlib.contextmanager
 def get_tmp_dir(src=None, **kwargs):
     tmp_dir = tempfile.mkdtemp(**kwargs)

--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -41,7 +41,7 @@ def _rmtree(name):
                     os.unlink(path)
                 # PermissionError is raised on FreeBSD for directories
                 except (IsADirectoryError, PermissionError):
-                    #_rmtree(path)
+                    # _rmtree(path)
                     pass
             except FileNotFoundError:
                 pass

--- a/test/test_image.py
+++ b/test/test_image.py
@@ -223,9 +223,9 @@ class ImageTester(unittest.TestCase):
         with open(fpath, 'wb') as f:
             f.write(content)
 
-        data = read_file(fpath)
-        expected = torch.tensor(list(content), dtype=torch.uint8)
-        self.assertTrue(data.equal(expected))
+        #data = read_file(fpath)
+        #expected = torch.tensor(list(content), dtype=torch.uint8)
+        #self.assertTrue(data.equal(expected))
         os.unlink(fpath)
 
         with self.assertRaisesRegex(

--- a/test/test_image.py
+++ b/test/test_image.py
@@ -218,7 +218,7 @@ class ImageTester(unittest.TestCase):
     def test_read_file(self):
         # TODO Improve workaround solution for tempfile on Windows
         d = IMAGE_ROOT
-        fname, content = 'test1', b'TorchVision\211\n'
+        fname, content = 'test1.bin', b'TorchVision\211\n'
         fpath = os.path.join(d, fname)
         with open(fpath, 'wb') as f:
             f.write(content)

--- a/test/test_image.py
+++ b/test/test_image.py
@@ -227,6 +227,10 @@ class ImageTester(unittest.TestCase):
             expected = torch.tensor(list(content), dtype=torch.uint8)
             self.assertTrue(data.equal(expected))
 
+        with self.assertRaisesRegex(
+                RuntimeError, "No such file or directory: 'tst'"):
+            read_file('tst')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_image.py
+++ b/test/test_image.py
@@ -1,6 +1,7 @@
 import os
 import io
 import glob
+import tempfile
 import unittest
 import sys
 
@@ -218,15 +219,14 @@ class ImageTester(unittest.TestCase):
             self.assertTrue(img_lpng.equal(img_pil))
 
     def test_read_file(self):
-        with get_tmp_dir() as d:
-            fname, content = 'test1', b'TorchVision\211\n'
-            fpath = os.path.join(d, fname)
-            with open(fpath, 'wb') as f:
-                f.write(content)
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            content = b'TorchVision\211\n'
+            f.write(content)
 
-            data = read_file(fpath)
-            expected = torch.tensor(list(content), dtype=torch.uint8)
-            self.assertTrue(data.equal(expected))
+        data = read_file(f.name)
+        expected = torch.tensor(list(content), dtype=torch.uint8)
+        self.assertTrue(data.equal(expected))
+        os.remove(f.name)
 
         with self.assertRaisesRegex(
                 RuntimeError, "No such file or directory: 'tst'"):

--- a/test/test_image.py
+++ b/test/test_image.py
@@ -223,9 +223,10 @@ class ImageTester(unittest.TestCase):
         with open(fpath, 'wb') as f:
             f.write(content)
 
-        #data = read_file(fpath)
-        #expected = torch.tensor(list(content), dtype=torch.uint8)
-        #self.assertTrue(data.equal(expected))
+        data = read_file(fpath)
+        expected = torch.tensor(list(content), dtype=torch.uint8)
+        self.assertTrue(data.equal(expected))
+        del data
         os.unlink(fpath)
 
         with self.assertRaisesRegex(

--- a/test/test_image.py
+++ b/test/test_image.py
@@ -1,7 +1,6 @@
 import os
 import io
 import glob
-import tempfile
 import unittest
 import sys
 
@@ -12,8 +11,6 @@ from torchvision.io.image import (
     read_png, decode_png, read_jpeg, decode_jpeg, encode_jpeg, write_jpeg, decode_image, read_file,
     encode_png, write_png)
 import numpy as np
-
-from common_utils import get_tmp_dir
 
 IMAGE_ROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "assets")
 IMAGE_DIR = os.path.join(IMAGE_ROOT, "fakedata", "imagefolder")
@@ -219,14 +216,17 @@ class ImageTester(unittest.TestCase):
             self.assertTrue(img_lpng.equal(img_pil))
 
     def test_read_file(self):
-        with tempfile.NamedTemporaryFile(delete=False) as f:
-            content = b'TorchVision\211\n'
+        # TODO Improve workaround solution for tempfile on Windows
+        d = IMAGE_ROOT
+        fname, content = 'test1', b'TorchVision\211\n'
+        fpath = os.path.join(d, fname)
+        with open(fpath, 'wb') as f:
             f.write(content)
 
-        data = read_file(f.name)
+        data = read_file(fpath)
         expected = torch.tensor(list(content), dtype=torch.uint8)
         self.assertTrue(data.equal(expected))
-        os.remove(f.name)
+        os.unlink(fpath)
 
         with self.assertRaisesRegex(
                 RuntimeError, "No such file or directory: 'tst'"):

--- a/test/test_image.py
+++ b/test/test_image.py
@@ -1,7 +1,6 @@
 import os
 import io
 import glob
-import tempfile
 import unittest
 import sys
 
@@ -12,6 +11,8 @@ from torchvision.io.image import (
     read_png, decode_png, read_jpeg, decode_jpeg, encode_jpeg, write_jpeg, decode_image, read_file,
     encode_png, write_png)
 import numpy as np
+
+from common_utils import get_tmp_dir
 
 IMAGE_ROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "assets")
 IMAGE_DIR = os.path.join(IMAGE_ROOT, "fakedata", "imagefolder")
@@ -217,7 +218,7 @@ class ImageTester(unittest.TestCase):
             self.assertTrue(img_lpng.equal(img_pil))
 
     def test_read_file(self):
-        with tempfile.TemporaryDirectory() as d:
+        with get_tmp_dir() as d:
             fname, content = 'test1', b'TorchVision\211\n'
             fpath = os.path.join(d, fname)
             with open(fpath, 'wb') as f:
@@ -226,7 +227,6 @@ class ImageTester(unittest.TestCase):
             data = read_file(fpath)
             expected = torch.tensor(list(content), dtype=torch.uint8)
             self.assertTrue(data.equal(expected))
-            os.remove(fpath)
 
         with self.assertRaisesRegex(
                 RuntimeError, "No such file or directory: 'tst'"):

--- a/test/test_image.py
+++ b/test/test_image.py
@@ -226,6 +226,7 @@ class ImageTester(unittest.TestCase):
             data = read_file(fpath)
             expected = torch.tensor(list(content), dtype=torch.uint8)
             self.assertTrue(data.equal(expected))
+            os.remove(fpath)
 
         with self.assertRaisesRegex(
                 RuntimeError, "No such file or directory: 'tst'"):

--- a/torchvision/csrc/cpu/image/image.cpp
+++ b/torchvision/csrc/cpu/image/image.cpp
@@ -19,4 +19,5 @@ static auto registry = torch::RegisterOperators()
                            .op("image::decode_jpeg", &decodeJPEG)
                            .op("image::encode_jpeg", &encodeJPEG)
                            .op("image::write_jpeg", &writeJPEG)
+                           .op("image::read_file", &read_file)
                            .op("image::decode_image", &decode_image);

--- a/torchvision/csrc/cpu/image/image.h
+++ b/torchvision/csrc/cpu/image/image.h
@@ -4,6 +4,7 @@
 #include <torch/script.h>
 #include <torch/torch.h>
 #include "read_image_cpu.h"
+#include "read_write_file_cpu.h"
 #include "readjpeg_cpu.h"
 #include "readpng_cpu.h"
 #include "writejpeg_cpu.h"

--- a/torchvision/csrc/cpu/image/read_write_file_cpu.cpp
+++ b/torchvision/csrc/cpu/image/read_write_file_cpu.cpp
@@ -1,0 +1,18 @@
+#include "read_write_file_cpu.h"
+
+torch::Tensor read_file(std::string filename) {
+  // CHECK if this only works on Windows for files smaller than 2GB
+  // https://stackoverflow.com/questions/5840148/how-can-i-get-a-files-size-in-c
+  struct stat stat_buf;
+  int rc = stat(filename.c_str(), &stat_buf);
+  // errno is a variable defined in errno.h
+  TORCH_CHECK(rc == 0, "[Errno ", errno, "] ", strerror(errno), ": '", filename, "'");
+  
+  int64_t size = stat_buf.st_size;
+
+  TORCH_CHECK(size > 0, "Expected a non empty file");
+
+  auto data = torch::from_file(filename, /*shared=*/false, /*size=*/size, torch::kU8);
+
+  return data;
+}

--- a/torchvision/csrc/cpu/image/read_write_file_cpu.cpp
+++ b/torchvision/csrc/cpu/image/read_write_file_cpu.cpp
@@ -8,13 +8,13 @@ torch::Tensor read_file(std::string filename) {
   // errno is a variable defined in errno.h
   TORCH_CHECK(
       rc == 0, "[Errno ", errno, "] ", strerror(errno), ": '", filename, "'");
-  
+
   int64_t size = stat_buf.st_size;
 
   TORCH_CHECK(size > 0, "Expected a non empty file");
 
   auto data =
-    torch::from_file(filename, /*shared=*/false, /*size=*/size, torch::kU8);
+      torch::from_file(filename, /*shared=*/false, /*size=*/size, torch::kU8);
 
   return data;
 }

--- a/torchvision/csrc/cpu/image/read_write_file_cpu.cpp
+++ b/torchvision/csrc/cpu/image/read_write_file_cpu.cpp
@@ -6,13 +6,15 @@ torch::Tensor read_file(std::string filename) {
   struct stat stat_buf;
   int rc = stat(filename.c_str(), &stat_buf);
   // errno is a variable defined in errno.h
-  TORCH_CHECK(rc == 0, "[Errno ", errno, "] ", strerror(errno), ": '", filename, "'");
+  TORCH_CHECK(
+      rc == 0, "[Errno ", errno, "] ", strerror(errno), ": '", filename, "'");
   
   int64_t size = stat_buf.st_size;
 
   TORCH_CHECK(size > 0, "Expected a non empty file");
 
-  auto data = torch::from_file(filename, /*shared=*/false, /*size=*/size, torch::kU8);
+  auto data =
+    torch::from_file(filename, /*shared=*/false, /*size=*/size, torch::kU8);
 
   return data;
 }

--- a/torchvision/csrc/cpu/image/read_write_file_cpu.h
+++ b/torchvision/csrc/cpu/image/read_write_file_cpu.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <torch/torch.h>
+#include <errno.h>
+#include <sys/stat.h>
+
+C10_EXPORT torch::Tensor read_file(std::string filename);

--- a/torchvision/csrc/cpu/image/read_write_file_cpu.h
+++ b/torchvision/csrc/cpu/image/read_write_file_cpu.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <torch/torch.h>
 #include <errno.h>
 #include <sys/stat.h>
+#include <torch/torch.h>
 
 C10_EXPORT torch::Tensor read_file(std::string filename);

--- a/torchvision/io/image.py
+++ b/torchvision/io/image.py
@@ -23,14 +23,18 @@ except (ImportError, OSError):
     pass
 
 
-def _read_file(path: str) -> torch.Tensor:
-    if not os.path.isfile(path):
-        raise ValueError("Expected a valid file path.")
+def read_file(path: str) -> torch.Tensor:
+    """
+    Reads and outputs the bytes contents of a file as a uint8 Tensor
+    with one dimension.
 
-    size = os.path.getsize(path)
-    if size == 0:
-        raise ValueError("Expected a non empty file.")
-    data = torch.from_file(path, dtype=torch.uint8, size=size)
+    Arguments:
+        path (str): the path to the file to be read
+
+    Returns:
+        data (Tensor)
+    """
+    data = torch.ops.image.read_file(path)
     return data
 
 
@@ -61,7 +65,7 @@ def read_png(path: str) -> torch.Tensor:
     Returns:
         output (Tensor[3, image_height, image_width])
     """
-    data = _read_file(path)
+    data = read_file(path)
     return decode_png(data)
 
 
@@ -119,7 +123,7 @@ def read_jpeg(path: str) -> torch.Tensor:
     Returns:
         output (Tensor[3, image_height, image_width])
     """
-    data = _read_file(path)
+    data = read_file(path)
     return decode_jpeg(data)
 
 
@@ -187,5 +191,5 @@ def read_image(path: str) -> torch.Tensor:
     Returns:
         output (Tensor[3, image_height, image_width])
     """
-    data = _read_file(path)
+    data = read_file(path)
     return decode_image(data)


### PR DESCRIPTION
This PR adds a `read_file` function in C++, making it possible to read from a file path and returning the raw bytes of the file as a uint8 Tensor.
This enables `read_image` to be torchscriptable.

In a follow-up PR I'll be removing `read_jpeg` and `read_png` as users should probably just use `read_image` instead, or the individual decoding functions, and will probably also expose `read_file` in the `io` namespace of torchvision, together with the other functions.

This function should probably live in PyTorch, as it is a small extension to `torch.from_file`.