### PR TITLE
Fix test_linear_transformation for ROCm

### DIFF
--- a/test/test_transforms_tensor.py
+++ b/test/test_transforms_tensor.py
@@ -452,6 +452,7 @@ class Tester(TransformsTester):
         # We skip some tests from _test_transform_vs_scripted_on_batch as
         # results for scripted and non-scripted transformations are not exactly the same
         torch.manual_seed(12)
+        torch.set_deterministic(True)
         transformed_batch = fn(batch_tensors)
         torch.manual_seed(12)
         s_transformed_batch = scripted_fn(batch_tensors)


### PR DESCRIPTION
For test_linear_transformation in test_transforms_tensor.py running on ROCm for batched tensors uses a BLAS config which does not give EXACT same output every time, which is why this test would result in a failure on ROCm. rocBLAS in pyTorch could be made to use deterministic algorithms by the setting `torch.set_deterministic(True)` implemented in PyTorch [PR#48654](https://github.com/pytorch/pytorch/pull/48654)
This PR adds that setting in the test.
@fmassa - Would you suggest using `torch.set_deterministic(True)` setting only for ROCm, and leave it as is for other platforms? In which case I can protect that using a conditional statement

cc: @jeffdaily @sunway513