### PR TITLE
check inf value for computing iou

### DIFF
--- a/torchvision/ops/boxes.py
+++ b/torchvision/ops/boxes.py
@@ -198,7 +198,10 @@ def _box_inter_union(boxes1: Tensor, boxes2: Tensor) -> Tuple[Tensor, Tensor]:
     inter = wh[:, :, 0] * wh[:, :, 1]  # [N,M]
 
     union = area1[:, None] + area2 - inter
-
+    
+    assert torch.count_nonzero(torch.isinf(inter)) == 0
+    assert torch.count_nonzero(torch.isinf(union)) == 0
+    
     return inter, union
 
 


### PR DESCRIPTION
While investigating a numeric overflow at #3371, I noticed that the implementations of  _box_inter_union() need to check inter and union value.

Actually, when the type of boxes is torch.float16, overflow easily happens.


I expect we can easily check the error with this assert code.

