### PR TITLE
Fix some deprecation warnings from PyTorch

### DIFF
--- a/torchvision/models/detection/retinanet.py
+++ b/torchvision/models/detection/retinanet.py
@@ -201,7 +201,7 @@ class RetinaNetRegressionHead(nn.Module):
             losses.append(torch.nn.functional.l1_loss(
                 bbox_regression_per_image,
                 target_regression,
-                size_average=False
+                reduction='sum'
             ) / max(1, num_foreground))
 
         return _sum(losses) / max(1, len(targets))

--- a/torchvision/transforms/_functional_video.py
+++ b/torchvision/transforms/_functional_video.py
@@ -23,7 +23,7 @@ def crop(clip, i, j, h, w):
 def resize(clip, target_size, interpolation_mode):
     assert len(target_size) == 2, "target size should be tuple (height, width)"
     return torch.nn.functional.interpolate(
-        clip, size=target_size, mode=interpolation_mode
+        clip, size=target_size, mode=interpolation_mode, align_corners=False
     )
 
 


### PR DESCRIPTION
Fixes some warnings that showed up in tests, see https://app.circleci.com/pipelines/github/pytorch/vision/6141/workflows/f4504c18-123c-483a-be33-e33b92997f42/jobs/398743 for some examples

The tests that had those warnings were
```
test/test_transforms_video.py::TestVideoTransforms::test_random_resized_crop_video
  /root/project/env/lib/python3.7/site-packages/torch/nn/functional.py:3463: UserWarning: Default upsampling behavior when mode=bilinear is changed to align_corners=False since 0.4.0. Please specify align_corners=True if the old behavior is desired. See the documentation of nn.Upsample for details.
```
and
```
test/test_models_detection_negative_samples.py::Tester::test_forward_negative_sample_retinanet
  /root/project/env/lib/python3.7/site-packages/torch/nn/_reduction.py:42: UserWarning: size_average and reduce args will be deprecated, please use reduction='sum' instead.
    warnings.warn(warning.format(ret))
```