### PR TITLE
make the version a link to /versions.html

### DIFF
--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -1,0 +1,8 @@
+{% extends "!layout.html" %}
+
+{% block sidebartitle %}
+    <div class="version">
+      <a href='http://pytorch.org/docs/vision/versions.html'>{{ version }} &#x25BC</a>
+    </div>
+    {% include "searchbox.html" %}
+{% endblock %}


### PR DESCRIPTION
This will change the static text "master" or "0.8.0" into a text link to the versions.html added in gh-3377