### PR TITLE
Enable custom default config for dataset tests

### DIFF
--- a/test/datasets_utils.py
+++ b/test/datasets_utils.py
@@ -224,19 +224,27 @@ class DatasetTestCase(unittest.TestCase):
     DEFAULT_CONFIG = None
     REQUIRED_PACKAGES = None
 
-
+    # These keyword arguments are checked by test_transforms in case they are available in DATASET_CLASS.
     _TRANSFORM_KWARGS = {
         "transform",
         "target_transform",
         "transforms",
     }
+    # These keyword arguments get a 'special' treatment and should not be set in CONFIGS or DEFAULT_CONFIG.
     _SPECIAL_KWARGS = {
         *_TRANSFORM_KWARGS,
         "download",
     }
+
+    # These fields are populated during setupClass() within _populate_private_class_attributes()
+
+    # This will be a dictionary containing all keyword arguments with their respective default values extracted from
+    # the dataset constructor.
     _KWARG_DEFAULTS = None
+    # This will be a set of all _SPECIAL_KWARGS that the dataset constructor takes.
     _HAS_SPECIAL_KWARG = None
 
+    # These functions are disabled during dataset creation in create_dataset().
     _CHECK_FUNCTIONS = {
         "check_md5",
         "check_integrity",

--- a/test/datasets_utils.py
+++ b/test/datasets_utils.py
@@ -166,9 +166,11 @@ class DatasetTestCase(unittest.TestCase):
 
     Optionally, you can overwrite the following class attributes:
 
-        - CONFIGS (Sequence[Dict[str, Any]]): Additional configs that should be tested. Each dictonary can contain an
+        - CONFIGS (Sequence[Dict[str, Any]]): Additional configs that should be tested. Each dictionary can contain an
             arbitrary combination of dataset parameters that are **not** ``transform``, ``target_transform``,
-            ``transforms``, or ``download``. The first element will be used as default configuration.
+            ``transforms``, or ``download``. Each config will be updated by potentially missing default values.
+        - DEFAULT_CONFIG (Dict[str, Any]): Config that will be used by default. This defaults to all keyword arguments
+            of the dataset minus ``transform``, ``target_transform``, ``transforms``, and ``download``.
         - REQUIRED_PACKAGES (Iterable[str]): Additional dependencies to use the dataset. If these packages are not
             available, the tests are skipped.
 

--- a/test/datasets_utils.py
+++ b/test/datasets_utils.py
@@ -426,8 +426,8 @@ class DatasetTestCase(unittest.TestCase):
                     importlib.import_module(pkg)
             except ImportError as error:
                 raise unittest.SkipTest(
-                    f"The package '{error.name}' is required to load the dataset '{cls.DATASET_CLASS.__name__}' but is "
-                    f"not installed."
+                    f"The package '{pkg}' is required to load the dataset '{cls.DATASET_CLASS.__name__}' but is not "
+                    f"installed."
                 )
 
     def _split_kwargs(self, kwargs):

--- a/test/datasets_utils.py
+++ b/test/datasets_utils.py
@@ -402,7 +402,7 @@ class DatasetTestCase(unittest.TestCase):
 
     @classmethod
     def _process_optional_public_class_attributes(cls):
-        def update_config(config, name):
+        def check_config(config, name):
             special_kwargs = tuple(f"'{name}'" for name in cls._SPECIAL_KWARGS if name in config)
             if special_kwargs:
                 raise UsageError(
@@ -412,13 +412,14 @@ class DatasetTestCase(unittest.TestCase):
                     f"you need to write a custom test (*not* test case), e.g. test_custom_transform()."
                 )
 
-            kwarg_defaults = cls._KWARG_DEFAULTS.copy()
-            kwarg_defaults.update(config)
-            return kwarg_defaults
+        if cls.CONFIGS is None:
+            for idx, config in enumerate(cls.CONFIGS):
+                check_config(config, f"CONFIGS[{idx}]")
 
-        if cls.CONFIGS:
-            cls.CONFIGS = tuple(update_config(config, f"CONFIGS[{idx}]") for idx, config in enumerate(cls.CONFIGS))
-        cls.DEFAULT_CONFIG = update_config(cls.DEFAULT_CONFIG or dict(), "DEFAULT_CONFIG")
+        if cls.DEFAULT_CONFIG is None:
+            cls.DEFAULT_CONFIG = cls._KWARG_DEFAULTS.copy()
+        else:
+            check_config(cls.DEFAULT_CONFIG , "DEFAULT_CONFIG")
 
         if cls.REQUIRED_PACKAGES:
             missing_pkgs = []

--- a/test/datasets_utils.py
+++ b/test/datasets_utils.py
@@ -368,11 +368,7 @@ class DatasetTestCase(unittest.TestCase):
                 continue
 
             defaults.append(
-                {
-                    kwarg: default
-                    for kwarg, default in zip(argspec.args[-len(argspec.defaults):], argspec.defaults)
-                    if kwarg not in cls._SPECIAL_KWARGS
-                }
+                {kwarg: default for kwarg, default in zip(argspec.args[-len(argspec.defaults) :], argspec.defaults)}
             )
 
             if not argspec.varkw:
@@ -381,9 +377,17 @@ class DatasetTestCase(unittest.TestCase):
         default_config = dict()
         for config in reversed(defaults):
             default_config.update(config)
-        cls._DEFAULT_CONFIG = default_config
 
-        cls._HAS_SPECIAL_KWARG = {name for name in cls._SPECIAL_KWARGS if name in argspec.args}
+        has_special_kwargs = set()
+        for name in cls._SPECIAL_KWARGS:
+            if name not in default_config:
+                continue
+
+            del default_config[name]
+            has_special_kwargs.add(name)
+
+        cls._DEFAULT_CONFIG = default_config
+        cls._HAS_SPECIAL_KWARG = has_special_kwargs
 
     @classmethod
     def _process_optional_public_class_attributes(cls):

--- a/test/datasets_utils.py
+++ b/test/datasets_utils.py
@@ -114,7 +114,7 @@ def requires_lazy_imports(*modules):
     return outer_wrapper
 
 
-def test_all_configs(*, remove_duplicates=True, strict=False):
+def test_all_configs(test):
     """Decorator to run test against all configurations.
 
     Add this as decorator to an arbitrary test to run it against all configurations. This includes
@@ -130,45 +130,36 @@ def test_all_configs(*, remove_duplicates=True, strict=False):
 
     .. note::
 
-        This will not preserve a potential ordering of the configuration or an inner ordering of a configuration.
-
-    Args:
-        remove_duplicates (bool): If ``True`` (default), tries to remove duplicate configurations. If any
-            :class:`Exception` is encountered, e.g. a configuration contains an unhashable value, the complete set of
-            configurations is used as fallback.
-        strict (bool): If ``True``, raise an :class:`Exception` during duplicate removing instead of using a fallback.
+        This will try to remove duplicate configurations. During this process it will not not preserve a potential
+        ordering of the configurations or an inner ordering of a configuration.
     """
 
-    def maybe_remove_duplicates(configs, *, strict):
+    def maybe_remove_duplicates(configs):
         try:
             return [dict(config_) for config_ in set(tuple(sorted(config.items())) for config in configs)]
-        except Exception:
-            if strict:
-                raise
-
+        except TypeError:
+            # A TypeError will be raised if a value of any config is not hashable, e.g. a list. In that case duplicate
+            # removal would be a lot more elaborate and we simply bail out.
             return configs
 
-    def decorator(test):
-        @functools.wraps(test)
-        def wrapper(self):
-            configs = []
-            if self.DEFAULT_CONFIG is not None:
-                configs.append(self.DEFAULT_CONFIG)
-            if self.ADDITIONAL_CONFIGS is not None:
-                configs.extend(self.ADDITIONAL_CONFIGS)
+    @functools.wraps(test)
+    def wrapper(self):
+        configs = []
+        if self.DEFAULT_CONFIG is not None:
+            configs.append(self.DEFAULT_CONFIG)
+        if self.ADDITIONAL_CONFIGS is not None:
+            configs.extend(self.ADDITIONAL_CONFIGS)
 
-            if not configs:
-                configs.append(self._KWARG_DEFAULTS.copy())
-            elif remove_duplicates:
-                configs = maybe_remove_duplicates(configs, strict=strict)
+        if not configs:
+            configs.append(self._KWARG_DEFAULTS.copy())
+        else:
+            configs = maybe_remove_duplicates(configs)
 
-            for config in configs:
-                with self.subTest(**config):
-                    test(self, config)
+        for config in configs:
+            with self.subTest(**config):
+                test(self, config)
 
-        return wrapper
-
-    return decorator
+    return wrapper
 
 
 def combinations_grid(**kwargs):
@@ -534,12 +525,12 @@ class DatasetTestCase(unittest.TestCase):
         with self.create_dataset() as (dataset, _):
             self.assertIsInstance(dataset, torchvision.datasets.VisionDataset)
 
-    @test_all_configs()
+    @test_all_configs
     def test_str_smoke(self, config):
         with self.create_dataset(config) as (dataset, _):
             self.assertIsInstance(str(dataset), str)
 
-    @test_all_configs()
+    @test_all_configs
     def test_feature_types(self, config):
         with self.create_dataset(config) as (dataset, _):
             example = dataset[0]
@@ -560,12 +551,12 @@ class DatasetTestCase(unittest.TestCase):
                 with self.subTest(idx=idx):
                     self.assertIsInstance(feature, expected_feature_type)
 
-    @test_all_configs()
+    @test_all_configs
     def test_num_examples(self, config):
         with self.create_dataset(config) as (dataset, info):
             self.assertEqual(len(dataset), info["num_examples"])
 
-    @test_all_configs()
+    @test_all_configs
     def test_transforms(self, config):
         mock = unittest.mock.Mock(wraps=lambda *args: args[0] if len(args) == 1 else args)
         for kwarg in self._TRANSFORM_KWARGS:

--- a/test/datasets_utils.py
+++ b/test/datasets_utils.py
@@ -151,7 +151,7 @@ def test_all_configs(test):
             configs.extend(self.ADDITIONAL_CONFIGS)
 
         if not configs:
-            configs.append(self._KWARG_DEFAULTS.copy())
+            configs = [self._KWARG_DEFAULTS.copy()]
         else:
             configs = maybe_remove_duplicates(configs)
 

--- a/test/datasets_utils.py
+++ b/test/datasets_utils.py
@@ -194,7 +194,8 @@ class DatasetTestCase(unittest.TestCase):
 
         - DEFAULT_CONFIG (Dict[str, Any]): Config that will be used by default. If omitted, this defaults to all
             keyword arguments of the dataset minus ``transform``, ``target_transform``, ``transforms``, and
-            ``download``.
+            ``download``. Overwrite this if you want to use a default value for a parameter for which the dataset does
+            not provide one.
         - ADDITIONAL_CONFIGS (Sequence[Dict[str, Any]]): Additional configs that should be tested. Each dictionary can
             contain an arbitrary combination of dataset parameters that are **not** ``transform``, ``target_transform``,
             ``transforms``, or ``download``.
@@ -257,7 +258,7 @@ class DatasetTestCase(unittest.TestCase):
         "target_transform",
         "transforms",
     }
-    # These keyword arguments get a 'special' treatment and should not be set in CONFIGS or DEFAULT_CONFIG.
+    # These keyword arguments get a 'special' treatment and should not be set in DEFAULT_CONFIG or ADDITIONAL_CONFIGS.
     _SPECIAL_KWARGS = {
         *_TRANSFORM_KWARGS,
         "download",
@@ -294,8 +295,8 @@ class DatasetTestCase(unittest.TestCase):
         Args:
             tmpdir (str): Path to a temporary directory. For most cases this acts as root directory for the dataset
                 to be created and in turn also for the fake data injected here.
-            config (Dict[str, Any]): Configuration that will be used to create the dataset. It provides at least fields
-                for all dataset parameters with default values.
+            config (Dict[str, Any]): Configuration that will be passed to the dataset constructor. It provides at least
+                fields for all dataset parameters with default values.
 
         Returns:
             (Tuple[str]): ``tmpdir`` which corresponds to ``root`` for most datasets.
@@ -312,8 +313,8 @@ class DatasetTestCase(unittest.TestCase):
         Args:
             tmpdir (str): Path to a temporary directory. For most cases this acts as root directory for the dataset
                 to be created and in turn also for the fake data injected here.
-            config (Dict[str, Any]): Configuration that will be used to create the dataset. It provides at least fields
-                for all dataset parameters with default values.
+            config (Dict[str, Any]): Configuration that will be passed to the dataset constructor. It provides at least
+                fields for all dataset parameters with default values.
 
         Needs to return one of the following:
 

--- a/test/datasets_utils.py
+++ b/test/datasets_utils.py
@@ -379,7 +379,7 @@ class DatasetTestCase(unittest.TestCase):
                 continue
 
             defaults.append(
-                {kwarg: default for kwarg, default in zip(argspec.args[-len(argspec.defaults) :], argspec.defaults)}
+                {kwarg: default for kwarg, default in zip(argspec.args[-len(argspec.defaults):], argspec.defaults)}
             )
 
             if not argspec.varkw:
@@ -420,14 +420,18 @@ class DatasetTestCase(unittest.TestCase):
             cls.CONFIGS = tuple(update_config(config, f"CONFIGS[{idx}]") for idx, config in enumerate(cls.CONFIGS))
         cls.DEFAULT_CONFIG = update_config(cls.DEFAULT_CONFIG or dict(), "DEFAULT_CONFIG")
 
-        if cls.REQUIRED_PACKAGES is not None:
-            try:
-                for pkg in cls.REQUIRED_PACKAGES:
+        if cls.REQUIRED_PACKAGES:
+            missing_pkgs = []
+            for pkg in cls.REQUIRED_PACKAGES:
+                try:
                     importlib.import_module(pkg)
-            except ImportError as error:
+                except ImportError:
+                    missing_pkgs.append(f"'{pkg}'")
+
+            if missing_pkgs:
                 raise unittest.SkipTest(
-                    f"The package '{pkg}' is required to load the dataset '{cls.DATASET_CLASS.__name__}' but is not "
-                    f"installed."
+                    f"The package(s) {', '.join(missing_pkgs)} are required to load the dataset "
+                    f"'{cls.DATASET_CLASS.__name__}', but are not installed."
                 )
 
     def _split_kwargs(self, kwargs):

--- a/test/datasets_utils.py
+++ b/test/datasets_utils.py
@@ -357,13 +357,31 @@ class DatasetTestCase(unittest.TestCase):
 
     @classmethod
     def _populate_private_class_attributes(cls):
-        argspec = inspect.getfullargspec(cls.DATASET_CLASS.__init__)
+        defaults = []
+        for cls_ in cls.DATASET_CLASS.__mro__:
+            if cls_ is torchvision.datasets.VisionDataset:
+                break
 
-        cls._DEFAULT_CONFIG = {
-            kwarg: default
-            for kwarg, default in zip(argspec.args[-len(argspec.defaults):], argspec.defaults)
-            if kwarg not in cls._SPECIAL_KWARGS
-        }
+            argspec = inspect.getfullargspec(cls_.__init__)
+
+            if not argspec.defaults:
+                continue
+
+            defaults.append(
+                {
+                    kwarg: default
+                    for kwarg, default in zip(argspec.args[-len(argspec.defaults):], argspec.defaults)
+                    if kwarg not in cls._SPECIAL_KWARGS
+                }
+            )
+
+            if not argspec.varkw:
+                break
+
+        default_config = dict()
+        for config in reversed(defaults):
+            default_config.update(config)
+        cls._DEFAULT_CONFIG = default_config
 
         cls._HAS_SPECIAL_KWARG = {name for name in cls._SPECIAL_KWARGS if name in argspec.args}
 

--- a/test/datasets_utils.py
+++ b/test/datasets_utils.py
@@ -412,14 +412,14 @@ class DatasetTestCase(unittest.TestCase):
                     f"you need to write a custom test (*not* test case), e.g. test_custom_transform()."
                 )
 
-        if cls.CONFIGS is None:
+        if cls.CONFIGS is not None:
             for idx, config in enumerate(cls.CONFIGS):
                 check_config(config, f"CONFIGS[{idx}]")
 
-        if cls.DEFAULT_CONFIG is None:
-            cls.DEFAULT_CONFIG = cls._KWARG_DEFAULTS.copy()
+        if cls.DEFAULT_CONFIG is not None:
+            check_config(cls.DEFAULT_CONFIG, "DEFAULT_CONFIG")
         else:
-            check_config(cls.DEFAULT_CONFIG , "DEFAULT_CONFIG")
+            cls.DEFAULT_CONFIG = cls._KWARG_DEFAULTS.copy()
 
         if cls.REQUIRED_PACKAGES:
             missing_pkgs = []

--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -369,7 +369,7 @@ class Caltech101TestCase(datasets_utils.ImageDatasetTestCase):
     DATASET_CLASS = datasets.Caltech101
     FEATURE_TYPES = (PIL.Image.Image, (int, np.ndarray, tuple))
 
-    CONFIGS = datasets_utils.combinations_grid(target_type=("category", "annotation", ["category", "annotation"]))
+    ADDITIONAL_CONFIGS = datasets_utils.combinations_grid(target_type=("annotation", ["category", "annotation"]))
     REQUIRED_PACKAGES = ("scipy",)
 
     def inject_fake_data(self, tmpdir, config):
@@ -467,7 +467,7 @@ class Caltech256TestCase(datasets_utils.ImageDatasetTestCase):
 class WIDERFaceTestCase(datasets_utils.ImageDatasetTestCase):
     DATASET_CLASS = datasets.WIDERFace
     FEATURE_TYPES = (PIL.Image.Image, (dict, type(None)))  # test split returns None as target
-    CONFIGS = datasets_utils.combinations_grid(split=('train', 'val', 'test'))
+    ADDITIONAL_CONFIGS = datasets_utils.combinations_grid(split=('val', 'test'))
 
     def inject_fake_data(self, tmpdir, config):
         widerface_dir = pathlib.Path(tmpdir) / 'widerface'
@@ -522,7 +522,7 @@ class WIDERFaceTestCase(datasets_utils.ImageDatasetTestCase):
 class ImageNetTestCase(datasets_utils.ImageDatasetTestCase):
     DATASET_CLASS = datasets.ImageNet
     REQUIRED_PACKAGES = ('scipy',)
-    CONFIGS = datasets_utils.combinations_grid(split=('train', 'val'))
+    ADDITIONAL_CONFIGS = [dict(split="val")]
 
     def inject_fake_data(self, tmpdir, config):
         tmpdir = pathlib.Path(tmpdir)
@@ -552,7 +552,7 @@ class ImageNetTestCase(datasets_utils.ImageDatasetTestCase):
 
 class CIFAR10TestCase(datasets_utils.ImageDatasetTestCase):
     DATASET_CLASS = datasets.CIFAR10
-    CONFIGS = datasets_utils.combinations_grid(train=(True, False))
+    ADDITIONAL_CONFIGS = [dict(train=False)]
 
     _VERSION_CONFIG = dict(
         base_folder="cifar-10-batches-py",
@@ -624,7 +624,7 @@ class CelebATestCase(datasets_utils.ImageDatasetTestCase):
     DATASET_CLASS = datasets.CelebA
     FEATURE_TYPES = (PIL.Image.Image, (torch.Tensor, int, tuple, type(None)))
 
-    CONFIGS = datasets_utils.combinations_grid(
+    ADDITIONAL_CONFIGS = datasets_utils.combinations_grid(
         split=("train", "valid", "test", "all"),
         target_type=("attr", "identity", "bbox", "landmarks", ["attr", "identity"]),
     )
@@ -741,7 +741,7 @@ class VOCSegmentationTestCase(datasets_utils.ImageDatasetTestCase):
     DATASET_CLASS = datasets.VOCSegmentation
     FEATURE_TYPES = (PIL.Image.Image, PIL.Image.Image)
 
-    CONFIGS = (
+    ADDITIONAL_CONFIGS = (
         *datasets_utils.combinations_grid(
             year=[f"20{year:02d}" for year in range(7, 13)], image_set=("train", "val", "trainval")
         ),
@@ -930,7 +930,7 @@ class CocoCaptionsTestCase(CocoDetectionTestCase):
 class UCF101TestCase(datasets_utils.VideoDatasetTestCase):
     DATASET_CLASS = datasets.UCF101
 
-    CONFIGS = datasets_utils.combinations_grid(fold=(1, 2, 3), train=(True, False))
+    ADDITIONAL_CONFIGS = datasets_utils.combinations_grid(fold=(1, 2, 3), train=(True, False))
 
     _VIDEO_FOLDER = "videos"
     _ANNOTATIONS_FOLDER = "annotations"
@@ -991,8 +991,8 @@ class LSUNTestCase(datasets_utils.ImageDatasetTestCase):
     DATASET_CLASS = datasets.LSUN
 
     REQUIRED_PACKAGES = ("lmdb",)
-    CONFIGS = datasets_utils.combinations_grid(
-        classes=("train", "test", "val", ["bedroom_train", "church_outdoor_train"])
+    ADDITIONAL_CONFIGS = datasets_utils.combinations_grid(
+        classes=("test", "val", ["bedroom_train", "church_outdoor_train"])
     )
 
     _CATEGORIES = (
@@ -1098,7 +1098,7 @@ class Kinetics400TestCase(datasets_utils.VideoDatasetTestCase):
 class HMDB51TestCase(datasets_utils.VideoDatasetTestCase):
     DATASET_CLASS = datasets.HMDB51
 
-    CONFIGS = datasets_utils.combinations_grid(fold=(1, 2, 3), train=(True, False))
+    ADDITIONAL_CONFIGS = datasets_utils.combinations_grid(fold=(1, 2, 3), train=(True, False))
 
     _VIDEO_FOLDER = "videos"
     _SPLITS_FOLDER = "splits"
@@ -1158,7 +1158,7 @@ class HMDB51TestCase(datasets_utils.VideoDatasetTestCase):
 class OmniglotTestCase(datasets_utils.ImageDatasetTestCase):
     DATASET_CLASS = datasets.Omniglot
 
-    CONFIGS = datasets_utils.combinations_grid(background=(True, False))
+    ADDITIONAL_CONFIGS = [dict(background=False)]
 
     def inject_fake_data(self, tmpdir, config):
         target_folder = (
@@ -1238,7 +1238,7 @@ class SEMEIONTestCase(datasets_utils.ImageDatasetTestCase):
 class USPSTestCase(datasets_utils.ImageDatasetTestCase):
     DATASET_CLASS = datasets.USPS
 
-    CONFIGS = datasets_utils.combinations_grid(train=(True, False))
+    ADDITIONAL_CONFIGS = [dict(train=False)]
 
     def inject_fake_data(self, tmpdir, config):
         num_images = 2 if config["train"] else 1
@@ -1260,7 +1260,7 @@ class SBDatasetTestCase(datasets_utils.ImageDatasetTestCase):
 
     REQUIRED_PACKAGES = ("scipy.io", "scipy.sparse")
 
-    CONFIGS = datasets_utils.combinations_grid(
+    ADDITIONAL_CONFIGS = datasets_utils.combinations_grid(
         image_set=("train", "val", "train_noval"), mode=("boundaries", "segmentation")
     )
 
@@ -1346,7 +1346,7 @@ class PhotoTourTestCase(datasets_utils.ImageDatasetTestCase):
     _TRAIN_FEATURE_TYPES = (torch.Tensor,)
     _TEST_FEATURE_TYPES = (torch.Tensor, torch.Tensor, torch.Tensor)
 
-    CONFIGS = datasets_utils.combinations_grid(train=(True, False))
+    ADDITIONAL_CONFIGS = [dict(train=False)]
 
     _NAME = "liberty"
 
@@ -1404,7 +1404,7 @@ class PhotoTourTestCase(datasets_utils.ImageDatasetTestCase):
 
         return archive
 
-    @datasets_utils.test_all_configs
+    @datasets_utils.test_all_configs()
     def test_feature_types(self, config):
         feature_types = self.FEATURE_TYPES
         self.FEATURE_TYPES = self._TRAIN_FEATURE_TYPES if config["train"] else self._TEST_FEATURE_TYPES

--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -468,7 +468,7 @@ class Caltech256TestCase(datasets_utils.ImageDatasetTestCase):
 class WIDERFaceTestCase(datasets_utils.ImageDatasetTestCase):
     DATASET_CLASS = datasets.WIDERFace
     FEATURE_TYPES = (PIL.Image.Image, (dict, type(None)))  # test split returns None as target
-    ADDITIONAL_CONFIGS = datasets_utils.combinations_grid(split=("train", "val", "test"))
+    ADDITIONAL_CONFIGS = datasets_utils.combinations_grid(split=('train', 'val', 'test'))
 
     def inject_fake_data(self, tmpdir, config):
         widerface_dir = pathlib.Path(tmpdir) / 'widerface'
@@ -523,7 +523,7 @@ class WIDERFaceTestCase(datasets_utils.ImageDatasetTestCase):
 class ImageNetTestCase(datasets_utils.ImageDatasetTestCase):
     DATASET_CLASS = datasets.ImageNet
     REQUIRED_PACKAGES = ('scipy',)
-    ADDITIONAL_CONFIGS = datasets_utils.combinations_grid(split=("train", "val"))
+    ADDITIONAL_CONFIGS = datasets_utils.combinations_grid(split=('train', 'val'))
 
     def inject_fake_data(self, tmpdir, config):
         tmpdir = pathlib.Path(tmpdir)

--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -1404,7 +1404,7 @@ class PhotoTourTestCase(datasets_utils.ImageDatasetTestCase):
 
         return archive
 
-    @datasets_utils.test_all_configs()
+    @datasets_utils.test_all_configs
     def test_feature_types(self, config):
         feature_types = self.FEATURE_TYPES
         self.FEATURE_TYPES = self._TRAIN_FEATURE_TYPES if config["train"] else self._TEST_FEATURE_TYPES

--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -369,7 +369,7 @@ class Caltech101TestCase(datasets_utils.ImageDatasetTestCase):
     DATASET_CLASS = datasets.Caltech101
     FEATURE_TYPES = (PIL.Image.Image, (int, np.ndarray, tuple))
 
-    ADDITIONAL_CONFIGS = datasets_utils.combinations_grid(target_type=("annotation", ["category", "annotation"]))
+    ADDITIONAL_CONFIGS = datasets_utils.combinations_grid(target_type=("category", "annotation", ["category", "annotation"]))
     REQUIRED_PACKAGES = ("scipy",)
 
     def inject_fake_data(self, tmpdir, config):
@@ -467,7 +467,7 @@ class Caltech256TestCase(datasets_utils.ImageDatasetTestCase):
 class WIDERFaceTestCase(datasets_utils.ImageDatasetTestCase):
     DATASET_CLASS = datasets.WIDERFace
     FEATURE_TYPES = (PIL.Image.Image, (dict, type(None)))  # test split returns None as target
-    ADDITIONAL_CONFIGS = datasets_utils.combinations_grid(split=('val', 'test'))
+    ADDITIONAL_CONFIGS = datasets_utils.combinations_grid(split=("train", 'val', 'test'))
 
     def inject_fake_data(self, tmpdir, config):
         widerface_dir = pathlib.Path(tmpdir) / 'widerface'
@@ -522,7 +522,7 @@ class WIDERFaceTestCase(datasets_utils.ImageDatasetTestCase):
 class ImageNetTestCase(datasets_utils.ImageDatasetTestCase):
     DATASET_CLASS = datasets.ImageNet
     REQUIRED_PACKAGES = ('scipy',)
-    ADDITIONAL_CONFIGS = [dict(split="val")]
+    ADDITIONAL_CONFIGS = datasets_utils.combinations_grid(split=("train", "val"))
 
     def inject_fake_data(self, tmpdir, config):
         tmpdir = pathlib.Path(tmpdir)
@@ -552,7 +552,7 @@ class ImageNetTestCase(datasets_utils.ImageDatasetTestCase):
 
 class CIFAR10TestCase(datasets_utils.ImageDatasetTestCase):
     DATASET_CLASS = datasets.CIFAR10
-    ADDITIONAL_CONFIGS = [dict(train=False)]
+    ADDITIONAL_CONFIGS =  datasets_utils.combinations_grid(train=(True, False))
 
     _VERSION_CONFIG = dict(
         base_folder="cifar-10-batches-py",
@@ -992,7 +992,7 @@ class LSUNTestCase(datasets_utils.ImageDatasetTestCase):
 
     REQUIRED_PACKAGES = ("lmdb",)
     ADDITIONAL_CONFIGS = datasets_utils.combinations_grid(
-        classes=("test", "val", ["bedroom_train", "church_outdoor_train"])
+        classes=("train", "test", "val", ["bedroom_train", "church_outdoor_train"])
     )
 
     _CATEGORIES = (
@@ -1158,7 +1158,7 @@ class HMDB51TestCase(datasets_utils.VideoDatasetTestCase):
 class OmniglotTestCase(datasets_utils.ImageDatasetTestCase):
     DATASET_CLASS = datasets.Omniglot
 
-    ADDITIONAL_CONFIGS = [dict(background=False)]
+    ADDITIONAL_CONFIGS = datasets_utils.combinations_grid(background=(True, False))
 
     def inject_fake_data(self, tmpdir, config):
         target_folder = (
@@ -1238,7 +1238,7 @@ class SEMEIONTestCase(datasets_utils.ImageDatasetTestCase):
 class USPSTestCase(datasets_utils.ImageDatasetTestCase):
     DATASET_CLASS = datasets.USPS
 
-    ADDITIONAL_CONFIGS = [dict(train=False)]
+    ADDITIONAL_CONFIGS = datasets_utils.combinations_grid(train=(True, False))
 
     def inject_fake_data(self, tmpdir, config):
         num_images = 2 if config["train"] else 1
@@ -1346,7 +1346,7 @@ class PhotoTourTestCase(datasets_utils.ImageDatasetTestCase):
     _TRAIN_FEATURE_TYPES = (torch.Tensor,)
     _TEST_FEATURE_TYPES = (torch.Tensor, torch.Tensor, torch.Tensor)
 
-    ADDITIONAL_CONFIGS = [dict(train=False)]
+    datasets_utils.combinations_grid(train=(True, False))
 
     _NAME = "liberty"
 

--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -369,7 +369,9 @@ class Caltech101TestCase(datasets_utils.ImageDatasetTestCase):
     DATASET_CLASS = datasets.Caltech101
     FEATURE_TYPES = (PIL.Image.Image, (int, np.ndarray, tuple))
 
-    ADDITIONAL_CONFIGS = datasets_utils.combinations_grid(target_type=("category", "annotation", ["category", "annotation"]))
+    ADDITIONAL_CONFIGS = datasets_utils.combinations_grid(
+        target_type=("category", "annotation", ["category", "annotation"])
+    )
     REQUIRED_PACKAGES = ("scipy",)
 
     def inject_fake_data(self, tmpdir, config):
@@ -467,7 +469,7 @@ class Caltech256TestCase(datasets_utils.ImageDatasetTestCase):
 class WIDERFaceTestCase(datasets_utils.ImageDatasetTestCase):
     DATASET_CLASS = datasets.WIDERFace
     FEATURE_TYPES = (PIL.Image.Image, (dict, type(None)))  # test split returns None as target
-    ADDITIONAL_CONFIGS = datasets_utils.combinations_grid(split=("train", 'val', 'test'))
+    ADDITIONAL_CONFIGS = datasets_utils.combinations_grid(split=("train", "val", "test"))
 
     def inject_fake_data(self, tmpdir, config):
         widerface_dir = pathlib.Path(tmpdir) / 'widerface'
@@ -552,7 +554,7 @@ class ImageNetTestCase(datasets_utils.ImageDatasetTestCase):
 
 class CIFAR10TestCase(datasets_utils.ImageDatasetTestCase):
     DATASET_CLASS = datasets.CIFAR10
-    ADDITIONAL_CONFIGS =  datasets_utils.combinations_grid(train=(True, False))
+    ADDITIONAL_CONFIGS = datasets_utils.combinations_grid(train=(True, False))
 
     _VERSION_CONFIG = dict(
         base_folder="cifar-10-batches-py",


### PR DESCRIPTION
This came up in https://github.com/pytorch/vision/pull/3423#discussion_r595170394https://github.com/pytorch/vision/pull/3423#discussion_r595170394. 

TL;DR: With the current architecture, it is not possible to test a dataset that has a positional parameter, which should change depending on the config.

To overcome this, this PR makes the `DEFAULT_CONFIG` a first class member. It still defaults to the keyword arguments extracted from the dataset constructor, but can now be safely overwritten if needed.