### PR TITLE
Remove JIT workaround on FPN

### DIFF
--- a/torchvision/ops/feature_pyramid_network.py
+++ b/torchvision/ops/feature_pyramid_network.py
@@ -95,36 +95,10 @@ class FeaturePyramidNetwork(nn.Module):
         self.extra_blocks = extra_blocks
 
     def get_result_from_inner_blocks(self, x: Tensor, idx: int) -> Tensor:
-        """
-        This is equivalent to self.inner_blocks[idx](x),
-        but torchscript doesn't support this yet
-        """
-        num_blocks = len(self.inner_blocks)
-        if idx < 0:
-            idx += num_blocks
-        i = 0
-        out = x
-        for module in self.inner_blocks:
-            if i == idx:
-                out = module(x)
-            i += 1
-        return out
+        return self.inner_blocks[idx](x)
 
     def get_result_from_layer_blocks(self, x: Tensor, idx: int) -> Tensor:
-        """
-        This is equivalent to self.layer_blocks[idx](x),
-        but torchscript doesn't support this yet
-        """
-        num_blocks = len(self.layer_blocks)
-        if idx < 0:
-            idx += num_blocks
-        i = 0
-        out = x
-        for module in self.layer_blocks:
-            if i == idx:
-                out = module(x)
-            i += 1
-        return out
+        return self.layer_blocks[idx](x)
 
     def forward(self, x: Dict[str, Tensor]) -> Dict[str, Tensor]:
         """

--- a/torchvision/ops/feature_pyramid_network.py
+++ b/torchvision/ops/feature_pyramid_network.py
@@ -94,11 +94,19 @@ class FeaturePyramidNetwork(nn.Module):
             assert isinstance(extra_blocks, ExtraFPNBlock)
         self.extra_blocks = extra_blocks
 
+    @staticmethod
+    def _get_result_from_blocks(x: Tensor, idx: int, blocks: nn.ModuleList) -> Tensor:
+        # handle negative numbers for JIT
+        num_blocks = len(blocks)
+        if idx < 0:
+            idx += num_blocks
+        return blocks[idx](x)
+
     def get_result_from_inner_blocks(self, x: Tensor, idx: int) -> Tensor:
-        return self.inner_blocks[idx](x)
+        return self._get_result_from_blocks(x, idx, self.inner_blocks)
 
     def get_result_from_layer_blocks(self, x: Tensor, idx: int) -> Tensor:
-        return self.layer_blocks[idx](x)
+        return self._get_result_from_blocks(x, idx, self.layer_blocks)
 
     def forward(self, x: Dict[str, Tensor]) -> Dict[str, Tensor]:
         """


### PR DESCRIPTION
JIT now supports `blocks[idx](x)` hence the workarounds on FPN are no longer needed. This is confirmed using the standard unit-tests on *RCNN that check for JIT-scriptable. Though it was tempting to remove the methods `get_result_from_inner_blocks()` and `get_result_from_layer_blocks()` (given they are implementation detail), I left them in for BC.