### PR TITLE
Fixed typing in constructors of models submodules

### DIFF
--- a/torchvision/models/_utils.py
+++ b/torchvision/models/_utils.py
@@ -41,7 +41,7 @@ class IntermediateLayerGetter(nn.ModuleDict):
         "return_layers": Dict[str, str],
     }
 
-    def __init__(self, model: nn.Module, return_layers: Dict[str, str]):
+    def __init__(self, model: nn.Module, return_layers: Dict[str, str]) -> None:
         if not set(return_layers).issubset([name for name, _ in model.named_children()]):
             raise ValueError("return_layers are not present in model")
         orig_return_layers = return_layers

--- a/torchvision/models/alexnet.py
+++ b/torchvision/models/alexnet.py
@@ -14,7 +14,7 @@ model_urls = {
 
 class AlexNet(nn.Module):
 
-    def __init__(self, num_classes: int = 1000):
+    def __init__(self, num_classes: int = 1000) -> None:
         super(AlexNet, self).__init__()
         self.features = nn.Sequential(
             nn.Conv2d(3, 64, kernel_size=11, stride=4, padding=2),

--- a/torchvision/models/mnasnet.py
+++ b/torchvision/models/mnasnet.py
@@ -32,7 +32,7 @@ class _InvertedResidual(nn.Module):
         stride: int,
         expansion_factor: int,
         bn_momentum: float = 0.1
-    ):
+    ) -> None:
         super(_InvertedResidual, self).__init__()
         assert stride in [1, 2]
         assert kernel_size in [3, 5]
@@ -109,7 +109,7 @@ class MNASNet(torch.nn.Module):
         alpha: float,
         num_classes: int = 1000,
         dropout: float = 0.2
-    ):
+    ) -> None:
         super(MNASNet, self).__init__()
         assert alpha > 0.0
         self.alpha = alpha

--- a/torchvision/models/squeezenet.py
+++ b/torchvision/models/squeezenet.py
@@ -20,7 +20,7 @@ class Fire(nn.Module):
         squeeze_planes: int,
         expand1x1_planes: int,
         expand3x3_planes: int
-    ):
+    ) -> None:
         super(Fire, self).__init__()
         self.inplanes = inplanes
         self.squeeze = nn.Conv2d(inplanes, squeeze_planes, kernel_size=1)
@@ -46,7 +46,7 @@ class SqueezeNet(nn.Module):
         self,
         version: str = '1_0',
         num_classes: int = 1000
-    ):
+    ) -> None:
         super(SqueezeNet, self).__init__()
         self.num_classes = num_classes
         if version == '1_0':


### PR DESCRIPTION
Hey there!

This is small fix for the PRs introducing typing in `_utils`, `alexnet`, `mnasnet`, `squeezenet` #2854 #2856 #2859 #2865 
Since it was my mistake to forget them in the first place, I figured I'd open this one :sweat_smile: 

Any feedback is welcome!