### PR TITLE
[release/0.8] .cirlceci: Be specific about CU_VERSION for pytorch

### DIFF
--- a/packaging/pkg_helpers.bash
+++ b/packaging/pkg_helpers.bash
@@ -228,9 +228,9 @@ setup_pip_pytorch_version() {
     fi
   else
     pip_install "torch==$PYTORCH_VERSION$PYTORCH_VERSION_SUFFIX" \
-      -f https://download.pytorch.org/whl/torch_stable.html \
-      -f https://download.pytorch.org/whl/test/torch_test.html \
-      -f https://download.pytorch.org/whl/nightly/torch_nightly.html
+      -f "https://download.pytorch.org/whl/${CU_VERSION}/torch_stable.html" \
+      -f "https://download.pytorch.org/whl/test/${CU_VERSION}/torch_test.html" \
+      -f "https://download.pytorch.org/whl/nightly/${CU_VERSION}/torch_nightly.html"
   fi
 }
 


### PR DESCRIPTION
ROCM builds were being picked up for CUDA 10.2 builds since they do not
specify a version suffix. We can utilize the CU_VERSION to be specific
about which index to actually pull from.

Logs of what happened during the release: https://app.circleci.com/pipelines/github/pytorch/vision/4454/workflows/efcd7fa9-7f94-46ef-bee3-a70cefd2dcd2/jobs/266058

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>