### PR TITLE
Clean up and Document io.image enhancements (#3034)

### DIFF
--- a/torchvision/csrc/io/image/cpu/readjpeg_cpu.cpp
+++ b/torchvision/csrc/io/image/cpu/readjpeg_cpu.cpp
@@ -117,7 +117,7 @@ torch::Tensor decodeJPEG(const torch::Tensor& data, ImageReadMode mode) {
        */
       default:
         jpeg_destroy_decompress(&cinfo);
-        TORCH_CHECK(false, "Provided mode not supported as the input is JPEG");
+        TORCH_CHECK(false, "The provided mode is not supported for JPEG files");
     }
 
     jpeg_calc_output_dimensions(&cinfo);

--- a/torchvision/csrc/io/image/cpu/readjpeg_cpu.cpp
+++ b/torchvision/csrc/io/image/cpu/readjpeg_cpu.cpp
@@ -117,7 +117,7 @@ torch::Tensor decodeJPEG(const torch::Tensor& data, ImageReadMode mode) {
        */
       default:
         jpeg_destroy_decompress(&cinfo);
-        TORCH_CHECK(false, "Provided mode not supported");
+        TORCH_CHECK(false, "Provided mode not supported as the input is JPEG");
     }
 
     jpeg_calc_output_dimensions(&cinfo);

--- a/torchvision/csrc/io/image/cpu/readpng_cpu.cpp
+++ b/torchvision/csrc/io/image/cpu/readpng_cpu.cpp
@@ -143,7 +143,7 @@ torch::Tensor decodePNG(const torch::Tensor& data, ImageReadMode mode) {
         break;
       default:
         png_destroy_read_struct(&png_ptr, &info_ptr, nullptr);
-        TORCH_CHECK(false, "Provided mode not supported");
+        TORCH_CHECK(false, "Provided mode not supported as the input is PNG");
     }
 
     png_read_update_info(png_ptr, info_ptr);

--- a/torchvision/csrc/io/image/cpu/readpng_cpu.cpp
+++ b/torchvision/csrc/io/image/cpu/readpng_cpu.cpp
@@ -143,7 +143,7 @@ torch::Tensor decodePNG(const torch::Tensor& data, ImageReadMode mode) {
         break;
       default:
         png_destroy_read_struct(&png_ptr, &info_ptr, nullptr);
-        TORCH_CHECK(false, "Provided mode not supported as the input is PNG");
+        TORCH_CHECK(false, "The provided mode is not supported for PNG files");
     }
 
     png_read_update_info(png_ptr, info_ptr);

--- a/torchvision/csrc/io/image/image_read_mode.h
+++ b/torchvision/csrc/io/image/image_read_mode.h
@@ -2,8 +2,8 @@
 
 /* Should be kept in-sync with Python ImageReadMode enum */
 using ImageReadMode = int64_t;
-#define IMAGE_READ_MODE_UNCHANGED 0
-#define IMAGE_READ_MODE_GRAY 1
-#define IMAGE_READ_MODE_GRAY_ALPHA 2
-#define IMAGE_READ_MODE_RGB 3
-#define IMAGE_READ_MODE_RGB_ALPHA 4
+const ImageReadMode IMAGE_READ_MODE_UNCHANGED = 0;
+const ImageReadMode IMAGE_READ_MODE_GRAY = 1;
+const ImageReadMode IMAGE_READ_MODE_GRAY_ALPHA = 2;
+const ImageReadMode IMAGE_READ_MODE_RGB = 3;
+const ImageReadMode IMAGE_READ_MODE_RGB_ALPHA = 4;

--- a/torchvision/io/image.py
+++ b/torchvision/io/image.py
@@ -51,11 +51,13 @@ except (ImportError, OSError):
 
 class ImageReadMode(Enum):
     """
-    Use `ImageReadMode.UNCHANGED` for loading
-    the image as-is, `ImageReadMode.GRAY` for converting to grayscale,
+    Support for various modes while reading images.
+
+    Use `ImageReadMode.UNCHANGED` for loading the image as-is,
+    `ImageReadMode.GRAY` for converting to grayscale,
     `ImageReadMode.GRAY_ALPHA` for grayscale with transparency,
     `ImageReadMode.RGB` for RGB and `ImageReadMode.RGB_ALPHA` for
-    RGB with transparency. Default: `ImageReadMode.UNCHANGED`
+    RGB with transparency.
     """
     UNCHANGED = 0
     GRAY = 1
@@ -101,11 +103,9 @@ def decode_png(input: torch.Tensor, mode: ImageReadMode = ImageReadMode.UNCHANGE
         input (Tensor[1]): a one dimensional uint8 tensor containing
     the raw bytes of the PNG image.
         mode (ImageReadMode): the read mode used for optionally
-    converting the image. Use `ImageReadMode.UNCHANGED` for loading
-    the image as-is, `ImageReadMode.GRAY` for converting to grayscale,
-    `ImageReadMode.GRAY_ALPHA` for grayscale with transparency,
-    `ImageReadMode.RGB` for RGB and `ImageReadMode.RGB_ALPHA` for
-     RGB with transparency. Default: `ImageReadMode.UNCHANGED`
+    converting the image. Default: `ImageReadMode.UNCHANGED`.
+    See `ImageReadMode` class for more information on various
+    available modes.
 
     Returns:
         output (Tensor[image_channels, image_height, image_width])
@@ -166,9 +166,9 @@ def decode_jpeg(input: torch.Tensor, mode: ImageReadMode = ImageReadMode.UNCHANG
         input (Tensor[1]): a one dimensional uint8 tensor containing
     the raw bytes of the JPEG image.
         mode (ImageReadMode): the read mode used for optionally
-    converting the image. Use `ImageReadMode.UNCHANGED` for loading
-    the image as-is, `ImageReadMode.GRAY` for converting to grayscale
-    and `ImageReadMode.RGB` for RGB. Default: `ImageReadMode.UNCHANGED`
+    converting the image. Default: `ImageReadMode.UNCHANGED`.
+    See `ImageReadMode` class for more information on various
+    available modes.
 
     Returns:
         output (Tensor[image_channels, image_height, image_width])
@@ -236,11 +236,10 @@ def decode_image(input: torch.Tensor, mode: ImageReadMode = ImageReadMode.UNCHAN
         a one dimensional uint8 tensor containing the raw bytes of the
         PNG or JPEG image.
     mode: ImageReadMode
-        the read mode used for optionally converting the image. JPEG
-        and PNG images have different permitted values. The default
-        value is `ImageReadMode.UNCHANGED` and it keeps the image as-is.
-        See `decode_jpeg()` and `decode_png()` for more information.
-        Default: `ImageReadMode.UNCHANGED`
+        the read mode used for optionally converting the image.
+        Default: `ImageReadMode.UNCHANGED`.
+        See `ImageReadMode` class for more information on various
+        available modes.
 
     Returns
     -------
@@ -261,11 +260,10 @@ def read_image(path: str, mode: ImageReadMode = ImageReadMode.UNCHANGED) -> torc
     path: str
         path of the JPEG or PNG image.
     mode: ImageReadMode
-        the read mode used for optionally converting the image. JPEG
-        and PNG images have different permitted values. The default
-        value is `ImageReadMode.UNCHANGED` and it keeps the image as-is.
-        See `decode_jpeg()` and `decode_png()` for more information.
-        Default: `ImageReadMode.UNCHANGED`
+        the read mode used for optionally converting the image.
+        Default: `ImageReadMode.UNCHANGED`.
+        See `ImageReadMode` class for more information on various
+        available modes.
 
     Returns
     -------

--- a/torchvision/io/image.py
+++ b/torchvision/io/image.py
@@ -50,6 +50,13 @@ except (ImportError, OSError):
 
 
 class ImageReadMode(Enum):
+    """
+    Use `ImageReadMode.UNCHANGED` for loading
+    the image as-is, `ImageReadMode.GRAY` for converting to grayscale,
+    `ImageReadMode.GRAY_ALPHA` for grayscale with transparency,
+    `ImageReadMode.RGB` for RGB and `ImageReadMode.RGB_ALPHA` for
+    RGB with transparency. Default: `ImageReadMode.UNCHANGED`
+    """
     UNCHANGED = 0
     GRAY = 1
     GRAY_ALPHA = 2


### PR DESCRIPTION
Fixes #3034

- I have not removed the documentation from `decode_png` and `decode_jpg` as docs in `decode_image` and `read_image` suggest the user to check `decode_jpeg` for the documentation. However, I have added the documentation to the enum.
- Keeping the above note in mind, I have replaced old define with `const`.

I hope this PR solves all the aforementioned issues. Do let me know if there are any concerns.