### PR TITLE
Added __repr__ to MultiScaleRoIAlign

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -357,6 +357,18 @@ class PSRoIAlignTester(RoIOpTester, unittest.TestCase):
         self._helper_boxes_shape(ops.ps_roi_align)
 
 
+class MultiScaleRoIAlignTester(unittest.TestCase):
+    def test_msroialign_repr(self):
+        output_size = (7, 7)
+        sampling_ratio = 2
+        # Pass mock feature map names
+        t = ops.poolers.MultiScaleRoIAlign(['0'], output_size, sampling_ratio)
+
+        # Check integrity of object __repr__ attribute
+        expected_string = f"MultiScaleRoIAlign(output_size={output_size}, sampling_ratio={sampling_ratio})"
+        self.assertEqual(t.__repr__(), expected_string)
+
+
 class NMSTester(unittest.TestCase):
     def reference_nms(self, boxes, scores, iou_threshold):
         """

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -359,13 +359,15 @@ class PSRoIAlignTester(RoIOpTester, unittest.TestCase):
 
 class MultiScaleRoIAlignTester(unittest.TestCase):
     def test_msroialign_repr(self):
+        fmap_names = ['0']
         output_size = (7, 7)
         sampling_ratio = 2
         # Pass mock feature map names
-        t = ops.poolers.MultiScaleRoIAlign(['0'], output_size, sampling_ratio)
+        t = ops.poolers.MultiScaleRoIAlign(fmap_names, output_size, sampling_ratio)
 
         # Check integrity of object __repr__ attribute
-        expected_string = f"MultiScaleRoIAlign(output_size={output_size}, sampling_ratio={sampling_ratio})"
+        expected_string = (f"MultiScaleRoIAlign(featmap_names={fmap_names}, output_size={output_size}, "
+                           f"sampling_ratio={sampling_ratio})")
         self.assertEqual(t.__repr__(), expected_string)
 
 

--- a/torchvision/ops/poolers.py
+++ b/torchvision/ops/poolers.py
@@ -260,4 +260,5 @@ class MultiScaleRoIAlign(nn.Module):
         return result
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}(output_size={self.output_size}, sampling_ratio={self.sampling_ratio})"
+        return (f"{self.__class__.__name__}(featmap_names={self.featmap_names}, "
+                f"output_size={self.output_size}, sampling_ratio={self.sampling_ratio})")

--- a/torchvision/ops/poolers.py
+++ b/torchvision/ops/poolers.py
@@ -258,3 +258,6 @@ class MultiScaleRoIAlign(nn.Module):
             result = _onnx_merge_levels(levels, tracing_results)
 
         return result
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(output_size={self.output_size}, sampling_ratio={self.sampling_ratio})"


### PR DESCRIPTION
Hello there :wave: 

I happen to be playing around with region pooling architectures lately, and printing the model in the console is useful to debug or figure out ways to improve the architecture. While `RoIPool` and `RoIAlign` have useful `__repr__` attributes, their multi-scale counterpart doesn't have any.

I figured this isn't worth opening an issue, so here is what this PR does:

- adding information in the `__repr__` attribute to the `MultiScaleRoIAlign` class
- adding a corresponding unittest

Suggestions are welcomed for the proposed formatting!