### PR TITLE
.circleci: Don't install numpy directly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,7 +119,7 @@ jobs:
           command: |
             sudo apt-get update -y
             sudo apt install -y libturbojpeg-dev
-            pip install --user --progress-bar off numpy mypy
+            pip install --user --progress-bar off mypy
             pip install --user --progress-bar off --pre torch -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
             pip install --user --progress-bar off --editable .
             mypy --config-file mypy.ini
@@ -153,7 +153,6 @@ jobs:
       - checkout
       - run:
           command: |
-            pip install --user --progress-bar off numpy
             pip install --user --progress-bar off --pre torch -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
             # need to install torchvision dependencies due to transitive imports
             pip install --user --progress-bar off --editable .
@@ -166,7 +165,6 @@ jobs:
       - checkout
       - run:
           command: |
-            pip install --user --progress-bar off numpy
             pip install --user --progress-bar off --pre torch -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
             # need to install torchvision dependencies due to transitive imports
             pip install --user --progress-bar off --editable .

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -119,7 +119,7 @@ jobs:
           command: |
             sudo apt-get update -y
             sudo apt install -y libturbojpeg-dev
-            pip install --user --progress-bar off numpy mypy
+            pip install --user --progress-bar off mypy
             pip install --user --progress-bar off --pre torch -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
             pip install --user --progress-bar off --editable .
             mypy --config-file mypy.ini
@@ -153,7 +153,6 @@ jobs:
       - checkout
       - run:
           command: |
-            pip install --user --progress-bar off numpy
             pip install --user --progress-bar off --pre torch -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
             # need to install torchvision dependencies due to transitive imports
             pip install --user --progress-bar off --editable .
@@ -166,7 +165,6 @@ jobs:
       - checkout
       - run:
           command: |
-            pip install --user --progress-bar off numpy
             pip install --user --progress-bar off --pre torch -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
             # need to install torchvision dependencies due to transitive imports
             pip install --user --progress-bar off --editable .

--- a/.circleci/smoke_test/docker/Dockerfile
+++ b/.circleci/smoke_test/docker/Dockerfile
@@ -30,7 +30,7 @@ RUN conda create -y --name python3.7 python=3.7
 RUN conda create -y --name python3.8 python=3.8
 SHELL [ "/bin/bash", "-c" ]
 RUN echo "source /usr/local/etc/profile.d/conda.sh" >> ~/.bashrc
-RUN source /usr/local/etc/profile.d/conda.sh && conda activate python3.6 && conda install -y numpy Pillow
-RUN source /usr/local/etc/profile.d/conda.sh && conda activate python3.7 && conda install -y numpy Pillow
-RUN source /usr/local/etc/profile.d/conda.sh && conda activate python3.8 && conda install -y numpy Pillow
+RUN source /usr/local/etc/profile.d/conda.sh && conda activate python3.6 && conda install -y Pillow
+RUN source /usr/local/etc/profile.d/conda.sh && conda activate python3.7 && conda install -y Pillow
+RUN source /usr/local/etc/profile.d/conda.sh && conda activate python3.8 && conda install -y Pillow
 CMD [ "/bin/bash"]

--- a/.circleci/unittest/linux/scripts/environment.yml
+++ b/.circleci/unittest/linux/scripts/environment.yml
@@ -1,7 +1,7 @@
 channels:
   - pytorch
   - defaults
-  # using conda-forge for python v3.9+
+  # using conda-forge for python v3.9
   - conda-forge
 dependencies:
   - pytest

--- a/.circleci/unittest/linux/scripts/install.sh
+++ b/.circleci/unittest/linux/scripts/install.sh
@@ -24,7 +24,7 @@ else
 fi
 
 printf "Installing PyTorch with %s\n" "${cudatoolkit}"
-conda install -y -c "pytorch-${UPLOAD_CHANNEL}" -c conda-forge pytorch "${cudatoolkit}"
+conda install -y -c "pytorch-${UPLOAD_CHANNEL}" -c conda-forge "pytorch-${UPLOAD_CHANNEL}"::pytorch "${cudatoolkit}"
 
 printf "* Installing torchvision\n"
 python setup.py develop

--- a/.circleci/unittest/linux/scripts/setup_env.sh
+++ b/.circleci/unittest/linux/scripts/setup_env.sh
@@ -36,13 +36,10 @@ conda activate "${env_dir}"
 
 # 3. Install Conda dependencies
 printf "* Installing dependencies (except PyTorch)\n"
-NUMPY_MIN_VER="1.11"
 FFMPEG_PIN="=4.2"
 if [[ "${PYTHON_VERSION}" = "3.9" ]]; then
-    NUMPY_MIN_VER="1.20"
     FFMPEG_PIN=">=4.2"
 fi
 
-conda install -y -c conda-forge "numpy >=${NUMPY_MIN_VER}"
 conda install -y -c pytorch "ffmpeg${FFMPEG_PIN}"
 conda env update --file "${this_dir}/environment.yml" --prune

--- a/.circleci/unittest/windows/scripts/install.sh
+++ b/.circleci/unittest/windows/scripts/install.sh
@@ -26,7 +26,7 @@ else
 fi
 
 printf "Installing PyTorch with %s\n" "${cudatoolkit}"
-conda install -y -c "pytorch-${UPLOAD_CHANNEL}" -c conda-forge pytorch "${cudatoolkit}"
+conda install -y -c "pytorch-${UPLOAD_CHANNEL}" -c conda-forge "pytorch-${UPLOAD_CHANNEL}"::pytorch "${cudatoolkit}"
 
 printf "* Installing torchvision\n"
 "$this_dir/vc_env_helper.bat" python setup.py develop

--- a/.circleci/unittest/windows/scripts/setup_env.sh
+++ b/.circleci/unittest/windows/scripts/setup_env.sh
@@ -36,9 +36,4 @@ conda activate "${env_dir}"
 
 # 3. Install Conda dependencies
 printf "* Installing dependencies (except PyTorch)\n"
-NUMPY_MIN_VER="1.11"
-if [[ "${PYTHON_VERSION}" = "3.9" ]]; then
-    NUMPY_MIN_VER="1.20"
-fi
-conda install -y -c conda-forge "numpy >=${NUMPY_MIN_VER}"
 conda env update --file "${this_dir}/environment.yml" --prune


### PR DESCRIPTION
numpy is a dependency of pytorch so we should let the package manager
resolve our numpy dependency instead of doing it ourselves

Similar to https://github.com/pytorch/audio/pull/1309

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>