### PR TITLE
Remove unused imports after manual review

### DIFF
--- a/references/classification/train_quantization.py
+++ b/references/classification/train_quantization.py
@@ -1,7 +1,6 @@
 import datetime
 import os
 import time
-import sys
 import copy
 
 import torch

--- a/references/detection/train.py
+++ b/references/detection/train.py
@@ -23,7 +23,6 @@ import time
 
 import torch
 import torch.utils.data
-from torch import nn
 import torchvision
 import torchvision.models.detection
 import torchvision.models.detection.mask_rcnn

--- a/references/detection/transforms.py
+++ b/references/detection/transforms.py
@@ -1,5 +1,4 @@
 import random
-import torch
 
 from torchvision.transforms import functional as F
 

--- a/references/similarity/model.py
+++ b/references/similarity/model.py
@@ -1,4 +1,3 @@
-import torch
 import torch.nn as nn
 import torchvision.models as models
 

--- a/torchvision/datasets/cityscapes.py
+++ b/torchvision/datasets/cityscapes.py
@@ -1,7 +1,6 @@
 import json
 import os
 from collections import namedtuple
-import zipfile
 from typing import Any, Callable, Dict, List, Optional, Union, Tuple
 
 from .utils import extract_archive, verify_str_arg, iterable_to_str

--- a/torchvision/datasets/omniglot.py
+++ b/torchvision/datasets/omniglot.py
@@ -1,6 +1,5 @@
 from PIL import Image
 from os.path import join
-import os
 from typing import Any, Callable, List, Optional, Tuple
 from .vision import VisionDataset
 from .utils import download_and_extract_archive, check_integrity, list_dir, list_files

--- a/torchvision/datasets/ucf101.py
+++ b/torchvision/datasets/ucf101.py
@@ -1,4 +1,3 @@
-import glob
 import os
 
 from .utils import list_dir

--- a/torchvision/datasets/utils.py
+++ b/torchvision/datasets/utils.py
@@ -2,7 +2,6 @@ import os
 import os.path
 import hashlib
 import gzip
-import errno
 import tarfile
 from typing import Any, Callable, List, Iterable, Optional, TypeVar
 import zipfile

--- a/torchvision/datasets/video_utils.py
+++ b/torchvision/datasets/video_utils.py
@@ -8,7 +8,6 @@ import torch
 from torchvision.io import (
     _probe_video_from_file,
     _read_video_from_file,
-    _read_video_timestamps_from_file,
     read_video,
     read_video_timestamps,
 )

--- a/torchvision/datasets/voc.py
+++ b/torchvision/datasets/voc.py
@@ -4,7 +4,7 @@ import collections
 from .vision import VisionDataset
 import xml.etree.ElementTree as ET
 from PIL import Image
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, Optional, Tuple
 from .utils import download_url, verify_str_arg
 
 DATASET_YEAR_DICT = {

--- a/torchvision/datasets/voc.py
+++ b/torchvision/datasets/voc.py
@@ -4,8 +4,8 @@ import collections
 from .vision import VisionDataset
 import xml.etree.ElementTree as ET
 from PIL import Image
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
-from .utils import download_url, check_integrity, verify_str_arg
+from typing import Any, Callable, Dict, List, Optional, Tuple
+from .utils import download_url, verify_str_arg
 
 DATASET_YEAR_DICT = {
     '2012': {

--- a/torchvision/models/detection/mask_rcnn.py
+++ b/torchvision/models/detection/mask_rcnn.py
@@ -1,6 +1,5 @@
 from collections import OrderedDict
 
-import torch
 from torch import nn
 import torch.nn.functional as F
 

--- a/torchvision/models/detection/mask_rcnn.py
+++ b/torchvision/models/detection/mask_rcnn.py
@@ -1,9 +1,7 @@
 from collections import OrderedDict
 
 from torch import nn
-import torch.nn.functional as F
 
-from torchvision.ops import misc as misc_nn_ops
 from torchvision.ops import MultiScaleRoIAlign
 
 from ._utils import overwrite_eps

--- a/torchvision/models/detection/transform.py
+++ b/torchvision/models/detection/transform.py
@@ -1,4 +1,3 @@
-import random
 import math
 import torch
 from torch import nn, Tensor

--- a/torchvision/models/video/resnet.py
+++ b/torchvision/models/video/resnet.py
@@ -1,4 +1,3 @@
-import torch
 import torch.nn as nn
 
 from ..utils import load_state_dict_from_url


### PR DESCRIPTION
Following up from https://github.com/pytorch/vision/pull/3226#issuecomment-756055585. @datumbox 

This was my first week with pytorch coming from a few years of tensorflow. I try to contribute in any small way to get a feeling for the codebase. I went through and looked for unused imports using my IDE (WingPro 7) which identifies unused imports. I then searched the script to confirm, followed by a manual inspection. I intentionally used a very light hand, there were many situations where an unused import was in a commented out line, or in the 'examples' in the docstring. I choose leave those in, since this was just a small style update. In a roundabout way this is also a nice test of code coverage and unit tests to make sure pull requests are adequately evaluated. I hope it is useful. 

Thanks for your work. 