### PR TITLE
Enabling to import `read_file` and the other methods from torchvision.io

### DIFF
--- a/torchvision/io/__init__.py
+++ b/torchvision/io/__init__.py
@@ -17,11 +17,15 @@ from .video import (
     write_video,
 )
 from .image import (
-    read_image,
     decode_image,
+    decode_jpeg,
+    decode_png,
     encode_jpeg,
-    write_jpeg,
     encode_png,
+    read_file,
+    read_image,
+    write_file,
+    write_jpeg,
     write_png,
 )
 
@@ -164,11 +168,15 @@ __all__ = [
     "_read_video_meta_data",
     "VideoMetaData",
     "Timebase",
-    "read_image",
     "decode_image",
+    "decode_jpeg",
+    "decode_png",
     "encode_jpeg",
-    "write_jpeg",
     "encode_png",
+    "read_file",
+    "read_image",
+    "write_file",
+    "write_jpeg",
     "write_png",
     "Video",
 ]


### PR DESCRIPTION
fixes: #2917 