### PR TITLE
Speedup DeformConvTester

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -5,6 +5,7 @@ import unittest
 import numpy as np
 
 import torch
+from functools import lru_cache
 from torch import Tensor
 from torch.autograd import gradcheck
 from torch.nn.modules.utils import _pair
@@ -496,6 +497,7 @@ class DeformConvTester(OpTester, unittest.TestCase):
         out += bias.view(1, n_out_channels, 1, 1)
         return out
 
+    @lru_cache(maxsize=None)
     def get_fn_args(self, device, contiguous, batch_sz, dtype):
         n_in_channels = 6
         n_out_channels = 2

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -614,9 +614,11 @@ class DeformConvTester(OpTester, unittest.TestCase):
         gradcheck(lambda z, off, wei, bi: script_func_no_mask(z, off, wei, bi, stride, padding, dilation),
                   (x, offset, weight, bias), nondet_tol=1e-5)
 
+    @unittest.skipIf(not torch.cuda.is_available(), "CUDA unavailable")
+    def test_compare_cpu_cuda_grads(self):
         # Test from https://github.com/pytorch/vision/issues/2598
         # Run on CUDA only
-        if "cuda" in device.type:
+        for contiguous in [False, True]:
             # compare grads computed on CUDA with grads computed on CPU
             true_cpu_grads = None
 


### PR DESCRIPTION
This PR refactors the tests of DeformConv2d to reduce some unnecessary repeated checks and estimations. Due to the fact that I change the structure of the tests, we can no longer compare them directly. Instead we measure the total time before and after the refactoring for the entire `DeformConvTester` class. The biggest improvements are on platforms that support CUDA but some minor improvements can be seen also on CPU due to the introduced caching.

Rough improvement per platform:

Linux: ~10%
- Before: 358.13s - [reference](https://app.circleci.com/pipelines/github/pytorch/vision/5568/workflows/4d290fd1-991a-4778-be02-4dc423578393/jobs/351986)
```
96.64s call     test/test_ops.py::DeformConvTester::test_backward_cuda_non_contiguous
91.25s call     test/test_ops.py::DeformConvTester::test_backward_cuda_contiguous
71.77s call     test/test_ops.py::DeformConvTester::test_backward_cpu_non_contiguous
54.86s call     test/test_ops.py::DeformConvTester::test_backward_cpu_contiguous
20.08s call     test/test_ops.py::DeformConvTester::test_autocast
7.86s call     test/test_ops.py::DeformConvTester::test_forward_cuda_non_contiguous
7.76s call     test/test_ops.py::DeformConvTester::test_forward_cuda_contiguous
3.98s call     test/test_ops.py::DeformConvTester::test_forward_cpu_non_contiguous
3.93s call     test/test_ops.py::DeformConvTester::test_forward_cpu_contiguous
```
- After: 323.3s - [reference](https://app.circleci.com/pipelines/github/pytorch/vision/5569/workflows/4c2355a8-ce8f-4e45-b461-b25cb62ea14a/jobs/351988)
```
71.90s call     test/test_ops.py::DeformConvTester::test_backward_cpu_non_contiguous
60.98s call     test/test_ops.py::DeformConvTester::test_backward_cuda_non_contiguous
55.69s call     test/test_ops.py::DeformConvTester::test_backward_cuda_contiguous
54.75s call     test/test_ops.py::DeformConvTester::test_backward_cpu_contiguous
36.10s call     test/test_ops.py::DeformConvTester::test_compare_cpu_cuda_grads
19.45s call     test/test_ops.py::DeformConvTester::test_autocast
8.08s call     test/test_ops.py::DeformConvTester::test_forward_cuda_non_contiguous
8.01s call     test/test_ops.py::DeformConvTester::test_forward_cuda_contiguous
4.18s call     test/test_ops.py::DeformConvTester::test_forward_cpu_contiguous
4.16s call     test/test_ops.py::DeformConvTester::test_forward_cpu_non_contiguous
```

Windows: ~12%
- Before: 351.38s - [reference](https://app.circleci.com/pipelines/github/pytorch/vision/5568/workflows/4d290fd1-991a-4778-be02-4dc423578393/jobs/351983)
```
90.24s call     test/test_ops.py::DeformConvTester::test_backward_cuda_non_contiguous
84.50s call     test/test_ops.py::DeformConvTester::test_backward_cuda_contiguous
79.99s call     test/test_ops.py::DeformConvTester::test_backward_cpu_non_contiguous
58.25s call     test/test_ops.py::DeformConvTester::test_backward_cpu_contiguous
17.03s call     test/test_ops.py::DeformConvTester::test_autocast
7.24s call     test/test_ops.py::DeformConvTester::test_forward_cuda_non_contiguous
6.88s call     test/test_ops.py::DeformConvTester::test_forward_cuda_contiguous
3.65s call     test/test_ops.py::DeformConvTester::test_forward_cpu_non_contiguous
3.60s call     test/test_ops.py::DeformConvTester::test_forward_cpu_contiguous
```
- After: 310.86s - [reference](https://app.circleci.com/pipelines/github/pytorch/vision/5569/workflows/4c2355a8-ce8f-4e45-b461-b25cb62ea14a/jobs/351991 )
```
78.86s call     test/test_ops.py::DeformConvTester::test_backward_cpu_non_contiguous
57.80s call     test/test_ops.py::DeformConvTester::test_backward_cpu_contiguous
51.68s call     test/test_ops.py::DeformConvTester::test_backward_cuda_non_contiguous
46.67s call     test/test_ops.py::DeformConvTester::test_backward_cuda_contiguous
36.42s call     test/test_ops.py::DeformConvTester::test_compare_cpu_cuda_grads
17.11s call     test/test_ops.py::DeformConvTester::test_autocast
7.19s call     test/test_ops.py::DeformConvTester::test_forward_cuda_contiguous
7.11s call     test/test_ops.py::DeformConvTester::test_forward_cuda_non_contiguous
4.08s call     test/test_ops.py::DeformConvTester::test_forward_cpu_contiguous
3.94s call     test/test_ops.py::DeformConvTester::test_forward_cpu_non_contiguous
```

MacOS: ~7%
- Before: 142.7s - [reference](https://app.circleci.com/pipelines/github/pytorch/vision/5568/workflows/4d290fd1-991a-4778-be02-4dc423578393/jobs/351985)
```
73.73s call     test/test_ops.py::DeformConvTester::test_backward_cpu_non_contiguous
55.91s call     test/test_ops.py::DeformConvTester::test_backward_cpu_contiguous
6.57s call     test/test_ops.py::DeformConvTester::test_forward_cpu_contiguous
6.49s call     test/test_ops.py::DeformConvTester::test_forward_cpu_non_contiguous
```
- After: 132.89 - [reference](https://app.circleci.com/pipelines/github/pytorch/vision/5569/workflows/4c2355a8-ce8f-4e45-b461-b25cb62ea14a/jobs/351990)
```
68.40s call     test/test_ops.py::DeformConvTester::test_backward_cpu_non_contiguous
52.53s call     test/test_ops.py::DeformConvTester::test_backward_cpu_contiguous
6.03s call     test/test_ops.py::DeformConvTester::test_forward_cpu_contiguous
5.93s call     test/test_ops.py::DeformConvTester::test_forward_cpu_non_contiguous
```

The above are rough estimations based on a couple or runs.

-----------

**Note:**
Since we don't change the quantity or quality of performed tests the gains are small. Significant speed ups can be achieved by reducing the batch size used on the tests from 33 to 1 or slightly larger:

https://github.com/pytorch/vision/blob/4cbe71401fc6e330e4c4fb40d47e814911e63399/test/test_ops.py#L541

https://github.com/pytorch/vision/blob/4cbe71401fc6e330e4c4fb40d47e814911e63399/test/test_ops.py#L580

The value 33 was selected to catch a bug reported on issue #2817. Nevertheless I believe that the likelihood of breaking the code again in exactly the same way are slim and not worth the 5 minutes per platform that adds to our testing time. Currently there is no quorum to change this value but this might happen on a future PR.