### PR TITLE
[FBcode->GH] Fix to_tensor for accimage backend

### DIFF
--- a/torchvision/transforms/functional.py
+++ b/torchvision/transforms/functional.py
@@ -119,9 +119,9 @@ def to_tensor(pic):
             return img
 
     if accimage is not None and isinstance(pic, accimage.Image):
-        nppic = np.zeros([pic.channels, pic.height, pic.width], dtype=default_float_dtype)
+        nppic = np.zeros([pic.channels, pic.height, pic.width], dtype=np.float32)
         pic.copyto(nppic)
-        return torch.from_numpy(nppic)
+        return torch.from_numpy(nppic).to(dtype=default_float_dtype)
 
     # handle PIL Image
     if pic.mode == 'I':


### PR DESCRIPTION
Fixes bug introduced in https://github.com/pytorch/vision/pull/3398 for `accimage` backends.

[`accimage` only supports `uint8` and `float` types](https://github.com/pytorch/accimage/blob/c6aa954b0377d5c85d037b94559e28aa8f38f1cd/accimagemodule.c#L170-L176), plus we were passing a `torch.dtype` into `np.zeros` causing errors.

`accimage` is not tested in OSS CI and that's why this wasn't caught before, we caught it in internal fb tests when importing it.

Note: this has already been fixed in fbcode