### PR TITLE
Remove hardcoded PNG_FOUND define.

### DIFF
--- a/torchvision/csrc/cpu/image/readpng_cpu.cpp
+++ b/torchvision/csrc/cpu/image/readpng_cpu.cpp
@@ -4,7 +4,6 @@
 #include <ATen/ATen.h>
 #include <string>
 
-#define PNG_FOUND 1
 #if !PNG_FOUND
 torch::Tensor decodePNG(const torch::Tensor& data, int64_t channels) {
   TORCH_CHECK(false, "decodePNG: torchvision not compiled with libPNG support");


### PR DESCRIPTION
PR #2988 had a hardcoded define that was meant only for debugging. This can cause problems to users who compile torchvision from source without the PNG libraries. Here I'm removing it.