### PR TITLE
Removing VISION_API from backward() methods and adding a ops.h

### DIFF
--- a/torchvision/csrc/ops/deform_conv2d.h
+++ b/torchvision/csrc/ops/deform_conv2d.h
@@ -24,9 +24,7 @@ VISION_API at::Tensor deform_conv2d(
 
 namespace detail {
 
-VISION_API
-std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor>
-_deform_conv2d_backward(
+std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor> _deform_conv2d_backward(
     const at::Tensor& grad,
     const at::Tensor& input,
     const at::Tensor& weight,

--- a/torchvision/csrc/ops/ops.h
+++ b/torchvision/csrc/ops/ops.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include "deform_conv2d.h"
+#include "nms.h"
+#include "ps_roi_align.h"
+#include "ps_roi_pool.h"
+#include "roi_align.h"
+#include "roi_pool.h"

--- a/torchvision/csrc/ops/ps_roi_align.h
+++ b/torchvision/csrc/ops/ps_roi_align.h
@@ -16,7 +16,7 @@ VISION_API std::tuple<at::Tensor, at::Tensor> ps_roi_align(
 
 namespace detail {
 
-VISION_API at::Tensor _ps_roi_align_backward(
+at::Tensor _ps_roi_align_backward(
     const at::Tensor& grad,
     const at::Tensor& rois,
     const at::Tensor& channel_mapping,

--- a/torchvision/csrc/ops/ps_roi_pool.h
+++ b/torchvision/csrc/ops/ps_roi_pool.h
@@ -15,7 +15,7 @@ VISION_API std::tuple<at::Tensor, at::Tensor> ps_roi_pool(
 
 namespace detail {
 
-VISION_API at::Tensor _ps_roi_pool_backward(
+at::Tensor _ps_roi_pool_backward(
     const at::Tensor& grad,
     const at::Tensor& rois,
     const at::Tensor& channel_mapping,

--- a/torchvision/csrc/ops/roi_align.h
+++ b/torchvision/csrc/ops/roi_align.h
@@ -17,7 +17,7 @@ VISION_API at::Tensor roi_align(
 
 namespace detail {
 
-VISION_API at::Tensor _roi_align_backward(
+at::Tensor _roi_align_backward(
     const at::Tensor& grad,
     const at::Tensor& rois,
     double spatial_scale,

--- a/torchvision/csrc/ops/roi_pool.h
+++ b/torchvision/csrc/ops/roi_pool.h
@@ -15,7 +15,7 @@ VISION_API std::tuple<at::Tensor, at::Tensor> roi_pool(
 
 namespace detail {
 
-VISION_API at::Tensor _roi_pool_backward(
+at::Tensor _roi_pool_backward(
     const at::Tensor& grad,
     const at::Tensor& rois,
     const at::Tensor& argmax,


### PR DESCRIPTION
Minor clean ups on the ops implementations:

- [x] PR #3154 added all the backward method inside the vision::ops::detail namespace. Those methods are part of the internal API and should not be marked with `VISION_API`. 
- [x] `ops` is missing a `ops.h` that conveniently adds all operator headers. `images` and `models` namespaces have similar header files, so I add one for ops as well.