### PR TITLE
Add missing type hints to __init__ functions per PEP-0484

### DIFF
--- a/references/classification/utils.py
+++ b/references/classification/utils.py
@@ -13,7 +13,7 @@ class SmoothedValue(object):
     window or the global series average.
     """
 
-    def __init__(self, window_size=20, fmt=None):
+    def __init__(self, window_size=20, fmt=None) -> None:
         if fmt is None:
             fmt = "{median:.4f} ({global_avg:.4f})"
         self.deque = deque(maxlen=window_size)
@@ -71,7 +71,7 @@ class SmoothedValue(object):
 
 
 class MetricLogger(object):
-    def __init__(self, delimiter="\t"):
+    def __init__(self, delimiter="\t") -> None:
         self.meters = defaultdict(SmoothedValue)
         self.delimiter = delimiter
 

--- a/references/detection/coco_eval.py
+++ b/references/detection/coco_eval.py
@@ -17,7 +17,7 @@ import utils
 
 
 class CocoEvaluator(object):
-    def __init__(self, coco_gt, iou_types):
+    def __init__(self, coco_gt, iou_types) -> None:
         assert isinstance(iou_types, (list, tuple))
         coco_gt = copy.deepcopy(coco_gt)
         self.coco_gt = coco_gt

--- a/references/detection/coco_utils.py
+++ b/references/detection/coco_utils.py
@@ -13,7 +13,7 @@ import transforms as T
 
 
 class FilterAndRemapCocoCategories(object):
-    def __init__(self, categories, remap=True):
+    def __init__(self, categories, remap=True) -> None:
         self.categories = categories
         self.remap = remap
 
@@ -207,7 +207,7 @@ def get_coco_api_from_dataset(dataset):
 
 
 class CocoDetection(torchvision.datasets.CocoDetection):
-    def __init__(self, img_folder, ann_file, transforms):
+    def __init__(self, img_folder, ann_file, transforms) -> None:
         super(CocoDetection, self).__init__(img_folder, ann_file)
         self._transforms = transforms
 

--- a/references/detection/group_by_aspect_ratio.py
+++ b/references/detection/group_by_aspect_ratio.py
@@ -34,7 +34,7 @@ class GroupedBatchSampler(BatchSampler):
             0, i.e. they must be in the range [0, num_groups).
         batch_size (int): Size of mini-batch.
     """
-    def __init__(self, sampler, group_ids, batch_size):
+    def __init__(self, sampler, group_ids, batch_size) -> None:
         if not isinstance(sampler, Sampler):
             raise ValueError(
                 "sampler should be an instance of "
@@ -93,7 +93,7 @@ def _compute_aspect_ratios_slow(dataset, indices=None):
         indices = range(len(dataset))
 
     class SubsetSampler(Sampler):
-        def __init__(self, indices):
+        def __init__(self, indices) -> None:
             self.indices = indices
 
         def __iter__(self):

--- a/references/detection/transforms.py
+++ b/references/detection/transforms.py
@@ -15,7 +15,7 @@ def _flip_coco_person_keypoints(kps, width):
 
 
 class Compose(object):
-    def __init__(self, transforms):
+    def __init__(self, transforms) -> None:
         self.transforms = transforms
 
     def __call__(self, image, target):
@@ -25,7 +25,7 @@ class Compose(object):
 
 
 class RandomHorizontalFlip(object):
-    def __init__(self, prob):
+    def __init__(self, prob) -> None:
         self.prob = prob
 
     def __call__(self, image, target):

--- a/references/detection/utils.py
+++ b/references/detection/utils.py
@@ -15,7 +15,7 @@ class SmoothedValue(object):
     window or the global series average.
     """
 
-    def __init__(self, window_size=20, fmt=None):
+    def __init__(self, window_size=20, fmt=None) -> None:
         if fmt is None:
             fmt = "{median:.4f} ({global_avg:.4f})"
         self.deque = deque(maxlen=window_size)
@@ -143,7 +143,7 @@ def reduce_dict(input_dict, average=True):
 
 
 class MetricLogger(object):
-    def __init__(self, delimiter="\t"):
+    def __init__(self, delimiter="\t") -> None:
         self.meters = defaultdict(SmoothedValue)
         self.delimiter = delimiter
 

--- a/references/segmentation/coco_utils.py
+++ b/references/segmentation/coco_utils.py
@@ -12,7 +12,7 @@ from transforms import Compose
 
 
 class FilterAndRemapCocoCategories(object):
-    def __init__(self, categories, remap=True):
+    def __init__(self, categories, remap=True) -> None:
         self.categories = categories
         self.remap = remap
 

--- a/references/segmentation/transforms.py
+++ b/references/segmentation/transforms.py
@@ -18,7 +18,7 @@ def pad_if_smaller(img, size, fill=0):
 
 
 class Compose(object):
-    def __init__(self, transforms):
+    def __init__(self, transforms) -> None:
         self.transforms = transforms
 
     def __call__(self, image, target):
@@ -28,7 +28,7 @@ class Compose(object):
 
 
 class RandomResize(object):
-    def __init__(self, min_size, max_size=None):
+    def __init__(self, min_size, max_size=None) -> None:
         self.min_size = min_size
         if max_size is None:
             max_size = min_size
@@ -42,7 +42,7 @@ class RandomResize(object):
 
 
 class RandomHorizontalFlip(object):
-    def __init__(self, flip_prob):
+    def __init__(self, flip_prob) -> None:
         self.flip_prob = flip_prob
 
     def __call__(self, image, target):
@@ -53,7 +53,7 @@ class RandomHorizontalFlip(object):
 
 
 class RandomCrop(object):
-    def __init__(self, size):
+    def __init__(self, size) -> None:
         self.size = size
 
     def __call__(self, image, target):
@@ -66,7 +66,7 @@ class RandomCrop(object):
 
 
 class CenterCrop(object):
-    def __init__(self, size):
+    def __init__(self, size) -> None:
         self.size = size
 
     def __call__(self, image, target):
@@ -83,7 +83,7 @@ class ToTensor(object):
 
 
 class Normalize(object):
-    def __init__(self, mean, std):
+    def __init__(self, mean, std) -> None:
         self.mean = mean
         self.std = std
 

--- a/references/segmentation/utils.py
+++ b/references/segmentation/utils.py
@@ -13,7 +13,7 @@ class SmoothedValue(object):
     window or the global series average.
     """
 
-    def __init__(self, window_size=20, fmt=None):
+    def __init__(self, window_size=20, fmt=None) -> None:
         if fmt is None:
             fmt = "{median:.4f} ({global_avg:.4f})"
         self.deque = deque(maxlen=window_size)
@@ -71,7 +71,7 @@ class SmoothedValue(object):
 
 
 class ConfusionMatrix(object):
-    def __init__(self, num_classes):
+    def __init__(self, num_classes) -> None:
         self.num_classes = num_classes
         self.mat = None
 
@@ -116,7 +116,7 @@ class ConfusionMatrix(object):
 
 
 class MetricLogger(object):
-    def __init__(self, delimiter="\t"):
+    def __init__(self, delimiter="\t") -> None:
         self.meters = defaultdict(SmoothedValue)
         self.delimiter = delimiter
 

--- a/references/similarity/loss.py
+++ b/references/similarity/loss.py
@@ -7,7 +7,7 @@ import torch.nn as nn
 
 
 class TripletMarginLoss(nn.Module):
-    def __init__(self, margin=1.0, p=2., mining='batch_all'):
+    def __init__(self, margin=1.0, p=2., mining='batch_all') -> None:
         super(TripletMarginLoss, self).__init__()
         self.margin = margin
         self.p = p

--- a/references/similarity/model.py
+++ b/references/similarity/model.py
@@ -4,7 +4,7 @@ import torchvision.models as models
 
 
 class EmbeddingNet(nn.Module):
-    def __init__(self, backbone=None):
+    def __init__(self, backbone=None) -> None:
         super(EmbeddingNet, self).__init__()
         if backbone is None:
             backbone = models.resnet50(num_classes=128)

--- a/references/similarity/sampler.py
+++ b/references/similarity/sampler.py
@@ -40,7 +40,7 @@ class PKSampler(Sampler):
         k (int): Number of samples for each label/group in a batch
     """
 
-    def __init__(self, groups, p, k):
+    def __init__(self, groups, p, k) -> None:
         self.p = p
         self.k = k
         self.groups = create_groups(groups, self.k)

--- a/references/video_classification/scheduler.py
+++ b/references/video_classification/scheduler.py
@@ -12,7 +12,7 @@ class WarmupMultiStepLR(torch.optim.lr_scheduler._LRScheduler):
         warmup_iters=5,
         warmup_method="linear",
         last_epoch=-1,
-    ):
+    ) -> None:
         if not milestones == sorted(milestones):
             raise ValueError(
                 "Milestones should be a list of" " increasing integers. Got {}",

--- a/references/video_classification/utils.py
+++ b/references/video_classification/utils.py
@@ -13,7 +13,7 @@ class SmoothedValue(object):
     window or the global series average.
     """
 
-    def __init__(self, window_size=20, fmt=None):
+    def __init__(self, window_size=20, fmt=None) -> None:
         if fmt is None:
             fmt = "{median:.4f} ({global_avg:.4f})"
         self.deque = deque(maxlen=window_size)
@@ -71,7 +71,7 @@ class SmoothedValue(object):
 
 
 class MetricLogger(object):
-    def __init__(self, delimiter="\t"):
+    def __init__(self, delimiter="\t") -> None:
         self.meters = defaultdict(SmoothedValue)
         self.delimiter = delimiter
 

--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -47,7 +47,7 @@ for i, arg in enumerate(sys.argv):
 
 
 class MapNestedTensorObjectImpl(object):
-    def __init__(self, tensor_map_fn):
+    def __init__(self, tensor_map_fn) -> None:
         self.tensor_map_fn = tensor_map_fn
 
     def __call__(self, object):

--- a/test/test_datasets_download.py
+++ b/test/test_datasets_download.py
@@ -117,7 +117,7 @@ def assert_file_downloads_correctly(url, md5):
 
 
 class DownloadConfig:
-    def __init__(self, url, md5=None, id=None):
+    def __init__(self, url, md5=None, id=None) -> None:
         self.url = url
         self.md5 = md5
         self.id = id or url

--- a/test/test_onnx.py
+++ b/test/test_onnx.py
@@ -79,7 +79,7 @@ class ONNXExporterTester(unittest.TestCase):
     @unittest.skip("Disable test until Split w/ zero sizes is implemented in ORT")
     def test_new_empty_tensor(self):
         class Module(torch.nn.Module):
-            def __init__(self):
+            def __init__(self) -> None:
                 super(Module, self).__init__()
                 self.conv2 = ops.misc.ConvTranspose2d(16, 33, (3, 5))
 
@@ -160,7 +160,7 @@ class ONNXExporterTester(unittest.TestCase):
 
     def test_resize_images(self):
         class TransformModule(torch.nn.Module):
-            def __init__(self_module):
+            def __init__(self_module) -> None:
                 super(TransformModule, self_module).__init__()
                 self_module.transform = self._init_test_generalized_rcnn_transform()
 
@@ -175,7 +175,7 @@ class ONNXExporterTester(unittest.TestCase):
     def test_transform_images(self):
 
         class TransformModule(torch.nn.Module):
-            def __init__(self_module):
+            def __init__(self_module) -> None:
                 super(TransformModule, self_module).__init__()
                 self_module.transform = self._init_test_generalized_rcnn_transform()
 
@@ -266,7 +266,7 @@ class ONNXExporterTester(unittest.TestCase):
 
     def test_rpn(self):
         class RPNModule(torch.nn.Module):
-            def __init__(self_module):
+            def __init__(self_module) -> None:
                 super(RPNModule, self_module).__init__()
                 self_module.rpn = self._init_test_rpn()
 
@@ -292,7 +292,7 @@ class ONNXExporterTester(unittest.TestCase):
     def test_multi_scale_roi_align(self):
 
         class TransformModule(torch.nn.Module):
-            def __init__(self):
+            def __init__(self) -> None:
                 super(TransformModule, self).__init__()
                 self.model = ops.MultiScaleRoIAlign(['feat1', 'feat2'], 3, 2)
                 self.image_sizes = [(512, 512)]
@@ -316,7 +316,7 @@ class ONNXExporterTester(unittest.TestCase):
 
     def test_roi_heads(self):
         class RoiHeadsModule(torch.nn.Module):
-            def __init__(self_module):
+            def __init__(self_module) -> None:
                 super(RoiHeadsModule, self_module).__init__()
                 self_module.transform = self._init_test_generalized_rcnn_transform()
                 self_module.rpn = self._init_test_rpn()

--- a/torchvision/datasets/folder.py
+++ b/torchvision/datasets/folder.py
@@ -240,7 +240,7 @@ class ImageFolder(DatasetFolder):
             target_transform: Optional[Callable] = None,
             loader: Callable[[str], Any] = default_loader,
             is_valid_file: Optional[Callable[[str], bool]] = None,
-    ):
+    ) -> None:
         super(ImageFolder, self).__init__(root, loader, IMG_EXTENSIONS if is_valid_file is None else None,
                                           transform=transform,
                                           target_transform=target_transform,

--- a/torchvision/datasets/hmdb51.py
+++ b/torchvision/datasets/hmdb51.py
@@ -54,7 +54,7 @@ class HMDB51(VisionDataset):
     def __init__(self, root, annotation_path, frames_per_clip, step_between_clips=1,
                  frame_rate=None, fold=1, train=True, transform=None,
                  _precomputed_metadata=None, num_workers=1, _video_width=0,
-                 _video_height=0, _video_min_dimension=0, _audio_samples=0):
+                 _video_height=0, _video_min_dimension=0, _audio_samples=0) -> None:
         super(HMDB51, self).__init__(root)
         if fold not in (1, 2, 3):
             raise ValueError("fold should be between 1 and 3, got {}".format(fold))

--- a/torchvision/datasets/ucf101.py
+++ b/torchvision/datasets/ucf101.py
@@ -45,7 +45,7 @@ class UCF101(VisionDataset):
     def __init__(self, root, annotation_path, frames_per_clip, step_between_clips=1,
                  frame_rate=None, fold=1, train=True, transform=None,
                  _precomputed_metadata=None, num_workers=1, _video_width=0,
-                 _video_height=0, _video_min_dimension=0, _audio_samples=0):
+                 _video_height=0, _video_min_dimension=0, _audio_samples=0) -> None:
         super(UCF101, self).__init__(root)
         if not 1 <= fold <= 3:
             raise ValueError("fold should be between 1 and 3, got {}".format(fold))

--- a/torchvision/datasets/video_utils.py
+++ b/torchvision/datasets/video_utils.py
@@ -55,7 +55,7 @@ class _VideoTimestampsDataset(object):
     pickled when forking.
     """
 
-    def __init__(self, video_paths: List[str]):
+    def __init__(self, video_paths: List[str]) -> None:
         self.video_paths = video_paths
 
     def __len__(self):
@@ -105,7 +105,7 @@ class VideoClips(object):
         _video_max_dimension=0,
         _audio_samples=0,
         _audio_channels=0,
-    ):
+    ) -> None:
 
         self.video_paths = video_paths
         self.num_workers = num_workers

--- a/torchvision/datasets/voc.py
+++ b/torchvision/datasets/voc.py
@@ -80,7 +80,7 @@ class VOCSegmentation(VisionDataset):
             transform: Optional[Callable] = None,
             target_transform: Optional[Callable] = None,
             transforms: Optional[Callable] = None,
-    ):
+    ) -> None:
         super(VOCSegmentation, self).__init__(root, transforms, transform, target_transform)
         self.year = year
         if year == "2007" and image_set == "test":
@@ -163,7 +163,7 @@ class VOCDetection(VisionDataset):
             transform: Optional[Callable] = None,
             target_transform: Optional[Callable] = None,
             transforms: Optional[Callable] = None,
-    ):
+    ) -> None:
         super(VOCDetection, self).__init__(root, transforms, transform, target_transform)
         self.year = year
         if year == "2007" and image_set == "test":

--- a/torchvision/io/__init__.py
+++ b/torchvision/io/__init__.py
@@ -93,7 +93,7 @@ class VideoReader:
             Currently available options include ``['video', 'audio']``
     """
 
-    def __init__(self, path, stream="video"):
+    def __init__(self, path, stream="video") -> None:
         if not _has_video_opt():
             raise RuntimeError(
                 "Not compiled with video_reader support, "

--- a/torchvision/io/_video_opt.py
+++ b/torchvision/io/_video_opt.py
@@ -65,7 +65,7 @@ class Timebase(object):
         self,
         numerator,  # type: int
         denominator,  # type: int
-    ) -> None:
+    ):
         # type: (...) -> None
         self.numerator = numerator
         self.denominator = denominator

--- a/torchvision/io/_video_opt.py
+++ b/torchvision/io/_video_opt.py
@@ -65,7 +65,7 @@ class Timebase(object):
         self,
         numerator,  # type: int
         denominator,  # type: int
-    ):
+    ) -> None:
         # type: (...) -> None
         self.numerator = numerator
         self.denominator = denominator
@@ -93,7 +93,7 @@ class VideoMetaData(object):
         "audio_sample_rate",
     ]
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.has_video = False
         self.video_timebase = Timebase(0, 1)
         self.video_duration = 0.0

--- a/torchvision/io/_video_opt.py
+++ b/torchvision/io/_video_opt.py
@@ -65,7 +65,7 @@ class Timebase(object):
         self,
         numerator,  # type: int
         denominator,  # type: int
-    ):
+    ) -> None:
         # type: (...) -> None
         self.numerator = numerator
         self.denominator = denominator

--- a/torchvision/models/detection/_utils.py
+++ b/torchvision/models/detection/_utils.py
@@ -12,7 +12,7 @@ class BalancedPositiveNegativeSampler(object):
     This class samples batches, ensuring that they contain a fixed proportion of positives
     """
 
-    def __init__(self, batch_size_per_image, positive_fraction):
+    def __init__(self, batch_size_per_image, positive_fraction) -> None:
         # type: (int, float) -> None
         """
         Arguments:
@@ -241,7 +241,7 @@ class Matcher(object):
         'BETWEEN_THRESHOLDS': int,
     }
 
-    def __init__(self, high_threshold, low_threshold, allow_low_quality_matches=False):
+    def __init__(self, high_threshold, low_threshold, allow_low_quality_matches=False) -> None:
         # type: (float, float, bool) -> None
         """
         Args:

--- a/torchvision/models/detection/backbone_utils.py
+++ b/torchvision/models/detection/backbone_utils.py
@@ -26,7 +26,7 @@ class BackboneWithFPN(nn.Module):
     Attributes:
         out_channels (int): the number of channels in the FPN
     """
-    def __init__(self, backbone, return_layers, in_channels_list, out_channels, extra_blocks=None):
+    def __init__(self, backbone, return_layers, in_channels_list, out_channels, extra_blocks=None) -> None:
         super(BackboneWithFPN, self).__init__()
 
         if extra_blocks is None:

--- a/torchvision/models/detection/faster_rcnn.py
+++ b/torchvision/models/detection/faster_rcnn.py
@@ -158,7 +158,7 @@ class FasterRCNN(GeneralizedRCNN):
                  box_score_thresh=0.05, box_nms_thresh=0.5, box_detections_per_img=100,
                  box_fg_iou_thresh=0.5, box_bg_iou_thresh=0.5,
                  box_batch_size_per_image=512, box_positive_fraction=0.25,
-                 bbox_reg_weights=None):
+                 bbox_reg_weights=None) -> None:
 
         if not hasattr(backbone, "out_channels"):
             raise ValueError(
@@ -244,7 +244,7 @@ class TwoMLPHead(nn.Module):
         representation_size (int): size of the intermediate representation
     """
 
-    def __init__(self, in_channels, representation_size):
+    def __init__(self, in_channels, representation_size) -> None:
         super(TwoMLPHead, self).__init__()
 
         self.fc6 = nn.Linear(in_channels, representation_size)
@@ -269,7 +269,7 @@ class FastRCNNPredictor(nn.Module):
         num_classes (int): number of output classes (including background)
     """
 
-    def __init__(self, in_channels, num_classes):
+    def __init__(self, in_channels, num_classes) -> None:
         super(FastRCNNPredictor, self).__init__()
         self.cls_score = nn.Linear(in_channels, num_classes)
         self.bbox_pred = nn.Linear(in_channels, num_classes * 4)

--- a/torchvision/models/detection/generalized_rcnn.py
+++ b/torchvision/models/detection/generalized_rcnn.py
@@ -25,7 +25,7 @@ class GeneralizedRCNN(nn.Module):
             the model
     """
 
-    def __init__(self, backbone, rpn, roi_heads, transform):
+    def __init__(self, backbone, rpn, roi_heads, transform) -> None:
         super(GeneralizedRCNN, self).__init__()
         self.transform = transform
         self.backbone = backbone

--- a/torchvision/models/detection/image_list.py
+++ b/torchvision/models/detection/image_list.py
@@ -12,7 +12,7 @@ class ImageList(object):
     and storing in a field the original sizes of each image
     """
 
-    def __init__(self, tensors, image_sizes):
+    def __init__(self, tensors, image_sizes) -> None:
         # type: (Tensor, List[Tuple[int, int]]) -> None
         """
         Arguments:

--- a/torchvision/models/detection/keypoint_rcnn.py
+++ b/torchvision/models/detection/keypoint_rcnn.py
@@ -166,7 +166,7 @@ class KeypointRCNN(FasterRCNN):
                  bbox_reg_weights=None,
                  # keypoint parameters
                  keypoint_roi_pool=None, keypoint_head=None, keypoint_predictor=None,
-                 num_keypoints=17):
+                 num_keypoints=17) -> None:
 
         assert isinstance(keypoint_roi_pool, (MultiScaleRoIAlign, type(None)))
         if min_size is None:
@@ -217,7 +217,7 @@ class KeypointRCNN(FasterRCNN):
 
 
 class KeypointRCNNHeads(nn.Sequential):
-    def __init__(self, in_channels, layers):
+    def __init__(self, in_channels, layers) -> None:
         d = []
         next_feature = in_channels
         for out_channels in layers:
@@ -232,7 +232,7 @@ class KeypointRCNNHeads(nn.Sequential):
 
 
 class KeypointRCNNPredictor(nn.Module):
-    def __init__(self, in_channels, num_keypoints):
+    def __init__(self, in_channels, num_keypoints) -> None:
         super(KeypointRCNNPredictor, self).__init__()
         input_features = in_channels
         deconv_kernel = 4

--- a/torchvision/models/detection/mask_rcnn.py
+++ b/torchvision/models/detection/mask_rcnn.py
@@ -168,7 +168,7 @@ class MaskRCNN(FasterRCNN):
                  box_batch_size_per_image=512, box_positive_fraction=0.25,
                  bbox_reg_weights=None,
                  # Mask parameters
-                 mask_roi_pool=None, mask_head=None, mask_predictor=None):
+                 mask_roi_pool=None, mask_head=None, mask_predictor=None) -> None:
 
         assert isinstance(mask_roi_pool, (MultiScaleRoIAlign, type(None)))
 
@@ -220,7 +220,7 @@ class MaskRCNN(FasterRCNN):
 
 
 class MaskRCNNHeads(nn.Sequential):
-    def __init__(self, in_channels, layers, dilation):
+    def __init__(self, in_channels, layers, dilation) -> None:
         """
         Arguments:
             in_channels (int): number of input channels
@@ -245,7 +245,7 @@ class MaskRCNNHeads(nn.Sequential):
 
 
 class MaskRCNNPredictor(nn.Sequential):
-    def __init__(self, in_channels, dim_reduced, num_classes):
+    def __init__(self, in_channels, dim_reduced, num_classes) -> None:
         super(MaskRCNNPredictor, self).__init__(OrderedDict([
             ("conv5_mask", nn.ConvTranspose2d(in_channels, dim_reduced, 2, 2, 0)),
             ("relu", nn.ReLU(inplace=True)),

--- a/torchvision/models/detection/retinanet.py
+++ b/torchvision/models/detection/retinanet.py
@@ -41,7 +41,7 @@ class RetinaNetHead(nn.Module):
         num_classes (int): number of classes to be predicted
     """
 
-    def __init__(self, in_channels, num_anchors, num_classes):
+    def __init__(self, in_channels, num_anchors, num_classes) -> None:
         super().__init__()
         self.classification_head = RetinaNetClassificationHead(in_channels, num_anchors, num_classes)
         self.regression_head = RetinaNetRegressionHead(in_channels, num_anchors)
@@ -71,7 +71,7 @@ class RetinaNetClassificationHead(nn.Module):
         num_classes (int): number of classes to be predicted
     """
 
-    def __init__(self, in_channels, num_anchors, num_classes, prior_probability=0.01):
+    def __init__(self, in_channels, num_anchors, num_classes, prior_probability=0.01) -> None:
         super().__init__()
 
         conv = []
@@ -163,7 +163,7 @@ class RetinaNetRegressionHead(nn.Module):
         'box_coder': det_utils.BoxCoder,
     }
 
-    def __init__(self, in_channels, num_anchors):
+    def __init__(self, in_channels, num_anchors) -> None:
         super().__init__()
 
         conv = []
@@ -342,7 +342,7 @@ class RetinaNet(nn.Module):
                  nms_thresh=0.5,
                  detections_per_img=300,
                  fg_iou_thresh=0.5, bg_iou_thresh=0.4,
-                 topk_candidates=1000):
+                 topk_candidates=1000) -> None:
         super().__init__()
 
         if not hasattr(backbone, "out_channels"):

--- a/torchvision/models/detection/roi_heads.py
+++ b/torchvision/models/detection/roi_heads.py
@@ -508,7 +508,7 @@ class RoIHeads(torch.nn.Module):
                  keypoint_roi_pool=None,
                  keypoint_head=None,
                  keypoint_predictor=None,
-                 ):
+                 ) -> None:
         super(RoIHeads, self).__init__()
 
         self.box_similarity = box_ops.box_iou

--- a/torchvision/models/detection/rpn.py
+++ b/torchvision/models/detection/rpn.py
@@ -36,7 +36,7 @@ class RPNHead(nn.Module):
         num_anchors (int): number of anchors to be predicted
     """
 
-    def __init__(self, in_channels, num_anchors):
+    def __init__(self, in_channels, num_anchors) -> None:
         super(RPNHead, self).__init__()
         self.conv = nn.Conv2d(
             in_channels, in_channels, kernel_size=3, stride=1, padding=1
@@ -141,7 +141,7 @@ class RegionProposalNetwork(torch.nn.Module):
                  fg_iou_thresh, bg_iou_thresh,
                  batch_size_per_image, positive_fraction,
                  #
-                 pre_nms_top_n, post_nms_top_n, nms_thresh):
+                 pre_nms_top_n, post_nms_top_n, nms_thresh) -> None:
         super(RegionProposalNetwork, self).__init__()
         self.anchor_generator = anchor_generator
         self.head = head

--- a/torchvision/models/detection/transform.py
+++ b/torchvision/models/detection/transform.py
@@ -67,7 +67,7 @@ class GeneralizedRCNNTransform(nn.Module):
     It returns a ImageList for the inputs, and a List[Dict[Tensor]] for the targets
     """
 
-    def __init__(self, min_size, max_size, image_mean, image_std):
+    def __init__(self, min_size, max_size, image_mean, image_std) -> None:
         super(GeneralizedRCNNTransform, self).__init__()
         if not isinstance(min_size, (list, tuple)):
             min_size = (min_size,)

--- a/torchvision/models/quantization/googlenet.py
+++ b/torchvision/models/quantization/googlenet.py
@@ -77,7 +77,7 @@ def googlenet(pretrained=False, progress=True, quantize=False, **kwargs):
 
 class QuantizableBasicConv2d(BasicConv2d):
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super(QuantizableBasicConv2d, self).__init__(*args, **kwargs)
         self.relu = nn.ReLU()
 
@@ -93,7 +93,7 @@ class QuantizableBasicConv2d(BasicConv2d):
 
 class QuantizableInception(Inception):
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super(QuantizableInception, self).__init__(
             conv_block=QuantizableBasicConv2d, *args, **kwargs)
         self.cat = nn.quantized.FloatFunctional()
@@ -105,7 +105,7 @@ class QuantizableInception(Inception):
 
 class QuantizableInceptionAux(InceptionAux):
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super(QuantizableInceptionAux, self).__init__(
             conv_block=QuantizableBasicConv2d, *args, **kwargs)
         self.relu = nn.ReLU()
@@ -131,7 +131,7 @@ class QuantizableInceptionAux(InceptionAux):
 
 class QuantizableGoogLeNet(GoogLeNet):
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super(QuantizableGoogLeNet, self).__init__(
             blocks=[QuantizableBasicConv2d, QuantizableInception, QuantizableInceptionAux],
             *args,

--- a/torchvision/models/quantization/inception.py
+++ b/torchvision/models/quantization/inception.py
@@ -85,7 +85,7 @@ def inception_v3(pretrained=False, progress=True, quantize=False, **kwargs):
 
 
 class QuantizableBasicConv2d(inception_module.BasicConv2d):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super(QuantizableBasicConv2d, self).__init__(*args, **kwargs)
         self.relu = nn.ReLU()
 
@@ -100,7 +100,7 @@ class QuantizableBasicConv2d(inception_module.BasicConv2d):
 
 
 class QuantizableInceptionA(inception_module.InceptionA):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super(QuantizableInceptionA, self).__init__(conv_block=QuantizableBasicConv2d, *args, **kwargs)
         self.myop = nn.quantized.FloatFunctional()
 
@@ -110,7 +110,7 @@ class QuantizableInceptionA(inception_module.InceptionA):
 
 
 class QuantizableInceptionB(inception_module.InceptionB):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super(QuantizableInceptionB, self).__init__(conv_block=QuantizableBasicConv2d, *args, **kwargs)
         self.myop = nn.quantized.FloatFunctional()
 
@@ -120,7 +120,7 @@ class QuantizableInceptionB(inception_module.InceptionB):
 
 
 class QuantizableInceptionC(inception_module.InceptionC):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super(QuantizableInceptionC, self).__init__(conv_block=QuantizableBasicConv2d, *args, **kwargs)
         self.myop = nn.quantized.FloatFunctional()
 
@@ -130,7 +130,7 @@ class QuantizableInceptionC(inception_module.InceptionC):
 
 
 class QuantizableInceptionD(inception_module.InceptionD):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super(QuantizableInceptionD, self).__init__(conv_block=QuantizableBasicConv2d, *args, **kwargs)
         self.myop = nn.quantized.FloatFunctional()
 
@@ -140,7 +140,7 @@ class QuantizableInceptionD(inception_module.InceptionD):
 
 
 class QuantizableInceptionE(inception_module.InceptionE):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super(QuantizableInceptionE, self).__init__(conv_block=QuantizableBasicConv2d, *args, **kwargs)
         self.myop1 = nn.quantized.FloatFunctional()
         self.myop2 = nn.quantized.FloatFunctional()
@@ -173,12 +173,12 @@ class QuantizableInceptionE(inception_module.InceptionE):
 
 
 class QuantizableInceptionAux(inception_module.InceptionAux):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super(QuantizableInceptionAux, self).__init__(conv_block=QuantizableBasicConv2d, *args, **kwargs)
 
 
 class QuantizableInception3(inception_module.Inception3):
-    def __init__(self, num_classes=1000, aux_logits=True, transform_input=False):
+    def __init__(self, num_classes=1000, aux_logits=True, transform_input=False) -> None:
         super(QuantizableInception3, self).__init__(
             num_classes=num_classes,
             aux_logits=aux_logits,

--- a/torchvision/models/quantization/mobilenet.py
+++ b/torchvision/models/quantization/mobilenet.py
@@ -14,7 +14,7 @@ quant_model_urls = {
 
 
 class QuantizableInvertedResidual(InvertedResidual):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super(QuantizableInvertedResidual, self).__init__(*args, **kwargs)
         self.skip_add = nn.quantized.FloatFunctional()
 
@@ -31,7 +31,7 @@ class QuantizableInvertedResidual(InvertedResidual):
 
 
 class QuantizableMobileNetV2(MobileNetV2):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         """
         MobileNet V2 main class
 

--- a/torchvision/models/quantization/resnet.py
+++ b/torchvision/models/quantization/resnet.py
@@ -21,7 +21,7 @@ quant_model_urls = {
 
 
 class QuantizableBasicBlock(BasicBlock):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super(QuantizableBasicBlock, self).__init__(*args, **kwargs)
         self.add_relu = torch.nn.quantized.FloatFunctional()
 
@@ -50,7 +50,7 @@ class QuantizableBasicBlock(BasicBlock):
 
 
 class QuantizableBottleneck(Bottleneck):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super(QuantizableBottleneck, self).__init__(*args, **kwargs)
         self.skip_add_relu = nn.quantized.FloatFunctional()
         self.relu1 = nn.ReLU(inplace=False)
@@ -84,7 +84,7 @@ class QuantizableBottleneck(Bottleneck):
 
 class QuantizableResNet(ResNet):
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super(QuantizableResNet, self).__init__(*args, **kwargs)
 
         self.quant = torch.quantization.QuantStub()

--- a/torchvision/models/quantization/shufflenetv2.py
+++ b/torchvision/models/quantization/shufflenetv2.py
@@ -22,7 +22,7 @@ quant_model_urls = {
 
 
 class QuantizableInvertedResidual(shufflenetv2.InvertedResidual):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super(QuantizableInvertedResidual, self).__init__(*args, **kwargs)
         self.cat = nn.quantized.FloatFunctional()
 
@@ -39,7 +39,7 @@ class QuantizableInvertedResidual(shufflenetv2.InvertedResidual):
 
 
 class QuantizableShuffleNetV2(shufflenetv2.ShuffleNetV2):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super(QuantizableShuffleNetV2, self).__init__(*args, inverted_residual=QuantizableInvertedResidual, **kwargs)
         self.quant = torch.quantization.QuantStub()
         self.dequant = torch.quantization.DeQuantStub()

--- a/torchvision/models/segmentation/_utils.py
+++ b/torchvision/models/segmentation/_utils.py
@@ -8,7 +8,7 @@ from torch.nn import functional as F
 class _SimpleSegmentationModel(nn.Module):
     __constants__ = ['aux_classifier']
 
-    def __init__(self, backbone, classifier, aux_classifier=None):
+    def __init__(self, backbone, classifier, aux_classifier=None) -> None:
         super(_SimpleSegmentationModel, self).__init__()
         self.backbone = backbone
         self.classifier = classifier

--- a/torchvision/models/segmentation/deeplabv3.py
+++ b/torchvision/models/segmentation/deeplabv3.py
@@ -27,7 +27,7 @@ class DeepLabV3(_SimpleSegmentationModel):
 
 
 class DeepLabHead(nn.Sequential):
-    def __init__(self, in_channels, num_classes):
+    def __init__(self, in_channels, num_classes) -> None:
         super(DeepLabHead, self).__init__(
             ASPP(in_channels, [12, 24, 36]),
             nn.Conv2d(256, 256, 3, padding=1, bias=False),
@@ -38,7 +38,7 @@ class DeepLabHead(nn.Sequential):
 
 
 class ASPPConv(nn.Sequential):
-    def __init__(self, in_channels, out_channels, dilation):
+    def __init__(self, in_channels, out_channels, dilation) -> None:
         modules = [
             nn.Conv2d(in_channels, out_channels, 3, padding=dilation, dilation=dilation, bias=False),
             nn.BatchNorm2d(out_channels),
@@ -48,7 +48,7 @@ class ASPPConv(nn.Sequential):
 
 
 class ASPPPooling(nn.Sequential):
-    def __init__(self, in_channels, out_channels):
+    def __init__(self, in_channels, out_channels) -> None:
         super(ASPPPooling, self).__init__(
             nn.AdaptiveAvgPool2d(1),
             nn.Conv2d(in_channels, out_channels, 1, bias=False),
@@ -63,7 +63,7 @@ class ASPPPooling(nn.Sequential):
 
 
 class ASPP(nn.Module):
-    def __init__(self, in_channels, atrous_rates, out_channels=256):
+    def __init__(self, in_channels, atrous_rates, out_channels=256) -> None:
         super(ASPP, self).__init__()
         modules = []
         modules.append(nn.Sequential(

--- a/torchvision/models/segmentation/fcn.py
+++ b/torchvision/models/segmentation/fcn.py
@@ -23,7 +23,7 @@ class FCN(_SimpleSegmentationModel):
 
 
 class FCNHead(nn.Sequential):
-    def __init__(self, in_channels, channels):
+    def __init__(self, in_channels, channels) -> None:
         inter_channels = in_channels // 4
         layers = [
             nn.Conv2d(in_channels, inter_channels, 3, padding=1, bias=False),

--- a/torchvision/models/video/resnet.py
+++ b/torchvision/models/video/resnet.py
@@ -19,7 +19,7 @@ class Conv3DSimple(nn.Conv3d):
                  out_planes,
                  midplanes=None,
                  stride=1,
-                 padding=1):
+                 padding=1) -> None:
 
         super(Conv3DSimple, self).__init__(
             in_channels=in_planes,
@@ -41,7 +41,7 @@ class Conv2Plus1D(nn.Sequential):
                  out_planes,
                  midplanes,
                  stride=1,
-                 padding=1):
+                 padding=1) -> None:
         super(Conv2Plus1D, self).__init__(
             nn.Conv3d(in_planes, midplanes, kernel_size=(1, 3, 3),
                       stride=(1, stride, stride), padding=(0, padding, padding),
@@ -64,7 +64,7 @@ class Conv3DNoTemporal(nn.Conv3d):
                  out_planes,
                  midplanes=None,
                  stride=1,
-                 padding=1):
+                 padding=1) -> None:
 
         super(Conv3DNoTemporal, self).__init__(
             in_channels=in_planes,
@@ -83,7 +83,7 @@ class BasicBlock(nn.Module):
 
     expansion = 1
 
-    def __init__(self, inplanes, planes, conv_builder, stride=1, downsample=None):
+    def __init__(self, inplanes, planes, conv_builder, stride=1, downsample=None) -> None:
         midplanes = (inplanes * planes * 3 * 3 * 3) // (inplanes * 3 * 3 + 3 * planes)
 
         super(BasicBlock, self).__init__()
@@ -117,7 +117,7 @@ class BasicBlock(nn.Module):
 class Bottleneck(nn.Module):
     expansion = 4
 
-    def __init__(self, inplanes, planes, conv_builder, stride=1, downsample=None):
+    def __init__(self, inplanes, planes, conv_builder, stride=1, downsample=None) -> None:
 
         super(Bottleneck, self).__init__()
         midplanes = (inplanes * planes * 3 * 3 * 3) // (inplanes * 3 * 3 + 3 * planes)
@@ -163,7 +163,7 @@ class Bottleneck(nn.Module):
 class BasicStem(nn.Sequential):
     """The default conv-batchnorm-relu stem
     """
-    def __init__(self):
+    def __init__(self) -> None:
         super(BasicStem, self).__init__(
             nn.Conv3d(3, 64, kernel_size=(3, 7, 7), stride=(1, 2, 2),
                       padding=(1, 3, 3), bias=False),
@@ -174,7 +174,7 @@ class BasicStem(nn.Sequential):
 class R2Plus1dStem(nn.Sequential):
     """R(2+1)D stem is different than the default one as it uses separated 3D convolution
     """
-    def __init__(self):
+    def __init__(self) -> None:
         super(R2Plus1dStem, self).__init__(
             nn.Conv3d(3, 45, kernel_size=(1, 7, 7),
                       stride=(1, 2, 2), padding=(0, 3, 3),
@@ -192,7 +192,7 @@ class VideoResNet(nn.Module):
 
     def __init__(self, block, conv_makers, layers,
                  stem, num_classes=400,
-                 zero_init_residual=False):
+                 zero_init_residual=False) -> None:
         """Generic resnet video generator.
 
         Args:

--- a/torchvision/ops/deform_conv.py
+++ b/torchvision/ops/deform_conv.py
@@ -118,7 +118,7 @@ class DeformConv2d(nn.Module):
         dilation: int = 1,
         groups: int = 1,
         bias: bool = True,
-    ):
+    ) -> None:
         super(DeformConv2d, self).__init__()
 
         if in_channels % groups != 0:

--- a/torchvision/ops/feature_pyramid_network.py
+++ b/torchvision/ops/feature_pyramid_network.py
@@ -73,7 +73,7 @@ class FeaturePyramidNetwork(nn.Module):
         in_channels_list: List[int],
         out_channels: int,
         extra_blocks: Optional[ExtraFPNBlock] = None,
-    ):
+    ) -> None:
         super(FeaturePyramidNetwork, self).__init__()
         self.inner_blocks = nn.ModuleList()
         self.layer_blocks = nn.ModuleList()
@@ -185,7 +185,7 @@ class LastLevelP6P7(ExtraFPNBlock):
     """
     This module is used in RetinaNet to generate extra layers, P6 and P7.
     """
-    def __init__(self, in_channels: int, out_channels: int):
+    def __init__(self, in_channels: int, out_channels: int) -> None:
         super(LastLevelP6P7, self).__init__()
         self.p6 = nn.Conv2d(in_channels, out_channels, 3, 2, 1)
         self.p7 = nn.Conv2d(out_channels, out_channels, 3, 2, 1)

--- a/torchvision/ops/misc.py
+++ b/torchvision/ops/misc.py
@@ -15,7 +15,7 @@ from torch.jit.annotations import List, Optional, Tuple
 
 
 class Conv2d(torch.nn.Conv2d):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         warnings.warn(
             "torchvision.ops.misc.Conv2d is deprecated and will be "
@@ -23,7 +23,7 @@ class Conv2d(torch.nn.Conv2d):
 
 
 class ConvTranspose2d(torch.nn.ConvTranspose2d):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         warnings.warn(
             "torchvision.ops.misc.ConvTranspose2d is deprecated and will be "
@@ -31,7 +31,7 @@ class ConvTranspose2d(torch.nn.ConvTranspose2d):
 
 
 class BatchNorm2d(torch.nn.BatchNorm2d):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         warnings.warn(
             "torchvision.ops.misc.BatchNorm2d is deprecated and will be "
@@ -53,7 +53,7 @@ class FrozenBatchNorm2d(torch.nn.Module):
         num_features: int,
         eps: float = 1e-5,
         n: Optional[int] = None,
-    ):
+    ) -> None:
         # n=None for backward-compatibility
         if n is not None:
             warnings.warn("`n` argument is deprecated and has been renamed `num_features`",

--- a/torchvision/ops/poolers.py
+++ b/torchvision/ops/poolers.py
@@ -63,7 +63,7 @@ class LevelMapper(object):
         canonical_scale: int = 224,
         canonical_level: int = 4,
         eps: float = 1e-6,
-    ):
+    ) -> None:
         self.k_min = k_min
         self.k_max = k_max
         self.s0 = canonical_scale
@@ -123,7 +123,7 @@ class MultiScaleRoIAlign(nn.Module):
         featmap_names: List[str],
         output_size: Union[int, Tuple[int], List[int]],
         sampling_ratio: int,
-    ):
+    ) -> None:
         super(MultiScaleRoIAlign, self).__init__()
         if isinstance(output_size, int):
             output_size = (output_size, output_size)

--- a/torchvision/ops/ps_roi_align.py
+++ b/torchvision/ops/ps_roi_align.py
@@ -61,7 +61,7 @@ class PSRoIAlign(nn.Module):
         output_size: int,
         spatial_scale: float,
         sampling_ratio: int,
-    ):
+    ) -> None:
         super(PSRoIAlign, self).__init__()
         self.output_size = output_size
         self.spatial_scale = spatial_scale

--- a/torchvision/ops/ps_roi_pool.py
+++ b/torchvision/ops/ps_roi_pool.py
@@ -49,7 +49,7 @@ class PSRoIPool(nn.Module):
     """
     See ps_roi_pool
     """
-    def __init__(self, output_size: int, spatial_scale: float):
+    def __init__(self, output_size: int, spatial_scale: float) -> None:
         super(PSRoIPool, self).__init__()
         self.output_size = output_size
         self.spatial_scale = spatial_scale

--- a/torchvision/ops/roi_align.py
+++ b/torchvision/ops/roi_align.py
@@ -63,7 +63,7 @@ class RoIAlign(nn.Module):
         spatial_scale: float,
         sampling_ratio: int,
         aligned: bool = False,
-    ):
+    ) -> None:
         super(RoIAlign, self).__init__()
         self.output_size = output_size
         self.spatial_scale = spatial_scale

--- a/torchvision/ops/roi_pool.py
+++ b/torchvision/ops/roi_pool.py
@@ -47,7 +47,7 @@ class RoIPool(nn.Module):
     """
     See roi_pool
     """
-    def __init__(self, output_size: BroadcastingList2[int], spatial_scale: float):
+    def __init__(self, output_size: BroadcastingList2[int], spatial_scale: float) -> None:
         super(RoIPool, self).__init__()
         self.output_size = output_size
         self.spatial_scale = spatial_scale

--- a/torchvision/transforms/_transforms_video.py
+++ b/torchvision/transforms/_transforms_video.py
@@ -22,7 +22,7 @@ __all__ = [
 
 
 class RandomCropVideo(RandomCrop):
-    def __init__(self, size):
+    def __init__(self, size) -> None:
         if isinstance(size, numbers.Number):
             self.size = (int(size), int(size))
         else:
@@ -80,7 +80,7 @@ class RandomResizedCropVideo(RandomResizedCrop):
 
 
 class CenterCropVideo(object):
-    def __init__(self, crop_size):
+    def __init__(self, crop_size) -> None:
         if isinstance(crop_size, numbers.Number):
             self.crop_size = (int(crop_size), int(crop_size))
         else:
@@ -109,7 +109,7 @@ class NormalizeVideo(object):
         inplace (boolean): whether do in-place normalization
     """
 
-    def __init__(self, mean, std, inplace=False):
+    def __init__(self, mean, std, inplace=False) -> None:
         self.mean = mean
         self.std = std
         self.inplace = inplace
@@ -132,7 +132,7 @@ class ToTensorVideo(object):
     permute the dimenions of clip tensor
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         pass
 
     def __call__(self, clip):
@@ -155,7 +155,7 @@ class RandomHorizontalFlipVideo(object):
         p (float): probability of the clip being flipped. Default value is 0.5
     """
 
-    def __init__(self, p=0.5):
+    def __init__(self, p=0.5) -> None:
         self.p = p
 
     def __call__(self, clip):

--- a/torchvision/transforms/transforms.py
+++ b/torchvision/transforms/transforms.py
@@ -59,7 +59,7 @@ class Compose:
 
     """
 
-    def __init__(self, transforms):
+    def __init__(self, transforms) -> None:
         self.transforms = transforms
 
     def __call__(self, img):
@@ -170,7 +170,7 @@ class ToPILImage:
 
     .. _PIL.Image mode: https://pillow.readthedocs.io/en/latest/handbook/concepts.html#concept-modes
     """
-    def __init__(self, mode=None):
+    def __init__(self, mode=None) -> None:
         self.mode = mode
 
     def __call__(self, pic):
@@ -209,7 +209,7 @@ class Normalize(torch.nn.Module):
 
     """
 
-    def __init__(self, mean, std, inplace=False):
+    def __init__(self, mean, std, inplace=False) -> None:
         super().__init__()
         self.mean = mean
         self.std = std
@@ -247,7 +247,7 @@ class Resize(torch.nn.Module):
             and ``PIL.Image.BICUBIC`` are supported.
     """
 
-    def __init__(self, size, interpolation=Image.BILINEAR):
+    def __init__(self, size, interpolation=Image.BILINEAR) -> None:
         super().__init__()
         if not isinstance(size, (int, Sequence)):
             raise TypeError("Size should be int or sequence. Got {}".format(type(size)))
@@ -275,7 +275,7 @@ class Scale(Resize):
     """
     Note: This transform is deprecated in favor of Resize.
     """
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         warnings.warn("The use of the transforms.Scale transform is deprecated, " +
                       "please use transforms.Resize instead.")
         super(Scale, self).__init__(*args, **kwargs)
@@ -292,7 +292,7 @@ class CenterCrop(torch.nn.Module):
             made. If provided a tuple or list of length 1, it will be interpreted as (size[0], size[0]).
     """
 
-    def __init__(self, size):
+    def __init__(self, size) -> None:
         super().__init__()
         self.size = _setup_size(size, error_msg="Please provide only two dimensions (h, w) for size.")
 
@@ -343,7 +343,7 @@ class Pad(torch.nn.Module):
                 will result in [2, 1, 1, 2, 3, 4, 4, 3]
     """
 
-    def __init__(self, padding, fill=0, padding_mode="constant"):
+    def __init__(self, padding, fill=0, padding_mode="constant") -> None:
         super().__init__()
         if not isinstance(padding, (numbers.Number, tuple, list)):
             raise TypeError("Got inappropriate padding arg")
@@ -384,7 +384,7 @@ class Lambda:
         lambd (function): Lambda/function to be used for transform.
     """
 
-    def __init__(self, lambd):
+    def __init__(self, lambd) -> None:
         if not callable(lambd):
             raise TypeError("Argument lambd should be callable, got {}".format(repr(type(lambd).__name__)))
         self.lambd = lambd
@@ -403,7 +403,7 @@ class RandomTransforms:
         transforms (list or tuple): list of transformations
     """
 
-    def __init__(self, transforms):
+    def __init__(self, transforms) -> None:
         if not isinstance(transforms, Sequence):
             raise TypeError("Argument transforms should be a sequence")
         self.transforms = transforms
@@ -440,7 +440,7 @@ class RandomApply(torch.nn.Module):
         p (float): probability
     """
 
-    def __init__(self, transforms, p=0.5):
+    def __init__(self, transforms, p=0.5) -> None:
         super().__init__()
         self.transforms = transforms
         self.p = p
@@ -549,7 +549,7 @@ class RandomCrop(torch.nn.Module):
         j = torch.randint(0, w - tw + 1, size=(1, )).item()
         return i, j, th, tw
 
-    def __init__(self, size, padding=None, pad_if_needed=False, fill=0, padding_mode="constant"):
+    def __init__(self, size, padding=None, pad_if_needed=False, fill=0, padding_mode="constant") -> None:
         super().__init__()
 
         self.size = tuple(_setup_size(
@@ -600,7 +600,7 @@ class RandomHorizontalFlip(torch.nn.Module):
         p (float): probability of the image being flipped. Default value is 0.5
     """
 
-    def __init__(self, p=0.5):
+    def __init__(self, p=0.5) -> None:
         super().__init__()
         self.p = p
 
@@ -630,7 +630,7 @@ class RandomVerticalFlip(torch.nn.Module):
         p (float): probability of the image being flipped. Default value is 0.5
     """
 
-    def __init__(self, p=0.5):
+    def __init__(self, p=0.5) -> None:
         super().__init__()
         self.p = p
 
@@ -668,7 +668,7 @@ class RandomPerspective(torch.nn.Module):
 
     """
 
-    def __init__(self, distortion_scale=0.5, p=0.5, interpolation=Image.BILINEAR, fill=0):
+    def __init__(self, distortion_scale=0.5, p=0.5, interpolation=Image.BILINEAR, fill=0) -> None:
         super().__init__()
         self.p = p
         self.interpolation = interpolation
@@ -836,7 +836,7 @@ class RandomSizedCrop(RandomResizedCrop):
     """
     Note: This transform is deprecated in favor of RandomResizedCrop.
     """
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         warnings.warn("The use of the transforms.RandomSizedCrop transform is deprecated, " +
                       "please use transforms.RandomResizedCrop instead.")
         super(RandomSizedCrop, self).__init__(*args, **kwargs)
@@ -870,7 +870,7 @@ class FiveCrop(torch.nn.Module):
          >>> result_avg = result.view(bs, ncrops, -1).mean(1) # avg over crops
     """
 
-    def __init__(self, size):
+    def __init__(self, size) -> None:
         super().__init__()
         self.size = _setup_size(size, error_msg="Please provide only two dimensions (h, w) for size.")
 
@@ -918,7 +918,7 @@ class TenCrop(torch.nn.Module):
          >>> result_avg = result.view(bs, ncrops, -1).mean(1) # avg over crops
     """
 
-    def __init__(self, size, vertical_flip=False):
+    def __init__(self, size, vertical_flip=False) -> None:
         super().__init__()
         self.size = _setup_size(size, error_msg="Please provide only two dimensions (h, w) for size.")
         self.vertical_flip = vertical_flip
@@ -955,7 +955,7 @@ class LinearTransformation(torch.nn.Module):
         mean_vector (Tensor): tensor [D], D = C x H x W
     """
 
-    def __init__(self, transformation_matrix, mean_vector):
+    def __init__(self, transformation_matrix, mean_vector) -> None:
         super().__init__()
         if transformation_matrix.size(0) != transformation_matrix.size(1):
             raise ValueError("transformation_matrix should be square. Got " +
@@ -1022,7 +1022,7 @@ class ColorJitter(torch.nn.Module):
             Should have 0<= hue <= 0.5 or -0.5 <= min <= max <= 0.5.
     """
 
-    def __init__(self, brightness=0, contrast=0, saturation=0, hue=0):
+    def __init__(self, brightness=0, contrast=0, saturation=0, hue=0) -> None:
         super().__init__()
         self.brightness = self._check_input(brightness, 'brightness')
         self.contrast = self._check_input(contrast, 'contrast')
@@ -1141,7 +1141,7 @@ class RandomRotation(torch.nn.Module):
 
     """
 
-    def __init__(self, degrees, resample=False, expand=False, center=None, fill=None):
+    def __init__(self, degrees, resample=False, expand=False, center=None, fill=None) -> None:
         super().__init__()
         self.degrees = _setup_angle(degrees, name="degrees", req_sizes=(2, ))
 
@@ -1219,7 +1219,7 @@ class RandomAffine(torch.nn.Module):
 
     """
 
-    def __init__(self, degrees, translate=None, scale=None, shear=None, resample=0, fillcolor=0):
+    def __init__(self, degrees, translate=None, scale=None, shear=None, resample=0, fillcolor=0) -> None:
         super().__init__()
         self.degrees = _setup_angle(degrees, name="degrees", req_sizes=(2, ))
 
@@ -1330,7 +1330,7 @@ class Grayscale(torch.nn.Module):
 
     """
 
-    def __init__(self, num_output_channels=1):
+    def __init__(self, num_output_channels=1) -> None:
         super().__init__()
         self.num_output_channels = num_output_channels
 
@@ -1365,7 +1365,7 @@ class RandomGrayscale(torch.nn.Module):
 
     """
 
-    def __init__(self, p=0.1):
+    def __init__(self, p=0.1) -> None:
         super().__init__()
         self.p = p
 

--- a/travis-scripts/run-clang-format/run-clang-format.py
+++ b/travis-scripts/run-clang-format/run-clang-format.py
@@ -80,13 +80,13 @@ def make_diff(file, original, reformatted):
 
 
 class DiffError(Exception):
-    def __init__(self, message, errs=None):
+    def __init__(self, message, errs=None) -> None:
         super(DiffError, self).__init__(message)
         self.errs = errs or []
 
 
 class UnexpectedError(Exception):
-    def __init__(self, message, exc=None):
+    def __init__(self, message, exc=None) -> None:
         super(UnexpectedError, self).__init__(message)
         self.formatted_traceback = traceback.format_exc()
         self.exc = exc


### PR DESCRIPTION
I noticed that some of the `__init__` functions are missing `-> None` while others are not. I've added -`> None` to the ones that were missing it. The change is based on PEP-0484: https://www.python.org/dev/peps/pep-0484/

The type hint errors in the failed tests don't seem to be caused by my changes.