### PR TITLE
enable tests for WIDERFace on Windows

### DIFF
--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -463,7 +463,6 @@ class Caltech256TestCase(datasets_utils.ImageDatasetTestCase):
         return num_images_per_category * len(categories)
 
 
-@unittest.skipIf(sys.platform in ('win32', 'cygwin'), 'temporarily disabled on Windows')
 class WIDERFaceTestCase(datasets_utils.ImageDatasetTestCase):
     DATASET_CLASS = datasets.WIDERFace
     FEATURE_TYPES = (PIL.Image.Image, (dict, type(None)))  # test split returns None as target


### PR DESCRIPTION
Not sure why we included it in the first place. I missed that during review in #2883.