### PR TITLE
DeformConv code cleanup

### DIFF
--- a/torchvision/csrc/DeformConv.h
+++ b/torchvision/csrc/DeformConv.h
@@ -317,5 +317,6 @@ DeformConv2d_backward_autograd(
       dilation_w,
       groups,
       offset_groups);
+
   return std::make_tuple(result[0], result[1], result[2], result[3]);
 }

--- a/torchvision/csrc/DeformConv.h
+++ b/torchvision/csrc/DeformConv.h
@@ -2,8 +2,13 @@
 
 #include "cpu/vision_cpu.h"
 
-#if defined(WITH_CUDA) || defined(WITH_HIP)
+#ifdef WITH_CUDA
 #include "autocast.h"
+#include "cuda/vision_cuda.h"
+#endif
+#ifdef WITH_HIP
+#include "autocast.h"
+#include "hip/vision_cuda.h"
 #endif
 
 // TODO: put this stuff in torchvision namespace

--- a/torchvision/csrc/DeformConv.h
+++ b/torchvision/csrc/DeformConv.h
@@ -11,14 +11,14 @@ at::Tensor deform_conv2d(
     const at::Tensor& weight,
     const at::Tensor& offset,
     const at::Tensor& bias,
-    const int64_t stride_h,
-    const int64_t stride_w,
-    const int64_t pad_h,
-    const int64_t pad_w,
-    const int64_t dilation_h,
-    const int64_t dilation_w,
-    const int64_t groups,
-    const int64_t offset_groups) {
+    int64_t stride_h,
+    int64_t stride_w,
+    int64_t pad_h,
+    int64_t pad_w,
+    int64_t dilation_h,
+    int64_t dilation_w,
+    int64_t groups,
+    int64_t offset_groups) {
   static auto op = c10::Dispatcher::singleton()
                        .findSchemaOrThrow("torchvision::deform_conv2d", "")
                        .typed<decltype(deform_conv2d)>();
@@ -43,14 +43,14 @@ at::Tensor DeformConv2d_autocast(
     const at::Tensor& weight,
     const at::Tensor& offset,
     const at::Tensor& bias,
-    const int64_t stride_h,
-    const int64_t stride_w,
-    const int64_t pad_h,
-    const int64_t pad_w,
-    const int64_t dilation_h,
-    const int64_t dilation_w,
-    const int64_t groups,
-    const int64_t offset_groups) {
+    int64_t stride_h,
+    int64_t stride_w,
+    int64_t pad_h,
+    int64_t pad_w,
+    int64_t dilation_h,
+    int64_t dilation_w,
+    int64_t groups,
+    int64_t offset_groups) {
   c10::impl::ExcludeDispatchKeyGuard no_autocast(c10::DispatchKey::Autocast);
   return deform_conv2d(
              at::autocast::cached_cast(at::kFloat, input),
@@ -76,14 +76,14 @@ _deform_conv2d_backward(
     const at::Tensor& weight,
     const at::Tensor& offset,
     const at::Tensor& bias,
-    const int64_t stride_h,
-    const int64_t stride_w,
-    const int64_t pad_h,
-    const int64_t pad_w,
-    const int64_t dilation_h,
-    const int64_t dilation_w,
-    const int64_t groups,
-    const int64_t offset_groups) {
+    int64_t stride_h,
+    int64_t stride_w,
+    int64_t pad_h,
+    int64_t pad_w,
+    int64_t dilation_h,
+    int64_t dilation_w,
+    int64_t groups,
+    int64_t offset_groups) {
   static auto op =
       c10::Dispatcher::singleton()
           .findSchemaOrThrow("torchvision::_deform_conv2d_backward", "")
@@ -109,10 +109,10 @@ class DeformConv2dFunction
  public:
   static torch::autograd::variable_list forward(
       torch::autograd::AutogradContext* ctx,
-      torch::autograd::Variable input,
-      torch::autograd::Variable weight,
-      torch::autograd::Variable offset,
-      torch::autograd::Variable bias,
+      const torch::autograd::Variable& input,
+      const torch::autograd::Variable& weight,
+      const torch::autograd::Variable& offset,
+      const torch::autograd::Variable& bias,
       int64_t stride_h,
       int64_t stride_w,
       int64_t pad_h,
@@ -121,7 +121,7 @@ class DeformConv2dFunction
       int64_t dilation_w,
       int64_t groups,
       int64_t offset_groups) {
-    at::AutoNonVariableTypeMode g; // TODO_vv: check if necessary
+    at::AutoNonVariableTypeMode g;
     auto output = deform_conv2d(
         input,
         weight,
@@ -153,7 +153,7 @@ class DeformConv2dFunction
 
   static torch::autograd::variable_list backward(
       torch::autograd::AutogradContext* ctx,
-      torch::autograd::variable_list grad_output) {
+      const torch::autograd::variable_list& grad_output) {
     auto saved = ctx->get_saved_variables();
     auto input = saved[0];
     auto weight = saved[1];
@@ -211,19 +211,19 @@ class DeformConv2dBackwardFunction
  public:
   static torch::autograd::variable_list forward(
       torch::autograd::AutogradContext* ctx,
-      torch::autograd::Variable grad,
-      torch::autograd::Variable input,
-      torch::autograd::Variable weight,
-      torch::autograd::Variable offset,
-      torch::autograd::Variable bias,
-      const int64_t stride_h,
-      const int64_t stride_w,
-      const int64_t pad_h,
-      const int64_t pad_w,
-      const int64_t dilation_h,
-      const int64_t dilation_w,
-      const int64_t groups,
-      const int64_t offset_groups) {
+      const torch::autograd::Variable& grad,
+      const torch::autograd::Variable& input,
+      const torch::autograd::Variable& weight,
+      const torch::autograd::Variable& offset,
+      const torch::autograd::Variable& bias,
+      int64_t stride_h,
+      int64_t stride_w,
+      int64_t pad_h,
+      int64_t pad_w,
+      int64_t dilation_h,
+      int64_t dilation_w,
+      int64_t groups,
+      int64_t offset_groups) {
     at::AutoNonVariableTypeMode g;
     auto result = _deform_conv2d_backward(
         grad,
@@ -255,7 +255,7 @@ class DeformConv2dBackwardFunction
 
   static torch::autograd::variable_list backward(
       torch::autograd::AutogradContext* ctx,
-      torch::autograd::variable_list grad_output) {
+      const torch::autograd::variable_list& grad_output) {
     TORCH_CHECK(0, "double backwards on deform_conv2d not supported");
   }
 };
@@ -265,14 +265,14 @@ at::Tensor DeformConv2d_autograd(
     const at::Tensor& weight,
     const at::Tensor& offset,
     const at::Tensor& bias,
-    const int64_t stride_h,
-    const int64_t stride_w,
-    const int64_t pad_h,
-    const int64_t pad_w,
-    const int64_t dilation_h,
-    const int64_t dilation_w,
-    const int64_t groups,
-    const int64_t offset_groups) {
+    int64_t stride_h,
+    int64_t stride_w,
+    int64_t pad_h,
+    int64_t pad_w,
+    int64_t dilation_h,
+    int64_t dilation_w,
+    int64_t groups,
+    int64_t offset_groups) {
   return DeformConv2dFunction::apply(
       input,
       weight,
@@ -295,14 +295,14 @@ DeformConv2d_backward_autograd(
     const at::Tensor& weight,
     const at::Tensor& offset,
     const at::Tensor& bias,
-    const int64_t stride_h,
-    const int64_t stride_w,
-    const int64_t pad_h,
-    const int64_t pad_w,
-    const int64_t dilation_h,
-    const int64_t dilation_w,
-    const int64_t groups,
-    const int64_t offset_groups) {
+    int64_t stride_h,
+    int64_t stride_w,
+    int64_t pad_h,
+    int64_t pad_w,
+    int64_t dilation_h,
+    int64_t dilation_w,
+    int64_t groups,
+    int64_t offset_groups) {
   auto result = DeformConv2dBackwardFunction::apply(
       grad,
       input,

--- a/torchvision/csrc/DeformConv.h
+++ b/torchvision/csrc/DeformConv.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "cpu/vision_cpu.h"
+
 #if defined(WITH_CUDA) || defined(WITH_HIP)
 #include "autocast.h"
 #endif

--- a/torchvision/csrc/cpu/DeformConv_cpu.cpp
+++ b/torchvision/csrc/cpu/DeformConv_cpu.cpp
@@ -79,8 +79,8 @@ const int kMaxParallelImgs = 32;
 template <typename scalar_t>
 static scalar_t bilinear_interpolate(
     const scalar_t* in,
-    const int height,
-    const int width,
+    int height,
+    int width,
     scalar_t h,
     scalar_t w) {
   if (h <= -1 || height <= h || w <= -1 || width <= w) {
@@ -117,24 +117,24 @@ static scalar_t bilinear_interpolate(
 
 template <typename scalar_t>
 static void deformable_im2col_kernel(
-    const int n,
+    int n,
     const scalar_t* input,
     const scalar_t* offset,
-    const int height,
-    const int width,
-    const int weight_h,
-    const int weight_w,
-    const int pad_h,
-    const int pad_w,
-    const int stride_h,
-    const int stride_w,
-    const int dil_h,
-    const int dil_w,
-    const int batch_sz,
-    const int n_in_channels,
-    const int n_offset_grps,
-    const int out_h,
-    const int out_w,
+    int height,
+    int width,
+    int weight_h,
+    int weight_w,
+    int pad_h,
+    int pad_w,
+    int stride_h,
+    int stride_w,
+    int dil_h,
+    int dil_w,
+    int batch_sz,
+    int n_in_channels,
+    int n_offset_grps,
+    int out_h,
+    int out_w,
     scalar_t* columns) {
   for (int index = 0; index != n; ++index) {
     const int out_x = index % out_w;
@@ -174,8 +174,8 @@ static void deformable_im2col_kernel(
 }
 
 static void deformable_im2col(
-    const at::Tensor input,
-    const at::Tensor data_offset,
+    const at::Tensor& input,
+    const at::Tensor& data_offset,
     int n_in_channels,
     int height,
     int width,
@@ -403,24 +403,24 @@ at::Tensor DeformConv2d_forward_cpu(
 
 template <typename scalar_t>
 static void deformable_col2im_kernel(
-    const int n,
+    int n,
     const scalar_t* col,
     const scalar_t* offset,
-    const int channels,
-    const int height,
-    const int width,
-    const int kernel_h,
-    const int kernel_w,
-    const int pad_h,
-    const int pad_w,
-    const int stride_h,
-    const int stride_w,
-    const int dilation_h,
-    const int dilation_w,
-    const int batch_sz,
-    const int n_offset_grps,
-    const int out_h,
-    const int out_w,
+    int channels,
+    int height,
+    int width,
+    int kernel_h,
+    int kernel_w,
+    int pad_h,
+    int pad_w,
+    int stride_h,
+    int stride_w,
+    int dilation_h,
+    int dilation_w,
+    int batch_sz,
+    int n_offset_grps,
+    int out_h,
+    int out_w,
     scalar_t* grad_im) {
   for (int index = 0; index != n; ++index) {
     const int out_x = index % out_w;
@@ -461,21 +461,21 @@ static void deformable_col2im_kernel(
 }
 
 static void compute_grad_input(
-    const at::Tensor columns,
-    const at::Tensor offset,
-    const int channels,
-    const int height,
-    const int width,
-    const int weight_h,
-    const int weight_w,
-    const int pad_h,
-    const int pad_w,
-    const int stride_h,
-    const int stride_w,
-    const int dilation_h,
-    const int dilation_w,
-    const int parallel_imgs,
-    const int n_offset_grps,
+    const at::Tensor& columns,
+    const at::Tensor& offset,
+    int channels,
+    int height,
+    int width,
+    int weight_h,
+    int weight_w,
+    int pad_h,
+    int pad_w,
+    int stride_h,
+    int stride_w,
+    int dilation_h,
+    int dilation_w,
+    int parallel_imgs,
+    int n_offset_grps,
     at::Tensor grad_im) {
   int out_h =
       (height + 2 * pad_h - (dilation_h * (weight_h - 1) + 1)) / stride_h + 1;
@@ -512,8 +512,8 @@ static void compute_grad_input(
 template <typename scalar_t>
 static scalar_t get_coordinate_weight(
     const scalar_t* im_data,
-    const int height,
-    const int width,
+    int height,
+    int width,
     scalar_t y,
     scalar_t x,
     bool is_y_direction) {
@@ -544,26 +544,26 @@ static scalar_t get_coordinate_weight(
 
 template <typename scalar_t>
 static void deformable_col2im_coord_kernel(
-    const int n,
+    int n,
     const scalar_t* col,
     const scalar_t* im,
     const scalar_t* offset,
-    const int channels,
-    const int height,
-    const int width,
-    const int weight_h,
-    const int weight_w,
-    const int pad_h,
-    const int pad_w,
-    const int stride_h,
-    const int stride_w,
-    const int dilation_h,
-    const int dilation_w,
-    const int batch_sz,
-    const int offset_channels,
-    const int n_offset_grps,
-    const int out_h,
-    const int out_w,
+    int channels,
+    int height,
+    int width,
+    int weight_h,
+    int weight_w,
+    int pad_h,
+    int pad_w,
+    int stride_h,
+    int stride_w,
+    int dilation_h,
+    int dilation_w,
+    int batch_sz,
+    int offset_channels,
+    int n_offset_grps,
+    int out_h,
+    int out_w,
     scalar_t* grad_offset) {
   for (int index = 0; index != n; ++index) {
     scalar_t val = 0;
@@ -619,22 +619,22 @@ static void deformable_col2im_coord_kernel(
 }
 
 static void compute_grad_offset(
-    const at::Tensor columns,
-    const at::Tensor input,
-    const at::Tensor offset,
-    const int channels,
-    const int height,
-    const int width,
-    const int weight_h,
-    const int weight_w,
-    const int pad_h,
-    const int pad_w,
-    const int stride_h,
-    const int stride_w,
-    const int dilation_h,
-    const int dilation_w,
-    const int parallel_imgs,
-    const int n_offset_grps,
+    const at::Tensor& columns,
+    const at::Tensor& input,
+    const at::Tensor& offset,
+    int channels,
+    int height,
+    int width,
+    int weight_h,
+    int weight_w,
+    int pad_h,
+    int pad_w,
+    int stride_h,
+    int stride_w,
+    int dilation_h,
+    int dilation_w,
+    int parallel_imgs,
+    int n_offset_grps,
     at::Tensor grad_offset) {
   int out_h =
       (height + 2 * pad_h - (dilation_h * (weight_h - 1) + 1)) / stride_h + 1;

--- a/torchvision/csrc/cuda/DeformConv_cuda.cu
+++ b/torchvision/csrc/cuda/DeformConv_cuda.cu
@@ -126,7 +126,7 @@ __device__ scalar_t bilinear_interpolate(
 }
 
 template <typename scalar_t>
-__global__ void deformable_im2col_kernel(
+__global__ void deformable_im2col_gpu_kernel(
     int n,
     const scalar_t* input_ptr,
     const scalar_t* offset_ptr,
@@ -205,7 +205,7 @@ static void deformable_im2col(
 
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
       input.scalar_type(), "deformable_im2col_gpu", ([&] {
-        deformable_im2col_kernel<<<
+        deformable_im2col_gpu_kernel<<<
             GET_BLOCKS(num_kernels),
             CUDA_NUM_THREADS>>>(
             num_kernels,
@@ -419,7 +419,7 @@ at::Tensor DeformConv2d_forward_cuda(
 }
 
 template <typename scalar_t>
-__global__ void deformable_col2im_kernel(
+__global__ void deformable_col2im_gpu_kernel(
     int n,
     const scalar_t* col,
     const scalar_t* offset_ptr,
@@ -502,7 +502,7 @@ static void compute_grad_input(
 
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
       columns.scalar_type(), "deformable_col2im_gpu", ([&] {
-        deformable_col2im_kernel<<<
+        deformable_col2im_gpu_kernel<<<
             GET_BLOCKS(num_kernels),
             CUDA_NUM_THREADS>>>(
             num_kernels,
@@ -566,7 +566,7 @@ __device__ scalar_t get_coordinate_weight(
 }
 
 template <typename scalar_t>
-__global__ void deformable_col2im_coord_kernel(
+__global__ void deformable_col2im_coord_gpu_kernel(
     int n,
     const scalar_t* col_ptr,
     const scalar_t* im_ptr,
@@ -666,7 +666,7 @@ static void compute_grad_offset(
 
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
       columns.scalar_type(), "deformable_col2im_coord_gpu", ([&] {
-        deformable_col2im_coord_kernel<<<
+        deformable_col2im_coord_gpu_kernel<<<
             GET_BLOCKS(num_kernels),
             CUDA_NUM_THREADS>>>(
             num_kernels,


### PR DESCRIPTION
I'm doing some code clean up on the implementation of DeformConv:
- Remove primitive const declaration from method names.
- Passing as const ref instead of value where possible.
- Safely aligning method names between cpu and cuda.

@fmassa All changes are optional, so flag any that we don't want and I'll revert this and the other cleanup PRs. 