### PR TITLE
Fixed problem with test error computation between results

### DIFF
--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -361,7 +361,8 @@ class TransformsTester(unittest.TestCase):
         if np_pil_image.ndim == 2:
             np_pil_image = np_pil_image[:, :, None]
         pil_tensor = torch.as_tensor(np_pil_image.transpose((2, 0, 1))).to(tensor)
-        err = getattr(torch, agg_method)(tensor - pil_tensor).item()
+        # error value can be mean absolute error, max abs error
+        err = getattr(torch, agg_method)(torch.abs(tensor - pil_tensor)).item()
         self.assertTrue(
             err < tol,
             msg="{}: err={}, tol={}: \n{}\nvs\n{}".format(msg, err, tol, tensor[0, :10, :10], pil_tensor[0, :10, :10])

--- a/test/test_functional_tensor.py
+++ b/test/test_functional_tensor.py
@@ -352,8 +352,8 @@ class Tester(TransformsTester):
             F_pil.adjust_hue,
             F_t.adjust_hue,
             [{"hue_factor": f} for f in [-0.45, -0.25, 0.0, 0.25, 0.45]],
-            tol=0.1,
-            agg_method="mean"
+            tol=16.1,
+            agg_method="max"
         )
 
     def test_adjust_gamma(self):

--- a/test/test_transforms_tensor.py
+++ b/test/test_transforms_tensor.py
@@ -111,13 +111,13 @@ class Tester(TransformsTester):
         for f in [0.2, 0.5, (-0.2, 0.3), [-0.4, 0.5]]:
             meth_kwargs = {"hue": f}
             self._test_class_op(
-                "ColorJitter", meth_kwargs=meth_kwargs, test_exact_match=False, tol=0.1, agg_method="mean"
+                "ColorJitter", meth_kwargs=meth_kwargs, test_exact_match=False, tol=16.1, agg_method="max"
             )
 
         # All 4 parameters together
         meth_kwargs = {"brightness": 0.2, "contrast": 0.2, "saturation": 0.2, "hue": 0.2}
         self._test_class_op(
-            "ColorJitter", meth_kwargs=meth_kwargs, test_exact_match=False, tol=0.1, agg_method="mean"
+            "ColorJitter", meth_kwargs=meth_kwargs, test_exact_match=False, tol=12.1, agg_method="max"
         )
 
     def test_pad(self):


### PR DESCRIPTION
Description:
- fixed problem with error computation between results: absent `abs` op to properly compute MAE, max AE.
- refactored tensor cast for resize: using `_cast_squeeze_in` and `_cast_squeeze_out`
  - put clamp outside `_cast_squeeze_out`
- fixed round usage: now we use round if we cast to integral type only (from float)