### PR TITLE
Disable pretrained backbone downloading if pretrained is True

### DIFF
--- a/torchvision/models/segmentation/segmentation.py
+++ b/torchvision/models/segmentation/segmentation.py
@@ -69,6 +69,7 @@ def _segm_model(name, backbone_name, num_classes, aux, pretrained_backbone=True)
 def _load_model(arch_type, backbone, pretrained, progress, num_classes, aux_loss, **kwargs):
     if pretrained:
         aux_loss = True
+        kwargs["pretrained_backbone"] = False
     model = _segm_model(arch_type, backbone, num_classes, aux_loss, **kwargs)
     if pretrained:
         _load_weights(model, arch_type, backbone, progress)


### PR DESCRIPTION
Fixes #3322

Description:
- Avoid downloading backbone weights and then segmentation model weights:
Actual behaviour:
```bash
python -c "import torchvision as tv; tv.models.segmentation.fcn_resnet101(pretrained=True)"
Downloading: "https://download.pytorch.org/models/resnet101-5d3b4d8f.pth" to /root/.cache/torch/hub/checkpoints/resnet101-5d3b4d8f.pth
100%|█████████| 170M/170M [00:01<00:00, 99.8MB/s]
Downloading: "https://download.pytorch.org/models/fcn_resnet101_coco-7ecb50ca.pth" to /root/.cache/torch/hub/checkpoints/fcn_resnet101_coco-7ecb50ca.pth
100%|█████████| 208M/208M [00:02<00:00, 102MB/s]
```
and new behaviour
```bash
python -c "import torchvision as tv; tv.models.segmentation.fcn_resnet101(pretrained=True)"
Downloading: "https://download.pytorch.org/models/fcn_resnet101_coco-7ecb50ca.pth" to /root/.cache/torch/hub/checkpoints/fcn_resnet101_coco-7ecb50ca.pth
100%|█████████| 208M/208M [00:02<00:00, 88.5MB/s]
```