### PR TITLE
fixed Gamma casting

### DIFF
--- a/torchvision/transforms/functional_tensor.py
+++ b/torchvision/transforms/functional_tensor.py
@@ -227,7 +227,7 @@ def adjust_gamma(img: Tensor, gamma: float, gain: float = 1) -> Tensor:
     result = (gain * result ** gamma).clamp(0, 1)
 
     if result.dtype != dtype:
-        result = result.to(dtype)
+        result = convert_image_dtype(result, dtype)
     return result
 
 

--- a/torchvision/transforms/functional_tensor.py
+++ b/torchvision/transforms/functional_tensor.py
@@ -226,8 +226,8 @@ def adjust_gamma(img: Tensor, gamma: float, gain: float = 1) -> Tensor:
 
     result = (gain * result ** gamma).clamp(0, 1)
 
-    result = convert_image_dtype(result, dtype)
-    result = result.to(dtype)
+    if result.dtype != dtype:
+        result = convert_image_dtype(result, dtype)
     return result
 
 

--- a/torchvision/transforms/functional_tensor.py
+++ b/torchvision/transforms/functional_tensor.py
@@ -227,7 +227,7 @@ def adjust_gamma(img: Tensor, gamma: float, gain: float = 1) -> Tensor:
     result = (gain * result ** gamma).clamp(0, 1)
 
     if result.dtype != dtype:
-        result = convert_image_dtype(result, dtype)
+        result = result.to(dtype)
     return result
 
 

--- a/torchvision/transforms/functional_tensor.py
+++ b/torchvision/transforms/functional_tensor.py
@@ -226,8 +226,7 @@ def adjust_gamma(img: Tensor, gamma: float, gain: float = 1) -> Tensor:
 
     result = (gain * result ** gamma).clamp(0, 1)
 
-    if result.dtype != dtype:
-        result = convert_image_dtype(result, dtype)
+    result = convert_image_dtype(result, dtype)
     return result
 
 


### PR DESCRIPTION
Fixes #3067 

Removed the double casting of the result to the original dtype.
Now, the casting is only done if the original dtype is different from float32 type which is used to adjust the gamma of the image / tensor.

Since the method requires the image dtype to be in float format. If not, then line no. 400 converts it to the float format. Then needs just one check to change it back to its original format. If it is already in float format then we don't need to change it. 

https://github.com/pytorch/vision/blob/9e71fdafd871e3de9e72a6022291b49100945e29/torchvision/transforms/functional_tensor.py#L397-L406 