### PR TITLE
packaging: Add version suffix to build version

### DIFF
--- a/packaging/pkg_helpers.bash
+++ b/packaging/pkg_helpers.bash
@@ -132,7 +132,7 @@ setup_build_version() {
   # Set build version based on tag if on tag
   if [[ -n "${CIRCLE_TAG}" ]]; then
     # Strip tag
-    export BUILD_VERSION="$(echo "${CIRCLE_TAG}" | sed -e 's/^v//' -e 's/-.*$//')"
+    export BUILD_VERSION="$(echo "${CIRCLE_TAG}" | sed -e 's/^v//' -e 's/-.*$//')${VERSION_SUFFIX}"
   fi
 }
 


### PR DESCRIPTION
This was a mistake since version suffix should always be appended

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>
(cherry picked from commit 6631b74db7cf8aebee8af196b4c65b1fce220baa)
Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

Same as #2913 but for master