### PR TITLE
Set `torch.set_deterministic` to false for GPU tests

### DIFF
--- a/test/test_transforms_tensor.py
+++ b/test/test_transforms_tensor.py
@@ -114,7 +114,6 @@ class Tester(TransformsTester):
         self._test_op('autocontrast', 'RandomAutocontrast')
 
     def test_random_equalize(self):
-        torch.set_deterministic(False)
         self._test_op('equalize', 'RandomEqualize')
 
     def test_color_jitter(self):
@@ -480,7 +479,6 @@ class Tester(TransformsTester):
         # We skip some tests from _test_transform_vs_scripted_on_batch as
         # results for scripted and non-scripted transformations are not exactly the same
         torch.manual_seed(12)
-        torch.set_deterministic(True)
         transformed_batch = fn(batch_tensors)
         torch.manual_seed(12)
         s_transformed_batch = scripted_fn(batch_tensors)
@@ -648,6 +646,7 @@ class Tester(TransformsTester):
 class CUDATester(Tester):
 
     def setUp(self):
+        torch.set_deterministic(False)
         self.device = "cuda"
 
 


### PR DESCRIPTION
Summary:
In CUDA-10.1 or below it is a no-op, but few of the tests will start to fail if update to 10.2 or newer, for example:
```
torchvision/transforms/transforms.py", line 1043, in forward
    transformed_tensor = torch.mm(flat_tensor, self.transformation_matrix)
RuntimeError: Deterministic behavior was enabled with either `torch.use_deterministic_algorithms(True)` or `at::Context::setDeterministicAlgorithms(true)`, but this operation is not deterministic because it uses CuBLAS and you have CUDA >= 10.2. To enable deterministic behavior in this case, you must set an environment variable before running your PyTorch application: CUBLAS_WORKSPACE_CONFIG=:4096:8 or CUBLAS_WORKSPACE_CONFIG=:16:8. For more information, go to https://docs.nvidia.com/cuda/cublas/index.html#cublasApi_reproducibility
```

Reviewed By: meyering

Differential Revision: D26563045

