### PR TITLE
Removed all backward methods from header files

### DIFF
--- a/torchvision/csrc/deform_conv2d.h
+++ b/torchvision/csrc/deform_conv2d.h
@@ -6,28 +6,7 @@
 namespace vision {
 namespace ops {
 
-// C++ Forward
 VISION_API at::Tensor deform_conv2d(
-    const at::Tensor& input,
-    const at::Tensor& weight,
-    const at::Tensor& offset,
-    const at::Tensor& mask,
-    const at::Tensor& bias,
-    int64_t stride_h,
-    int64_t stride_w,
-    int64_t pad_h,
-    int64_t pad_w,
-    int64_t dilation_h,
-    int64_t dilation_w,
-    int64_t groups,
-    int64_t offset_groups,
-    bool use_mask);
-
-// C++ Backward
-VISION_API
-std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor>
-_deform_conv2d_backward(
-    const at::Tensor& grad,
     const at::Tensor& input,
     const at::Tensor& weight,
     const at::Tensor& offset,

--- a/torchvision/csrc/nms.h
+++ b/torchvision/csrc/nms.h
@@ -6,7 +6,6 @@
 namespace vision {
 namespace ops {
 
-// C++ Forward
 VISION_API at::Tensor nms(
     const at::Tensor& dets,
     const at::Tensor& scores,

--- a/torchvision/csrc/ps_roi_align.h
+++ b/torchvision/csrc/ps_roi_align.h
@@ -6,7 +6,6 @@
 namespace vision {
 namespace ops {
 
-// C++ Forward
 VISION_API std::tuple<at::Tensor, at::Tensor> ps_roi_align(
     const at::Tensor& input,
     const at::Tensor& rois,
@@ -14,20 +13,6 @@ VISION_API std::tuple<at::Tensor, at::Tensor> ps_roi_align(
     int64_t pooled_height,
     int64_t pooled_width,
     int64_t sampling_ratio);
-
-// C++ Backward
-VISION_API at::Tensor _ps_roi_align_backward(
-    const at::Tensor& grad,
-    const at::Tensor& rois,
-    const at::Tensor& channel_mapping,
-    double spatial_scale,
-    int64_t pooled_height,
-    int64_t pooled_width,
-    int64_t sampling_ratio,
-    int64_t batch_size,
-    int64_t channels,
-    int64_t height,
-    int64_t width);
 
 } // namespace ops
 } // namespace vision

--- a/torchvision/csrc/ps_roi_pool.h
+++ b/torchvision/csrc/ps_roi_pool.h
@@ -6,26 +6,12 @@
 namespace vision {
 namespace ops {
 
-// C++ Forward
 VISION_API std::tuple<at::Tensor, at::Tensor> ps_roi_pool(
     const at::Tensor& input,
     const at::Tensor& rois,
     double spatial_scale,
     int64_t pooled_height,
     int64_t pooled_width);
-
-// C++ Backward
-VISION_API at::Tensor _ps_roi_pool_backward(
-    const at::Tensor& grad,
-    const at::Tensor& rois,
-    const at::Tensor& channel_mapping,
-    double spatial_scale,
-    int64_t pooled_height,
-    int64_t pooled_width,
-    int64_t batch_size,
-    int64_t channels,
-    int64_t height,
-    int64_t width);
 
 } // namespace ops
 } // namespace vision

--- a/torchvision/csrc/roi_align.h
+++ b/torchvision/csrc/roi_align.h
@@ -6,27 +6,12 @@
 namespace vision {
 namespace ops {
 
-// C++ Forward
 VISION_API at::Tensor roi_align(
     const at::Tensor& input,
     const at::Tensor& rois,
     double spatial_scale,
     int64_t pooled_height,
     int64_t pooled_width,
-    int64_t sampling_ratio,
-    bool aligned);
-
-// C++ Backward
-VISION_API at::Tensor _roi_align_backward(
-    const at::Tensor& grad,
-    const at::Tensor& rois,
-    double spatial_scale,
-    int64_t pooled_height,
-    int64_t pooled_width,
-    int64_t batch_size,
-    int64_t channels,
-    int64_t height,
-    int64_t width,
     int64_t sampling_ratio,
     bool aligned);
 

--- a/torchvision/csrc/roi_pool.h
+++ b/torchvision/csrc/roi_pool.h
@@ -6,26 +6,12 @@
 namespace vision {
 namespace ops {
 
-// C++ Forward
 VISION_API std::tuple<at::Tensor, at::Tensor> roi_pool(
     const at::Tensor& input,
     const at::Tensor& rois,
     double spatial_scale,
     int64_t pooled_height,
     int64_t pooled_width);
-
-// C++ Backward
-VISION_API at::Tensor _roi_pool_backward(
-    const at::Tensor& grad,
-    const at::Tensor& rois,
-    const at::Tensor& argmax,
-    double spatial_scale,
-    int64_t pooled_height,
-    int64_t pooled_width,
-    int64_t batch_size,
-    int64_t channels,
-    int64_t height,
-    int64_t width);
 
 } // namespace ops
 } // namespace vision


### PR DESCRIPTION
As discussed in #3135 keeping the backward methods public is unnecessary, so this PR removes them.