### PR TITLE
Fixes #2880 - failing macosx cmake ci job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -627,7 +627,7 @@ jobs:
   cmake_macos_cpu:
     <<: *binary_common
     macos:
-      xcode: "9.0"
+      xcode: "9.4.1"
     steps:
       - checkout_merge
       - run:

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -627,7 +627,7 @@ jobs:
   cmake_macos_cpu:
     <<: *binary_common
     macos:
-      xcode: "9.0"
+      xcode: "9.4.1"
     steps:
       - checkout_merge
       - run:


### PR DESCRIPTION
Fixes #2880


Just updated xcode image to 9.4.1 which is not yet deprecated.