### PR TITLE
Fix potential overflow in convert_image_dtype

### DIFF
--- a/torchvision/transforms/functional_tensor.py
+++ b/torchvision/transforms/functional_tensor.py
@@ -105,13 +105,14 @@ def convert_image_dtype(image: torch.Tensor, dtype: torch.dtype = torch.float) -
         return result.to(dtype)
     else:
         input_max = _max_value(image.dtype)
-        output_max = _max_value(dtype)
 
         # int to float
         # TODO: replace with dtype.is_floating_point when torchscript supports it
         if torch.tensor(0, dtype=dtype).is_floating_point():
             image = image.to(dtype)
             return image / input_max
+
+        output_max = _max_value(dtype)
 
         # int to int
         if input_max > output_max:


### PR DESCRIPTION
We could have errors with `convert_image_dtype` such as
```
aten/src/ATen/native/cpu/PowKernel.cpp:41:5:  runtime error: 5.7896e+76 is outside the range of representable values of type 'float'
```

This fixes it for now, while we can't use `torch.iinfo` and `torch.finfo` in torchscript