### PR TITLE
Replace ImageList impl with NamedTuple

### DIFF
--- a/torchvision/models/detection/image_list.py
+++ b/torchvision/models/detection/image_list.py
@@ -1,10 +1,10 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
 import torch
 from torch import Tensor
-from typing import List, Tuple
+from typing import List, Tuple, NamedTuple
 
 
-class ImageList(object):
+class ImageList(NamedTuple):
     """
     Structure that holds a list of images (of possibly
     varying sizes) as a single tensor.
@@ -12,14 +12,8 @@ class ImageList(object):
     and storing in a field the original sizes of each image
     """
 
-    def __init__(self, tensors: Tensor, image_sizes: List[Tuple[int, int]]):
-        """
-        Args:
-            tensors (tensor)
-            image_sizes (list[tuple[int, int]])
-        """
-        self.tensors = tensors
-        self.image_sizes = image_sizes
+    tensors: Tensor
+    image_sizes: List[Tuple[int, int]]
 
     def to(self, device: torch.device) -> 'ImageList':
         cast_tensor = self.tensors.to(device)


### PR DESCRIPTION
For better support with torch.jit.script.

See https://github.com/pytorch/pytorch/issues/42258 for background, https://github.com/pytorch/audio/pull/861 for a similar change. 

This allows export of FasterRCNN in scripting mode.