### PR TITLE
Improve dataset test infrastructure

### DIFF
--- a/test/datasets_utils.py
+++ b/test/datasets_utils.py
@@ -6,6 +6,8 @@ import inspect
 import itertools
 import os
 import pathlib
+import random
+import string
 import unittest
 import unittest.mock
 from typing import Any, Callable, Dict, Iterator, List, Optional, Sequence, Tuple, Union
@@ -32,6 +34,7 @@ __all__ = [
     "create_image_folder",
     "create_video_file",
     "create_video_folder",
+    "create_random_string",
 ]
 
 
@@ -713,3 +716,18 @@ def create_video_folder(
         create_video_file(root, file_name_fn(idx), size=size(idx) if callable(size) else size)
         for idx in range(num_examples)
     ]
+
+
+def create_random_string(length: int, *digits: str) -> str:
+    """Create a random string.
+
+    Args:
+        length (int): Number of characters in the generated string.
+        *characters (str): Characters to sample from. If omitted defaults to :attr:`string.ascii_lowercase`.
+    """
+    if not digits:
+        digits = string.ascii_lowercase
+    else:
+        digits = "".join(itertools.chain(*digits))
+
+    return "".join(random.choice(digits) for _ in range(length))

--- a/test/datasets_utils.py
+++ b/test/datasets_utils.py
@@ -116,7 +116,7 @@ def test_all_configs(test):
 
     @functools.wraps(test)
     def wrapper(self):
-        for config in self.CONFIGS:
+        for config in self.CONFIGS or (self._DEFAULT_CONFIG,):
             with self.subTest(**config):
                 test(self, config)
 

--- a/test/datasets_utils.py
+++ b/test/datasets_utils.py
@@ -359,7 +359,6 @@ class DatasetTestCase(unittest.TestCase):
 
     @classmethod
     def _process_optional_public_class_attributes(cls):
-        argspec = inspect.getfullargspec(cls.DATASET_CLASS.__init__)
         if cls.REQUIRED_PACKAGES is not None:
             try:
                 for pkg in cls.REQUIRED_PACKAGES:


### PR DESCRIPTION
- Currently, we only use the default config if the user didn't specify any `CONFIGS`. This means on the other hand that if he specifies a config, only the specified values are forwarded to `inject_fake_data`. 

    Since it may be the case that the user only specifies a part of available parameters and wants to leave the others on their default value, we should include them. With this PR the default config is always used as base and simply updated by the config of the user.
- Sometimes the image or video filename is a random string. This PR adds a `create_random_string()` function for a convenient interface.
- The output checking of the `inject_fake_data()` method takes up most of the body of the `create_dataset()` and thus drowning the actual important parts. In order to make the base class more maintainable, this PR moves the checking into a dedicated function.
- This PR splits the patching of the download / extract and check logic and only makes the patching of the check logic optional. Before we might run into scenarios where the `test_not_found_or_corrupted` test actually tried to download the dataset. This happens for example for `datasets.SBU` since it uses `download=True` as default and in contrast to most other datasets.