### PR TITLE
reword parallel execution description for Dataset

### DIFF
--- a/docs/source/datasets.rst
+++ b/docs/source/datasets.rst
@@ -4,7 +4,7 @@ torchvision.datasets
 All datasets are subclasses of :class:`torch.utils.data.Dataset`
 i.e, they have ``__getitem__`` and ``__len__`` methods implemented.
 Hence, they can all be passed to a :class:`torch.utils.data.DataLoader`
-which can load multiple samples parallelly using ``torch.multiprocessing`` workers.
+which can load multiple samples in parallel using ``torch.multiprocessing`` workers.
 For example: ::
 
     imagenet_data = torchvision.datasets.ImageNet('path/to/imagenet_root/')


### PR DESCRIPTION
Suggestion: replace "parallelly" with "in parallel" which sounds more natural, at least in American English.