### PR TITLE
Fix ops registration on windows

### DIFF
--- a/test/tracing/frcnn/test_frcnn_tracing.cpp
+++ b/test/tracing/frcnn/test_frcnn_tracing.cpp
@@ -3,11 +3,6 @@
 #include <torchvision/vision.h>
 #include <torchvision/ops/nms.h>
 
-#ifdef _WIN32
-// Windows only
-// This is necessary until operators are automatically registered on include
-static auto _nms = &vision::ops::nms;
-#endif
 
 int main() {
   torch::DeviceType device_type;

--- a/torchvision/csrc/macros.h
+++ b/torchvision/csrc/macros.h
@@ -15,6 +15,7 @@
 #else
 #ifdef _MSC_VER
 #define VISION_INLINE_VARIABLE __declspec(selectany)
+#define HINT_MSVC_LINKER_INCLUDE_SYMBOL
 #else
 #define VISION_INLINE_VARIABLE __attribute__((weak))
 #endif

--- a/torchvision/csrc/vision.h
+++ b/torchvision/csrc/vision.h
@@ -7,9 +7,10 @@ namespace vision {
 VISION_API int64_t cuda_version();
 
 namespace detail {
-// Dummy variable to reference a symbol from vision.cpp.
-// This ensures that the torchvision library and the ops registration
-// initializers are not pruned.
-VISION_INLINE_VARIABLE int64_t _cuda_version = cuda_version();
+extern "C" VISION_INLINE_VARIABLE auto _register_ops = &cuda_version;
+#ifdef HINT_MSVC_LINKER_INCLUDE_SYMBOL
+#pragma comment(linker, "/include:_register_ops")
+#endif
+
 } // namespace detail
 } // namespace vision


### PR DESCRIPTION
It turns out that on windows,  a `__declspec(selectany)` variable is not the same as a C++17 inline variable.
I have therefore added a linker instruction to force the inclusion of the weak symbol.
