### PR TITLE
Implement ZipFolder

### DIFF
--- a/torchvision/datasets/folder.py
+++ b/torchvision/datasets/folder.py
@@ -1,13 +1,12 @@
 from .vision import VisionDataset
 
 from PIL import Image
+
 import io
 import os
 import os.path
 import zipfile
-
-from pathlib import Path
-from typing import Any, BinaryIO, Callable, cast, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, cast, Dict, List, Optional, Tuple, Union
 
 
 def has_file_allowed_extension(filename: str, extensions: Tuple[str, ...]) -> bool:
@@ -193,16 +192,16 @@ class DatasetFolder(VisionDataset):
 IMG_EXTENSIONS = ('.jpg', '.jpeg', '.png', '.ppm', '.bmp', '.pgm', '.tif', '.tiff', '.webp')
 
 
-def pil_loader(path: Union[str, Path, BinaryIO]) -> Image.Image:
+def pil_loader(path: Union[str, io.IOBase]) -> Image.Image:
     # open path as file to avoid ResourceWarning (https://github.com/python-pillow/Pillow/issues/835)
-    f = path if isinstance(path, BinaryIO) else open(path, 'rb')
+    f = open(path, 'rb') if isinstance(path, str) else path
     img = Image.open(f)
     f.close()
     return img.convert('RGB')
 
 
 # TODO: specify the return type
-def accimage_loader(path: Union[str, Path, BinaryIO]) -> Any:
+def accimage_loader(path: Union[str, io.IOBase]) -> Any:
     import accimage
     try:
         return accimage.Image(path)
@@ -211,7 +210,7 @@ def accimage_loader(path: Union[str, Path, BinaryIO]) -> Any:
         return pil_loader(path)
 
 
-def default_loader(path: Union[str, Path, BinaryIO]) -> Any:
+def default_loader(path: Union[str, io.IOBase]) -> Any:
     from torchvision import get_image_backend
     if get_image_backend() == 'accimage':
         return accimage_loader(path)

--- a/torchvision/datasets/folder.py
+++ b/torchvision/datasets/folder.py
@@ -7,7 +7,7 @@ import os.path
 import zipfile
 
 from pathlib import Path
-from typing import Any, BinaryIO, Callable, cast, Dict, List, Optional,Tuple, Union
+from typing import Any, BinaryIO, Callable, cast, Dict, List, Optional, Tuple, Union
 
 
 def has_file_allowed_extension(filename: str, extensions: Tuple[str, ...]) -> bool:
@@ -142,7 +142,8 @@ class DatasetFolder(VisionDataset):
         self.samples = samples
         self.targets = [s[1] for s in samples]
 
-    def make_dataset(self,
+    def make_dataset(
+        self,
         directory: str,
         class_to_idx: Dict[str, int],
         extensions: Optional[Tuple[str, ...]] = None,
@@ -290,7 +291,8 @@ class ZipFolder(DatasetFolder):
                     zip_path = os.path.join(zip_root, _file)
                     zf.write(org_path, zip_path)
 
-    def make_dataset(self,
+    def make_dataset(
+        self,
         directory: str,
         class_to_idx: Dict[str, int],
         extensions: Optional[Tuple[str, ...]] = None,

--- a/torchvision/datasets/folder.py
+++ b/torchvision/datasets/folder.py
@@ -192,7 +192,7 @@ class DatasetFolder(VisionDataset):
 IMG_EXTENSIONS = ('.jpg', '.jpeg', '.png', '.ppm', '.bmp', '.pgm', '.tif', '.tiff', '.webp')
 
 
-def pil_loader(path: Union[str, io.IOBase]) -> Image.Image:
+def pil_loader(path: Union[str, io.BytesIO]) -> Image.Image:
     # open path as file to avoid ResourceWarning (https://github.com/python-pillow/Pillow/issues/835)
     f = open(path, 'rb') if isinstance(path, str) else path
     img = Image.open(f)
@@ -201,7 +201,7 @@ def pil_loader(path: Union[str, io.IOBase]) -> Image.Image:
 
 
 # TODO: specify the return type
-def accimage_loader(path: Union[str, io.IOBase]) -> Any:
+def accimage_loader(path: Union[str, io.BytesIO]) -> Any:
     import accimage
     try:
         return accimage.Image(path)
@@ -210,7 +210,7 @@ def accimage_loader(path: Union[str, io.IOBase]) -> Any:
         return pil_loader(path)
 
 
-def default_loader(path: Union[str, io.IOBase]) -> Any:
+def default_loader(path: Union[str, io.BytesIO]) -> Any:
     from torchvision import get_image_backend
     if get_image_backend() == 'accimage':
         return accimage_loader(path)

--- a/torchvision/datasets/folder.py
+++ b/torchvision/datasets/folder.py
@@ -1,5 +1,4 @@
 from .vision import VisionDataset
-from torchvision import get_image_backend
 
 from PIL import Image
 import io
@@ -210,6 +209,7 @@ def accimage_loader(path: str) -> Any:
 
 
 def default_loader(path: str) -> Any:
+    from torchvision import get_image_backend
     if get_image_backend() == 'accimage':
         return accimage_loader(path)
     else:

--- a/torchvision/datasets/folder.py
+++ b/torchvision/datasets/folder.py
@@ -1,9 +1,11 @@
 from .vision import VisionDataset
+from torchvision import get_image_backend
 
 from PIL import Image
-
+import io
 import os
 import os.path
+import zipfile
 from typing import Any, Callable, cast, Dict, List, Optional, Tuple
 
 
@@ -208,7 +210,6 @@ def accimage_loader(path: str) -> Any:
 
 
 def default_loader(path: str) -> Any:
-    from torchvision import get_image_backend
     if get_image_backend() == 'accimage':
         return accimage_loader(path)
     else:
@@ -255,3 +256,84 @@ class ImageFolder(DatasetFolder):
                                           target_transform=target_transform,
                                           is_valid_file=is_valid_file)
         self.imgs = self.samples
+
+class ZipFolder(DatasetFolder):
+    def __init__(self, root: str, transform: Optional[Callable] = None, target_transform: Optional[Callable] = None,
+                 is_valid_file: Optional[Callable[[str], bool]] = None, memory: bool = True) -> None:
+        if not root.endswith('.zip'):
+            raise TypeError("Need ZIP file for data source: ", root)
+        if memory:
+            with open(root, 'rb') as z:
+                data = z.read()
+            self.root_zip = zipfile.ZipFile(io.BytesIO(data), 'r')
+        else:
+            self.root_zip = zipfile.ZipFile(root, 'r')
+        super().__init__(root, self.zip_loader, IMG_EXTENSIONS if is_valid_file is None else None,
+                         transform=transform, target_transform=target_transform, is_valid_file=is_valid_file)
+        self.imgs = self.samples
+
+    @staticmethod
+    def initialize_from_folder(root: str, zip_path: str = None):
+        root = os.path.normpath(root)
+        folder_dir, folder_base = os.path.split(root)
+        if zip_path is None:
+            zip_path = os.path.join(folder_dir, f'{folder_base}_store.zip')
+        with zipfile.ZipFile(zip_path, mode='w', compression=zipfile.ZIP_STORED) as zf:
+            for walk_root, walk_dirs, walk_files in os.walk(root):
+                zip_root = walk_root.removeprefix(folder_dir)
+                for _file in walk_files:
+                    org_path = os.path.join(walk_root, _file)
+                    zip_path = os.path.join(zip_root, _file)
+                    zf.write(org_path, zip_path)
+
+    def make_dataset(
+        self,
+        directory: str,
+        class_to_idx: dict[str, int],
+        extensions: Optional[tuple[str, ...]] = None,
+        is_valid_file: Optional[Callable[[str], bool]] = None,
+    ) -> list[tuple[str, int]]:
+        instances = []
+        both_none = extensions is None and is_valid_file is None
+        both_something = extensions is not None and is_valid_file is not None
+        if both_none or both_something:
+            raise ValueError("Both extensions and is_valid_file cannot be None or not None at the same time")
+        if extensions is not None:
+            def is_valid_file(x: str) -> bool:
+                return has_file_allowed_extension(x, cast(tuple[str, ...], extensions))
+        is_valid_file = cast(Callable[[str], bool], is_valid_file)
+        for filepath in self.root_zip.namelist():
+            if is_valid_file(filepath):
+                target_class = os.path.basename(os.path.dirname(filepath))
+                instances.append((filepath, class_to_idx[target_class]))
+        return instances
+
+    def zip_loader(self, path: str) -> Image.Image:
+        f = io.BytesIO(self.root_zip.read(path))
+        if get_image_backend() == 'accimage':
+            try:
+                import accimage  # type: ignore
+                return accimage.Image(f)
+            except IOError:
+                pass   # fall through to PIL
+        return Image.open(f).convert('RGB')
+
+    def _find_classes(self, *args, **kwargs):
+        """
+        Finds the class folders in a dataset.
+        Args:
+            dir (string): Root directory path.
+        Returns:
+            tuple: (classes, class_to_idx) where classes are relative to (dir), and class_to_idx is a dictionary.
+        Ensures:
+            No class is a subdirectory of another.
+        """
+        classes = set()
+        for filepath in self.root_zip.namelist():
+            root, target_class = os.path.split(os.path.dirname(filepath))
+            if root:
+                classes.add(target_class)
+        classes = list(classes)
+        classes.sort()
+        class_to_idx = {classes[i]: i for i in range(len(classes))}
+        return classes, class_to_idx

--- a/torchvision/datasets/folder.py
+++ b/torchvision/datasets/folder.py
@@ -257,6 +257,7 @@ class ImageFolder(DatasetFolder):
                                           is_valid_file=is_valid_file)
         self.imgs = self.samples
 
+
 class ZipFolder(DatasetFolder):
     def __init__(self, root: str, transform: Optional[Callable] = None, target_transform: Optional[Callable] = None,
                  is_valid_file: Optional[Callable[[str], bool]] = None, memory: bool = True) -> None:
@@ -289,10 +290,10 @@ class ZipFolder(DatasetFolder):
     def make_dataset(
         self,
         directory: str,
-        class_to_idx: dict[str, int],
-        extensions: Optional[tuple[str, ...]] = None,
+        class_to_idx: Dict[str, int],
+        extensions: Optional[Tuple[str, ...]] = None,
         is_valid_file: Optional[Callable[[str], bool]] = None,
-    ) -> list[tuple[str, int]]:
+    ) -> List[Tuple[str, int]]:
         instances = []
         both_none = extensions is None and is_valid_file is None
         both_something = extensions is not None and is_valid_file is not None
@@ -300,7 +301,7 @@ class ZipFolder(DatasetFolder):
             raise ValueError("Both extensions and is_valid_file cannot be None or not None at the same time")
         if extensions is not None:
             def is_valid_file(x: str) -> bool:
-                return has_file_allowed_extension(x, cast(tuple[str, ...], extensions))
+                return has_file_allowed_extension(x, cast(Tuple[str, ...], extensions))
         is_valid_file = cast(Callable[[str], bool], is_valid_file)
         for filepath in self.root_zip.namelist():
             if is_valid_file(filepath):
@@ -308,15 +309,8 @@ class ZipFolder(DatasetFolder):
                 instances.append((filepath, class_to_idx[target_class]))
         return instances
 
-    def zip_loader(self, path: str) -> Image.Image:
-        f = io.BytesIO(self.root_zip.read(path))
-        if get_image_backend() == 'accimage':
-            try:
-                import accimage  # type: ignore
-                return accimage.Image(f)
-            except IOError:
-                pass   # fall through to PIL
-        return Image.open(f).convert('RGB')
+    def zip_loader(self, path: str) -> Any:
+        return default_loader(io.BytesIO(self.root_zip.read(path)))
 
     def _find_classes(self, *args, **kwargs):
         """

--- a/torchvision/datasets/folder.py
+++ b/torchvision/datasets/folder.py
@@ -195,9 +195,9 @@ IMG_EXTENSIONS = ('.jpg', '.jpeg', '.png', '.ppm', '.bmp', '.pgm', '.tif', '.tif
 def pil_loader(path: Union[str, io.BytesIO]) -> Image.Image:
     # open path as file to avoid ResourceWarning (https://github.com/python-pillow/Pillow/issues/835)
     f = open(path, 'rb') if isinstance(path, str) else path
-    img = Image.open(f)
+    img = Image.open(f).convert('RGB')
     f.close()
-    return img.convert('RGB')
+    return img
 
 
 # TODO: specify the return type


### PR DESCRIPTION
Implement a `ZipFolder` class, which follows my previous PR #3215 .  
The idea is very similar to the `TarDataset` issue on [pytorch/pytorch](https://github.com/pytorch/pytorch/issues/49440).  
It archives the ImageFolder to be a `zip` without any compression. The functions are almost the same as `ImageFolder`.  

Advantage: it's better for long term use with one single archive file, and makes loading and transferring faster and more convenient by avoiding small files IO (when `memory=True`), especially on HDD disk.  
When argument `memory` is set to be true, it'll read all bytes of the zip into memory at beginning. Otherwise, the default loading by `zipfile` would be lazy, leading to the same mechanism as `ImageFolder`.

Besides the basic utility, I also add a staticmethod `initialize_from_folder` that makes a folder (follows the `ImageFolder` requirements) to be the zip format.  
