### PR TITLE
Re-enable RetinaNet unit-tests on GPU

### DIFF
--- a/test/test_models.py
+++ b/test/test_models.py
@@ -94,6 +94,7 @@ autocast_flaky_numerics = (
     "resnet101",
     "resnet152",
     "wide_resnet101_2",
+    "retinanet_resnet50_fpn",
 )
 
 
@@ -182,9 +183,6 @@ class ModelTester(TestCase):
                 test_value = map_nested_tensor_object(out, tensor_map_fn=compute_mean_std)
                 # mean values are small, use large prec
                 self.assertExpected(test_value, prec=.01, strip_suffix="_" + dev)
-            elif name == "retinanet_resnet50_fpn" and dev == "cuda":
-                # retinanet_resnet50_fpn is numerically unstable on GPU, so disable for now
-                pass
             else:
                 self.assertExpected(map_nested_tensor_object(out, tensor_map_fn=subsample_tensor),
                                     prec=0.01,


### PR DESCRIPTION
Fixing #2824 

When running the tests of ReminaNet on GPU, the outputs are checked twice:
https://github.com/pytorch/vision/blob/5e33cc87979a2320b3795dd971883b07d20aeeed/test/test_models.py#L193

https://github.com/pytorch/vision/blob/5e33cc87979a2320b3795dd971883b07d20aeeed/test/test_models.py#L210-L215

On the first check, the values are very close:
```
expected: 
[{'boxes': tensor([[ 60.6603, 115.2130,  86.0578, 129.6661],
        [ 27.7266,  42.5258,  92.2687, 115.0305],
        [ 28.3789, 138.9524,  91.5207, 211.4824]], requires_grad=True), 'scores': tensor([0.0130, 0.0130, 0.0130], requires_grad=True), 'labels': tensor([2, 4, 4])}]

output: 
[{'boxes': tensor([[ 60.6603, 115.2130,  86.0578, 129.6661],
        [ 27.7266,  42.5258,  92.2687, 115.0306],
        [ 28.3788, 138.9524,  91.5207, 211.4824]], device='cuda:0',
       grad_fn=<StackBackward>), 'scores': tensor([0.0130, 0.0130, 0.0130], device='cuda:0', grad_fn=<CatBackward>), 'labels': tensor([2, 4, 4], device='cuda:0')}]
```

On the second that uses autocast() are not:
```
expected: 
[{'boxes': tensor([[ 60.6603, 115.2130,  86.0578, 129.6661],
        [ 27.7266,  42.5258,  92.2687, 115.0305],
        [ 28.3789, 138.9524,  91.5207, 211.4824]], requires_grad=True), 'scores': tensor([0.0130, 0.0130, 0.0130], requires_grad=True), 'labels': tensor([2, 4, 4])}]

output: 
[{'boxes': tensor([[ 60.6603, 115.2104,  86.0584, 129.6646],
        [ 54.6808,  85.3325,  80.0379,  99.6362],
        [ 28.3769, 138.9522,  91.5294, 211.4853],
        [ 27.7301,  42.4879,  92.2699, 115.0121]], device='cuda:0',
       grad_fn=<StackBackward>), 'scores': tensor([0.0130, 0.0130, 0.0130, 0.0130], device='cuda:0', dtype=torch.float16,
       grad_fn=<CatBackward>), 'labels': tensor([2, 2, 4, 4], device='cuda:0')}]
```

I thought it would be better to partially test the results on GPU, so I decided to re-enable it and include it in the `autocast_flaky_numerics` list.