### PR TITLE
Fixes line count of Jupyter Notebooks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,7 +2,7 @@
 # Jupyter notebook
 
 # For text count
-*.ipynb text
+# *.ipynb text
 
 # To ignore it use below
-# *.ipynb linguist-documentation
+*.ipynb linguist-documentation


### PR DESCRIPTION
Follow up of #2771 

I think this should fix the line count.

If not then `linguist` keeps track of git history and renders the line counts. For that, I'm not sure what is a possible solution.
Let's see.

An example where this works is in [here](https://github.com/Quick-AI/quickvision/blob/master/.gitattributes)

Even there some [examples](https://github.com/Quick-AI/quickvision/tree/master/examples/notebooks) are using Jupyter Notebooks but it isn't counted.


