### PR TITLE
Remove noexcept from cuda_version

### DIFF
--- a/torchvision/csrc/vision.cpp
+++ b/torchvision/csrc/vision.cpp
@@ -26,7 +26,7 @@ PyMODINIT_FUNC PyInit__C(void) {
 #endif
 
 namespace vision {
-int64_t cuda_version() noexcept {
+int64_t cuda_version() {
 #ifdef WITH_CUDA
   return CUDA_VERSION;
 #else

--- a/torchvision/csrc/vision.h
+++ b/torchvision/csrc/vision.h
@@ -6,7 +6,7 @@
 #include "macros.h"
 
 namespace vision {
-VISION_API int64_t cuda_version() noexcept;
+VISION_API int64_t cuda_version();
 
 namespace detail {
 // Dummy variable to reference a symbol from vision.cpp.


### PR DESCRIPTION
Operator registration of functions with noexcept doesn't work on some compilers, see https://github.com/pytorch/pytorch/issues/48667

cc @bmanga FYI