### PR TITLE
Removing python headers and Win32 Python2 inits in C++

### DIFF
--- a/torchvision/csrc/cpu/image/image.cpp
+++ b/torchvision/csrc/cpu/image/image.cpp
@@ -1,6 +1,16 @@
 
 #include "image.h"
 #include <ATen/ATen.h>
+#include <Python.h>
+
+// If we are in a Windows environment, we need to define
+// initialization functions for the _custom_ops extension
+#ifdef _WIN32
+PyMODINIT_FUNC PyInit_image(void) {
+  // No need to do anything.
+  return NULL;
+}
+#endif
 
 static auto registry = torch::RegisterOperators()
                            .op("image::decode_png", &decodePNG)

--- a/torchvision/csrc/cpu/image/image.cpp
+++ b/torchvision/csrc/cpu/image/image.cpp
@@ -1,16 +1,6 @@
 
 #include "image.h"
 #include <ATen/ATen.h>
-#include <Python.h>
-
-// If we are in a Windows environment, we need to define
-// initialization functions for the _custom_ops extension
-#ifdef _WIN32
-PyMODINIT_FUNC PyInit_image(void) {
-  // No need to do anything.
-  return NULL;
-}
-#endif
 
 static auto registry = torch::RegisterOperators()
                            .op("image::decode_png", &decodePNG)

--- a/torchvision/csrc/cpu/video/Video.cpp
+++ b/torchvision/csrc/cpu/video/Video.cpp
@@ -9,22 +9,6 @@
 using namespace std;
 using namespace ffmpeg;
 
-// If we are in a Windows environment, we need to define
-// initialization functions for the _custom_ops extension
-// #ifdef _WIN32
-// #if PY_MAJOR_VERSION < 3
-// PyMODINIT_FUNC init_video_reader(void) {
-//   // No need to do anything.
-//   return NULL;
-// }
-// #else
-// PyMODINIT_FUNC PyInit_video_reader(void) {
-//   // No need to do anything.
-//   return NULL;
-// }
-// #endif
-// #endif
-
 const size_t decoderTimeoutMs = 600000;
 const AVPixelFormat defaultVideoPixelFormat = AV_PIX_FMT_RGB24;
 const AVSampleFormat defaultAudioSampleFormat = AV_SAMPLE_FMT_FLT;

--- a/torchvision/csrc/cpu/video/Video.cpp
+++ b/torchvision/csrc/cpu/video/Video.cpp
@@ -1,4 +1,3 @@
-
 #include "Video.h"
 #include <c10/util/Logging.h>
 #include <torch/script.h>

--- a/torchvision/csrc/cpu/video/Video.h
+++ b/torchvision/csrc/cpu/video/Video.h
@@ -6,7 +6,6 @@
 #include <vector>
 
 #include <ATen/ATen.h>
-#include <Python.h>
 #include <c10/util/Logging.h>
 #include <torch/script.h>
 

--- a/torchvision/csrc/cpu/video_reader/VideoReader.cpp
+++ b/torchvision/csrc/cpu/video_reader/VideoReader.cpp
@@ -1,6 +1,5 @@
 #include "VideoReader.h"
 #include <ATen/ATen.h>
-#include <Python.h>
 #include <c10/util/Logging.h>
 #include <exception>
 #include "memory_buffer.h"
@@ -8,22 +7,6 @@
 
 using namespace std;
 using namespace ffmpeg;
-
-// If we are in a Windows environment, we need to define
-// initialization functions for the _custom_ops extension
-#ifdef _WIN32
-#if PY_MAJOR_VERSION < 3
-PyMODINIT_FUNC init_video_reader(void) {
-  // No need to do anything.
-  return NULL;
-}
-#else
-PyMODINIT_FUNC PyInit_video_reader(void) {
-  // No need to do anything.
-  return NULL;
-}
-#endif
-#endif
 
 namespace video_reader {
 

--- a/torchvision/csrc/cpu/video_reader/VideoReader.cpp
+++ b/torchvision/csrc/cpu/video_reader/VideoReader.cpp
@@ -1,5 +1,6 @@
 #include "VideoReader.h"
 #include <ATen/ATen.h>
+#include <Python.h>
 #include <c10/util/Logging.h>
 #include <exception>
 #include "memory_buffer.h"
@@ -7,6 +8,15 @@
 
 using namespace std;
 using namespace ffmpeg;
+
+// If we are in a Windows environment, we need to define
+// initialization functions for the _custom_ops extension
+#ifdef _WIN32
+PyMODINIT_FUNC PyInit_video_reader(void) {
+  // No need to do anything.
+  return NULL;
+}
+#endif
 
 namespace video_reader {
 

--- a/torchvision/csrc/empty_tensor_op.h
+++ b/torchvision/csrc/empty_tensor_op.h
@@ -2,8 +2,6 @@
 
 // All pure C++ headers for the C++ frontend.
 #include <torch/all.h>
-// Python bindings for the C++ frontend (includes Python.h).
-#include <torch/python.h>
 
 class NewEmptyTensorOp : public torch::autograd::Function<NewEmptyTensorOp> {
  public:

--- a/torchvision/csrc/vision.cpp
+++ b/torchvision/csrc/vision.cpp
@@ -1,4 +1,3 @@
-#include <Python.h>
 #include <torch/script.h>
 
 #ifdef WITH_CUDA
@@ -15,24 +14,6 @@
 #include "ROIPool.h"
 #include "empty_tensor_op.h"
 #include "nms.h"
-
-// If we are in a Windows environment, we need to define
-// initialization functions for the _C extension
-#ifdef _WIN32
-#if PY_MAJOR_VERSION < 3
-PyMODINIT_FUNC init_C(void) {
-  // No need to do anything.
-  // extension.py will run on load
-  return NULL;
-}
-#else
-PyMODINIT_FUNC PyInit__C(void) {
-  // No need to do anything.
-  // extension.py will run on load
-  return NULL;
-}
-#endif
-#endif
 
 namespace vision {
 int64_t cuda_version() noexcept {

--- a/torchvision/csrc/vision.cpp
+++ b/torchvision/csrc/vision.cpp
@@ -1,3 +1,4 @@
+#include <Python.h>
 #include <torch/script.h>
 
 #ifdef WITH_CUDA
@@ -14,6 +15,15 @@
 #include "ROIPool.h"
 #include "empty_tensor_op.h"
 #include "nms.h"
+
+// If we are in a Windows environment, we need to define
+// initialization functions for the _custom_ops extension
+#ifdef _WIN32
+PyMODINIT_FUNC PyInit__C(void) {
+  // No need to do anything.
+  return NULL;
+}
+#endif
 
 namespace vision {
 int64_t cuda_version() noexcept {


### PR DESCRIPTION
As discussed with @fmassa, we do some clean up on the C++ files:
- Removed unnecessary imports of Python headers.
- Eliminated Python2 inits for windows

Unfortunately removing completely the initialization functions for Win32 is [not possible](https://app.circleci.com/pipelines/github/pytorch/vision/5017/workflows/5de9ebc9-9981-4306-9e92-e6cef579e73d/jobs/309164).