### PR TITLE
Added annotation typing to models._utils

### DIFF
--- a/torchvision/models/_utils.py
+++ b/torchvision/models/_utils.py
@@ -2,7 +2,7 @@ from collections import OrderedDict
 
 import torch
 from torch import nn
-from torch.jit.annotations import Dict
+from typing import Dict
 
 
 class IntermediateLayerGetter(nn.ModuleDict):

--- a/torchvision/models/_utils.py
+++ b/torchvision/models/_utils.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict
 
 import torch
+from torch import Tensor
 from torch import nn
 from torch.jit.annotations import Dict
 
@@ -41,7 +42,7 @@ class IntermediateLayerGetter(nn.ModuleDict):
         "return_layers": Dict[str, str],
     }
 
-    def __init__(self, model, return_layers):
+    def __init__(self, model: nn.Module, return_layers: Dict[str, str]):
         if not set(return_layers).issubset([name for name, _ in model.named_children()]):
             raise ValueError("return_layers are not present in model")
         orig_return_layers = return_layers
@@ -57,7 +58,7 @@ class IntermediateLayerGetter(nn.ModuleDict):
         super(IntermediateLayerGetter, self).__init__(layers)
         self.return_layers = orig_return_layers
 
-    def forward(self, x):
+    def forward(self, x: Tensor) -> Tensor:
         out = OrderedDict()
         for name, module in self.items():
             x = module(x)

--- a/torchvision/models/_utils.py
+++ b/torchvision/models/_utils.py
@@ -57,7 +57,7 @@ class IntermediateLayerGetter(nn.ModuleDict):
         super(IntermediateLayerGetter, self).__init__(layers)
         self.return_layers = orig_return_layers
 
-    def forward(self, x: torch.Tensor) -> Dict[str, torch.Tensor]:
+    def forward(self, x):
         out = OrderedDict()
         for name, module in self.items():
             x = module(x)

--- a/torchvision/models/_utils.py
+++ b/torchvision/models/_utils.py
@@ -1,7 +1,6 @@
 from collections import OrderedDict
 
 import torch
-from torch import Tensor
 from torch import nn
 from torch.jit.annotations import Dict
 
@@ -58,7 +57,7 @@ class IntermediateLayerGetter(nn.ModuleDict):
         super(IntermediateLayerGetter, self).__init__(layers)
         self.return_layers = orig_return_layers
 
-    def forward(self, x: Tensor) -> Tensor:
+    def forward(self, x: torch.Tensor) -> Dict[str, torch.Tensor]:
         out = OrderedDict()
         for name, module in self.items():
             x = module(x)


### PR DESCRIPTION
Hello folks :wave: 

As per #2025, annotation typing are welcome in torchvision. So I started with `torchvision.models._utils` in this PR. A few points of attention:
- I picked `Callable[..., nn.Module]` for module constructors (passing `BatchNorm2d` for instance), I'm unsure whether that is good choice? any recommendation?
-  I only used black styling in class constructors for now, the rest are only annotation typing additions. Happy to change everything to black linting if you prefer.

Any feedback is welcome!