### PR TITLE
Remove model download from tests

### DIFF
--- a/test/test_models.py
+++ b/test/test_models.py
@@ -330,7 +330,7 @@ class ModelTester(TestCase):
         kwargs['transform_input'] = True
         kwargs['aux_logits'] = True
         kwargs['init_weights'] = False
-        model = models.GoogLeNet()
+        model = models.GoogLeNet(**kwargs)
         model.aux_logits = False
         model.aux1 = None
         model.aux2 = None

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -325,7 +325,16 @@ class ModelTester(TestCase):
         self.assertTrue("labels" in out[0])
 
     def test_googlenet_eval(self):
-        m = torch.jit.script(models.googlenet(pretrained=True).eval())
+        # replacement for models.googlenet(pretrained=True) that does not download weights
+        kwargs = {}
+        kwargs['transform_input'] = True
+        kwargs['aux_logits'] = True
+        kwargs['init_weights'] = False
+        model = models.GoogLeNet()
+        model.aux_logits = False
+        model.aux1 = None
+        model.aux2 = None
+        m = torch.jit.script(model.eval())
         self.checkModule(m, "googlenet", torch.rand(1, 3, 224, 224))
 
     @unittest.skipIf(not torch.cuda.is_available(), 'needs GPU')

--- a/test/test_models_detection_utils.py
+++ b/test/test_models_detection_utils.py
@@ -3,7 +3,7 @@ import torch
 from torchvision.models.detection import _utils
 from torchvision.models.detection.transform import GeneralizedRCNNTransform
 import unittest
-from torchvision.models.detection import fasterrcnn_resnet50_fpn, maskrcnn_resnet50_fpn, keypointrcnn_resnet50_fpn
+from torchvision.models.detection import backbone_utils
 
 
 class Tester(unittest.TestCase):
@@ -20,50 +20,26 @@ class Tester(unittest.TestCase):
         self.assertEqual(neg[0].sum(), 3)
         self.assertEqual(neg[0][0:6].sum(), 3)
 
-    def test_fasterrcnn_resnet50_fpn_frozen_layers(self):
+    def test_resnet_fpn_backbone_frozen_layers(self):
         # we know how many initial layers and parameters of the network should
-        # be frozen for each trainable_backbone_layers paramter value
+        # be frozen for each trainable_backbone_layers parameter value
         # i.e all 53 params are frozen if trainable_backbone_layers=0
         # ad first 24 params are frozen if trainable_backbone_layers=2
         expected_frozen_params = {0: 53, 1: 43, 2: 24, 3: 11, 4: 1, 5: 0}
         for train_layers, exp_froz_params in expected_frozen_params.items():
-            model = fasterrcnn_resnet50_fpn(pretrained=False, progress=False,
-                                            num_classes=91, pretrained_backbone=False,
-                                            trainable_backbone_layers=train_layers)
+            model = backbone_utils.resnet_fpn_backbone(
+                'resnet50', pretrained=False, trainable_layers=train_layers)
             # boolean list that is true if the param at that index is frozen
             is_frozen = [not parameter.requires_grad for _, parameter in model.named_parameters()]
             # check that expected initial number of layers are frozen
             self.assertTrue(all(is_frozen[:exp_froz_params]))
 
-    def test_maskrcnn_resnet50_fpn_frozen_layers(self):
-        # we know how many initial layers and parameters of the maskrcnn should
-        # be frozen for each trainable_backbone_layers paramter value
-        # i.e all 53 params are frozen if trainable_backbone_layers=0
-        # ad first 24 params are frozen if trainable_backbone_layers=2
-        expected_frozen_params = {0: 53, 1: 43, 2: 24, 3: 11, 4: 1, 5: 0}
-        for train_layers, exp_froz_params in expected_frozen_params.items():
-            model = maskrcnn_resnet50_fpn(pretrained=False, progress=False,
-                                          num_classes=91, pretrained_backbone=False,
-                                          trainable_backbone_layers=train_layers)
-            # boolean list that is true if the parameter at that index is frozen
-            is_frozen = [not parameter.requires_grad for _, parameter in model.named_parameters()]
-            # check that expected initial number of layers in maskrcnn are frozen
-            self.assertTrue(all(is_frozen[:exp_froz_params]))
-
-    def test_keypointrcnn_resnet50_fpn_frozen_layers(self):
-        # we know how many initial layers and parameters of the keypointrcnn should
-        # be frozen for each trainable_backbone_layers paramter value
-        # i.e all 53 params are frozen if trainable_backbone_layers=0
-        # ad first 24 params are frozen if trainable_backbone_layers=2
-        expected_frozen_params = {0: 53, 1: 43, 2: 24, 3: 11, 4: 1, 5: 0}
-        for train_layers, exp_froz_params in expected_frozen_params.items():
-            model = keypointrcnn_resnet50_fpn(pretrained=False, progress=False,
-                                              num_classes=2, pretrained_backbone=False,
-                                              trainable_backbone_layers=train_layers)
-            # boolean list that is true if the parameter at that index is frozen
-            is_frozen = [not parameter.requires_grad for _, parameter in model.named_parameters()]
-            # check that expected initial number of layers in keypointrcnn are frozen
-            self.assertTrue(all(is_frozen[:exp_froz_params]))
+    def test_validate_resnet_inputs_detection(self):
+        # for pretrained in [True, False]:
+        #     for pretrained_backbone in [True, False]:
+        #         for trainable_layers
+        # backbone_utils._validate_resnet_trainable_layers(pretrained, pretrained_backbone, trainable_layers)
+        pass
 
     def test_transform_copy_targets(self):
         transform = GeneralizedRCNNTransform(300, 500, torch.zeros(3), torch.ones(3))

--- a/test/test_models_detection_utils.py
+++ b/test/test_models_detection_utils.py
@@ -49,7 +49,6 @@ class Tester(unittest.TestCase):
                 pretrained=False, trainable_backbone_layers=0)
         self.assertEqual(ret, 5)
 
-
     def test_transform_copy_targets(self):
         transform = GeneralizedRCNNTransform(300, 500, torch.zeros(3), torch.ones(3))
         image = [torch.rand(3, 200, 300), torch.rand(3, 200, 200)]

--- a/test/test_models_detection_utils.py
+++ b/test/test_models_detection_utils.py
@@ -35,11 +35,20 @@ class Tester(unittest.TestCase):
             self.assertTrue(all(is_frozen[:exp_froz_params]))
 
     def test_validate_resnet_inputs_detection(self):
-        # for pretrained in [True, False]:
-        #     for pretrained_backbone in [True, False]:
-        #         for trainable_layers
-        # backbone_utils._validate_resnet_trainable_layers(pretrained, pretrained_backbone, trainable_layers)
-        pass
+        # default number of backbone layers to train
+        ret = backbone_utils._validate_resnet_trainable_layers(
+            pretrained=True, trainable_backbone_layers=None)
+        self.assertEqual(ret, 3)
+        # can't go beyond 5
+        with self.assertRaises(AssertionError):
+            ret = backbone_utils._validate_resnet_trainable_layers(
+                pretrained=True, trainable_backbone_layers=6)
+        # if not pretrained, should use all trainable layers and warn
+        with self.assertWarns(UserWarning):
+            ret = backbone_utils._validate_resnet_trainable_layers(
+                pretrained=False, trainable_backbone_layers=0)
+        self.assertEqual(ret, 5)
+
 
     def test_transform_copy_targets(self):
         transform = GeneralizedRCNNTransform(300, 500, torch.zeros(3), torch.ones(3))

--- a/test/test_models_detection_utils.py
+++ b/test/test_models_detection_utils.py
@@ -27,7 +27,7 @@ class Tester(unittest.TestCase):
         # ad first 24 params are frozen if trainable_backbone_layers=2
         expected_frozen_params = {0: 53, 1: 43, 2: 24, 3: 11, 4: 1, 5: 0}
         for train_layers, exp_froz_params in expected_frozen_params.items():
-            model = fasterrcnn_resnet50_fpn(pretrained=True, progress=False,
+            model = fasterrcnn_resnet50_fpn(pretrained=False, progress=False,
                                             num_classes=91, pretrained_backbone=False,
                                             trainable_backbone_layers=train_layers)
             # boolean list that is true if the param at that index is frozen
@@ -42,7 +42,7 @@ class Tester(unittest.TestCase):
         # ad first 24 params are frozen if trainable_backbone_layers=2
         expected_frozen_params = {0: 53, 1: 43, 2: 24, 3: 11, 4: 1, 5: 0}
         for train_layers, exp_froz_params in expected_frozen_params.items():
-            model = maskrcnn_resnet50_fpn(pretrained=True, progress=False,
+            model = maskrcnn_resnet50_fpn(pretrained=False, progress=False,
                                           num_classes=91, pretrained_backbone=False,
                                           trainable_backbone_layers=train_layers)
             # boolean list that is true if the parameter at that index is frozen
@@ -57,7 +57,7 @@ class Tester(unittest.TestCase):
         # ad first 24 params are frozen if trainable_backbone_layers=2
         expected_frozen_params = {0: 53, 1: 43, 2: 24, 3: 11, 4: 1, 5: 0}
         for train_layers, exp_froz_params in expected_frozen_params.items():
-            model = keypointrcnn_resnet50_fpn(pretrained=True, progress=False,
+            model = keypointrcnn_resnet50_fpn(pretrained=False, progress=False,
                                               num_classes=2, pretrained_backbone=False,
                                               trainable_backbone_layers=train_layers)
             # boolean list that is true if the parameter at that index is frozen

--- a/torchvision/models/detection/backbone_utils.py
+++ b/torchvision/models/detection/backbone_utils.py
@@ -105,3 +105,19 @@ def resnet_fpn_backbone(
     in_channels_list = [in_channels_stage2 * 2 ** (i - 1) for i in returned_layers]
     out_channels = 256
     return BackboneWithFPN(backbone, return_layers, in_channels_list, out_channels, extra_blocks=extra_blocks)
+
+
+def _validate_resnet_trainable_layers(pretrained, pretrained_backbone, trainable_backbone_layers)
+    # dont freeze any layers if pretrained model or backbone is not used
+    if not (pretrained or pretrained_backbone):
+        if trainable_backbone_layers is not None:
+            warnings.warn(
+                "Changing trainable_backbone_layers has not effect if "
+                "neither pretrained nor pretrained_backbone have been set to True, "
+                "falling back to trainable_backbone_layers=5 so that all layers are trainable")
+        trainable_backbone_layers = 5
+    # by default, freeze first 2 blocks following Faster R-CNN
+    if trainable_backbone_layers is None:
+        trainable_backbone_layers = 3
+    assert trainable_backbone_layers <= 5 and trainable_backbone_layers >= 0
+    return trainable_backbone_layers

--- a/torchvision/models/detection/backbone_utils.py
+++ b/torchvision/models/detection/backbone_utils.py
@@ -1,3 +1,4 @@
+import warnings
 from collections import OrderedDict
 from torch import nn
 from torchvision.ops.feature_pyramid_network import FeaturePyramidNetwork, LastLevelMaxPool
@@ -107,9 +108,9 @@ def resnet_fpn_backbone(
     return BackboneWithFPN(backbone, return_layers, in_channels_list, out_channels, extra_blocks=extra_blocks)
 
 
-def _validate_resnet_trainable_layers(pretrained, pretrained_backbone, trainable_backbone_layers)
+def _validate_resnet_trainable_layers(pretrained, trainable_backbone_layers):
     # dont freeze any layers if pretrained model or backbone is not used
-    if not (pretrained or pretrained_backbone):
+    if not pretrained:
         if trainable_backbone_layers is not None:
             warnings.warn(
                 "Changing trainable_backbone_layers has not effect if "

--- a/torchvision/models/detection/faster_rcnn.py
+++ b/torchvision/models/detection/faster_rcnn.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict
+import warnings
 
 import torch
 from torch import nn
@@ -14,7 +15,7 @@ from .generalized_rcnn import GeneralizedRCNN
 from .rpn import RPNHead, RegionProposalNetwork
 from .roi_heads import RoIHeads
 from .transform import GeneralizedRCNNTransform
-from .backbone_utils import resnet_fpn_backbone
+from .backbone_utils import resnet_fpn_backbone, _validate_resnet_trainable_layers
 
 
 __all__ = [
@@ -290,7 +291,7 @@ model_urls = {
 
 
 def fasterrcnn_resnet50_fpn(pretrained=False, progress=True,
-                            num_classes=91, pretrained_backbone=True, trainable_backbone_layers=3, **kwargs):
+                            num_classes=91, pretrained_backbone=True, trainable_backbone_layers=None, **kwargs):
     """
     Constructs a Faster R-CNN model with a ResNet-50-FPN backbone.
 
@@ -348,10 +349,10 @@ def fasterrcnn_resnet50_fpn(pretrained=False, progress=True,
         trainable_backbone_layers (int): number of trainable (not frozen) resnet layers starting from final block.
             Valid values are between 0 and 5, with 5 meaning all backbone layers are trainable.
     """
-    assert trainable_backbone_layers <= 5 and trainable_backbone_layers >= 0
-    # dont freeze any layers if pretrained model or backbone is not used
-    if not (pretrained or pretrained_backbone):
-        trainable_backbone_layers = 5
+    # check default parameters and by default set it to 3 if possible
+    trainable_backbone_layers = _validate_resnet_trainable_layers(
+        pretrained, pretrained_backbone, trainable_backbone_layers):
+
     if pretrained:
         # no need to download the backbone if pretrained is set
         pretrained_backbone = False

--- a/torchvision/models/detection/faster_rcnn.py
+++ b/torchvision/models/detection/faster_rcnn.py
@@ -1,5 +1,4 @@
 from collections import OrderedDict
-import warnings
 
 import torch
 from torch import nn
@@ -351,7 +350,7 @@ def fasterrcnn_resnet50_fpn(pretrained=False, progress=True,
     """
     # check default parameters and by default set it to 3 if possible
     trainable_backbone_layers = _validate_resnet_trainable_layers(
-        pretrained, pretrained_backbone, trainable_backbone_layers)
+        pretrained or pretrained_backbone, trainable_backbone_layers)
 
     if pretrained:
         # no need to download the backbone if pretrained is set

--- a/torchvision/models/detection/faster_rcnn.py
+++ b/torchvision/models/detection/faster_rcnn.py
@@ -351,7 +351,7 @@ def fasterrcnn_resnet50_fpn(pretrained=False, progress=True,
     """
     # check default parameters and by default set it to 3 if possible
     trainable_backbone_layers = _validate_resnet_trainable_layers(
-        pretrained, pretrained_backbone, trainable_backbone_layers):
+        pretrained, pretrained_backbone, trainable_backbone_layers)
 
     if pretrained:
         # no need to download the backbone if pretrained is set

--- a/torchvision/models/detection/keypoint_rcnn.py
+++ b/torchvision/models/detection/keypoint_rcnn.py
@@ -318,7 +318,7 @@ def keypointrcnn_resnet50_fpn(pretrained=False, progress=True,
     """
     # check default parameters and by default set it to 3 if possible
     trainable_backbone_layers = _validate_resnet_trainable_layers(
-        pretrained, pretrained_backbone, trainable_backbone_layers)
+        pretrained or pretrained_backbone, trainable_backbone_layers)
 
     if pretrained:
         # no need to download the backbone if pretrained is set

--- a/torchvision/models/detection/keypoint_rcnn.py
+++ b/torchvision/models/detection/keypoint_rcnn.py
@@ -6,7 +6,7 @@ from torchvision.ops import MultiScaleRoIAlign
 from ..utils import load_state_dict_from_url
 
 from .faster_rcnn import FasterRCNN
-from .backbone_utils import resnet_fpn_backbone
+from .backbone_utils import resnet_fpn_backbone, _validate_resnet_trainable_layers
 
 
 __all__ = [
@@ -267,7 +267,7 @@ model_urls = {
 
 def keypointrcnn_resnet50_fpn(pretrained=False, progress=True,
                               num_classes=2, num_keypoints=17,
-                              pretrained_backbone=True, trainable_backbone_layers=3, **kwargs):
+                              pretrained_backbone=True, trainable_backbone_layers=None, **kwargs):
     """
     Constructs a Keypoint R-CNN model with a ResNet-50-FPN backbone.
 
@@ -316,10 +316,10 @@ def keypointrcnn_resnet50_fpn(pretrained=False, progress=True,
         trainable_backbone_layers (int): number of trainable (not frozen) resnet layers starting from final block.
             Valid values are between 0 and 5, with 5 meaning all backbone layers are trainable.
     """
-    assert trainable_backbone_layers <= 5 and trainable_backbone_layers >= 0
-    # dont freeze any layers if pretrained model or backbone is not used
-    if not (pretrained or pretrained_backbone):
-        trainable_backbone_layers = 5
+    # check default parameters and by default set it to 3 if possible
+    trainable_backbone_layers = _validate_resnet_trainable_layers(
+        pretrained, pretrained_backbone, trainable_backbone_layers):
+
     if pretrained:
         # no need to download the backbone if pretrained is set
         pretrained_backbone = False

--- a/torchvision/models/detection/keypoint_rcnn.py
+++ b/torchvision/models/detection/keypoint_rcnn.py
@@ -318,7 +318,7 @@ def keypointrcnn_resnet50_fpn(pretrained=False, progress=True,
     """
     # check default parameters and by default set it to 3 if possible
     trainable_backbone_layers = _validate_resnet_trainable_layers(
-        pretrained, pretrained_backbone, trainable_backbone_layers):
+        pretrained, pretrained_backbone, trainable_backbone_layers)
 
     if pretrained:
         # no need to download the backbone if pretrained is set

--- a/torchvision/models/detection/mask_rcnn.py
+++ b/torchvision/models/detection/mask_rcnn.py
@@ -317,7 +317,7 @@ def maskrcnn_resnet50_fpn(pretrained=False, progress=True,
     """
     # check default parameters and by default set it to 3 if possible
     trainable_backbone_layers = _validate_resnet_trainable_layers(
-        pretrained, pretrained_backbone, trainable_backbone_layers)
+        pretrained or pretrained_backbone, trainable_backbone_layers)
 
     if pretrained:
         # no need to download the backbone if pretrained is set

--- a/torchvision/models/detection/mask_rcnn.py
+++ b/torchvision/models/detection/mask_rcnn.py
@@ -10,7 +10,7 @@ from torchvision.ops import MultiScaleRoIAlign
 from ..utils import load_state_dict_from_url
 
 from .faster_rcnn import FasterRCNN
-from .backbone_utils import resnet_fpn_backbone
+from .backbone_utils import resnet_fpn_backbone, _validate_resnet_trainable_layers
 
 __all__ = [
     "MaskRCNN", "maskrcnn_resnet50_fpn",
@@ -265,7 +265,7 @@ model_urls = {
 
 
 def maskrcnn_resnet50_fpn(pretrained=False, progress=True,
-                          num_classes=91, pretrained_backbone=True, trainable_backbone_layers=3, **kwargs):
+                          num_classes=91, pretrained_backbone=True, trainable_backbone_layers=None, **kwargs):
     """
     Constructs a Mask R-CNN model with a ResNet-50-FPN backbone.
 
@@ -315,10 +315,10 @@ def maskrcnn_resnet50_fpn(pretrained=False, progress=True,
         trainable_backbone_layers (int): number of trainable (not frozen) resnet layers starting from final block.
             Valid values are between 0 and 5, with 5 meaning all backbone layers are trainable.
     """
-    assert trainable_backbone_layers <= 5 and trainable_backbone_layers >= 0
-    # dont freeze any layers if pretrained model or backbone is not used
-    if not (pretrained or pretrained_backbone):
-        trainable_backbone_layers = 5
+    # check default parameters and by default set it to 3 if possible
+    trainable_backbone_layers = _validate_resnet_trainable_layers(
+        pretrained, pretrained_backbone, trainable_backbone_layers):
+
     if pretrained:
         # no need to download the backbone if pretrained is set
         pretrained_backbone = False

--- a/torchvision/models/detection/mask_rcnn.py
+++ b/torchvision/models/detection/mask_rcnn.py
@@ -317,7 +317,7 @@ def maskrcnn_resnet50_fpn(pretrained=False, progress=True,
     """
     # check default parameters and by default set it to 3 if possible
     trainable_backbone_layers = _validate_resnet_trainable_layers(
-        pretrained, pretrained_backbone, trainable_backbone_layers):
+        pretrained, pretrained_backbone, trainable_backbone_layers)
 
     if pretrained:
         # no need to download the backbone if pretrained is set


### PR DESCRIPTION
They can introduce flakiness [due to connection errors](https://app.circleci.com/pipelines/github/pytorch/vision/4389/workflows/8cad266c-b547-4551-aedb-8b5bc0958c7f/jobs/261054), and slow tests down, while not being needed for the tests that we currently have.