### PR TITLE
[FBCode->GH] accept python bytes in _read_video_from_memory()

### DIFF
--- a/torchvision/io/_video_opt.py
+++ b/torchvision/io/_video_opt.py
@@ -381,6 +381,9 @@ def _read_video_from_memory(
     _validate_pts(video_pts_range)
     _validate_pts(audio_pts_range)
 
+    if not isinstance(video_data, torch.Tensor):
+        video_data = torch.from_numpy(np.frombuffer(video_data, dtype=np.uint8))
+
     result = torch.ops.video_reader.read_video_from_memory(
         video_data,
         seek_frame_margin,


### PR DESCRIPTION
Summary:
We accept python bytes for video in existing API, such as `_read_video_timestamps_from_memory`.
We should do so to `_read_video_timestamps_from_memory` as well.

Reviewed By: fmassa

Differential Revision: D26216777

fbshipit-source-id: 5d7ecf15c5a65dc5c57f17b343e7c63b4933189e