### PR TITLE
[iOS] Remove the context for building jobs, only keep it for nightly build uploading

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1498,13 +1498,11 @@ workflows:
       - torch_onnx_test
       - binary_ios_build:
           build_environment: binary-libtorchvision_ops-ios-12.0.0-x86_64
-          context: org-member
           ios_arch: x86_64
           ios_platform: SIMULATOR
           name: binary_libtorchvision_ops_ios_12.0.0_x86_64
       - binary_ios_build:
           build_environment: binary-libtorchvision_ops-ios-12.0.0-arm64
-          context: org-member
           ios_arch: arm64
           ios_platform: OS
           name: binary_libtorchvision_ops_ios_12.0.0_arm64
@@ -1657,7 +1655,6 @@ workflows:
       - torch_onnx_test
       - binary_ios_build:
           build_environment: nightly-binary-libtorchvision_ops-ios-12.0.0-x86_64
-          context: org-member
           filters:
             branches:
               only:
@@ -1667,7 +1664,6 @@ workflows:
           name: nightly_binary_libtorchvision_ops_ios_12.0.0_x86_64
       - binary_ios_build:
           build_environment: nightly-binary-libtorchvision_ops-ios-12.0.0-arm64
-          context: org-member
           filters:
             branches:
               only:

--- a/.circleci/regenerate.py
+++ b/.circleci/regenerate.py
@@ -271,7 +271,6 @@ def ios_workflows(indentation=6, nightly=False):
         build_job_names.append(name)
         build_job = {
             'build_environment': f'{env_prefix}binary-libtorchvision_ops-ios-12.0.0-{arch}',
-            'context': 'org-member',
             'ios_arch': arch,
             'ios_platform': platform,
             'name': name,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#3622 [iOS] Remove the context for building jobs, only keep it for nightly build uploading**

