### PR TITLE
separate caching logic from download for PhotoTour dataset

### DIFF
--- a/torchvision/datasets/phototour.py
+++ b/torchvision/datasets/phototour.py
@@ -82,8 +82,10 @@ class PhotoTour(VisionDataset):
             self.download()
 
         if not self._check_datafile_exists():
-            raise RuntimeError('Dataset not found.' +
-                               ' You can use download=True to download it')
+            try:
+                self.cache()
+            except Exception as error:
+                raise RuntimeError("Dataset not found. You can use download=True to download it") from error
 
         # load the serialized data
         self.data, self.labels, self.matches = torch.load(self.data_file)
@@ -141,6 +143,7 @@ class PhotoTour(VisionDataset):
 
             os.unlink(fpath)
 
+    def cache(self) -> None:
         # process and save as torch files
         print('# Caching data {}'.format(self.data_file))
 


### PR DESCRIPTION
This separates the caching logic from the `download()` method. Ultimately, the caching should be removed similar to #3420. 

Since we have no tests and the combination of downloading and caching makes it hard to test we separate it first (this PR), add tests in a follow-up PR and only then remove the caching.