### PR TITLE
Add float check in GeneralizedRCNN normalize

### DIFF
--- a/test/test_models_detection_utils.py
+++ b/test/test_models_detection_utils.py
@@ -58,6 +58,13 @@ class Tester(unittest.TestCase):
         self.assertTrue(torch.equal(targets[0]['boxes'], targets_copy[0]['boxes']))
         self.assertTrue(torch.equal(targets[1]['boxes'], targets_copy[1]['boxes']))
 
+    def test_not_float_normalize(self):
+        transform = GeneralizedRCNNTransform(300, 500, torch.zeros(3), torch.ones(3))
+        image = [torch.randint(0, 255, (3, 200, 300), dtype=torch.uint8)]
+        targets = [{'boxes': torch.rand(3, 4)}]
+        with self.assertRaises(TypeError):
+            out = transform(image, targets)  # noqa: F841
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/torchvision/models/detection/transform.py
+++ b/torchvision/models/detection/transform.py
@@ -117,6 +117,11 @@ class GeneralizedRCNNTransform(nn.Module):
         return image_list, targets
 
     def normalize(self, image):
+        if not image.is_floating_point():
+            raise TypeError(
+                f"Expected input images to be of floating type (in range [0, 1]), "
+                f"but found type {image.dtype} instead"
+            )
         dtype, device = image.dtype, image.device
         mean = torch.as_tensor(self.image_mean, dtype=dtype, device=device)
         std = torch.as_tensor(self.image_std, dtype=dtype, device=device)


### PR DESCRIPTION
This PR fixes issue #3228 by raising a `TypeError` whenever the input image of the `normalize` method in the `GeneralizedRCNNTransform` is not of floating type. This PR follows the discussion started in #3238.

A single unit test has been added, to ensure that passing a `uint8` image to the normalize method raises the TypeError exception.