### PR TITLE
[WIP] Unify checking for Sequence and Number

### DIFF
--- a/torchvision/models/detection/_utils.py
+++ b/torchvision/models/detection/_utils.py
@@ -2,7 +2,7 @@ import math
 
 import torch
 from torch import Tensor
-from typing import List, Tuple
+from typing import Sequence, List, Tuple
 
 from torchvision.ops.misc import FrozenBatchNorm2d
 
@@ -166,7 +166,7 @@ class BoxCoder(object):
 
     def decode(self, rel_codes, boxes):
         # type: (Tensor, List[Tensor]) -> Tensor
-        assert isinstance(boxes, (list, tuple))
+        assert isinstance(boxes, Sequence)
         assert isinstance(rel_codes, torch.Tensor)
         boxes_per_image = [b.size(0) for b in boxes]
         concat_boxes = torch.cat(boxes, dim=0)

--- a/torchvision/models/detection/anchor_utils.py
+++ b/torchvision/models/detection/anchor_utils.py
@@ -2,7 +2,7 @@
 import torch
 from torch import nn, Tensor
 
-from typing import List, Optional, Dict
+from typing import Sequence, List, Optional, Dict
 from .image_list import ImageList
 
 
@@ -39,10 +39,10 @@ class AnchorGenerator(nn.Module):
     ):
         super(AnchorGenerator, self).__init__()
 
-        if not isinstance(sizes[0], (list, tuple)):
+        if not isinstance(sizes[0], Sequence):
             # TODO change this
             sizes = tuple((s,) for s in sizes)
-        if not isinstance(aspect_ratios[0], (list, tuple)):
+        if not isinstance(aspect_ratios[0], Sequence):
             aspect_ratios = (aspect_ratios,) * len(sizes)
 
         assert len(sizes) == len(aspect_ratios)

--- a/torchvision/models/detection/transform.py
+++ b/torchvision/models/detection/transform.py
@@ -3,7 +3,7 @@ import torch
 from torch import nn, Tensor
 from torch.nn import functional as F
 import torchvision
-from typing import List, Tuple, Dict, Optional
+from typing import Sequence, List, Tuple, Dict, Optional
 
 from .image_list import ImageList
 from .roi_heads import paste_masks_in_image
@@ -68,7 +68,7 @@ class GeneralizedRCNNTransform(nn.Module):
 
     def __init__(self, min_size, max_size, image_mean, image_std):
         super(GeneralizedRCNNTransform, self).__init__()
-        if not isinstance(min_size, (list, tuple)):
+        if not isinstance(min_size, Sequence):
             min_size = (min_size,)
         self.min_size = min_size
         self.max_size = max_size

--- a/torchvision/ops/_utils.py
+++ b/torchvision/ops/_utils.py
@@ -1,6 +1,6 @@
 import torch
 from torch import Tensor
-from typing import List
+from typing import List, Sequence
 
 
 def _cat(tensors: List[Tensor], dim: int = 0) -> Tensor:
@@ -8,7 +8,7 @@ def _cat(tensors: List[Tensor], dim: int = 0) -> Tensor:
     Efficient version of torch.cat that avoids a copy if there is only a single element in a list
     """
     # TODO add back the assert
-    # assert isinstance(tensors, (list, tuple))
+    # assert isinstance(tensors, Sequence)
     if len(tensors) == 1:
         return tensors[0]
     return torch.cat(tensors, dim)
@@ -25,7 +25,7 @@ def convert_boxes_to_roi_format(boxes: List[Tensor]) -> Tensor:
 
 
 def check_roi_boxes_shape(boxes: Tensor):
-    if isinstance(boxes, (list, tuple)):
+    if isinstance(boxes, Sequence):
         for _tensor in boxes:
             assert _tensor.size(1) == 4, \
                 'The shape of the tensor in the boxes list is not correct as List[Tensor[L, 4]]'

--- a/torchvision/transforms/autoaugment.py
+++ b/torchvision/transforms/autoaugment.py
@@ -1,4 +1,5 @@
 import math
+import numbers
 import torch
 
 from enum import Enum
@@ -188,7 +189,7 @@ class AutoAugment(torch.nn.Module):
         """
         fill = self.fill
         if isinstance(img, Tensor):
-            if isinstance(fill, (int, float)):
+            if isinstance(fill, numbers.Number):
                 fill = [float(fill)] * F._get_image_num_channels(img)
             elif fill is not None:
                 fill = [float(f) for f in fill]

--- a/torchvision/transforms/functional.py
+++ b/torchvision/transforms/functional.py
@@ -8,7 +8,7 @@ from PIL import Image
 
 import torch
 from torch import Tensor
-from typing import List, Tuple, Any, Optional
+from typing import List, Tuple, Sequence, Any, Optional
 
 try:
     import accimage
@@ -463,7 +463,7 @@ def center_crop(img: Tensor, output_size: List[int]) -> Tensor:
     """
     if isinstance(output_size, numbers.Number):
         output_size = (int(output_size), int(output_size))
-    elif isinstance(output_size, (tuple, list)) and len(output_size) == 1:
+    elif isinstance(output_size, Sequence) and len(output_size) == 1:
         output_size = (output_size[0], output_size[0])
 
     image_width, image_height = _get_image_size(img)
@@ -643,7 +643,7 @@ def five_crop(img: Tensor, size: List[int]) -> Tuple[Tensor, Tensor, Tensor, Ten
     """
     if isinstance(size, numbers.Number):
         size = (int(size), int(size))
-    elif isinstance(size, (tuple, list)) and len(size) == 1:
+    elif isinstance(size, Sequence) and len(size) == 1:
         size = (size[0], size[0])
 
     if len(size) != 2:
@@ -690,7 +690,7 @@ def ten_crop(img: Tensor, size: List[int], vertical_flip: bool = False) -> List[
     """
     if isinstance(size, numbers.Number):
         size = (int(size), int(size))
-    elif isinstance(size, (tuple, list)) and len(size) == 1:
+    elif isinstance(size, Sequence) and len(size) == 1:
         size = (size[0], size[0])
 
     if len(size) != 2:
@@ -930,10 +930,10 @@ def rotate(
         )
         interpolation = _interpolation_modes_from_int(interpolation)
 
-    if not isinstance(angle, (int, float)):
-        raise TypeError("Argument angle should be int or float")
+    if not isinstance(angle, numbers.Number):
+        raise TypeError("Argument angle should be a number")
 
-    if center is not None and not isinstance(center, (list, tuple)):
+    if center is not None and not isinstance(center, Sequence):
         raise TypeError("Argument center should be a sequence")
 
     if not isinstance(interpolation, InterpolationMode):
@@ -981,7 +981,7 @@ def affine(
             In torchscript mode single int/float value is not supported, please use a sequence
             of length 1: ``[value, ]``.
             If input is PIL Image, the options is only available for ``Pillow>=5.0.0``.
-        fillcolor (sequence, int, float): deprecated argument and will be removed since v0.10.0.
+        fillcolor (sequence, numbers.Number): deprecated argument and will be removed since v0.10.0.
             Please use the ``fill`` parameter instead.
         resample (int, optional): deprecated argument and will be removed since v0.10.0.
             Please use the ``interpolation`` parameter instead.
@@ -1009,10 +1009,10 @@ def affine(
         )
         fill = fillcolor
 
-    if not isinstance(angle, (int, float)):
-        raise TypeError("Argument angle should be int or float")
+    if not isinstance(angle, numbers.Number):
+        raise TypeError("Argument angle should be a number")
 
-    if not isinstance(translate, (list, tuple)):
+    if not isinstance(translate, Sequence):
         raise TypeError("Argument translate should be a sequence")
 
     if len(translate) != 2:
@@ -1021,7 +1021,7 @@ def affine(
     if scale <= 0.0:
         raise ValueError("Argument scale should be positive")
 
-    if not isinstance(shear, (numbers.Number, (list, tuple))):
+    if not isinstance(shear, (numbers.Number, Sequence)):
         raise TypeError("Shear should be either a single value or a sequence of two values")
 
     if not isinstance(interpolation, InterpolationMode):
@@ -1152,7 +1152,7 @@ def gaussian_blur(img: Tensor, kernel_size: List[int], sigma: Optional[List[floa
     Returns:
         PIL Image or Tensor: Gaussian Blurred version of the image.
     """
-    if not isinstance(kernel_size, (int, list, tuple)):
+    if not isinstance(kernel_size, (int, Sequence)):
         raise TypeError('kernel_size should be int or a sequence of integers. Got {}'.format(type(kernel_size)))
     if isinstance(kernel_size, int):
         kernel_size = [kernel_size, kernel_size]
@@ -1165,11 +1165,11 @@ def gaussian_blur(img: Tensor, kernel_size: List[int], sigma: Optional[List[floa
     if sigma is None:
         sigma = [ksize * 0.15 + 0.35 for ksize in kernel_size]
 
-    if sigma is not None and not isinstance(sigma, (int, float, list, tuple)):
+    if sigma is not None and not isinstance(sigma, (numbers.Number, Sequence)):
         raise TypeError('sigma should be either float or sequence of floats. Got {}'.format(type(sigma)))
-    if isinstance(sigma, (int, float)):
+    if isinstance(sigma, numbers.Number):
         sigma = [float(sigma), float(sigma)]
-    if isinstance(sigma, (list, tuple)) and len(sigma) == 1:
+    if isinstance(sigma, Sequence) and len(sigma) == 1:
         sigma = [sigma[0], sigma[0]]
     if len(sigma) != 2:
         raise ValueError('If sigma is a sequence, its length should be 2. Got {}'.format(len(sigma)))

--- a/torchvision/transforms/functional.py
+++ b/torchvision/transforms/functional.py
@@ -981,7 +981,7 @@ def affine(
             In torchscript mode single int/float value is not supported, please use a sequence
             of length 1: ``[value, ]``.
             If input is PIL Image, the options is only available for ``Pillow>=5.0.0``.
-        fillcolor (sequence, numbers.Number): deprecated argument and will be removed since v0.10.0.
+        fillcolor (sequence or number): deprecated argument and will be removed since v0.10.0.
             Please use the ``fill`` parameter instead.
         resample (int, optional): deprecated argument and will be removed since v0.10.0.
             Please use the ``interpolation`` parameter instead.

--- a/torchvision/transforms/functional_pil.py
+++ b/torchvision/transforms/functional_pil.py
@@ -125,7 +125,7 @@ def pad(img, padding, fill=0, padding_mode="constant"):
     if not _is_pil_image(img):
         raise TypeError("img should be PIL Image. Got {}".format(type(img)))
 
-    if not isinstance(padding, (numbers.Number, tuple, list)):
+    if not isinstance(padding, (numbers.Number, Sequence)):
         raise TypeError("Got inappropriate padding arg")
     if not isinstance(fill, (numbers.Number, str, tuple)):
         raise TypeError("Got inappropriate fill arg")
@@ -244,9 +244,9 @@ def _parse_fill(fill, img, min_pil_version, name="fillcolor"):
     num_bands = len(img.getbands())
     if fill is None:
         fill = 0
-    if isinstance(fill, (int, float)) and num_bands > 1:
+    if isinstance(fill, numbers.Number) and num_bands > 1:
         fill = tuple([fill] * num_bands)
-    if isinstance(fill, (list, tuple)):
+    if isinstance(fill, Sequence):
         if len(fill) != num_bands:
             msg = ("The number of elements in 'fill' does not match the number of "
                    "bands of the image ({} != {})")

--- a/torchvision/transforms/transforms.py
+++ b/torchvision/transforms/transforms.py
@@ -355,7 +355,7 @@ class Pad(torch.nn.Module):
 
     def __init__(self, padding, fill=0, padding_mode="constant"):
         super().__init__()
-        if not isinstance(padding, (numbers.Number, tuple, list)):
+        if not isinstance(padding, (numbers.Number, Sequence)):
             raise TypeError("Got inappropriate padding arg")
 
         if not isinstance(fill, (numbers.Number, str, tuple)):
@@ -705,7 +705,7 @@ class RandomPerspective(torch.nn.Module):
 
         fill = self.fill
         if isinstance(img, Tensor):
-            if isinstance(fill, (int, float)):
+            if isinstance(fill, numbers.Number):
                 fill = [float(fill)] * F._get_image_num_channels(img)
             else:
                 fill = [float(f) for f in fill]
@@ -1081,11 +1081,11 @@ class ColorJitter(torch.nn.Module):
             value = [center - float(value), center + float(value)]
             if clip_first_on_zero:
                 value[0] = max(value[0], 0.0)
-        elif isinstance(value, (tuple, list)) and len(value) == 2:
+        elif isinstance(value, Sequence) and len(value) == 2:
             if not bound[0] <= value[0] <= value[1] <= bound[1]:
                 raise ValueError("{} values should be between {}".format(name, bound))
         else:
-            raise TypeError("{} should be a single number or a list/tuple with lenght 2.".format(name))
+            raise TypeError("{} should be a single number or a sequence with lenght 2.".format(name))
 
         # if value is 0 or (1., 1.) for brightness/contrast/saturation
         # or (0., 0.) for hue, do nothing
@@ -1234,7 +1234,7 @@ class RandomRotation(torch.nn.Module):
         """
         fill = self.fill
         if isinstance(img, Tensor):
-            if isinstance(fill, (int, float)):
+            if isinstance(fill, numbers.Number):
                 fill = [float(fill)] * F._get_image_num_channels(img)
             else:
                 fill = [float(f) for f in fill]
@@ -1388,7 +1388,7 @@ class RandomAffine(torch.nn.Module):
         """
         fill = self.fill
         if isinstance(img, Tensor):
-            if isinstance(fill, (int, float)):
+            if isinstance(fill, numbers.Number):
                 fill = [float(fill)] * F._get_image_num_channels(img)
             else:
                 fill = [float(f) for f in fill]
@@ -1516,13 +1516,13 @@ class RandomErasing(torch.nn.Module):
 
     def __init__(self, p=0.5, scale=(0.02, 0.33), ratio=(0.3, 3.3), value=0, inplace=False):
         super().__init__()
-        if not isinstance(value, (numbers.Number, str, tuple, list)):
+        if not isinstance(value, (numbers.Number, str, Sequence)):
             raise TypeError("Argument value should be either a number or str or a sequence")
         if isinstance(value, str) and value != "random":
             raise ValueError("If value is str, it should be 'random'")
-        if not isinstance(scale, (tuple, list)):
+        if not isinstance(scale, Sequence):
             raise TypeError("Scale should be a sequence")
-        if not isinstance(ratio, (tuple, list)):
+        if not isinstance(ratio, Sequence):
             raise TypeError("Ratio should be a sequence")
         if (scale[0] > scale[1]) or (ratio[0] > ratio[1]):
             warnings.warn("Scale and ratio should be of kind (min, max)")
@@ -1589,7 +1589,7 @@ class RandomErasing(torch.nn.Module):
         if torch.rand(1) < self.p:
 
             # cast self.value to script acceptable type
-            if isinstance(self.value, (int, float)):
+            if isinstance(self.value, numbers.Number):
                 value = [self.value, ]
             elif isinstance(self.value, str):
                 value = None
@@ -1641,7 +1641,7 @@ class GaussianBlur(torch.nn.Module):
             if not 0. < sigma[0] <= sigma[1]:
                 raise ValueError("sigma values should be positive and of the form (min, max).")
         else:
-            raise ValueError("sigma should be a single number or a list/tuple with length 2.")
+            raise ValueError("sigma should be a single number or a sequence with length 2.")
 
         self.sigma = sigma
 


### PR DESCRIPTION
As mentioned in [#3200](https://github.com/pytorch/vision/pull/3200#issuecomment-749474552), I want to unify checking for Sequence instead of `int or list`  and numbers.Number instead of `int or float` in this separate PR. Only changing the checks and docs should not concern torchscript. 
Not sure if this is what you meant back then? @datumbox 

