### PR TITLE
Adapt to new pytorch onnx exporter API for dictionary

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,7 +157,7 @@ jobs:
             # need to install torchvision dependencies due to transitive imports
             pip install --user --progress-bar off --editable .
             pip install --user onnx
-            pip install --user -i https://test.pypi.org/simple/ ort-nightly==1.5.2.dev202012031
+            pip install --user onnxruntime
             python test/test_onnx.py
 
   binary_linux_wheel:

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -157,7 +157,7 @@ jobs:
             # need to install torchvision dependencies due to transitive imports
             pip install --user --progress-bar off --editable .
             pip install --user onnx
-            pip install --user -i https://test.pypi.org/simple/ ort-nightly==1.5.2.dev202012031
+            pip install --user onnxruntime
             python test/test_onnx.py
 
   binary_linux_wheel:

--- a/test/test_onnx.py
+++ b/test/test_onnx.py
@@ -33,8 +33,12 @@ class ONNXExporterTester(unittest.TestCase):
         model.eval()
 
         onnx_io = io.BytesIO()
+        if isinstance(inputs_list[0][-1], dict):
+            torch_onnx_input = inputs_list[0] + ({},)
+        else:
+            torch_onnx_input = inputs_list[0]
         # export to onnx with the first input
-        torch.onnx.export(model, inputs_list[0], onnx_io,
+        torch.onnx.export(model, torch_onnx_input, onnx_io,
                           do_constant_folding=do_constant_folding, opset_version=_onnx_opset_version,
                           dynamic_axes=dynamic_axes, input_names=input_names, output_names=output_names)
         # validate the exported model with onnx runtime


### PR DESCRIPTION
The [PR](https://github.com/pytorch/pytorch/pull/47367) is merged at 12:31 pm on 12/10/2020 (yesterday) which uses a new API if the last input is a dictionary -- It need add a dummy dictionary input at the end.
This API change breaks the torch vision test, and here we fix the test.

Other minor: 
We update to use stable version of onnxruntime, because test.pypi removes old ort-nightly periodically.
