### PR TITLE
Loosening precision to make test pass

### DIFF
--- a/test/test_models.py
+++ b/test/test_models.py
@@ -70,7 +70,7 @@ class ModelTester(TestCase):
         # RNG always on CPU, to ensure x in cuda tests is bitwise identical to x in cpu tests
         x = torch.rand(input_shape).to(device=dev)
         out = model(x)
-        self.assertExpected(out.cpu(), prec=0.1, strip_suffix=f"_{dev}")
+        self.assertExpected(out.cpu(), prec=0.2, strip_suffix=f"_{dev}")
         self.assertEqual(out.shape[-1], 50)
         self.check_jit_scriptable(model, (x,), unwrapper=script_model_unwrapper.get(name, None))
 


### PR DESCRIPTION
Hi,

The tests `ModelTester.test_vgg13_bn_cpu` and `ModelTester.test_vgg13_cpu` in `test\test_models.py` have a high failure rate when run without the seed set on Line 65 in the test file(`set_rng_seed(0)`). Both tests failed 66 out of 100 times on my local machine without the seed set.

Increasing the precision to 0.2 makes the tests pass consistently (I observed 0 failures with this precision). Do you guys think this is a reasonable change? I think these tests should _ideally_ have a high success rate even without seeds. Please let me know your thoughts on this.

I also have more observations regarding other tests (and the use of seeds) in your test-suite if this interests you.

 Environment:
```
python 3.7.9
OS: Ubuntu 18.04

torch 1.7.0
numpy 1.19.4
```

Let me know if you have any questions/suggestions.