### PR TITLE
Update resnet.py

### DIFF
--- a/torchvision/models/resnet.py
+++ b/torchvision/models/resnet.py
@@ -1,7 +1,7 @@
 import torch
 from torch import Tensor
 import torch.nn as nn
-from .utils import load_state_dict_from_url
+from torch.hub import load_state_dict_from_url
 from typing import Type, Any, Callable, Union, List, Optional
 
 


### PR DESCRIPTION
The original code "from .utils import load_state_dict_from_url" is not applicable.
you connot import  load_state_dict_from_url from .utils.
change ".utils" to "torch.hub" can fix the problem.