### PR TITLE
Removed temporarily the MobileNetV3 Small quantized model endpoint

### DIFF
--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -280,7 +280,6 @@ a model with random weights by calling its constructor:
     inception_v3 = models.quantization.inception_v3()
     mobilenet_v2 = models.quantization.mobilenet_v2()
     mobilenet_v3_large = models.quantization.mobilenet_v3_large()
-    mobilenet_v3_small = models.quantization.mobilenet_v3_small()
     resnet18 = models.quantization.resnet18()
     resnet50 = models.quantization.resnet50()
     resnext101_32x8d = models.quantization.resnext101_32x8d()

--- a/torchvision/models/quantization/mobilenet.py
+++ b/torchvision/models/quantization/mobilenet.py
@@ -1,4 +1,4 @@
 from .mobilenetv2 import QuantizableMobileNetV2, mobilenet_v2, __all__ as mv2_all
-from .mobilenetv3 import QuantizableMobileNetV3, mobilenet_v3_large, mobilenet_v3_small, __all__ as mv3_all
+from .mobilenetv3 import QuantizableMobileNetV3, mobilenet_v3_large, __all__ as mv3_all
 
 __all__ = mv2_all + mv3_all

--- a/torchvision/models/quantization/mobilenetv3.py
+++ b/torchvision/models/quantization/mobilenetv3.py
@@ -8,12 +8,11 @@ from typing import Any, List, Optional
 from .utils import _replace_relu
 
 
-__all__ = ['QuantizableMobileNetV3', 'mobilenet_v3_large', 'mobilenet_v3_small']
+__all__ = ['QuantizableMobileNetV3', 'mobilenet_v3_large']
 
 quant_model_urls = {
     'mobilenet_v3_large_qnnpack':
         "https://download.pytorch.org/models/quantized/mobilenet_v3_large_qnnpack-5bcacf28.pth",
-    'mobilenet_v3_small_qnnpack': None,
 }
 
 
@@ -128,24 +127,5 @@ def mobilenet_v3_large(pretrained=False, progress=True, quantize=False, **kwargs
      quantize (bool): If True, returns a quantized model, else returns a float model
     """
     arch = "mobilenet_v3_large"
-    inverted_residual_setting, last_channel = _mobilenet_v3_conf(arch, kwargs)
-    return _mobilenet_v3_model(arch, inverted_residual_setting, last_channel, pretrained, progress, quantize, **kwargs)
-
-
-def mobilenet_v3_small(pretrained=False, progress=True, quantize=False, **kwargs):
-    """
-    Constructs a MobileNetV3 Small architecture from
-    `"Searching for MobileNetV3" <https://arxiv.org/abs/1905.02244>`_.
-
-    Note that quantize = True returns a quantized model with 8 bit
-    weights. Quantized models only support inference and run on CPUs.
-    GPU inference is not yet supported
-
-    Args:
-     pretrained (bool): If True, returns a model pre-trained on ImageNet.
-     progress (bool): If True, displays a progress bar of the download to stderr
-     quantize (bool): If True, returns a quantized model, else returns a float model
-    """
-    arch = "mobilenet_v3_small"
     inverted_residual_setting, last_channel = _mobilenet_v3_conf(arch, kwargs)
     return _mobilenet_v3_model(arch, inverted_residual_setting, last_channel, pretrained, progress, quantize, **kwargs)


### PR DESCRIPTION
The smaller version of mobilenetv3 seems to have some problems that affect its accuracy. While we investigate we will remove the endpoint.

This PR needs to be reverted before picking up again the #3363.