### PR TITLE
Enabled typing check for densenet

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -12,10 +12,6 @@ ignore_errors = True
 
 ignore_errors = True
 
-[mypy-torchvision.models.densenet.*]
-
-ignore_errors=True
-
 [mypy-torchvision.models.detection.*]
 
 ignore_errors = True

--- a/torchvision/models/densenet.py
+++ b/torchvision/models/densenet.py
@@ -71,13 +71,13 @@ class _DenseLayer(nn.Module):
     def forward(self, input: List[Tensor]) -> Tensor:
         pass
 
-    @torch.jit._overload_method  # noqa: F811
+    @torch.jit._overload_method  # type: ignore[no-redef] # noqa: F811
     def forward(self, input: Tensor) -> Tensor:
         pass
 
     # torchscript does not yet support *args, so we overload method
     # allowing it to take either a List[Tensor] or single Tensor
-    def forward(self, input: Tensor) -> Tensor:  # noqa: F811
+    def forward(self, input: Tensor) -> Tensor:  # type: ignore[no-redef] # noqa: F811
         if isinstance(input, Tensor):
             prev_features = [input]
         else:
@@ -121,7 +121,7 @@ class _DenseBlock(nn.ModuleDict):
             )
             self.add_module('denselayer%d' % (i + 1), layer)
 
-    def forward(self, init_features: Tensor) -> Tensor:
+    def forward(self, init_features: Tensor) -> Tensor:  # type: ignore[override]
         features = [init_features]
         for name, layer in self.items():
             new_features = layer(features)


### PR DESCRIPTION
Following up on #3029, this PR introduces the following modifications:
- enabled typing check for `torchvision.models.densenet`
- added proper typing exceptions when needed thanks to https://github.com/pytorch/pytorch/pull/51675

Please note that there is still an error related to a typing issue in torch (adaptive pooling), I'll check with them if this has been solved.

Any feedback is welcome!

cc @pmeier 