### PR TITLE
Add test that returns number of registered vision ops

### DIFF
--- a/test/cpp-ops/CMakeLists.txt
+++ b/test/cpp-ops/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.8)
+project(vision-ops-test)
+
+set(CMAKE_CXX_STANDARD 14)
+
+find_package(TorchVision REQUIRED)
+
+add_executable(vision-ops-test main.cpp)
+target_link_libraries(vision-ops-test TorchVision::TorchVision)

--- a/test/cpp-ops/main.cpp
+++ b/test/cpp-ops/main.cpp
@@ -1,0 +1,14 @@
+#include <torchvision/vision.h>
+#include <torch/csrc/jit/runtime/operator.h>
+
+int main() {
+  auto ops = torch::jit::getAllOperators();
+  int vision_ops_count = 0;
+  for (const auto &op : ops) {
+    const auto &schema = op->schema();
+    const auto &ns = schema.getNamespace();
+    if (ns.has_value() && ns.value() == "torchvision")
+      ++vision_ops_count;
+  }
+  return vision_ops_count;
+}


### PR DESCRIPTION
Adds a simple executable that returns the number of registered torchvision ops. This should tell us whether the torchvision ops were successfully registered when `<torchvision/vision.h>` is included (pending PR #2798).

It's still missing integration in the CI as I am not familiar with that. The CI script should check that the program return value is > 0 (should return 9 for now).
@fmassa who should I ask for help in that regard?