### PR TITLE
[FBcode->GH] change image type for LSUN tests

### DIFF
--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -988,7 +988,7 @@ class LSUNTestCase(datasets_utils.ImageDatasetTestCase):
         folder = f"{cls}_lmdb"
 
         num_images = torch.randint(1, 4, size=()).item()
-        format = "webp"
+        format = "png"
         files = datasets_utils.create_image_folder(root, folder, lambda idx: f"{idx}.{format}", num_images)
 
         with lmdb.open(str(root / folder)) as env, env.begin(write=True) as txn:


### PR DESCRIPTION
The `PIL` binary used in FB internal tests does not support `webp` images. I've only used them, because this type was [used in the official code](https://github.com/fyu/lsun/blob/91e6a9fddc4ffadbb7f08364e9620f7ea2055b10/data.py#L47). Since `LSUN` is otherwise type agnostic, we can simply change the tests.