### PR TITLE
Negative padding for functional_tensor symmetric

### DIFF
--- a/test/test_functional_tensor.py
+++ b/test/test_functional_tensor.py
@@ -285,9 +285,6 @@ class Tester(TransformsTester):
 
                     self._test_fn_on_batch(batch_tensors, F.pad, padding=script_pad, **kwargs)
 
-        with self.assertRaises(ValueError, msg="Padding can not be negative for symmetric padding_mode"):
-            F_t.pad(tensor, (-2, -3), padding_mode="symmetric")
-
     def _test_adjust_fn(self, fn, fn_pil, fn_t, configs, tol=2.0 + 1e-10, agg_method="max"):
         script_fn = torch.jit.script(fn)
         torch.manual_seed(15)

--- a/test/test_transforms_tensor.py
+++ b/test/test_transforms_tensor.py
@@ -123,9 +123,7 @@ class Tester(TransformsTester):
     def test_pad(self):
         for m in ["constant", "edge", "reflect", "symmetric"]:
             fill = 127 if m == "constant" else 0
-            # Negative pad currently unsupported for Tensor and symmetric
-            multipliers = [1] if m == "symmetric" else [1, -1]
-            for mul in multipliers:
+            for mul in [1, -1]:
                 # Test functional.pad (PIL and Tensor) with padding as single int
                 self._test_functional_op(
                     "pad", fn_kwargs={"padding": mul * 2, "fill": fill, "padding_mode": m}

--- a/torchvision/transforms/functional_tensor.py
+++ b/torchvision/transforms/functional_tensor.py
@@ -528,6 +528,13 @@ def _hsv2rgb(img):
 
 def _pad_symmetric(img: Tensor, padding: List[int]) -> Tensor:
     # padding is left, right, top, bottom
+
+    # crop if needed
+    if padding[0] < 0 or padding[1] < 0 or padding[2] < 0 or padding[3] < 0:
+        crop_left, crop_right, crop_top, crop_bottom = [-min(x, 0) for x in padding]
+        img = img[..., crop_top:img.shape[-2] - crop_bottom, crop_left:img.shape[-1] - crop_right]
+        padding = [max(x, 0) for x in padding]
+
     in_sizes = img.size()
 
     x_indices = [i for i in range(in_sizes[-1])]  # [0, 1, 2, 3, ...]
@@ -630,8 +637,6 @@ def pad(img: Tensor, padding: List[int], fill: int = 0, padding_mode: str = "con
         padding_mode = "replicate"
     elif padding_mode == "symmetric":
         # route to another implementation
-        if p[0] < 0 or p[1] < 0 or p[2] < 0 or p[3] < 0:  # no any support for torch script
-            raise ValueError("Padding can not be negative for symmetric padding_mode")
         return _pad_symmetric(img, p)
 
     need_squeeze = False


### PR DESCRIPTION
Along with #2744 this will make negative padding
uniform between PIL and Tensor #2381

The natural test would be [not excluding "symmetric" here](https://github.com/pytorch/vision/pull/2744/commits/50655d35538ca22d32c66157fcf3064bdbc7d820#diff-f302244baf8e5f39415c16c4e59dfba4R127) but that relies on the changes in #2744 so I haven't included it here yet.