### PR TITLE
Enable GPU/RE teags for pytorch/*/TARGETS that needs GPU (#3361)

### DIFF
--- a/test/_utils_internal.py
+++ b/test/_utils_internal.py
@@ -1,0 +1,7 @@
+import os
+
+
+# Get relative file path
+# this returns relative path from current file.
+def get_relative_path(curr_file, *path_components):
+    return os.path.join(os.path.dirname(curr_file), *path_components)

--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -14,6 +14,7 @@ import random
 from numbers import Number
 from torch._six import string_classes
 from collections import OrderedDict
+from _utils_internal import get_relative_path
 
 import numpy as np
 from PIL import Image
@@ -106,19 +107,23 @@ class TestCase(unittest.TestCase):
         # lives, NOT where test/common_utils.py lives.
         module_id = self.__class__.__module__
         munged_id = remove_prefix_suffix(self.id(), module_id + ".", strip_suffix)
-        test_file = os.path.realpath(sys.modules[module_id].__file__)
-        expected_file = os.path.join(os.path.dirname(test_file),
-                                     "expect",
-                                     munged_id)
 
+        # Determine expected file based on environment
+        expected_file_base = get_relative_path(
+            os.path.realpath(sys.modules[module_id].__file__),
+            "expect")
+
+        # Set expected_file based on subname.
+        expected_file = os.path.join(expected_file_base, munged_id)
         if subname:
             expected_file += "_" + subname
         expected_file += "_expect.pkl"
 
         if not ACCEPT and not os.path.exists(expected_file):
             raise RuntimeError(
-                ("No expect file exists for {}; to accept the current output, run:\n"
-                 "python {} {} --accept").format(os.path.basename(expected_file), __main__.__file__, munged_id))
+                f"No expect file exists for {os.path.basename(expected_file)} in {expected_file}; "
+                "to accept the current output, run:\n"
+                f"python {__main__.__file__} {munged_id} --accept")
 
         return expected_file
 


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/pytorch/vision/pull/3361

Convert pytorch_gpu to use GPU/RE

Differential Revision: D26264102

