### PR TITLE
Added eps in the __repr__ of FrozenBN

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -607,10 +607,11 @@ class DeformConvTester(OpTester, unittest.TestCase):
 class FrozenBNTester(unittest.TestCase):
     def test_frozenbatchnorm2d_repr(self):
         num_features = 32
-        t = ops.misc.FrozenBatchNorm2d(num_features)
+        eps = 1e-5
+        t = ops.misc.FrozenBatchNorm2d(num_features, eps=eps)
 
         # Check integrity of object __repr__ attribute
-        expected_string = f"FrozenBatchNorm2d({num_features})"
+        expected_string = f"FrozenBatchNorm2d({num_features}, eps={eps})"
         self.assertEqual(t.__repr__(), expected_string)
 
     def test_frozenbatchnorm2d_eps(self):

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -623,12 +623,13 @@ class FrozenBNTester(unittest.TestCase):
                           running_var=torch.rand(sample_size[1]),
                           num_batches_tracked=torch.tensor(100))
 
-        # Check that default eps is the same as BN
+        # Check that default eps is zero for backward-compatibility
         fbn = ops.misc.FrozenBatchNorm2d(sample_size[1])
         fbn.load_state_dict(state_dict, strict=False)
-        bn = torch.nn.BatchNorm2d(sample_size[1])
+        bn = torch.nn.BatchNorm2d(sample_size[1], eps=0).eval()
         bn.load_state_dict(state_dict)
-        self.assertEqual(fbn.eps, bn.eps)
+        # Difference is expected to fall in an acceptable range
+        self.assertTrue(torch.allclose(fbn(x), bn(x), atol=1e-6))
 
         # Check computation for eps > 0
         fbn = ops.misc.FrozenBatchNorm2d(sample_size[1], eps=1e-5)

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -623,13 +623,12 @@ class FrozenBNTester(unittest.TestCase):
                           running_var=torch.rand(sample_size[1]),
                           num_batches_tracked=torch.tensor(100))
 
-        # Check that default eps is zero for backward-compatibility
+        # Check that default eps is the same as BN
         fbn = ops.misc.FrozenBatchNorm2d(sample_size[1])
         fbn.load_state_dict(state_dict, strict=False)
-        bn = torch.nn.BatchNorm2d(sample_size[1], eps=0).eval()
+        bn = torch.nn.BatchNorm2d(sample_size[1])
         bn.load_state_dict(state_dict)
-        # Difference is expected to fall in an acceptable range
-        self.assertTrue(torch.allclose(fbn(x), bn(x), atol=1e-6))
+        self.assertEqual(fbn.eps, bn.eps)
 
         # Check computation for eps > 0
         fbn = ops.misc.FrozenBatchNorm2d(sample_size[1], eps=1e-5)

--- a/torchvision/ops/misc.py
+++ b/torchvision/ops/misc.py
@@ -96,4 +96,4 @@ class FrozenBatchNorm2d(torch.nn.Module):
         return x * scale + bias
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}({self.weight.shape[0]})"
+        return f"{self.__class__.__name__}({self.weight.shape[0]}, eps={self.eps})"

--- a/torchvision/ops/misc.py
+++ b/torchvision/ops/misc.py
@@ -51,7 +51,7 @@ class FrozenBatchNorm2d(torch.nn.Module):
     def __init__(
         self,
         num_features: int,
-        eps: float = 0.,
+        eps: float = 1e-5,
         n: Optional[int] = None,
     ):
         # n=None for backward-compatibility

--- a/torchvision/ops/misc.py
+++ b/torchvision/ops/misc.py
@@ -51,7 +51,7 @@ class FrozenBatchNorm2d(torch.nn.Module):
     def __init__(
         self,
         num_features: int,
-        eps: float = 1e-5,
+        eps: float = 0.,
         n: Optional[int] = None,
     ):
         # n=None for backward-compatibility


### PR DESCRIPTION
Hey there :wave: 

A few months back I suggested the PR #2190 that added the `eps` attribute to FrozenBN. At that time, we set the default to 0 for backward compatibility. As per #2599, the silent difference of eps is an issue. So here is what this PR does:
- updates `__repr__` method to adds `eps` to align the method with the one of `torch.nn.BatchNorm2d`
- updates the unittest on `__repr__`

Any suggestion is welcome!