### PR TITLE
Replace hardcoded error code with ENODATA

### DIFF
--- a/torchvision/csrc/io/video/Video.cpp
+++ b/torchvision/csrc/io/video/Video.cpp
@@ -311,8 +311,8 @@ std::tuple<torch::Tensor, double> Video::Next() {
     // currently not supporting other formats (will do soon)
 
     out.payload.reset();
-  } else if (res == 61) {
-    LOG(INFO) << "Decoder ran out of frames (error 61)\n";
+  } else if (res == ENODATA) {
+    LOG(INFO) << "Decoder ran out of frames (ENODATA)\n";
   } else {
     LOG(ERROR) << "Decoder failed with ERROR_CODE " << res;
   }


### PR DESCRIPTION
The video reader suppressed code 61 (`ENODATA` on Linux) that occured at the end of a stream and logged an `INFO` message. On macOS `ENODATA` has a different code (96), which resulted in an error message being logged.

This small patch replaces the hard-coded value with the `ENODATA` constant to suppress the macOS error.

Fixes #3274 