### PR TITLE
add CI qualifier to push docs for new tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1171,6 +1171,8 @@ workflows:
             branches:
               only:
               - nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
           name: upload_docs
           python_version: '3.7'
           requires:

--- a/.circleci/regenerate.py
+++ b/.circleci/regenerate.py
@@ -21,6 +21,8 @@ import os.path
 
 PYTHON_VERSIONS = ["3.6", "3.7", "3.8"]
 
+RC_PATTERN = r"/v[0-9]+(\.[0-9]+)*-rc[0-9]+/"
+
 
 def build_workflows(prefix='', filter_branch=None, upload=False, indentation=6, windows_latest_only=False):
     w = []
@@ -90,7 +92,8 @@ def upload_doc_job(filter_branch):
     }
 
     if filter_branch:
-        job["filters"] = gen_filter_branch_tree(filter_branch)
+        job["filters"] = gen_filter_branch_tree(filter_branch,
+                                                tags_list=RC_PATTERN)
     return [{"upload_docs": job}]
 
 
@@ -140,8 +143,11 @@ def generate_base_workflow(base_workflow_name, python_version, cu_version,
     return {w: d}
 
 
-def gen_filter_branch_tree(*branches):
-    return {"branches": {"only": [b for b in branches]}}
+def gen_filter_branch_tree(*branches, tags_list=None):
+    filter_dict = {"branches": {"only": [b for b in branches]}}
+    if tags_list is not None:
+        filter_dict["tags"] = {"only": tags_list}
+    return filter_dict
 
 
 def generate_upload_workflow(base_workflow_name, os_type, btype, cu_version, *, filter_branch=None):


### PR DESCRIPTION
In addition to pushing nightly docs, also push docs with a tag. The [script that pushes](https://github.com/pytorch/vision/blob/master/.circleci/config.yml#L778) is already primed for this, just the trigger was missing.

@brianjo
