### PR TITLE
Added __repr__ to FeaturePyramidNetwork

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -806,5 +806,17 @@ class GenBoxIouTester(unittest.TestCase):
         assert ((out - expected).abs().max() < tolerance).item() is True
 
 
+class FPNTester(unittest.TestCase):
+    def test_featurepyramidnetwork_repr(self):
+        in_chans = [32, 64]
+        out_chan = 32
+        # Pass mock number of channels
+        t = ops.feature_pyramid_network.FeaturePyramidNetwork(in_chans, out_chan)
+
+        # Check integrity of object __repr__ attribute
+        expected_string = f"FeaturePyramidNetwork(in_channels_list={in_chans}, out_channels={out_chan})"
+        self.assertEqual(t.__repr__(), expected_string)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/torchvision/ops/feature_pyramid_network.py
+++ b/torchvision/ops/feature_pyramid_network.py
@@ -165,6 +165,9 @@ class FeaturePyramidNetwork(nn.Module):
 
         return out
 
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(in_channels_list={self.in_channels_list}, out_channels={self.out_channels})"
+
 
 class LastLevelMaxPool(ExtraFPNBlock):
     """


### PR DESCRIPTION
Hello there :wave: 

This is a follow-up PR on #2840 that aims at:
- adding information in the  `__repr__` attribute to the `FeaturePyramidNetwork` class
- adding a corresponding unittest