### PR TITLE
Speed up equalize transform: use bincount instead of histc

### DIFF
--- a/test/test_functional_tensor.py
+++ b/test/test_functional_tensor.py
@@ -984,10 +984,11 @@ class CUDATester(Tester):
         # TODO: when # https://github.com/pytorch/pytorch/issues/53194 is fixed,
         # only use bincount and remove that test.
         size = 1_000
-        img_chan = torch.randint(0, 256, size=(1_000,)).to('cpu')
+        img_chan = torch.randint(0, 256, size=size).to('cpu')
         scaled_cpu = F_t._scale_channel(img_chan)
         scaled_cuda = F_t._scale_channel(img_chan.to('cuda'))
-        self.assertTrue(scaled_cpu.equal(scaled_cuda))
+        self.assertTrue(scaled_cpu.equal(scaled_cuda.to('cpu')))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_functional_tensor.py
+++ b/test/test_functional_tensor.py
@@ -983,7 +983,7 @@ class CUDATester(Tester):
         """
         # TODO: when # https://github.com/pytorch/pytorch/issues/53194 is fixed,
         # only use bincount and remove that test.
-        size = 1_000
+        size = (1_000,)
         img_chan = torch.randint(0, 256, size=size).to('cpu')
         scaled_cpu = F_t._scale_channel(img_chan)
         scaled_cuda = F_t._scale_channel(img_chan.to('cuda'))

--- a/test/test_functional_tensor.py
+++ b/test/test_functional_tensor.py
@@ -977,6 +977,17 @@ class CUDATester(Tester):
     def setUp(self):
         self.device = "cuda"
 
+    def test_scale_channel(self):
+        """Make sure that _scale_channel gives the same results on CPU and GPU as
+        histc or bincount are used depending on the device.
+        """
+        # TODO: when # https://github.com/pytorch/pytorch/issues/53194 is fixed,
+        # only use bincount and remove that test.
+        size = 1_000
+        img_chan = torch.randint(0, 256, size=(1_000,)).to('cpu')
+        scaled_cpu = F_t._scale_channel(img_chan)
+        scaled_cuda = F_t._scale_channel(img_chan.to('cuda'))
+        self.assertTrue(scaled_cpu.equal(scaled_cuda))
 
 if __name__ == '__main__':
     unittest.main()

--- a/torchvision/transforms/functional_tensor.py
+++ b/torchvision/transforms/functional_tensor.py
@@ -886,7 +886,10 @@ def autocontrast(img: Tensor) -> Tensor:
 
 
 def _scale_channel(img_chan):
-    hist = torch.bincount(img_chan.view(-1),  minlength=256)
+    if img_chan.is_cuda:
+        hist = torch.histc(img_chan.to(torch.float32), bins=256, min=0, max=255)
+    else:
+        hist = torch.bincount(img_chan.view(-1), minlength=256)
 
     nonzero_hist = hist[hist != 0]
     step = nonzero_hist[:-1].sum() // 255

--- a/torchvision/transforms/functional_tensor.py
+++ b/torchvision/transforms/functional_tensor.py
@@ -886,7 +886,7 @@ def autocontrast(img: Tensor) -> Tensor:
 
 
 def _scale_channel(img_chan):
-    hist = torch.histc(img_chan.to(torch.float32), bins=256, min=0, max=255)
+    hist = torch.bincount(img_chan.view(-1),  minlength=256)
 
     nonzero_hist = hist[hist != 0]
     step = nonzero_hist[:-1].sum() // 255

--- a/torchvision/transforms/functional_tensor.py
+++ b/torchvision/transforms/functional_tensor.py
@@ -902,6 +902,10 @@ def autocontrast(img: Tensor) -> Tensor:
 
 
 def _scale_channel(img_chan):
+    # TODO: we should expect bincount to always be faster than histc, but this
+    # isn't always the case. Once
+    # https://github.com/pytorch/pytorch/issues/53194 is fixed, remove the if
+    # block and only use bincount.
     if img_chan.is_cuda:
         hist = torch.histc(img_chan.to(torch.float32), bins=256, min=0, max=255)
     else:


### PR DESCRIPTION
`bincount` is faster than `histc` on CPU, so this should speed up (~2X) the `equalize` transforms.

This is sort of a follow-up to https://github.com/pytorch/vision/pull/3334 and https://github.com/pytorch/vision/issues/3173

On GPU:

```py
In [16]: img = torch.randint(0, 256, size=(460 * 680,)).to('cuda')

In [17]: %timeit torch.bincount(img, minlength=256)
1.52 ms ± 25.3 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

In [18]: %timeit torch.histc(img.to(torch.float32), bins=256, min=0, max=255)
127 µs ± 1.07 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```

on CPU (different machine):

```py
img = torch.randint(0, 256, size=(460 * 680,))

%timeit torch.histc(img.to(torch.float32), bins=256, min=0, max=255)
696 µs ± 10.1 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

%timeit torch.bincount(img, minlength=256)
289 µs ± 1.06 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

```