### PR TITLE
Correcting the schema for nms, roi_align and _roi_align_backward.

### DIFF
--- a/torchvision/csrc/vision.cpp
+++ b/torchvision/csrc/vision.cpp
@@ -45,11 +45,11 @@ int64_t cuda_version() noexcept {
 } // namespace vision
 
 TORCH_LIBRARY(torchvision, m) {
-  m.def("nms(Tensor dets, Tensor scores, float iou_threshold) -> Tensor");
+  m.def("nms(Tensor dets, Tensor scores, double iou_threshold) -> Tensor");
   m.def(
-      "roi_align(Tensor input, Tensor rois, float spatial_scale, int pooled_height, int pooled_width, int sampling_ratio, bool aligned) -> Tensor");
+      "roi_align(Tensor input, Tensor rois, double spatial_scale, int pooled_height, int pooled_width, int sampling_ratio, bool aligned) -> Tensor");
   m.def(
-      "_roi_align_backward(Tensor grad, Tensor rois, float spatial_scale, int pooled_height, int pooled_width, int batch_size, int channels, int height, int width, int sampling_ratio, bool aligned) -> Tensor");
+      "_roi_align_backward(Tensor grad, Tensor rois, double spatial_scale, int pooled_height, int pooled_width, int batch_size, int channels, int height, int width, int sampling_ratio, bool aligned) -> Tensor");
   m.def("roi_pool", &roi_pool);
   m.def("_new_empty_tensor_op", &new_empty_tensor);
   m.def("ps_roi_align", &ps_roi_align);


### PR DESCRIPTION
In the schema of `nms()`, `roi_align()` and `_roi_align_backward()`, the variables `iou_threshold` and `spatial_scale` are defined as floats:

https://github.com/pytorch/vision/blob/190a5f8a32f9ae775d4379c55db7e2deb6eada6b/torchvision/csrc/vision.cpp#L46-L50

while their C++ headers define them as doubles:

https://github.com/pytorch/vision/blob/190a5f8a32f9ae775d4379c55db7e2deb6eada6b/torchvision/csrc/nms.h#L17

https://github.com/pytorch/vision/blob/190a5f8a32f9ae775d4379c55db7e2deb6eada6b/torchvision/csrc/ROIAlign.h#L20

https://github.com/pytorch/vision/blob/190a5f8a32f9ae775d4379c55db7e2deb6eada6b/torchvision/csrc/ROIAlign.h#L66

This PR fixes the bug.