### PR TITLE
Update squeezenet weights urls

### DIFF
--- a/torchvision/models/squeezenet.py
+++ b/torchvision/models/squeezenet.py
@@ -7,8 +7,8 @@ from typing import Any
 __all__ = ['SqueezeNet', 'squeezenet1_0', 'squeezenet1_1']
 
 model_urls = {
-    'squeezenet1_0': 'https://download.pytorch.org/models/squeezenet1_0-a815701f.pth',
-    'squeezenet1_1': 'https://download.pytorch.org/models/squeezenet1_1-f364aa15.pth',
+    'squeezenet1_0': 'https://download.pytorch.org/models/squeezenet1_0-b66bff10.pth',
+    'squeezenet1_1': 'https://download.pytorch.org/models/squeezenet1_1-b8a52dc0.pth',
 }
 
 


### PR DESCRIPTION
Addresses part of https://github.com/pytorch/vision/issues/2068 - weights are unchanged, but the files can now be properly unpickled.

The new `pth` files have been uploaded to the S3 bucket and to the FB internal db.

For ref, here's the script that was used: https://nbviewer.jupyter.org/gist/NicolasHug/fb2c28d758951959da94d3db326ce21b