### PR TITLE
Fix redirect behavior of datasets.utils.download_url

### DIFF
--- a/torchvision/datasets/utils.py
+++ b/torchvision/datasets/utils.py
@@ -65,7 +65,7 @@ def _get_redirect_url(url: str, max_hops: int = 10) -> str:
     import requests
 
     for hop in range(max_hops + 1):
-        response = requests.get(url)
+        response = requests.head(url)
 
         if response.url == url or response.url is None:
             return url


### PR DESCRIPTION
Fixes #3560. #3236 introduced redirect resolving in [`datasets.utils.download_url()`](https://github.com/pytorch/vision/blob/c808d163f6c65ca851db59e9966807a9220fc493/torchvision/datasets/utils.py#L116). For this `requests.get()` is used:

https://github.com/pytorch/vision/blob/c808d163f6c65ca851db59e9966807a9220fc493/torchvision/datasets/utils.py#L64-L75

This has two downsides:

1. `requests.get()` already downloads the data although we only want to check if a redirect happens. Meaning, we download the data twice. This never stood out in our tests, since we download a small amount of data which leads to a minimal increase in testing time. For large datasets, say `STL10` #3560, this is not acceptable. We should switch to a head requests, e.g. `requests.head()`, that also carries the redirect information without downloading any data.
2. Every dataset that has a the `download` flag is now indirectly dependent on `requests` without any mention of this in the documentation.

This PR solves both.
