### PR TITLE
Updated RandomApply as scriptable transform

### DIFF
--- a/examples/python/tensor_transforms.ipynb
+++ b/examples/python/tensor_transforms.ipynb
@@ -179,7 +179,7 @@
     "Next, we show how to combine input transformations and model's forward pass and use `torch.jit.script` to obtain a single scripted module.\n",
     "\n",
     "**Note:** we have to use only scriptable transformations that should be derived from `torch.nn.Module`. \n",
-    "Since v0.8.0, all transformations are scriptable except `Compose`, `RandomApply`, `RandomChoice`, `RandomOrder`, `Lambda` and those applied on PIL images. \n",
+    "Since v0.8.0, all transformations are scriptable except `Compose`, `RandomChoice`, `RandomOrder`, `Lambda` and those applied on PIL images.\n",
     "The transformations like `Compose` are kept for backward compatibility and can be easily replaced by existing torch modules, like `nn.Sequential`.\n",
     "\n",
     "Let's define a module `Predictor` that transforms input tensor and applies ImageNet pretrained resnet18 model on it."


### PR DESCRIPTION
Description:
- Following the discussion with @fmassa to update RandomApply to be torchscriptable
  - [x] updated RandomApply
  - [x] added tests
- Finally I think there is less gain to do that for Compose (+ fear of BC break)
```python
# current way
transforms = torch.nn.Sequential(
     transforms.CenterCrop(10),
     transforms.Normalize((0.485, 0.456, 0.406), (0.229, 0.224, 0.225)),
)
# vs can be implemented as for RandomApply 
transforms = transforms.Compose(torch.nn.ModuleList([
     transforms.CenterCrop(10),
     transforms.Normalize((0.485, 0.456, 0.406), (0.229, 0.224, 0.225)),
]))
```

