### PR TITLE
Fix external DLL loading on wheels

### DIFF
--- a/cmake/TorchVisionConfig.cmake.in
+++ b/cmake/TorchVisionConfig.cmake.in
@@ -32,7 +32,7 @@ if(NOT TARGET Python3::Python)
 find_package(Python3 COMPONENTS Development)
 endif()
 
-set_target_properties(TorchVision::TorchVision PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_INCLUDEDIR@" INTERFACE_LINK_LIBRARIES "torch;Python3::Python" )
+set_target_properties(TorchVision::TorchVision PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${${PN}_INCLUDE_DIR}" INTERFACE_LINK_LIBRARIES "torch;Python3::Python" )
 
 
 if(@WITH_CUDA@)

--- a/packaging/wheel/relocate.py
+++ b/packaging/wheel/relocate.py
@@ -259,6 +259,12 @@ def relocate_elf_library(patchelf, output_dir, output_library, binary):
 
 
 def relocate_dll_library(dumpbin, output_dir, output_library, binary):
+    """
+    Relocate a DLL/PE shared library to be packaged on a wheel.
+
+    Given a shared library, find the transitive closure of its dependencies,
+    rename and copy them into the wheel.
+    """
     print('Relocating {0}'.format(binary))
     binary_path = osp.join(output_library, binary)
 

--- a/torchvision/extension.py
+++ b/torchvision/extension.py
@@ -21,22 +21,12 @@ def _register_extensions():
         with_load_library_flags = hasattr(kernel32, 'AddDllDirectory')
         prev_error_mode = kernel32.SetErrorMode(0x0001)
 
-        kernel32.LoadLibraryW.restype = ctypes.c_void_p
         if with_load_library_flags:
-            kernel32.SetDefaultDllDirectories.restype = ctypes.c_bool
             kernel32.AddDllDirectory.restype = ctypes.c_void_p
-            kernel32.LoadLibraryExW.restype = ctypes.c_void_p
 
         if sys.version_info >= (3, 8):
             os.add_dll_directory(lib_dir)
         elif with_load_library_flags:
-            # res = kernel32.SetDefaultDllDirectories(0x00001000)
-            # if not res:
-            #     err = ctypes.WinError(ctypes.get_last_error())
-            #     err.strerror += (' Error setting LOAD_LIBRARY_SEARCH_DEFAULT_DIRS'
-            #                      ' when calling SetDefaultDllDirectories.')
-            #     raise err
-
             res = kernel32.AddDllDirectory(lib_dir)
             if res is None:
                 err = ctypes.WinError(ctypes.get_last_error())

--- a/torchvision/extension.py
+++ b/torchvision/extension.py
@@ -37,11 +37,13 @@ def _register_extensions():
                                  ' when calling SetDefaultDllDirectories.')
                 raise err
 
-            res = kernel32.AddDllDirectory(lib_dir)
-            if res is None:
-                err = ctypes.WinError(ctypes.get_last_error())
-                err.strerror += f' Error adding "{lib_dir}" to the DLL directories.'
-                raise err
+            dll_dirs = os.environ['PATH'].split(os.pathsep) + [lib_dir]
+            for dll_dir in dll_dirs:
+                res = kernel32.AddDllDirectory(dll_dir)
+                if res is None:
+                    err = ctypes.WinError(ctypes.get_last_error())
+                    err.strerror += f' Error adding "{dll_dir}" to the DLL directories.'
+                    raise err
 
         kernel32.SetErrorMode(prev_error_mode)
 

--- a/torchvision/extension.py
+++ b/torchvision/extension.py
@@ -30,20 +30,18 @@ def _register_extensions():
         if sys.version_info >= (3, 8):
             os.add_dll_directory(lib_dir)
         elif with_load_library_flags:
-            res = kernel32.SetDefaultDllDirectories(0x00001000)
-            if not res:
-                err = ctypes.WinError(ctypes.get_last_error())
-                err.strerror += (' Error setting LOAD_LIBRARY_SEARCH_DEFAULT_DIRS'
-                                 ' when calling SetDefaultDllDirectories.')
-                raise err
+            # res = kernel32.SetDefaultDllDirectories(0x00001000)
+            # if not res:
+            #     err = ctypes.WinError(ctypes.get_last_error())
+            #     err.strerror += (' Error setting LOAD_LIBRARY_SEARCH_DEFAULT_DIRS'
+            #                      ' when calling SetDefaultDllDirectories.')
+            #     raise err
 
-            dll_dirs = os.environ['PATH'].split(os.pathsep) + [lib_dir]
-            for dll_dir in dll_dirs:
-                res = kernel32.AddDllDirectory(dll_dir)
-                if res is None:
-                    err = ctypes.WinError(ctypes.get_last_error())
-                    err.strerror += f' Error adding "{dll_dir}" to the DLL directories.'
-                    raise err
+            res = kernel32.AddDllDirectory(lib_dir)
+            if res is None:
+                err = ctypes.WinError(ctypes.get_last_error())
+                err.strerror += f' Error adding "{lib_dir}" to the DLL directories.'
+                raise err
 
         kernel32.SetErrorMode(prev_error_mode)
 

--- a/torchvision/extension.py
+++ b/torchvision/extension.py
@@ -12,6 +12,39 @@ def _register_extensions():
 
     # load the custom_op_library and register the custom ops
     lib_dir = os.path.dirname(__file__)
+    if os.name == 'nt':
+        # Register the main torchvision library location on the default DLL path
+        import ctypes
+        import sys
+
+        kernel32 = ctypes.WinDLL('kernel32.dll', use_last_error=True)
+        with_load_library_flags = hasattr(kernel32, 'AddDllDirectory')
+        prev_error_mode = kernel32.SetErrorMode(0x0001)
+
+        kernel32.LoadLibraryW.restype = ctypes.c_void_p
+        if with_load_library_flags:
+            kernel32.SetDefaultDllDirectories.restype = ctypes.c_bool
+            kernel32.AddDllDirectory.restype = ctypes.c_void_p
+            kernel32.LoadLibraryExW.restype = ctypes.c_void_p
+
+        if sys.version_info >= (3, 8):
+            os.add_dll_directory(lib_dir)
+        elif with_load_library_flags:
+            res = kernel32.SetDefaultDllDirectories(0x00001000)
+            if not res:
+                err = ctypes.WinError(ctypes.get_last_error())
+                err.strerror += (' Error setting LOAD_LIBRARY_SEARCH_DEFAULT_DIRS'
+                                 ' when calling SetDefaultDllDirectories.')
+                raise err
+
+            res = kernel32.AddDllDirectory(lib_dir)
+            if res is None:
+                err = ctypes.WinError(ctypes.get_last_error())
+                err.strerror += f' Error adding "{lib_dir}" to the DLL directories.'
+                raise err
+
+        kernel32.SetErrorMode(prev_error_mode)
+
     loader_details = (
         importlib.machinery.ExtensionFileLoader,
         importlib.machinery.EXTENSION_SUFFIXES

--- a/torchvision/io/_video_opt.py
+++ b/torchvision/io/_video_opt.py
@@ -15,6 +15,11 @@ _HAS_VIDEO_OPT = False
 try:
     lib_dir = os.path.join(os.path.dirname(__file__), "..")
 
+    if os.name == 'nt':
+        # This is required to load the wheel external binaries
+        os.environ['PATH'] = os.pathsep.join(
+            [os.path.abspath(lib_dir)] + [os.environ['PATH']])
+
     loader_details = (
         importlib.machinery.ExtensionFileLoader,
         importlib.machinery.EXTENSION_SUFFIXES

--- a/torchvision/io/_video_opt.py
+++ b/torchvision/io/_video_opt.py
@@ -13,12 +13,7 @@ import torch
 _HAS_VIDEO_OPT = False
 
 try:
-    lib_dir = os.path.join(os.path.dirname(__file__), "..")
-
-    if os.name == 'nt':
-        # This is required to load the wheel external binaries
-        os.environ['PATH'] = os.pathsep.join(
-            [os.path.abspath(lib_dir)] + [os.environ['PATH']])
+    lib_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 
     loader_details = (
         importlib.machinery.ExtensionFileLoader,

--- a/torchvision/io/_video_opt.py
+++ b/torchvision/io/_video_opt.py
@@ -40,7 +40,7 @@ try:
             if res is None:
                 err = ctypes.WinError(ctypes.get_last_error())
                 err.strerror += (f' Error loading "{ext_specs.origin}" or any or '
-                                'its dependencies.')
+                                 'its dependencies.')
                 raise err
 
         kernel32.SetErrorMode(prev_error_mode)

--- a/torchvision/io/_video_opt.py
+++ b/torchvision/io/_video_opt.py
@@ -35,12 +35,13 @@ try:
         if with_load_library_flags:
             kernel32.LoadLibraryExW.restype = ctypes.c_void_p
 
-        res = kernel32.LoadLibraryExW(ext_specs.origin, None, 0x00001100)
-        if res is None:
-            err = ctypes.WinError(ctypes.get_last_error())
-            err.strerror += (f' Error loading "{ext_specs.origin}" or any or '
-                             'its dependencies.')
-            raise err
+        if ext_specs is not None:
+            res = kernel32.LoadLibraryExW(ext_specs.origin, None, 0x00001100)
+            if res is None:
+                err = ctypes.WinError(ctypes.get_last_error())
+                err.strerror += (f' Error loading "{ext_specs.origin}" or any or '
+                                'its dependencies.')
+                raise err
 
         kernel32.SetErrorMode(prev_error_mode)
 

--- a/torchvision/io/_video_opt.py
+++ b/torchvision/io/_video_opt.py
@@ -22,6 +22,28 @@ try:
 
     extfinder = importlib.machinery.FileFinder(lib_dir, loader_details)
     ext_specs = extfinder.find_spec("video_reader")
+
+    if os.name == 'nt':
+        # Load the video_reader extension using LoadLibraryExW
+        import ctypes
+        import sys
+
+        kernel32 = ctypes.WinDLL('kernel32.dll', use_last_error=True)
+        with_load_library_flags = hasattr(kernel32, 'AddDllDirectory')
+        prev_error_mode = kernel32.SetErrorMode(0x0001)
+
+        if with_load_library_flags:
+            kernel32.LoadLibraryExW.restype = ctypes.c_void_p
+
+        res = kernel32.LoadLibraryExW(ext_specs.origin, None, 0x00001100)
+        if res is None:
+            err = ctypes.WinError(ctypes.get_last_error())
+            err.strerror += (f' Error loading "{ext_specs.origin}" or any or '
+                             'its dependencies.')
+            raise err
+
+        kernel32.SetErrorMode(prev_error_mode)
+
     if ext_specs is not None:
         torch.ops.load_library(ext_specs.origin)
         _HAS_VIDEO_OPT = True

--- a/torchvision/io/image.py
+++ b/torchvision/io/image.py
@@ -7,12 +7,7 @@ import importlib.machinery
 _HAS_IMAGE_OPT = False
 
 try:
-    lib_dir = osp.join(osp.dirname(__file__), "..")
-
-    if os.name == 'nt':
-        # This is required to load the wheel external binaries
-        os.environ['PATH'] = os.pathsep.join(
-            [osp.abspath(lib_dir)] + [os.environ['PATH']])
+    lib_dir = osp.abspath(osp.join(osp.dirname(__file__), ".."))
 
     loader_details = (
         importlib.machinery.ExtensionFileLoader,

--- a/torchvision/io/image.py
+++ b/torchvision/io/image.py
@@ -9,6 +9,11 @@ _HAS_IMAGE_OPT = False
 try:
     lib_dir = osp.join(osp.dirname(__file__), "..")
 
+    if os.name == 'nt':
+        # This is required to load the wheel external binaries
+        os.environ['PATH'] = os.pathsep.join(
+            [osp.abspath(lib_dir)] + [os.environ['PATH']])
+
     loader_details = (
         importlib.machinery.ExtensionFileLoader,
         importlib.machinery.EXTENSION_SUFFIXES

--- a/torchvision/io/image.py
+++ b/torchvision/io/image.py
@@ -35,7 +35,7 @@ try:
             if res is None:
                 err = ctypes.WinError(ctypes.get_last_error())
                 err.strerror += (f' Error loading "{ext_specs.origin}" or any or '
-                                'its dependencies.')
+                                 'its dependencies.')
                 raise err
 
         kernel32.SetErrorMode(prev_error_mode)

--- a/torchvision/io/image.py
+++ b/torchvision/io/image.py
@@ -30,12 +30,13 @@ try:
         if with_load_library_flags:
             kernel32.LoadLibraryExW.restype = ctypes.c_void_p
 
-        res = kernel32.LoadLibraryExW(ext_specs.origin, None, 0x00001100)
-        if res is None:
-            err = ctypes.WinError(ctypes.get_last_error())
-            err.strerror += (f' Error loading "{ext_specs.origin}" or any or '
-                             'its dependencies.')
-            raise err
+        if ext_specs is not None:
+            res = kernel32.LoadLibraryExW(ext_specs.origin, None, 0x00001100)
+            if res is None:
+                err = ctypes.WinError(ctypes.get_last_error())
+                err.strerror += (f' Error loading "{ext_specs.origin}" or any or '
+                                'its dependencies.')
+                raise err
 
         kernel32.SetErrorMode(prev_error_mode)
 


### PR DESCRIPTION
This PR registers the path of the main torchvision library via `AddDllDirectory` on Python < 3.7 and `os.add_dll_directory` on Python >= 3.8. The extensions are preloaded using `LoadLibraryExW` to circunvent the limitation imposed by `AddDllDirectory` without calling `SetDefaultDllDirectories`