### PR TITLE
Fix flake8 warning on macOS

### DIFF
--- a/torchvision/models/densenet.py
+++ b/torchvision/models/densenet.py
@@ -67,12 +67,12 @@ class _DenseLayer(nn.Module):
 
         return cp.checkpoint(closure, *input)
 
-    @torch.jit._overload_method  # noqa: F811
-    def forward(self, input: List[Tensor]) -> Tensor:
+    @torch.jit._overload_method
+    def forward(self, input: List[Tensor]) -> Tensor:  # noqa: F811
         pass
 
-    @torch.jit._overload_method  # noqa: F811
-    def forward(self, input: Tensor) -> Tensor:
+    @torch.jit._overload_method
+    def forward(self, input: Tensor) -> Tensor:  # noqa: F811
         pass
 
     # torchscript does not yet support *args, so we overload method


### PR DESCRIPTION
BEFORE:
```
/bin/python -m flake8 --config=setup.cfg
./torchvision/models/densenet.py:75:5: F811 redefinition of unused 'forward' from line 71

Process finished with exit code 1
```

AFTER:
```
/bin/python -m flake8 --config=setup.cfg

Process finished with exit code 0
```