### PR TITLE
[OPS, TEST] Add onnx test for batched_nms

### DIFF
--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -330,7 +330,7 @@ class TestCase(unittest.TestCase):
             results = m(*args)
         with freeze_rng_state():
             results_from_imported = m_import(*args)
-        self.assertEqual(results, results_from_imported)
+        self.assertEqual(results, results_from_imported, prec=3e-5)
 
 
 @contextlib.contextmanager

--- a/test/test_onnx.py
+++ b/test/test_onnx.py
@@ -93,17 +93,16 @@ class ONNXExporterTester(unittest.TestCase):
         self.run_model(Module(), [(boxes, scores)])
 
     def test_batched_nms(self):
-        num_boxes = 100
-        boxes = torch.rand(num_boxes, 4)
-        boxes[:, 2:] += torch.rand(num_boxes, 2)
-        scores = torch.randn(num_boxes)
-        idxs = torch.randint(0, 5, size=(num_boxes,))
-
         class Module(torch.nn.Module):
             def forward(self, boxes, scores, idxs):
                 return ops.batched_nms(boxes, scores, idxs, 0.5)
 
-        self.run_model(Module(), [(boxes, scores, idxs)])
+        for num_boxes in (5, 100, 5_000):
+            boxes = torch.rand(num_boxes, 4)
+            boxes[:, 2:] += torch.rand(num_boxes, 2)
+            scores = torch.randn(num_boxes)
+            idxs = torch.randint(0, 5, size=(num_boxes,))
+            self.run_model(Module(), [(boxes, scores, idxs)])
 
     def test_clip_boxes_to_image(self):
         boxes = torch.randn(5, 4) * 500

--- a/test/test_onnx.py
+++ b/test/test_onnx.py
@@ -84,7 +84,7 @@ class ONNXExporterTester(unittest.TestCase):
     def test_nms(self):
         num_boxes = 100
         boxes = torch.rand(num_boxes, 4)
-        boxes[:, 2:] += 1 + torch.rand(num_boxes, 2)
+        boxes[:, 2:] += boxes[:, :2]
         scores = torch.randn(num_boxes)
 
         class Module(torch.nn.Module):
@@ -94,15 +94,16 @@ class ONNXExporterTester(unittest.TestCase):
         self.run_model(Module(), [(boxes, scores)])
 
     def test_batched_nms(self):
+        num_boxes = 100
+        boxes = torch.rand(num_boxes, 4)
+        boxes[:, 2:] += boxes[:, :2]
+        scores = torch.randn(num_boxes)
+        idxs = torch.randint(0, 5, size=(num_boxes,))
+
         class Module(torch.nn.Module):
             def forward(self, boxes, scores, idxs):
                 return ops.batched_nms(boxes, scores, idxs, 0.5)
 
-        num_boxes = 100
-        boxes = torch.rand(num_boxes, 4)
-        boxes[:, 2:] += 1 + torch.rand(num_boxes, 2)
-        scores = torch.randn(num_boxes)
-        idxs = torch.randint(0, 5, size=(num_boxes,))
         self.run_model(Module(), [(boxes, scores, idxs)])
 
     def test_clip_boxes_to_image(self):

--- a/test/test_onnx.py
+++ b/test/test_onnx.py
@@ -82,9 +82,10 @@ class ONNXExporterTester(unittest.TestCase):
                     raise
 
     def test_nms(self):
-        boxes = torch.rand(5, 4)
-        boxes[:, 2:] += torch.rand(5, 2)
-        scores = torch.randn(5)
+        num_boxes = 100
+        boxes = torch.rand(num_boxes, 4)
+        boxes[:, 2:] += 1 + torch.rand(num_boxes, 2)
+        scores = torch.randn(num_boxes)
 
         class Module(torch.nn.Module):
             def forward(self, boxes, scores):
@@ -97,12 +98,12 @@ class ONNXExporterTester(unittest.TestCase):
             def forward(self, boxes, scores, idxs):
                 return ops.batched_nms(boxes, scores, idxs, 0.5)
 
-        for num_boxes in (5, 100, 5_000):
-            boxes = torch.rand(num_boxes, 4)
-            boxes[:, 2:] += 1 + torch.rand(num_boxes, 2)
-            scores = torch.randn(num_boxes)
-            idxs = torch.randint(0, 5, size=(num_boxes,))
-            self.run_model(Module(), [(boxes, scores, idxs)])
+        num_boxes = 100
+        boxes = torch.rand(num_boxes, 4)
+        boxes[:, 2:] += 1 + torch.rand(num_boxes, 2)
+        scores = torch.randn(num_boxes)
+        idxs = torch.randint(0, 5, size=(num_boxes,))
+        self.run_model(Module(), [(boxes, scores, idxs)])
 
     def test_clip_boxes_to_image(self):
         boxes = torch.randn(5, 4) * 500

--- a/test/test_onnx.py
+++ b/test/test_onnx.py
@@ -91,7 +91,7 @@ class ONNXExporterTester(unittest.TestCase):
                 return ops.nms(boxes, scores, 0.5)
 
         self.run_model(Module(), [(boxes, scores)])
-    
+
     def test_batched_nms(self):
         num_boxes = 100
         boxes = torch.rand(num_boxes, 4)

--- a/test/test_onnx.py
+++ b/test/test_onnx.py
@@ -91,6 +91,19 @@ class ONNXExporterTester(unittest.TestCase):
                 return ops.nms(boxes, scores, 0.5)
 
         self.run_model(Module(), [(boxes, scores)])
+    
+    def test_batched_nms(self):
+        num_boxes = 100
+        boxes = torch.rand(num_boxes, 4)
+        boxes[:, 2:] += torch.rand(num_boxes, 2)
+        scores = torch.randn(num_boxes)
+        idxs = torch.randint(0, 5, size=(num_boxes,))
+
+        class Module(torch.nn.Module):
+            def forward(self, boxes, scores, idxs):
+                return ops.batched_nms(boxes, scores, idxs, 0.5)
+
+        self.run_model(Module(), [(boxes, scores, idxs)])
 
     def test_clip_boxes_to_image(self):
         boxes = torch.randn(5, 4) * 500

--- a/test/test_onnx.py
+++ b/test/test_onnx.py
@@ -99,7 +99,7 @@ class ONNXExporterTester(unittest.TestCase):
 
         for num_boxes in (5, 100, 5_000):
             boxes = torch.rand(num_boxes, 4)
-            boxes[:, 2:] += torch.rand(num_boxes, 2)
+            boxes[:, 2:] += 1 + torch.rand(num_boxes, 2)
             scores = torch.randn(num_boxes)
             idxs = torch.randint(0, 5, size=(num_boxes,))
             self.run_model(Module(), [(boxes, scores, idxs)])


### PR DESCRIPTION
Towards debugging the issues in https://github.com/pytorch/vision/pull/3426

This PR just adds a minor simple onnx test for `batch_nms`, as there is already one for `nms`. 