### PR TITLE
Fixed tuple creation for gcc 5.4

### DIFF
--- a/torchvision/csrc/cpu/video/Video.cpp
+++ b/torchvision/csrc/cpu/video/Video.cpp
@@ -334,6 +334,5 @@ std::tuple<torch::Tensor, double> Video::Next() {
     LOG(ERROR) << "Decoder failed with ERROR_CODE " << res;
   }
 
-  std::tuple<torch::Tensor, double> result = {outFrame, frame_pts_s};
-  return result;
+  return std::make_tuple(outFrame, frame_pts_s);
 }


### PR DESCRIPTION
Fixes #2932

Description:
- Replaced tuple creation by one acceptable by majority of compilers