### PR TITLE
Revert "Update resnet18 test value to fix tests"

### DIFF
--- a/test/test_hub.py
+++ b/test/test_hub.py
@@ -13,7 +13,7 @@ def sum_of_model_parameters(model):
     return s
 
 
-SUM_OF_PRETRAINED_RESNET18_PARAMS = -12703.8974609375
+SUM_OF_PRETRAINED_RESNET18_PARAMS = -12703.9931640625
 
 
 @unittest.skipIf('torchvision' in sys.modules,


### PR DESCRIPTION
Reverts pytorch/vision#2978

It seems that PyTorch reverted the change that affected our expected values. Here is Travis failing for a new PR:
- https://travis-ci.org/github/pytorch/vision/jobs/742929916
- https://travis-ci.org/github/pytorch/vision/jobs/742929917

It seems now the old values are the ones that work, so I propose to revert the change.