### PR TITLE
Typo: fix stable version link

### DIFF
--- a/versions.html
+++ b/versions.html
@@ -21,7 +21,7 @@
           <a class="reference internal" href="master/">master (unstable)</a>
         </li>
         <li class="toctree-l1">
-          <a class="reference internal" href="0.8.0/">v0.8.0 (stable release)</a>
+          <a class="reference internal" href="0.8/">v0.8 (stable release)</a>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
The correct link is 0.8, not as I had before.