### PR TITLE
Update required cmake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.12)
 project(torchvision)
 set(CMAKE_CXX_STANDARD 14)
 set(TORCHVISION_VERSION 0.7.0)


### PR DESCRIPTION
`find_package(Python3 COMPONENTS Development)` is used in this `CMakeLists.txt`. This feature is supported only after cmake 3.12:

* 3.12: https://cmake.org/cmake/help/v3.12/module/FindPython3.html?highlight=python3
* 3.11: https://cmake.org/cmake/help/v3.11/search.html?q=python3