### PR TITLE
rename version 'master (0.9.0+cu111 )' -> '0.9.0'

### DIFF
--- a/0.9/datasets.html
+++ b/0.9/datasets.html
@@ -190,7 +190,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/vision/versions.html'>master (0.9.0+cu111 ) &#x25BC</a>
+      <a href='https://pytorch.org/vision/versions.html'>0.9.0 &#x25BC</a>
     </div>
     
 

--- a/0.9/genindex.html
+++ b/0.9/genindex.html
@@ -189,7 +189,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/vision/versions.html'>master (0.9.0+cu111 ) &#x25BC</a>
+      <a href='https://pytorch.org/vision/versions.html'>0.9.0 &#x25BC</a>
     </div>
     
 

--- a/0.9/index.html
+++ b/0.9/index.html
@@ -189,7 +189,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/vision/versions.html'>master (0.9.0+cu111 ) &#x25BC</a>
+      <a href='https://pytorch.org/vision/versions.html'>0.9.0 &#x25BC</a>
     </div>
     
 

--- a/0.9/io.html
+++ b/0.9/io.html
@@ -190,7 +190,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/vision/versions.html'>master (0.9.0+cu111 ) &#x25BC</a>
+      <a href='https://pytorch.org/vision/versions.html'>0.9.0 &#x25BC</a>
     </div>
     
 

--- a/0.9/models.html
+++ b/0.9/models.html
@@ -190,7 +190,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/vision/versions.html'>master (0.9.0+cu111 ) &#x25BC</a>
+      <a href='https://pytorch.org/vision/versions.html'>0.9.0 &#x25BC</a>
     </div>
     
 

--- a/0.9/ops.html
+++ b/0.9/ops.html
@@ -190,7 +190,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/vision/versions.html'>master (0.9.0+cu111 ) &#x25BC</a>
+      <a href='https://pytorch.org/vision/versions.html'>0.9.0 &#x25BC</a>
     </div>
     
 

--- a/0.9/py-modindex.html
+++ b/0.9/py-modindex.html
@@ -191,7 +191,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/vision/versions.html'>master (0.9.0+cu111 ) &#x25BC</a>
+      <a href='https://pytorch.org/vision/versions.html'>0.9.0 &#x25BC</a>
     </div>
     
 

--- a/0.9/search.html
+++ b/0.9/search.html
@@ -188,7 +188,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/vision/versions.html'>master (0.9.0+cu111 ) &#x25BC</a>
+      <a href='https://pytorch.org/vision/versions.html'>0.9.0 &#x25BC</a>
     </div>
     
 

--- a/0.9/transforms.html
+++ b/0.9/transforms.html
@@ -190,7 +190,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/vision/versions.html'>master (0.9.0+cu111 ) &#x25BC</a>
+      <a href='https://pytorch.org/vision/versions.html'>0.9.0 &#x25BC</a>
     </div>
     
 

--- a/0.9/utils.html
+++ b/0.9/utils.html
@@ -189,7 +189,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/vision/versions.html'>master (0.9.0+cu111 ) &#x25BC</a>
+      <a href='https://pytorch.org/vision/versions.html'>0.9.0 &#x25BC</a>
     </div>
     
 


### PR DESCRIPTION
I forgot to tweak the lines in `conf.py` that adjust the version name when generating the release documents, so I ran a sed script to replace it now. This should be part of the conf.py: when RELEASE is set it should trim the version apporpriately.

@brianjo 