### PR TITLE
Put back skip windows decorator for cityscape dataset

### DIFF
--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -119,6 +119,7 @@ class Tester(DatasetTestcase):
                     root, loader=lambda x: x, is_valid_file=lambda x: False
                 )
 
+    @unittest.skipIf(sys.platform in ('win32', 'cygwin'), 'temporarily disabled on Windows')
     def test_cityscapes(self):
         with cityscapes_root() as root:
 


### PR DESCRIPTION
The test was skipped on windows but the skip decorator was removed in https://github.com/pytorch/vision/pull/3423/.

It looks like it making the CI fail now