### PR TITLE
fix test_extract_(zip|tar|tar_xz|gzip) on windows

### DIFF
--- a/test/test_datasets_utils.py
+++ b/test/test_datasets_utils.py
@@ -103,7 +103,7 @@ class Tester(unittest.TestCase):
     def test_extract_zip(self):
         def create_archive(root, content="this is the content"):
             file = os.path.join(root, "dst.txt")
-            archive = os.path.join(root, f"archive.zip")
+            archive = os.path.join(root, "archive.zip")
 
             with zipfile.ZipFile(archive, "w") as zf:
                 zf.writestr(os.path.basename(file), content)


### PR DESCRIPTION
These tests were disabled before, because they would fail on Windows due to this construct

https://github.com/pytorch/vision/blob/3428a7de4ddf2c6fc27891ab0d3ede128d75372f/test/test_datasets_utils.py#L108-L110

On Windows this raised a `PermissionsError` because `zipfile.ZipFile` tried to open an already open file. You can find a similar construct in all the disabled tests.

Given that all this already happens in a temporary directory that will be deleted after the test is complete, it is unnecessarily complicated to also create the names of the files at random. This PR fixes this which makes the tests more legible as well as able to run on Windows. 
