### PR TITLE
Require CMP0053=New.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.1)
 project(torchvision)
 set(CMAKE_CXX_STANDARD 14)
 set(TORCHVISION_VERSION 0.7.0)


### PR DESCRIPTION
This is to workaround CMake 3.18.3 bug with a bad regex, which happens to be valid with new parser.
Since probably any distro with CMake 3 won't stuck with 3.0, there shall be no real impact with this increase.
Fix https://github.com/pytorch/vision/issues/2701