### PR TITLE
[FBcode->GH] Add link-whole to torchvision ops-cpp

### DIFF
--- a/test/cpp/test_custom_operators.cpp
+++ b/test/cpp/test_custom_operators.cpp
@@ -28,3 +28,33 @@ TEST(test_custom_operators, nms) {
   ASSERT_TRUE(output_jit.allclose(output));
 
 }
+
+TEST(test_custom_operators, roi_align_visible) {
+  // make sure that the torchvision ops are visible to the jit interpreter even if
+  // not explicitly included
+  auto& ops = torch::jit::getAllOperatorsFor(torch::jit::Symbol::fromQualString("torchvision::roi_align"));
+  ASSERT_EQ(ops.size(), 1);
+
+  auto& op = ops.front();
+  ASSERT_EQ(op->schema().name(), "torchvision::roi_align");
+
+  torch::jit::Stack stack;
+  float roi_data[] = {
+    0., 0., 0., 5., 5.,
+    0., 5., 5., 10., 10.
+  };
+  at::Tensor input = at::rand({1, 2, 10, 10}), rois = at::from_blob(roi_data, {2, 5});
+  double spatial_scale = 1.0;
+  int64_t pooled_height = 3, pooled_width = 3, sampling_ratio = -1;
+  bool aligned = true;
+
+  torch::jit::push(stack, input, rois, spatial_scale, pooled_height, pooled_width, sampling_ratio, aligned);
+  op->getOperation()(&stack);
+  at::Tensor output_jit;
+  torch::jit::pop(stack, output_jit);
+
+  ASSERT_EQ(output_jit.sizes()[0], 2);
+  ASSERT_EQ(output_jit.sizes()[1], 2);
+  ASSERT_EQ(output_jit.sizes()[2], 3);
+  ASSERT_EQ(output_jit.sizes()[3], 3);
+}


### PR DESCRIPTION
Summary:
In opt mode, the linker could strip out the symbols related to the torchvision ops if they had not been explicitly requested.

Adding link-whole is one way of fixing this.

Reviewed By: datumbox, ppwwyyxx

Differential Revision: D26249713

fbshipit-source-id: 4e55e2ebb483922fe308fd8b83456439bde728c9