### PR TITLE
[BC-breaking] remove normalize from save_image

### DIFF
--- a/torchvision/utils.py
+++ b/torchvision/utils.py
@@ -115,7 +115,6 @@ def make_grid(
 def save_image(
     tensor: Union[torch.Tensor, List[torch.Tensor]],
     fp: Union[Text, pathlib.Path, BinaryIO],
-    normalize: bool = False,
     format: Optional[str] = None,
     **kwargs
 ) -> None:


### PR DESCRIPTION
The `normalize` parameter has currently no effect on the `save_image()` method due to a bug. The parameter was probably introduced accidentally in the method signature and by defining it, it is no longer captured in the `kwargs` and passed to the `make_grid()` method as intended. 

This PR fixes the bug by removing the declaration from `save_image()`, letting it be captured by `kwargs` and passed to `make_grid()`. Though it's unlikely to break any code, we mark it as BC-breaking because it removes a parameter from the signature. For more information check https://github.com/pytorch/vision/pull/3299#discussion_r564512843

CC @datumbox, @fmassa 