### PR TITLE
Fixed compilation warnings on C++ codebase

### DIFF
--- a/torchvision/csrc/io/image/cpu/decode_jpeg.cpp
+++ b/torchvision/csrc/io/image/cpu/decode_jpeg.cpp
@@ -24,14 +24,10 @@ struct torch_jpeg_mgr {
 static void torch_jpeg_init_source(j_decompress_ptr cinfo) {}
 
 static boolean torch_jpeg_fill_input_buffer(j_decompress_ptr cinfo) {
-  torch_jpeg_mgr* src = (torch_jpeg_mgr*)cinfo->src;
   // No more data.  Probably an incomplete image;  Raise exception.
   torch_jpeg_error_ptr myerr = (torch_jpeg_error_ptr)cinfo->err;
   strcpy(myerr->jpegLastErrorMsg, "Image is incomplete or truncated");
   longjmp(myerr->setjmp_buffer, 1);
-  src->pub.next_input_byte = EOI_BUFFER;
-  src->pub.bytes_in_buffer = 1;
-  return TRUE;
 }
 
 static void torch_jpeg_skip_input_data(j_decompress_ptr cinfo, long num_bytes) {

--- a/torchvision/csrc/io/image/cpu/decode_jpeg.cpp
+++ b/torchvision/csrc/io/image/cpu/decode_jpeg.cpp
@@ -36,7 +36,7 @@ static boolean torch_jpeg_fill_input_buffer(j_decompress_ptr cinfo) {
 
 static void torch_jpeg_skip_input_data(j_decompress_ptr cinfo, long num_bytes) {
   torch_jpeg_mgr* src = (torch_jpeg_mgr*)cinfo->src;
-  if (src->pub.bytes_in_buffer < num_bytes) {
+  if (src->pub.bytes_in_buffer < (size_t)num_bytes) {
     // Skipping over all of remaining data;  output EOI.
     src->pub.next_input_byte = EOI_BUFFER;
     src->pub.bytes_in_buffer = 1;

--- a/torchvision/csrc/io/image/cpu/encode_png.cpp
+++ b/torchvision/csrc/io/image/cpu/encode_png.cpp
@@ -28,11 +28,6 @@ struct torch_png_error_mgr {
 
 using torch_png_error_mgr_ptr = torch_png_error_mgr*;
 
-void torch_png_warn(png_structp png_ptr, png_const_charp warn_msg) {
-  /* Display warning to user */
-  TORCH_WARN_ONCE(warn_msg);
-}
-
 void torch_png_error(png_structp png_ptr, png_const_charp error_msg) {
   /* png_ptr->err really points to a torch_png_error_mgr struct, so coerce
    * pointer */

--- a/torchvision/csrc/io/image/cpu/encode_png.cpp
+++ b/torchvision/csrc/io/image/cpu/encode_png.cpp
@@ -155,7 +155,7 @@ torch::Tensor encode_png(const torch::Tensor& data, int64_t compression_level) {
   auto ptr = input.data_ptr<uint8_t>();
 
   // Encode PNG file
-  for (size_t y = 0; y < height; ++y) {
+  for (int y = 0; y < height; ++y) {
     png_write_row(png_write, ptr);
     ptr += stride;
   }

--- a/torchvision/csrc/io/video/video.cpp
+++ b/torchvision/csrc/io/video/video.cpp
@@ -22,6 +22,14 @@ size_t fillTensorList(DecoderOutputMessage& msgs, torch::Tensor& frame) {
   return sizeof(T);
 }
 
+size_t fillVideoTensor(DecoderOutputMessage& msgs, torch::Tensor& videoFrame) {
+  return fillTensorList<uint8_t>(msgs, videoFrame);
+}
+
+size_t fillAudioTensor(DecoderOutputMessage& msgs, torch::Tensor& audioFrame) {
+  return fillTensorList<float>(msgs, audioFrame);
+}
+
 std::array<std::pair<std::string, ffmpeg::MediaType>, 4>::const_iterator
 _parse_type(const std::string& stream_string) {
   static const std::array<std::pair<std::string, MediaType>, 4> types = {{
@@ -282,6 +290,7 @@ std::tuple<torch::Tensor, double> Video::Next() {
       int outWidth = format.format.video.width;
       int numChannels = 3;
       outFrame = torch::zeros({outHeight, outWidth, numChannels}, torch::kByte);
+      fillVideoTensor(out, outFrame);
       outFrame = outFrame.permute({2, 0, 1});
 
     } else if (format.type == TYPE_AUDIO) {
@@ -296,6 +305,8 @@ std::tuple<torch::Tensor, double> Video::Next() {
 
       outFrame =
           torch::zeros({numAudioSamples, outAudioChannels}, torch::kFloat);
+
+      fillAudioTensor(out, outFrame);
     }
     // currently not supporting other formats (will do soon)
 

--- a/torchvision/csrc/io/video/video.cpp
+++ b/torchvision/csrc/io/video/video.cpp
@@ -9,7 +9,6 @@ namespace {
 
 const size_t decoderTimeoutMs = 600000;
 const AVPixelFormat defaultVideoPixelFormat = AV_PIX_FMT_RGB24;
-const AVSampleFormat defaultAudioSampleFormat = AV_SAMPLE_FMT_FLT;
 
 // returns number of written bytes
 template <typename T>

--- a/torchvision/csrc/io/video/video.cpp
+++ b/torchvision/csrc/io/video/video.cpp
@@ -22,14 +22,6 @@ size_t fillTensorList(DecoderOutputMessage& msgs, torch::Tensor& frame) {
   return sizeof(T);
 }
 
-size_t fillVideoTensor(DecoderOutputMessage& msgs, torch::Tensor& videoFrame) {
-  return fillTensorList<uint8_t>(msgs, videoFrame);
-}
-
-size_t fillAudioTensor(DecoderOutputMessage& msgs, torch::Tensor& audioFrame) {
-  return fillTensorList<float>(msgs, audioFrame);
-}
-
 std::array<std::pair<std::string, ffmpeg::MediaType>, 4>::const_iterator
 _parse_type(const std::string& stream_string) {
   static const std::array<std::pair<std::string, MediaType>, 4> types = {{

--- a/torchvision/csrc/io/video/video.cpp
+++ b/torchvision/csrc/io/video/video.cpp
@@ -291,7 +291,6 @@ std::tuple<torch::Tensor, double> Video::Next() {
       int outWidth = format.format.video.width;
       int numChannels = 3;
       outFrame = torch::zeros({outHeight, outWidth, numChannels}, torch::kByte);
-      auto numberWrittenBytes = fillVideoTensor(out, outFrame);
       outFrame = outFrame.permute({2, 0, 1});
 
     } else if (format.type == TYPE_AUDIO) {
@@ -306,8 +305,6 @@ std::tuple<torch::Tensor, double> Video::Next() {
 
       outFrame =
           torch::zeros({numAudioSamples, outAudioChannels}, torch::kFloat);
-
-      auto numberWrittenBytes = fillAudioTensor(out, outFrame);
     }
     // currently not supporting other formats (will do soon)
 

--- a/torchvision/csrc/io/video/video.h
+++ b/torchvision/csrc/io/video/video.h
@@ -27,13 +27,11 @@ struct Video : torch::CustomClassHolder {
   std::tuple<torch::Tensor, double> Next();
 
  private:
-  bool video_any_frame = false; // add this to input parameters?
   bool succeeded = false; // decoder init flag
   // seekTS and doSeek act as a flag - if it's not set, next function simply
   // retruns the next frame. If it's set, we look at the global seek
   // time in comination with any_frame settings
   double seekTS = -1;
-  bool doSeek = false;
 
   void _getDecoderParams(
       double videoStartS,

--- a/torchvision/csrc/io/video_reader/video_reader.cpp
+++ b/torchvision/csrc/io/video_reader/video_reader.cpp
@@ -491,7 +491,6 @@ torch::List<torch::Tensor> probeVideo(
     videoTimeBase = torch::zeros({2}, torch::kInt);
     int* videoTimeBaseData = videoTimeBase.data_ptr<int>();
     const auto& header = videoMetadata;
-    const auto& media = header.format;
 
     videoTimeBaseData[0] = header.num;
     videoTimeBaseData[1] = header.den;

--- a/torchvision/csrc/io/video_reader/video_reader.cpp
+++ b/torchvision/csrc/io/video_reader/video_reader.cpp
@@ -87,7 +87,7 @@ size_t fillTensor(
   }
   T* frameData = frame.numel() > 0 ? frame.data_ptr<T>() : nullptr;
   int64_t* framePtsData = framePts.data_ptr<int64_t>();
-  CHECK_EQ(framePts.size(0), msgs.size());
+  CHECK_EQ(framePts.size(0), (int64_t)msgs.size());
   size_t avgElementsInFrame = frame.numel() / msgs.size();
 
   size_t offset = 0;


### PR DESCRIPTION
This PR fixes the various compilation warnings that appear on our C++ codebase. It excludes warnings appearing from 
 upstream `pytorch`, external libraries such as `libavcodec` and the `decoder` folder. The summary of changes:
- [x] Fixed various comparison warnings.
- [x] Removed unreachable code.
- [x] Removed unused methods that are in anonymous namespaces.
- [x] Removed unused variables in methods, anonymous namespaces and private class members. 

Each commit removes one type of issue per file for easier review.