### PR TITLE
Add verbose kwarg to download functions

### DIFF
--- a/torchvision/datasets/utils.py
+++ b/torchvision/datasets/utils.py
@@ -43,7 +43,7 @@ def check_integrity(fpath: str, md5: Optional[str] = None) -> bool:
     return check_md5(fpath, md5)
 
 
-def download_url(url: str, root: str, filename: Optional[str] = None, md5: Optional[str] = None) -> None:
+def download_url(url: str, root: str, filename: Optional[str] = None, md5: Optional[str] = None, verbose: bool = True) -> None:
     """Download a file from a url and place it in root.
 
     Args:
@@ -63,7 +63,8 @@ def download_url(url: str, root: str, filename: Optional[str] = None, md5: Optio
 
     # check if file is already present locally
     if check_integrity(fpath, md5):
-        print('Using downloaded and verified file: ' + fpath)
+        if verbose:
+            print('Using downloaded and verified file: ' + fpath)
     else:   # download the file
         try:
             print('Downloading ' + url + ' to ' + fpath)
@@ -123,7 +124,7 @@ def _quota_exceeded(response: "requests.models.Response") -> bool:  # type: igno
     return "Google Drive - Quota exceeded" in response.text
 
 
-def download_file_from_google_drive(file_id: str, root: str, filename: Optional[str] = None, md5: Optional[str] = None):
+def download_file_from_google_drive(file_id: str, root: str, filename: Optional[str] = None, md5: Optional[str] = None, verbose: bool = True) -> None:
     """Download a Google Drive file from  and place it in root.
 
     Args:
@@ -144,7 +145,8 @@ def download_file_from_google_drive(file_id: str, root: str, filename: Optional[
     os.makedirs(root, exist_ok=True)
 
     if os.path.isfile(fpath) and check_integrity(fpath, md5):
-        print('Using downloaded and verified file: ' + fpath)
+        if verbose:
+            print('Using downloaded and verified file: ' + fpath)
     else:
         session = requests.Session()
 

--- a/torchvision/datasets/utils.py
+++ b/torchvision/datasets/utils.py
@@ -51,6 +51,7 @@ def download_url(url: str, root: str, filename: Optional[str] = None, md5: Optio
         root (str): Directory to place downloaded file in
         filename (str, optional): Name to save the file under. If None, use the basename of the URL
         md5 (str, optional): MD5 checksum of the download. If None, do not check
+        verbose (bool): If true, print message if file has been previously downloaded and verified
     """
     import urllib
 
@@ -132,6 +133,7 @@ def download_file_from_google_drive(file_id: str, root: str, filename: Optional[
         root (str): Directory to place downloaded file in
         filename (str, optional): Name to save the file under. If None, use the id of the file.
         md5 (str, optional): MD5 checksum of the download. If None, do not check
+        verbose (bool): If true, print message if file has been previously downloaded and verified
     """
     # Based on https://stackoverflow.com/questions/38511444/python-download-files-from-google-drive-using-url
     import requests

--- a/torchvision/datasets/utils.py
+++ b/torchvision/datasets/utils.py
@@ -43,7 +43,13 @@ def check_integrity(fpath: str, md5: Optional[str] = None) -> bool:
     return check_md5(fpath, md5)
 
 
-def download_url(url: str, root: str, filename: Optional[str] = None, md5: Optional[str] = None, verbose: bool = True) -> None:
+def download_url(
+    url: str,
+    root: str,
+    filename: Optional[str] = None,
+    md5: Optional[str] = None,
+    verbose: bool = True,
+) -> None:
     """Download a file from a url and place it in root.
 
     Args:
@@ -125,7 +131,13 @@ def _quota_exceeded(response: "requests.models.Response") -> bool:  # type: igno
     return "Google Drive - Quota exceeded" in response.text
 
 
-def download_file_from_google_drive(file_id: str, root: str, filename: Optional[str] = None, md5: Optional[str] = None, verbose: bool = True) -> None:
+def download_file_from_google_drive(
+    file_id: str,
+    root: str,
+    filename: Optional[str] = None,
+    md5: Optional[str] = None,
+    verbose: bool = True,
+) -> None:
     """Download a Google Drive file from  and place it in root.
 
     Args:


### PR DESCRIPTION
Resolves #2830.

At the moment, messages are still printed when `verbose=True` if the file needs to be downloaded or there's an error. Possible changes include printing only if `verbose=True` as well, or use three verbosity levels.

I also added a missing typing hint for `download_file_from_google_drive`.

Edit: I forgot to ping @pmeier here.