### PR TITLE
store LSUN cache in root directory rather than in cwd

### DIFF
--- a/torchvision/datasets/lsun.py
+++ b/torchvision/datasets/lsun.py
@@ -23,7 +23,7 @@ class LSUNClass(VisionDataset):
                              readahead=False, meminit=False)
         with self.env.begin(write=False) as txn:
             self.length = txn.stat()['entries']
-        cache_file = '_cache_' + ''.join(c for c in root if c in string.ascii_letters)
+        cache_file = os.path.join(root, '_cache_' + ''.join(c for c in root if c in string.ascii_letters))
         if os.path.isfile(cache_file):
             self.keys = pickle.load(open(cache_file, "rb"))
         else:


### PR DESCRIPTION
Follow-up from and blocked by https://github.com/pytorch/vision/pull/3454#discussion_r582681328.