### PR TITLE
Replace functional.sigmoid with torch.sigmoid in RPN

### DIFF
--- a/torchvision/models/detection/rpn.py
+++ b/torchvision/models/detection/rpn.py
@@ -252,7 +252,7 @@ class RegionProposalNetwork(torch.nn.Module):
         levels = levels[batch_idx, top_n_idx]
         proposals = proposals[batch_idx, top_n_idx]
 
-        objectness_prob = F.sigmoid(objectness)
+        objectness_prob = torch.sigmoid(objectness)
 
         final_boxes = []
         final_scores = []


### PR DESCRIPTION
Removes deprecation warning introduced in #3205 
```
/Users/fmassa/anaconda3/lib/python3.6/site-packages/torch/nn/functional.py:1709: UserWarning: nn.functional.sigmoid is deprecated. Use torch.sigmoid instead.
```