### PR TITLE
Fixes contributing link from md as rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -137,7 +137,7 @@ You can find the API documentation on the pytorch website: https://pytorch.org/d
 Contributing
 ============
 
-See the [CONTRIBUTING](CONTRIBUTING.md) file for how to help out.
+See the `CONTRIBUTING <CONTRIBUTING.md>`_ file for how to help out.
 
 Disclaimer on Datasets
 ======================


### PR DESCRIPTION
My bad, I added initially a link as Markdown but README is rST.

Now it is OK, see https://github.com/Quansight/vision/tree/fix-contributing-link#contributing