### PR TITLE
Deprecate _transforms_video and _functional_video

### DIFF
--- a/test/test_transforms_video.py
+++ b/test/test_transforms_video.py
@@ -1,14 +1,19 @@
 import torch
-import torchvision.transforms._transforms_video as transforms
 from torchvision.transforms import Compose
 import unittest
 import random
 import numpy as np
+import warnings
 
 try:
     from scipy import stats
 except ImportError:
     stats = None
+
+
+with warnings.catch_warnings(record=True):
+    warnings.simplefilter("always")
+    import torchvision.transforms._transforms_video as transforms
 
 
 class TestVideoTransforms(unittest.TestCase):

--- a/torchvision/transforms/_functional_video.py
+++ b/torchvision/transforms/_functional_video.py
@@ -7,7 +7,6 @@ warnings.warn(
 )
 
 
-
 def _is_tensor_video_clip(clip):
     if not torch.is_tensor(clip):
         raise TypeError("clip should be Tesnor. Got %s" % type(clip))

--- a/torchvision/transforms/_functional_video.py
+++ b/torchvision/transforms/_functional_video.py
@@ -1,4 +1,11 @@
 import torch
+import warnings
+
+
+warnings.warn(
+    "The _functional_video module is deprecated. Please use the functional module instead."
+)
+
 
 
 def _is_tensor_video_clip(clip):

--- a/torchvision/transforms/_transforms_video.py
+++ b/torchvision/transforms/_transforms_video.py
@@ -2,6 +2,7 @@
 
 import numbers
 import random
+import warnings
 
 from torchvision.transforms import (
     RandomCrop,
@@ -19,6 +20,11 @@ __all__ = [
     "ToTensorVideo",
     "RandomHorizontalFlipVideo",
 ]
+
+
+warnings.warn(
+    "The _transforms_video module is deprecated. Please use the transforms module instead."
+)
 
 
 class RandomCropVideo(RandomCrop):


### PR DESCRIPTION
These modules are private and they have equivalent transforms in the `transform` module.