### PR TITLE
Cleanup and deduplicate tests for transforms

### DIFF
--- a/test/test_functional_tensor.py
+++ b/test/test_functional_tensor.py
@@ -863,19 +863,14 @@ class Tester(TransformsTester):
                             )
 
     def test_invert(self):
-        script_invert = torch.jit.script(F.invert)
-
-        img_tensor, pil_img = self._create_data(16, 18, device=self.device)
-        inverted_img = F.invert(img_tensor)
-        inverted_pil_img = F.invert(pil_img)
-        self.compareTensorToPIL(inverted_img, inverted_pil_img)
-
-        # scriptable function test
-        inverted_img_script = script_invert(img_tensor)
-        self.assertTrue(inverted_img.equal(inverted_img_script))
-
-        batch_tensors = self._create_data_batch(16, 18, num_samples=4, device=self.device)
-        self._test_fn_on_batch(batch_tensors, F.invert)
+        self._test_adjust_fn(
+            F.invert,
+            F_pil.invert,
+            F_t.invert,
+            [{}],
+            tol=1.0,
+            agg_method="max"
+        )
 
 
 @unittest.skipIf(not torch.cuda.is_available(), reason="Skip if no CUDA device")

--- a/torchvision/transforms/functional_pil.py
+++ b/torchvision/transforms/functional_pil.py
@@ -610,19 +610,6 @@ def to_grayscale(img, num_output_channels):
 
 @torch.jit.unused
 def invert(img):
-    """PRIVATE METHOD. Invert the colors of an image.
-
-    .. warning::
-
-        Module ``transforms.functional_pil`` is private and should not be used in user application.
-        Please, consider instead using methods from `transforms.functional` module.
-
-    Args:
-        img (PIL Image): Image to have its colors inverted.
-
-    Returns:
-        PIL Image: Color inverted image Tensor.
-    """
     if not _is_pil_image(img):
         raise TypeError('img should be PIL Image. Got {}'.format(type(img)))
     return ImageOps.invert(img)

--- a/torchvision/transforms/functional_tensor.py
+++ b/torchvision/transforms/functional_tensor.py
@@ -1182,19 +1182,6 @@ def gaussian_blur(img: Tensor, kernel_size: List[int], sigma: List[float]) -> Te
 
 
 def invert(img: Tensor) -> Tensor:
-    """PRIVATE METHOD. Invert the colors of a grayscale or RGB image.
-
-    .. warning::``
-
-        Module ``transforms.functional_tensor`` is private and should not be used in user application.
-        Please, consider instead using methods from `transforms.functional` module.
-
-    Args:
-        img (Tensor): Image to have its colors inverted in the form [C, H, W].
-
-    Returns:
-        Tensor: Color inverted image Tensor.
-    """
     if not _is_tensor_a_torch_image(img):
         raise TypeError('tensor is not a torch image.')
 


### PR DESCRIPTION
Part of #3050

Making use or create generic testing methods to reduce code duplication on subsequent PRs.