### PR TITLE
Replace include directory variable in CMakeConfig.cmake.in

### DIFF
--- a/cmake/TorchVisionConfig.cmake.in
+++ b/cmake/TorchVisionConfig.cmake.in
@@ -32,7 +32,7 @@ if(NOT TARGET Python3::Python)
 find_package(Python3 COMPONENTS Development)
 endif()
 
-set_target_properties(TorchVision::TorchVision PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_INCLUDEDIR@" INTERFACE_LINK_LIBRARIES "torch;Python3::Python" )
+set_target_properties(TorchVision::TorchVision PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${${PN}_INCLUDE_DIR}" INTERFACE_LINK_LIBRARIES "torch;Python3::Python" )
 
 
 if(@WITH_CUDA@)


### PR DESCRIPTION
If the torch target was not already defined before `find_package(TorchVision)`, the CMake config file tries to find it itself.
However, `find_package(Torch)` ends up overriding the `PACKAGE_PREFIX_DIR` variable, resulting in the wrong `INTERFACE_INCLUDE_DIRECTORIES` for the TorchVision target.

Use the variable created at the top of the file instead.