### PR TITLE
Refactor & enable JIT tests in all models and add warnings if skipped

### DIFF
--- a/.circleci/unittest/linux/scripts/run_test.sh
+++ b/.circleci/unittest/linux/scripts/run_test.sh
@@ -5,5 +5,6 @@ set -e
 eval "$(./conda/bin/conda shell.bash hook)"
 conda activate ./env
 
+export PYTORCH_TEST_WITH_SLOW='1'
 python -m torch.utils.collect_env
 pytest --cov=torchvision --junitxml=test-results/junit.xml -v --durations 20 test --ignore=test/test_datasets_download.py

--- a/.circleci/unittest/windows/scripts/run_test.sh
+++ b/.circleci/unittest/windows/scripts/run_test.sh
@@ -5,5 +5,6 @@ set -e
 eval "$(./conda/Scripts/conda.exe 'shell.bash' 'hook')"
 conda activate ./env
 
+export PYTORCH_TEST_WITH_SLOW='1'
 python -m torch.utils.collect_env
 pytest --cov=torchvision --junitxml=test-results/junit.xml -v --durations 20 test --ignore=test/test_datasets_download.py

--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -291,7 +291,7 @@ class TestCase(unittest.TestCase):
             if unwrapper:
                 script_out = unwrapper(script_out)
 
-        self.assertEqual(eager_out, script_out)
+        self.assertEqual(eager_out, script_out, prec=1e-4)
         self.assertExportImportModule(sm, args)
 
         return sm

--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -7,7 +7,7 @@ import argparse
 import sys
 import io
 import torch
-import errno
+import warnings
 import __main__
 
 from numbers import Number
@@ -272,7 +272,14 @@ class TestCase(unittest.TestCase):
         """
         if not TEST_WITH_SLOW or skip:
             # TorchScript is not enabled, skip these tests
-            return
+            msg = "The checkModule test for {} was skipped. " \
+                  "This test checks if the module's results in TorchScript " \
+                  "match eager and that it can be exported. To run these " \
+                  "tests make sure you set the environment variable " \
+                  "PYTORCH_TEST_WITH_SLOW=1 and that the test is not " \
+                  "manually skipped.".format(nn_module.__class__.__name__)
+            warnings.warn(msg, RuntimeWarning)
+            return None
 
         sm = torch.jit.script(nn_module)
 

--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -265,14 +265,14 @@ class TestCase(unittest.TestCase):
         else:
             super(TestCase, self).assertEqual(x, y, message)
 
-    def checkModule(self, nn_module, args, unwrapper=None, skip=False):
+    def check_jit_scriptable(self, nn_module, args, unwrapper=None, skip=False):
         """
         Check that a nn.Module's results in TorchScript match eager and that it
         can be exported
         """
         if not TEST_WITH_SLOW or skip:
             # TorchScript is not enabled, skip these tests
-            msg = "The checkModule test for {} was skipped. " \
+            msg = "The check_jit_scriptable test for {} was skipped. " \
                   "This test checks if the module's results in TorchScript " \
                   "match eager and that it can be exported. To run these " \
                   "tests make sure you set the environment variable " \

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -318,8 +318,8 @@ class ModelTester(TestCase):
         model = models.Inception3(**kwargs)
         model.aux_logits = False
         model.AuxLogits = None
-        m = torch.jit.script(model.eval())
-        self.checkModule(m, "inception_v3", torch.rand(1, 3, 299, 299))
+        model = model.eval()
+        self.checkModule(model, "inception_v3", [torch.rand(1, 3, 299, 299)])
 
     def test_fasterrcnn_double(self):
         model = models.detection.fasterrcnn_resnet50_fpn(num_classes=50, pretrained_backbone=False)
@@ -345,8 +345,8 @@ class ModelTester(TestCase):
         model.aux_logits = False
         model.aux1 = None
         model.aux2 = None
-        m = torch.jit.script(model.eval())
-        self.checkModule(m, "googlenet", torch.rand(1, 3, 224, 224))
+        model = model.eval()
+        self.checkModule(model, "googlenet", [torch.rand(1, 3, 224, 224)])
 
     @unittest.skipIf(not torch.cuda.is_available(), 'needs GPU')
     def test_fasterrcnn_switch_devices(self):


### PR DESCRIPTION
Fixes #3028

Initial commits of this PR should have caused the following models to fail:
- googlenet
- inceptionv3
- maskrcnn

The failures were related to non JIT problems on the tests but we could not see them because the tests were not running.

This PR fixes the problems on the above tests, refactors the unit-tests and re-enables JIT tests for all models.