### PR TITLE
[FBCode->GH] Specify tls cert file to decoder through config

### DIFF
--- a/torchvision/csrc/io/decoder/decoder.cpp
+++ b/torchvision/csrc/io/decoder/decoder.cpp
@@ -316,6 +316,12 @@ bool Decoder::init(
     av_dict_set_int(&options, "analyzeduration", params_.timeoutMs * 1000, 0);
     av_dict_set_int(&options, "stimeout", params_.timeoutMs * 1000, 0);
     av_dict_set_int(&options, "rw_timeout", params_.timeoutMs * 1000, 0);
+    if (!params_.tlsCertFile.empty()) {
+      av_dict_set(&options, "cert_file", params_.tlsCertFile.data(), 0);
+    }
+    if (!params_.tlsKeyFile.empty()) {
+      av_dict_set(&options, "key_file", params_.tlsCertFile.data(), 0);
+    }
   }
 
   interrupted_ = false;

--- a/torchvision/csrc/io/decoder/defs.h
+++ b/torchvision/csrc/io/decoder/defs.h
@@ -202,6 +202,9 @@ struct DecoderParameters {
   size_t cacheTimeoutMs{1000}; // timeout on bytes writing
   bool enforceCacheSize{false}; // drop output frames if cache is full
   bool mergeAudioMessages{false}; // combine collocated audio messages together
+
+  std::string tlsCertFile;
+  std::string tlsKeyFile;
 };
 
 struct DecoderHeader {


### PR DESCRIPTION
Summary:
Upgrading service to platform009 enforces tls1.3 authentication.
Specify tls cert file to decoder through config.
Context: https://fb.workplace.com/groups/2020511478062223

Differential Revision: D26026259

fbshipit-source-id: e89f88ff7e41ec6b6a62e85d9015d78f6377aa65