### PR TITLE
Remove python3.5 typing dependency

### DIFF
--- a/packaging/conda/build_vision.sh
+++ b/packaging/conda/build_vision.sh
@@ -163,12 +163,6 @@ for py_ver in "${DESIRED_PYTHON[@]}"; do
     rm -rf "$output_folder"
     mkdir "$output_folder"
 
-    if [[ "$py_ver" == 3.5 ]]; then
-      export CONDA_TYPING_CONSTRAINT="- typing"
-    else
-      export CONDA_TYPING_CONSTRAINT=""
-    fi
-
     export VSTOOLCHAIN_PACKAGE=vs2017
 
     # We need to build the compiler activation scripts first on Windows

--- a/packaging/pkg_helpers.bash
+++ b/packaging/pkg_helpers.bash
@@ -143,14 +143,6 @@ setup_macos() {
   fi
 }
 
-# set variable to determine whether the typing library needs to be built in
-setup_typing() {
-  if [[ "$PYTHON_VERSION" == 3.5 ]]; then
-    export CONDA_TYPING_CONSTRAINT="- typing"
-  else
-    export CONDA_TYPING_CONSTRAINT=""
-  fi
-}
 
 # Top-level entry point for things every package will need to do
 #
@@ -159,7 +151,6 @@ setup_env() {
   setup_cuda
   setup_build_version "$1"
   setup_macos
-  setup_typing
 }
 
 # Function to retry functions that sometimes timeout or have flaky failures

--- a/packaging/torchvision/meta.yaml
+++ b/packaging/torchvision/meta.yaml
@@ -52,7 +52,6 @@ test:
     - scipy
     - av =8.0.1
     - ca-certificates
-    {{ environ.get('CONDA_TYPING_CONSTRAINT') }}
 
 
 about:


### PR DESCRIPTION
Removing old code from packaging files that handled typing dependencies for Python 3.5.