### PR TITLE
Speedup InceptionV3 and GoogleNet tests on windows (upgrade scipy)

### DIFF
--- a/.circleci/unittest/windows/scripts/environment.yml
+++ b/.circleci/unittest/windows/scripts/environment.yml
@@ -13,6 +13,6 @@ dependencies:
   - pip:
     - future
     - pillow>=4.1.1
-    - scipy==1.4.1
+    - scipy
     - av
     - dataclasses

--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -39,7 +39,6 @@ def set_rng_seed(seed):
 
 ACCEPT = os.getenv('EXPECTTEST_ACCEPT')
 TEST_WITH_SLOW = os.getenv('PYTORCH_TEST_WITH_SLOW', '0') == '1'
-# TEST_WITH_SLOW = True  # TODO: Delete this line once there is a PYTORCH_TEST_WITH_SLOW aware CI job
 
 
 parser = argparse.ArgumentParser(add_help=False)

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -268,7 +268,7 @@ class ModelTester(TestCase):
             f = 2 ** sum(i)
             self.assertEqual(out.shape, (1, 2048, 7 * f, 7 * f))
 
-    def test_mobilenetv2_residual_setting(self):
+    def test_mobilenet_v2_residual_setting(self):
         model = models.__dict__["mobilenet_v2"](inverted_residual_setting=[[1, 16, 1, 1], [6, 24, 2, 2]])
         model.eval()
         x = torch.rand(1, 3, 224, 224)
@@ -286,7 +286,7 @@ class ModelTester(TestCase):
         self.assertFalse(any(isinstance(x, nn.BatchNorm2d) for x in model.modules()))
         self.assertTrue(any(isinstance(x, nn.GroupNorm) for x in model.modules()))
 
-    def test_inceptionv3_eval(self):
+    def test_inception_v3_eval(self):
         # replacement for models.inception_v3(pretrained=True) that does not download weights
         kwargs = {}
         kwargs['transform_input'] = True


### PR DESCRIPTION
Rough improvement: ~96%
- Before: 931.24s - [reference](https://app.circleci.com/pipelines/github/pytorch/vision/5594/workflows/a84d80ba-a832-4ca6-856d-fde31313bc24/jobs/353553)
```
327.29s call     test/test_models.py::ModelTester::test_inception_v3_cpu
326.23s call     test/test_models.py::ModelTester::test_inception_v3_cuda
135.34s call     test/test_models.py::ModelTester::test_googlenet_cuda
133.91s call     test/test_models.py::ModelTester::test_googlenet_cpu
5.43s call     test/test_models.py::ModelTester::test_inceptionv3_eval
3.04s call     test/test_models.py::ModelTester::test_googlenet_eval
```
- After: 32.38s - [reference](https://app.circleci.com/pipelines/github/pytorch/vision/5595/workflows/85e9e739-c5ec-4704-9854-8e2803a37257/jobs/353561)
```
7.97s call     test/test_models.py::ModelTester::test_googlenet_cuda
7.41s call     test/test_models.py::ModelTester::test_inception_v3_cpu
5.24s call     test/test_models.py::ModelTester::test_inception_v3_cuda
4.52s call     test/test_models.py::ModelTester::test_googlenet_cpu
4.50s call     test/test_models.py::ModelTester::test_inception_v3_eval
2.74s call     test/test_models.py::ModelTester::test_googlenet_eval
```

The above are rough estimations based on a couple or runs.

The problem is traced to the use of scipy in the weight initialization of the two models:
https://github.com/pytorch/vision/blob/90645ccd0e774ad76200245e32222a23d09f2312/torchvision/models/inception.py#L122-L124

https://github.com/pytorch/vision/blob/90645ccd0e774ad76200245e32222a23d09f2312/torchvision/models/googlenet.py#L126-L128

The slow down is caused by a regression on scipy affecting versions 1.4.x: https://github.com/scipy/scipy/issues/11299. The reason why only Windows runs are affected is because our CI config is pinning the version of scipy to 1.4.1 on Windows but not on Linux. This was introduced at #2328 (first commit of the file) and it's probably by accident that the two files are not aligned. 

By unpinning the version and allowing scipy to use newer versions on Windows, the issue is fixed. This is an alternative solution to #3195.