### PR TITLE
pil_to_tensor accimage backend return uint8

### DIFF
--- a/torchvision/transforms/functional.py
+++ b/torchvision/transforms/functional.py
@@ -155,7 +155,8 @@ def pil_to_tensor(pic):
         raise TypeError('pic should be PIL Image. Got {}'.format(type(pic)))
 
     if accimage is not None and isinstance(pic, accimage.Image):
-        nppic = np.zeros([pic.channels, pic.height, pic.width], dtype=np.float32)
+        # accimage format is always uint8 internally, so always return uint8 here
+        nppic = np.zeros([pic.channels, pic.height, pic.width], dtype=np.uint8)
         pic.copyto(nppic)
         return torch.as_tensor(nppic)
 


### PR DESCRIPTION
accimage always stores images as uint8, so let's be compatible with the internal representation and return uint8 as well.
Tests were failing without this as it would return a float32 image normalized between 0-1, but we don't have accimage installed in CI anymore so this wasn't caught before.