### PR TITLE
[POC] Base class for dataset tests

### DIFF
--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -393,3 +393,11 @@ def int_dtypes():
 
 def float_dtypes():
     return torch.testing.floating_types()
+
+
+@contextlib.contextmanager
+def disable_console_output():
+    with contextlib.ExitStack() as stack, open(os.devnull, "w") as devnull:
+        stack.enter_context(contextlib.redirect_stdout(devnull))
+        stack.enter_context(contextlib.redirect_stderr(devnull))
+        yield

--- a/test/datasets_testcases.py
+++ b/test/datasets_testcases.py
@@ -1,0 +1,318 @@
+import contextlib
+import functools
+import importlib
+import inspect
+import itertools
+import unittest
+import unittest.mock
+
+from PIL import Image
+
+import torchvision.datasets
+
+from datasets_utils import tmpdir, disable_console_output
+
+
+__all__ = ["DatasetTestCase", "ImageDatasetTestCase", "VideoDatasetTestCase", "test_all_configs"]
+
+
+class UsageError(RuntimeError):
+    """Should be raised instead of a generic ``RuntimeError`` in case a test case is not correctly configured."""
+
+
+# As of Python 3.7 this is provided by contextlib
+# https://docs.python.org/3.7/library/contextlib.html#contextlib.nullcontext
+# TODO: If the minimum Python requirement is >= 3.7, replace this
+@contextlib.contextmanager
+def nullcontext(enter_result=None):
+    yield enter_result
+
+
+def test_all_configs(test):
+    """Decorator to run test against all configurations.
+
+    Add this as decorator to an arbitrary test to run it against all configurations. The current configuration is
+    provided as the first parameter:
+
+    .. code-block::
+
+        @test_all_configs
+        def test_foo(self, config):
+            pass
+    """
+
+    @functools.wraps(test)
+    def wrapper(self):
+        for config in self.CONFIGS:
+            with self.subTest(**config):
+                test(self, config)
+
+    return wrapper
+
+
+class DatasetTestCase(unittest.TestCase):
+    """Abstract base class for all dataset testcases.
+
+    You have to overwrite the following class attributes:
+
+        - DATASET_CLASS (torchvision.datasets.VisionDataset): Class of dataset to be tested.
+        - FEATURE_TYPES (Sequence[Any]): Types of the elements returned by index access of the dataset. Instead of
+            providing these manually, you can instead subclass ``ImageDatasetTestCase`` or ``VideoDatasetTestCase```to
+            get a reasonable default, that should work for most cases.
+
+    Optionally, you can overwrite the following class attributes:
+
+        - CONFIGS (Sequence[Dict[str, Any]]): Additional configs that should be tested. Each dictonary can contain an
+            arbitrary combination of dataset parameters that are **not** ``transform``, ``target_transform``,
+            ``transforms``, or ``download``. The first element will be used as default configuration.
+        - REQUIRED_PACKAGES (Iterable[str]): Additional dependencies to use the dataset. If these packages are not
+            available, the tests are skipped.
+
+    Additionally, you need to overwrite the ``inject_fake_data()`` method that provides the data that the tests rely on.
+    The fake data should resemble the original data as close as necessary, while containing only few examples. During
+    the creation of the dataset check-, download-, and extract-functions from ``torchvision.datasets.utils`` are
+    disabled.
+
+    Without further configuration, the testcase will test if
+
+    1. the dataset raises a ``RuntimeError`` if the data files are not found,
+    2. the dataset inherits from `torchvision.datasets.VisionDataset`,
+    3. the dataset can be turned into a string,
+    4. the feature types of a returned example matches ``FEATURE_TYPES``, and
+    5. the number of examples matches the injected fake data.
+
+    Case 3., 4., and 5. are tested against all configurations in ``CONFIGS``.
+
+    To add dataset-specific tests, create a new method that takes no arguments with ``test_`` as a name prefix:
+
+    .. code-block::
+
+        def test_foo(self):
+            pass
+
+    If you want to run the test against all configs, add the ``@test_all_configs`` decorator to the definition and
+    accept a single argument:
+
+    .. code-block::
+
+        @test_all_configs
+        def test_bar(self, config):
+            pass
+
+    Within the test you can use the ``create_dataset()`` method that yields the dataset as well as additional information
+    provided by the ``ìnject_fake_data()`` method:
+
+    .. code-block::
+
+        def test_baz(self):
+            with self.create_dataset() as (dataset, info):
+                pass
+    """
+
+    DATASET_CLASS = None
+    FEATURE_TYPES = None
+
+    CONFIGS = None
+    REQUIRED_PACKAGES = None
+
+    _SPECIAL_KWARGS = {
+        "transform",
+        "target_transform",
+        "transforms",
+        "download",
+    }
+    _HAS_SPECIAL_KWARG = None
+
+    _CHECK_FUNCTIONS = {
+        "check_md5",
+        "check_integrity",
+    }
+    _DOWNLOAD_EXTRACT_FUNCTIONS = {
+        "download_url",
+        "download_file_from_google_drive",
+        "extract_archive",
+        "download_and_extract_archive",
+    }
+
+    def inject_fake_data(self, root: str, config: dict[str, Any]) -> dict[str, Any]:
+        """Inject fake data into the root of the dataset.
+
+        Args:
+            root (str): Root of the dataset.
+            config (dict[str, Any]): Configuration that will be used to create the dataset.
+
+        Returns:
+            info (dict[str, Any]): Additional information about the injected fake data. Must contain the field
+                ``"num_examples"`` that corresponds to the length of the dataset to be created.
+        """
+        raise NotImplementedError("You need to provide fake data in order for the tests to run.")
+
+    @contextlib.contextmanager
+    def create_dataset(self, config=None, inject_fake_data=True, disable_download_extract=None, **kwargs):
+        r"""Create the dataset in a temporary directory.
+
+        Args:
+            config (Optional[dict[str, Any]]): Configuration that will be used to create the dataset. If omitted, the
+                default configuration is used.
+            inject_fake_data (bool): If ``True`` (default) inject the fake data with :meth:`.inject_fake_data` before
+                creating the dataset.
+            disable_download_extract (Optional[bool]): If ``True`` disable download and extract logic while creating
+                the dataset. If ``None`` (default) this takes the same value as ``inject_fake_data``.
+            **kwargs (Any): Additional parameters passed to the dataset. These parameters take precedence in case they
+                overlap with ``config``.
+
+        Yields:
+            dataset (torchvision.dataset.VisionDataset): Dataset.
+            info (dict[str, Any]): Additional information about the injected fake data. See :meth:`.inject_fake_data`
+                for details.
+        """
+        if config is None:
+            config = self.CONFIGS[0]
+
+        special_kwargs, other_kwargs = self._split_kwargs(kwargs)
+        config.update(other_kwargs)
+
+        if disable_download_extract is None:
+            disable_download_extract = inject_fake_data
+
+        with tmpdir() as root:
+            info = self.inject_fake_data(root, config) if inject_fake_data else None
+            if info is None or "num_examples" not in info:
+                raise UsageError(
+                    "The method 'inject_fake_data' needs to return a dictionary that contains at least a "
+                    "'num_examples' field."
+                )
+
+            cm = self._disable_download_extract if disable_download_extract else nullcontext
+            with cm(special_kwargs), disable_console_output():
+                dataset = self.DATASET_CLASS(root, **config, **special_kwargs)
+
+            yield dataset, info
+
+    @classmethod
+    def setUpClass(cls):
+        cls._verify_required_public_class_attributes()
+        cls._populate_private_class_attributes()
+        cls._process_optional_public_class_attributes()
+        super().setUpClass()
+
+    @classmethod
+    def _verify_required_public_class_attributes(cls):
+        if cls.DATASET_CLASS is None:
+            raise UsageError(
+                "The class attribute 'DATASET_CLASS' needs to be overwritten. "
+                "It should contain the class of the dataset to be tested."
+            )
+        if cls.FEATURE_TYPES is None:
+            raise UsageError(
+                "The class attribute 'FEATURE_TYPES' needs to be overwritten. "
+                "It should contain a sequence of types that the dataset returns when accessed by index."
+            )
+
+    @property
+    @classmethod
+    def _argspec(cls):
+        return inspect.getfullargspec(cls.DATASET_CLASS.__init__)
+
+    @property
+    @classmethod
+    def _name(cls):
+        return cls.DATASET_CLASS.__name__
+
+    @classmethod
+    def _populate_private_class_attributes(cls):
+        cls._HAS_SPECIAL_KWARG = {name: name in cls._argspec.args for name in cls._SPECIAL_KWARGS}
+
+    @classmethod
+    def _process_optional_public_class_attributes(cls):
+        argspec = cls._argspec
+        if cls.CONFIGS is None:
+            config = {
+                kwarg: default
+                for kwarg, default in zip(argspec.args[-len(argspec.defaults) :], argspec.defaults)
+                if kwarg not in cls._SPECIAL_KWARGS
+            }
+            cls.CONFIGS = (config,)
+
+        if cls.REQUIRED_PACKAGES is not None:
+            try:
+                for pkg in cls.REQUIRED_PACKAGES:
+                    importlib.import_module(pkg)
+            except ImportError as error:
+                raise unittest.SkipTest(
+                    f"The package '{error.name}' is required to load the dataset '{cls._name}' but is not installed."
+                )
+
+    def _split_kwargs(self, kwargs):
+        special_kwargs = kwargs.copy()
+        other_kwargs = {key: special_kwargs.pop(key) for key in set(special_kwargs.keys()) - self._SPECIAL_KWARGS}
+        return special_kwargs, other_kwargs
+
+    @contextlib.contextmanager
+    def _disable_download_extract(self, special_kwargs):
+        inject_download_kwarg = self._HAS_SPECIAL_KWARG["download"] and "download" not in special_kwargs
+        if inject_download_kwarg:
+            special_kwargs["download"] = False
+
+        module = inspect.getmodule(self.DATASET_CLASS).__name__
+        with contextlib.ExitStack() as stack:
+            mocks = {}
+            for function, kwargs in itertools.chain(
+                zip(self._CHECK_FUNCTIONS, [dict(return_value=True)] * len(self._CHECK_FUNCTIONS)),
+                zip(self._DOWNLOAD_EXTRACT_FUNCTIONS, [dict()] * len(self._DOWNLOAD_EXTRACT_FUNCTIONS)),
+            ):
+                with contextlib.suppress(AttributeError):
+                    patcher = unittest.mock.patch(f"{module}.{function}", **kwargs)
+                    mocks[function] = stack.enter_context(patcher)
+
+            try:
+                yield mocks
+            finally:
+                if inject_download_kwarg:
+                    del special_kwargs["download"]
+
+    def test_not_found(self):
+        with self.assertRaises(RuntimeError):
+            with self.create_dataset(inject_fake_data=False):
+                pass
+
+    def test_smoke(self, config):
+        with self.create_dataset(config) as (dataset, _):
+            self.assertIsInstance(dataset, torchvision.datasets.VisionDataset)
+
+    @test_all_configs
+    def test_str_smoke(self, config):
+        with self.create_dataset(config) as (dataset, _):
+            self.assertIsInstance(str(dataset), str)
+
+    @test_all_configs
+    def test_feature_types(self, config):
+        with self.create_dataset(config) as (dataset, _):
+            example = dataset[0]
+
+            actual = len(example)
+            expected = len(self.FEATURE_TYPES)
+            self.assertEqual(
+                actual,
+                expected,
+                f"The number of the returned features does not match the the number of elements in in FEATURE_TYPES: "
+                f"{actual} != {expected}",
+            )
+
+            for idx, (feature, expected_feature_type) in enumerate(zip(example, self.FEATURE_TYPES)):
+                with self.subTest(idx=idx):
+                    self.assertIsInstance(feature, expected_feature_type)
+
+    @test_all_configs
+    def test_num_examples(self, config):
+        with self.create_dataset(config) as (dataset, info):
+            self.assertEqual(len(dataset), info["num_examples"])
+
+
+class ImageDatasetTestCase(DatasetTestCase):
+    FEATURE_TYPES = (Image.Image, int)
+
+
+class VideoDatasetTestCase(DatasetTestCase):
+    FEATURE_TYPES = (torch.Tensor, torch.Tensor, int)
+    REQUIRED_PACKAGES = ("av",)

--- a/test/datasets_utils.py
+++ b/test/datasets_utils.py
@@ -5,6 +5,7 @@ import inspect
 import itertools
 import unittest
 import unittest.mock
+from typing import Any, Iterator, Sequence, Tuple, Union
 
 from PIL import Image
 
@@ -134,25 +135,31 @@ class DatasetTestCase(unittest.TestCase):
         "download_and_extract_archive",
     }
 
-    def inject_fake_data(self, root: str, config: dict[str, Any]) -> dict[str, Any]:
+    def inject_fake_data(self, root: str, config: Dict[str, Any]) -> Dict[str, Any]:
         """Inject fake data into the root of the dataset.
 
         Args:
             root (str): Root of the dataset.
-            config (dict[str, Any]): Configuration that will be used to create the dataset.
+            config (Dict[str, Any]): Configuration that will be used to create the dataset.
 
         Returns:
-            info (dict[str, Any]): Additional information about the injected fake data. Must contain the field
+            info (Dict[str, Any]): Additional information about the injected fake data. Must contain the field
                 ``"num_examples"`` that corresponds to the length of the dataset to be created.
         """
         raise NotImplementedError("You need to provide fake data in order for the tests to run.")
 
     @contextlib.contextmanager
-    def create_dataset(self, config=None, inject_fake_data=True, disable_download_extract=None, **kwargs):
+    def create_dataset(
+        self,
+        config: Optional[Dict[str, Any]] = None,
+        inject_fake_data: bool = True,
+        disable_download_extract: Optional[bool] = None,
+        **kwargs: Any,
+    ) -> Iterator[Tuple[torchvision.datasets.VisionDataset, Dict[str, Any]]]:
         r"""Create the dataset in a temporary directory.
 
         Args:
-            config (Optional[dict[str, Any]]): Configuration that will be used to create the dataset. If omitted, the
+            config (Optional[Dict[str, Any]]): Configuration that will be used to create the dataset. If omitted, the
                 default configuration is used.
             inject_fake_data (bool): If ``True`` (default) inject the fake data with :meth:`.inject_fake_data` before
                 creating the dataset.
@@ -163,7 +170,7 @@ class DatasetTestCase(unittest.TestCase):
 
         Yields:
             dataset (torchvision.dataset.VisionDataset): Dataset.
-            info (dict[str, Any]): Additional information about the injected fake data. See :meth:`.inject_fake_data`
+            info (Dict[str, Any]): Additional information about the injected fake data. See :meth:`.inject_fake_data`
                 for details.
         """
         if config is None:

--- a/test/datasets_utils.py
+++ b/test/datasets_utils.py
@@ -317,9 +317,21 @@ class DatasetTestCase(unittest.TestCase):
 
 
 class ImageDatasetTestCase(DatasetTestCase):
+    """Abstract base class for image dataset testcases.
+
+    - Overwrites the FEATURE_TYPES class attribute to expect a :class:`PIL.Image.Image` and an integer label.
+    """
+
     FEATURE_TYPES = (Image.Image, int)
 
 
 class VideoDatasetTestCase(DatasetTestCase):
+    """Abstract base class for video dataset testcases.
+
+    - Overwrites the FEATURE_TYPES class attribute to expect two :class:`torch.Tensor` s for the video and audio as
+      well as an integer label.
+    - Overwrites the REQUIRED_PACKAGES class attribute to require PyAV (``av``).
+    """
+
     FEATURE_TYPES = (torch.Tensor, torch.Tensor, int)
     REQUIRED_PACKAGES = ("av",)

--- a/test/datasets_utils.py
+++ b/test/datasets_utils.py
@@ -151,8 +151,8 @@ class DatasetTestCase(unittest.TestCase):
         def test_bar(self, config):
             pass
 
-    Within the test you can use the ``create_dataset()`` method that yields the dataset as well as additional information
-    provided by the ``ìnject_fake_data()`` method:
+    Within the test you can use the ``create_dataset()`` method that yields the dataset as well as additional
+    information provided by the ``ìnject_fake_data()`` method:
 
     .. code-block::
 
@@ -278,7 +278,7 @@ class DatasetTestCase(unittest.TestCase):
         if cls.CONFIGS is None:
             config = {
                 kwarg: default
-                for kwarg, default in zip(argspec.args[-len(argspec.defaults) :], argspec.defaults)
+                for kwarg, default in zip(argspec.args[-len(argspec.defaults):], argspec.defaults)
                 if kwarg not in cls._SPECIAL_KWARGS
             }
             cls.CONFIGS = (config,)

--- a/test/datasets_utils.py
+++ b/test/datasets_utils.py
@@ -581,7 +581,7 @@ def create_video_folder(
             # The 'libx264' video codec, which is the default of torchvision.io.write_video, requires the height and
             # width of the video to be divisible by 2.
             height, width = (torch.randint(2, 6, size=(2,), dtype=torch.int) * 2).tolist()
-            return (length, num_channels, height, width)
+            return (num_frames, num_channels, height, width)
 
     root = pathlib.Path(root) / name
     os.makedirs(root)

--- a/test/datasets_utils.py
+++ b/test/datasets_utils.py
@@ -421,7 +421,7 @@ def create_image_folder(
 
         def size(idx: int) -> Tuple[int, int, int]:
             num_channels = 3
-            height, width = torch.randint(3, 11, size=(2,), dtype=np.int).tolist()
+            height, width = torch.randint(3, 11, size=(2,), dtype=torch.int).tolist()
             return (num_channels, height, width)
 
     root = pathlib.Path(root) / name
@@ -505,7 +505,7 @@ def create_video_folder(
             num_channels = 3
             # The 'libx264' video codec, which is the default of torchvision.io.write_video, requires the height and
             # width of the video to be divisible by 2.
-            height, width = (torch.randint(2, 6, size=(2,), dtype=np.int) * 2).tolist()
+            height, width = (torch.randint(2, 6, size=(2,), dtype=torch.int) * 2).tolist()
             return (length, num_channels, height, width)
 
     root = pathlib.Path(root) / name

--- a/test/datasets_utils.py
+++ b/test/datasets_utils.py
@@ -403,7 +403,7 @@ class DatasetTestCase(unittest.TestCase):
     def test_transforms(self, config):
         mock = unittest.mock.Mock(wraps=lambda *args: args[0] if len(args) == 1 else args)
         for kwarg in self._TRANSFORM_KWARGS:
-            if not kwarg in self._HAS_SPECIAL_KWARG:
+            if kwarg not in self._HAS_SPECIAL_KWARG:
                 continue
 
             mock.reset_mock()

--- a/test/datasets_utils.py
+++ b/test/datasets_utils.py
@@ -250,23 +250,14 @@ class DatasetTestCase(unittest.TestCase):
                 "It should contain a sequence of types that the dataset returns when accessed by index."
             )
 
-    @property
-    @classmethod
-    def _argspec(cls):
-        return inspect.getfullargspec(cls.DATASET_CLASS.__init__)
-
-    @property
-    @classmethod
-    def _name(cls):
-        return cls.DATASET_CLASS.__name__
-
     @classmethod
     def _populate_private_class_attributes(cls):
-        cls._HAS_SPECIAL_KWARG = {name: name in cls._argspec.args for name in cls._SPECIAL_KWARGS}
+        argspec = inspect.getfullargspec(cls.DATASET_CLASS.__init__)
+        cls._HAS_SPECIAL_KWARG = {name: name in argspec.args for name in cls._SPECIAL_KWARGS}
 
     @classmethod
     def _process_optional_public_class_attributes(cls):
-        argspec = cls._argspec
+        argspec = inspect.getfullargspec(cls.DATASET_CLASS.__init__)
         if cls.CONFIGS is None:
             config = {
                 kwarg: default
@@ -281,7 +272,8 @@ class DatasetTestCase(unittest.TestCase):
                     importlib.import_module(pkg)
             except ImportError as error:
                 raise unittest.SkipTest(
-                    f"The package '{error.name}' is required to load the dataset '{cls._name}' but is not installed."
+                    f"The package '{error.name}' is required to load the dataset '{cls.DATASET_CLASS.__name__}' but is "
+                    f"not installed."
                 )
 
     def _split_kwargs(self, kwargs):

--- a/test/datasets_utils.py
+++ b/test/datasets_utils.py
@@ -57,9 +57,9 @@ class LazyImporter:
     def __init__(self):
         cls = type(self)
         for module in self.MODULES:
-            # We need the quirky module=module argument to the lambda since otherwise the lookup for module in this
-            # scope happens at runtime rather than at definition. Thus, without it every property would try to import
-            # the last module in MODULES
+            # We need the quirky 'module=module' argument to the lambda since otherwise the lookup for 'module' in this
+            # scope would happen at runtime rather than at definition. Thus, without it, every property would try to
+            # import the last 'module' in MODULES.
             setattr(cls, module.split(".", 1)[0], property(lambda self, module=module: LazyImporter._import(module)))
 
     @staticmethod

--- a/test/datasets_utils.py
+++ b/test/datasets_utils.py
@@ -400,7 +400,7 @@ def create_image_file(
 def create_image_folder(
     root: Union[pathlib.Path, str],
     name: Union[pathlib.Path, str],
-    file_name_fn: Callable[[idx], str],
+    file_name_fn: Callable[[int], str],
     num_examples: int,
     size: Optional[Union[Sequence[int], int, Callable[[int], Union[Sequence[int], int]]]] = None,
     **kwargs: Any,
@@ -410,7 +410,7 @@ def create_image_folder(
     Args:
         root (Union[str, pathlib.Path]): Root directory the image folder will be placed in.
         name (Union[str, pathlib.Path]): Name of the image folder.
-        file_name_fn (Callable[[idx], str]): Should return a file name if called with the file index.
+        file_name_fn (Callable[[int], str]): Should return a file name if called with the file index.
         num_examples (int): Number of images to create.
         size (Optional[Union[Sequence[int], int, Callable[[int], Union[Sequence[int], int]]]]): Size of the images. If
             callable, will be called with the index of the corresponding file. If omitted, a random height and width
@@ -475,7 +475,7 @@ def create_video_file(
 def create_video_folder(
     root: Union[str, pathlib.Path],
     name: Union[str, pathlib.Path],
-    file_name_fn: Callable[[idx], str],
+    file_name_fn: Callable[[int], str],
     num_examples: int,
     size: Optional[Union[Sequence[int], int, Callable[[int], Union[Sequence[int], int]]]] = None,
     fps=25,
@@ -486,7 +486,7 @@ def create_video_folder(
     Args:
         root (Union[str, pathlib.Path]): Root directory the image folder will be placed in.
         name (Union[str, pathlib.Path]): Name of the image folder.
-        file_name_fn (Callable[[idx], str]): Should return a file name if called with the file index.
+        file_name_fn (Callable[[int], str]): Should return a file name if called with the file index.
         num_examples (int): Number of images to create.
         size (Optional[Union[Sequence[int], int, Callable[[int], Union[Sequence[int], int]]]]): Size of the images. If
             callable, will be called with the index of the corresponding file. If omitted, a random length between 0.5

--- a/test/datasets_utils.py
+++ b/test/datasets_utils.py
@@ -309,8 +309,8 @@ class DatasetTestCase(unittest.TestCase):
             with self.create_dataset(inject_fake_data=False):
                 pass
 
-    def test_smoke(self, config):
-        with self.create_dataset(config) as (dataset, _):
+    def test_smoke(self):
+        with self.create_dataset() as (dataset, _):
             self.assertIsInstance(dataset, torchvision.datasets.VisionDataset)
 
     @test_all_configs

--- a/test/datasets_utils.py
+++ b/test/datasets_utils.py
@@ -7,15 +7,14 @@ import os
 import pathlib
 import unittest
 import unittest.mock
-from typing import Any, Iterator, Sequence, Tuple, Union
+from typing import Any, Callable, Dict, Iterator, Optional, Sequence, Tuple, Union
 
 import PIL.Image
 
 import torch
 import torchvision.datasets
 
-from common_utils import get_tmp_dir
-from datasets_utils import tmpdir, disable_console_output
+from common_utils import get_tmp_dir, disable_console_output
 
 try:
     from torchvision.io import write_video
@@ -217,7 +216,7 @@ class DatasetTestCase(unittest.TestCase):
         if disable_download_extract is None:
             disable_download_extract = inject_fake_data
 
-        with tmpdir() as root:
+        with get_tmp_dir() as root:
             info = self.inject_fake_data(root, config) if inject_fake_data else None
             if info is None or "num_examples" not in info:
                 raise UsageError(

--- a/test/datasets_utils.py
+++ b/test/datasets_utils.py
@@ -266,7 +266,7 @@ class DatasetTestCase(unittest.TestCase):
                 for details.
         """
         if config is None:
-            config = self.CONFIGS[0]
+            config = self.CONFIGS[0].copy()
 
         special_kwargs, other_kwargs = self._split_kwargs(kwargs)
         config.update(other_kwargs)

--- a/test/datasets_utils.py
+++ b/test/datasets_utils.py
@@ -475,9 +475,6 @@ def create_video_file(
     Raises:
         UsageError: If PyAV is not available.
     """
-    if not PYAV_AVAILABLE:
-        raise PyAVNotAvailableError
-
     if isinstance(size, int):
         size = (size, size)
     if len(size) == 2:

--- a/test/datasets_utils.py
+++ b/test/datasets_utils.py
@@ -433,6 +433,11 @@ def create_image_folder(
             callable, will be called with the index of the corresponding file. If omitted, a random height and width
             between 3 and 10 pixels is selected on a per-image basis.
         kwargs (Any): Additional parameters passed to :func:`create_image_file`.
+
+
+    .. seealso::
+
+        - :func:`create_image_file`
     """
     if size is None:
 
@@ -514,6 +519,10 @@ def create_video_folder(
 
     Raises:
         UsageError: If PyAV is not available.
+
+    .. seealso::
+
+        - :func:`create_video_file`
     """
     if size is None:
 

--- a/test/datasets_utils.py
+++ b/test/datasets_utils.py
@@ -457,7 +457,7 @@ def create_image_folder(
 def create_video_file(
     root: Union[pathlib.Path, str],
     name: Union[pathlib.Path, str],
-    size: Union[Sequence[int], int] = (25, 3, 10, 10),
+    size: Union[Sequence[int], int] = (1, 3, 10, 10),
     fps: float = 25,
     **kwargs: Any,
 ) -> None:
@@ -467,8 +467,8 @@ def create_video_file(
         root (Union[str, pathlib.Path]): Root directory the video file will be placed in.
         name (Union[str, pathlib.Path]): Name of the video file.
         size (Union[Sequence[int], int]): Size of the video that represents the
-            ``(length, num_channels, height, width)``. If scalar, the value is used for the height and width.
-            If not provided, three channels are assumed. If not provided, the length is set to one second.
+            ``(num_frames, num_channels, height, width)``. If scalar, the value is used for the height and width.
+            If not provided, ``num_frames=1`` and ``num_channels=3`` are assumed.
         fps (float): Frame rate in frames per second.
         kwargs (Any): Additional parameters passed to :func:`torchvision.io.write_video`.
 
@@ -483,7 +483,7 @@ def create_video_file(
     if len(size) == 2:
         size = (3, *size)
     if len(size) == 3:
-        size = (fps, *size)
+        size = (1, *size)
     if len(size) != 4:
         raise UsageError(
             f"The 'size' argument should either be an int or a sequence of length 2, 3, or 4. Got {len(size)} instead"
@@ -510,10 +510,9 @@ def create_video_folder(
         name (Union[str, pathlib.Path]): Name of the image folder.
         file_name_fn (Callable[[int], str]): Should return a file name if called with the file index.
         num_examples (int): Number of images to create.
-        size (Optional[Union[Sequence[int], int, Callable[[int], Union[Sequence[int], int]]]]): Size of the images. If
-            callable, will be called with the index of the corresponding file. If omitted, a random length between 0.5
-            and 1.5 seconds as well as random even height and width between 4 and 10 pixels are selected on a
-            per-video basis.
+        size (Optional[Union[Sequence[int], int, Callable[[int], Union[Sequence[int], int]]]]): Size of the videos. If
+            callable, will be called with the index of the corresponding file. If omitted, a random even height and
+            width between 4 and 10 pixels is selected on a per-video basis.
         fps (float): Frame rate in frames per second.
         kwargs (Any): Additional parameters passed to :func:`create_video_file`.
 
@@ -527,7 +526,7 @@ def create_video_folder(
     if size is None:
 
         def size(idx):
-            length = int((torch.rand(()).item() + 0.5) * fps)
+            num_frames = 1
             num_channels = 3
             # The 'libx264' video codec, which is the default of torchvision.io.write_video, requires the height and
             # width of the video to be divisible by 2.

--- a/test/datasets_utils.py
+++ b/test/datasets_utils.py
@@ -85,6 +85,23 @@ def test_all_configs(test):
     return wrapper
 
 
+def combinations_grid(**kwargs):
+    """Creates a grid of input combinations.
+
+    Each element in the returned sequence is a dictionary containing one possible combination as values.
+
+    Example:
+        >>> combinations_grid(foo=("bar", "baz"), spam=("eggs", "ham"))
+        [
+            {'foo': 'bar', 'spam': 'eggs'},
+            {'foo': 'bar', 'spam': 'ham'},
+            {'foo': 'baz', 'spam': 'eggs'},
+            {'foo': 'baz', 'spam': 'ham'}
+        ]
+    """
+    return [dict(zip(kwargs.keys(), values)) for values in itertools.product(*kwargs.values())]
+
+
 class DatasetTestCase(unittest.TestCase):
     """Abstract base class for all dataset testcases.
 

--- a/test/datasets_utils.py
+++ b/test/datasets_utils.py
@@ -456,7 +456,7 @@ class ImageDatasetTestCase(DatasetTestCase):
                 image.load()
             return image
 
-        with unittest.mock.patch(f"PIL.Image.open", new=new):
+        with unittest.mock.patch("PIL.Image.open", new=new):
             yield
 
 

--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -489,5 +489,75 @@ class Caltech256TestCase(datasets_utils.ImageDatasetTestCase):
         return dict(num_examples=num_images_per_category * len(categories))
 
 
-if __name__ == '__main__':
+class CIFAR10TestCase(datasets_utils.ImageDatasetTestCase):
+    DATASET_CLASS = datasets.CIFAR10
+    CONFIGS = datasets_utils.combinations_grid(train=(True, False))
+
+    _VERSION_CONFIG = dict(
+        base_folder="cifar-10-batches-py",
+        train_files=tuple(f"data_batch_{idx}" for idx in range(1, 6)),
+        test_files=("test_batch",),
+        labels_key="labels",
+        meta_file="batches.meta",
+        num_categories=10,
+        categories_key="label_names",
+    )
+
+    def inject_fake_data(self, root, config):
+        root = pathlib.Path(root) / self._VERSION_CONFIG["base_folder"]
+        os.makedirs(root)
+
+        num_images_per_file = 1
+        for name in itertools.chain(self._VERSION_CONFIG["train_files"], self._VERSION_CONFIG["test_files"]):
+            self._create_batch_file(root, name, num_images_per_file)
+
+        categories = self._create_meta_file(root)
+
+        return dict(
+            num_examples=num_images_per_file
+            * len(self._VERSION_CONFIG["train_files"] if config["train"] else self._VERSION_CONFIG["test_files"]),
+            categories=categories,
+        )
+
+    def _create_batch_file(self, root, name, num_images):
+        data = datasets_utils.create_image_or_video_tensor((num_images, 32 * 32 * 3))
+        labels = np.random.randint(0, self._VERSION_CONFIG["num_categories"], size=num_images).tolist()
+        self._create_binary_file(root, name, {"data": data, self._VERSION_CONFIG["labels_key"]: labels})
+
+    def _create_meta_file(self, root):
+        categories = [
+            f"{idx:0{len(str(self._VERSION_CONFIG['num_categories'] - 1))}d}"
+            for idx in range(self._VERSION_CONFIG["num_categories"])
+        ]
+        self._create_binary_file(
+            root, self._VERSION_CONFIG["meta_file"], {self._VERSION_CONFIG["categories_key"]: categories}
+        )
+        return categories
+
+    def _create_binary_file(self, root, name, content):
+        with open(pathlib.Path(root) / name, "wb") as fh:
+            pickle.dump(content, fh)
+
+    def test_class_to_idx(self):
+        with self.create_dataset() as (dataset, info):
+            expected = {category: label for label, category in enumerate(info["categories"])}
+            actual = dataset.class_to_idx
+            self.assertEqual(actual, expected)
+
+
+class CIFAR100(CIFAR10TestCase):
+    DATASET_CLASS = datasets.CIFAR100
+
+    _VERSION_CONFIG = dict(
+        base_folder="cifar-100-python",
+        train_files=("train",),
+        test_files=("test",),
+        labels_key="fine_labels",
+        meta_file="meta",
+        num_categories=100,
+        categories_key="fine_label_names",
+    )
+
+
+if __name__ == "__main__":
     unittest.main()

--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -473,21 +473,21 @@ class STL10Tester(DatasetTestcase):
 class Caltech256TestCase(datasets_utils.ImageDatasetTestCase):
     DATASET_CLASS = datasets.Caltech256
 
-    def inject_fake_data(self, root, config):
-        root = pathlib.Path(root) / "caltech256" / "256_ObjectCategories"
+    def inject_fake_data(self, tmpdir, config):
+        tmpdir = pathlib.Path(tmpdir) / "caltech256" / "256_ObjectCategories"
 
         categories = ((1, "ak47"), (127, "laptop-101"), (257, "clutter"))
         num_images_per_category = 2
 
         for idx, category in categories:
             datasets_utils.create_image_folder(
-                root,
+                tmpdir,
                 name=f"{idx:03d}.{category}",
-                file_name_fn=lambda image_idx: f"{idx:03d}_{image_idx:04d}.jpg",
+                file_name_fn=lambda image_idx: f"{idx:03d}_{image_idx + 1:04d}.jpg",
                 num_examples=num_images_per_category,
             )
 
-        return dict(num_examples=num_images_per_category * len(categories))
+        return num_images_per_category * len(categories)
 
 
 class CIFAR10TestCase(datasets_utils.ImageDatasetTestCase):
@@ -504,15 +504,15 @@ class CIFAR10TestCase(datasets_utils.ImageDatasetTestCase):
         categories_key="label_names",
     )
 
-    def inject_fake_data(self, root, config):
-        root = pathlib.Path(root) / self._VERSION_CONFIG["base_folder"]
-        os.makedirs(root)
+    def inject_fake_data(self, tmpdir, config):
+        tmpdir = pathlib.Path(tmpdir) / self._VERSION_CONFIG["base_folder"]
+        os.makedirs(tmpdir)
 
         num_images_per_file = 1
         for name in itertools.chain(self._VERSION_CONFIG["train_files"], self._VERSION_CONFIG["test_files"]):
-            self._create_batch_file(root, name, num_images_per_file)
+            self._create_batch_file(tmpdir, name, num_images_per_file)
 
-        categories = self._create_meta_file(root)
+        categories = self._create_meta_file(tmpdir)
 
         return dict(
             num_examples=num_images_per_file

--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -15,6 +15,9 @@ from fakedata_generation import mnist_root, cifar_root, imagenet_root, \
 import xml.etree.ElementTree as ET
 from urllib.request import Request, urlopen
 import itertools
+import datasets_utils
+import pathlib
+from torchvision import datasets
 
 
 try:
@@ -464,6 +467,26 @@ class STL10Tester(DatasetTestcase):
     def test_repr_smoke(self):
         with self.mocked_dataset() as (dataset, _):
             self.assertIsInstance(repr(dataset), str)
+
+
+class Caltech256TestCase(datasets_utils.ImageDatasetTestCase):
+    DATASET_CLASS = datasets.Caltech256
+
+    def inject_fake_data(self, root, config):
+        root = pathlib.Path(root) / "caltech256" / "256_ObjectCategories"
+
+        categories = ((1, "ak47"), (127, "laptop-101"), (257, "clutter"))
+        num_images_per_category = 2
+
+        for idx, category in categories:
+            datasets_utils.create_image_folder(
+                root,
+                name=f"{idx:03d}.{category}",
+                file_name_fn=lambda image_idx: f"{idx:03d}_{image_idx:04d}.jpg",
+                num_examples=num_images_per_category,
+            )
+
+        return dict(num_examples=num_images_per_category * len(categories))
 
 
 if __name__ == '__main__':

--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -17,6 +17,7 @@ from urllib.request import Request, urlopen
 import itertools
 import datasets_utils
 import pathlib
+import pickle
 from torchvision import datasets
 
 


### PR DESCRIPTION
Proof-of-concept for #3375. 

We provide the fully-documented `DatasetTestCase` class that needs to be subclassed for each individual dataset. In most cases the user only has to configure the `DATASET_CLASS` to indicate which dataset should be tested and supply fake data within the `inject_fake_data` method. I've added tests for `Caltech256`, `CIFAR10`, and `CIFAR100` to showcase this.

The user can add additional `CONFIGS` that are all tested instead of only the standard configuration. This can be used to test if the dataset works as intended for different splits or other parameter combinations.

---

Two things we need to discuss:

1. Some datasets require additional arguments without default values. For example


   https://github.com/pytorch/vision/blob/61e00d586354d86af7f6b0222825c7810b7e4580/torchvision/datasets/ucf101.py#L46

   https://github.com/pytorch/vision/blob/61e00d586354d86af7f6b0222825c7810b7e4580/torchvision/datasets/coco.py#L49-L52

   We need an interface for the user to be able to provide them. My idea was to put this into `inject_fake_data`. In addition to the `info` dict, it could return a sequence of arguments passed to the constructor. If not returned, we could simply assume that only `root` should be passed, making this optional.

2. As of now, no tests for the `(target_)transforms?` is implemented. Writing the test is trivial, but we need a way to indicate which transform is applied to which output argument. Most of the time `transform` is applied to the first, `target_transform` to the second, and `transforms` to the first two. But there are exceptions to this:

    https://github.com/pytorch/vision/blob/61e00d586354d86af7f6b0222825c7810b7e4580/torchvision/datasets/phototour.py#L106-L109

    https://github.com/pytorch/vision/blob/61e00d586354d86af7f6b0222825c7810b7e4580/torchvision/datasets/ucf101.py#L108-L111

    My idea is to provide `TRANSFORM_IDCS` and `TARGET_TRANSFORM_IDCS` class attributes (`TRANSFORMS_IDCS` is not necessary as it can be combined from the other two). These would be mandatory, but could have good default values in `(Image|Video)DatasetTestCase`.

