### PR TITLE
make_grid should not avoid DBZ by adding eps

### DIFF
--- a/torchvision/utils.py
+++ b/torchvision/utils.py
@@ -60,9 +60,9 @@ def make_grid(
             assert isinstance(range, tuple), \
                 "range has to be a tuple (min, max) if specified. min and max are numbers"
 
-        def norm_ip(img, min, max):
-            img.clamp_(min=min, max=max)
-            img.add_(-min).div_(max(max - min, 1e-5))
+        def norm_ip(img, low, high):
+            img.clamp_(min=low, max=high)
+            img.sub_(low).div_(max(high - low, 1e-5))
 
         def norm_range(t, range):
             if range is not None:

--- a/torchvision/utils.py
+++ b/torchvision/utils.py
@@ -62,7 +62,7 @@ def make_grid(
 
         def norm_ip(img, min, max):
             img.clamp_(min=min, max=max)
-            img.add_(-min).div_(max - min + 1e-5)
+            img.add_(-min).div_(max(max - min, 1e-5))
 
         def norm_range(t, range):
             if range is not None:


### PR DESCRIPTION
While this doesn't matter in most cases where the image is quantized to [0,255] afterwards, it still is not a faithful de-normalization. It is a simple change to make it use clamp instead.