### PR TITLE
[FBcode->GH] Revert "Implementing multithreaded video decoding"

### DIFF
--- a/torchvision/csrc/io/decoder/decoder.cpp
+++ b/torchvision/csrc/io/decoder/decoder.cpp
@@ -432,7 +432,7 @@ bool Decoder::openStreams(std::vector<DecoderMetadata>* metadata) {
           it->format,
           params_.loggingUuid);
       CHECK(stream);
-      if (stream->openCodec(metadata, params_.numThreads) < 0) {
+      if (stream->openCodec(metadata) < 0) {
         LOG(ERROR) << "uuid=" << params_.loggingUuid
                    << " open codec failed, stream_idx=" << i;
         return false;

--- a/torchvision/csrc/io/decoder/defs.h
+++ b/torchvision/csrc/io/decoder/defs.h
@@ -194,9 +194,6 @@ struct DecoderParameters {
   bool preventStaleness{true};
   // seek tolerated accuracy (us)
   double seekAccuracy{1000000.0};
-  // Allow multithreaded decoding for numThreads > 1;
-  // 0 numThreads=0 sets up sensible defaults
-  int numThreads{1};
   // what media types should be processed, default none
   std::set<MediaFormat> formats;
 

--- a/torchvision/csrc/io/decoder/stream.h
+++ b/torchvision/csrc/io/decoder/stream.h
@@ -20,8 +20,7 @@ class Stream {
   virtual ~Stream();
 
   // returns 0 - on success or negative error
-  // num_threads sets up the codec context for multithreading if needed
-  int openCodec(std::vector<DecoderMetadata>* metadata, int num_threads = 1);
+  int openCodec(std::vector<DecoderMetadata>* metadata);
   // returns 1 - if packet got consumed, 0 - if it's not, and < 0 on error
   int decodePacket(
       const AVPacket* packet,

--- a/torchvision/csrc/io/video/video.h
+++ b/torchvision/csrc/io/video/video.h
@@ -16,15 +16,14 @@ struct Video : torch::CustomClassHolder {
   // global video metadata
   c10::Dict<std::string, c10::Dict<std::string, std::vector<double>>>
       streamsMetadata;
-  int64_t numThreads_{0};
 
  public:
-  Video(std::string videoPath, std::string stream, int64_t numThreads);
+  Video(std::string videoPath, std::string stream);
   std::tuple<std::string, int64_t> getCurrentStream() const;
   c10::Dict<std::string, c10::Dict<std::string, std::vector<double>>>
   getStreamMetadata() const;
   void Seek(double ts);
-  bool setCurrentStream(std::string stream = "video");
+  bool setCurrentStream(std::string stream);
   std::tuple<torch::Tensor, double> Next();
 
  private:
@@ -38,10 +37,9 @@ struct Video : torch::CustomClassHolder {
       double videoStartS,
       int64_t getPtsOnly,
       std::string stream,
-      long stream_id = -1,
-      bool all_streams = false,
-      int64_t num_threads = 0,
-      double seekFrameMarginUs = 10); // this needs to be improved
+      long stream_id,
+      bool all_streams,
+      double seekFrameMarginUs); // this needs to be improved
 
   std::map<std::string, std::vector<double>> streamTimeBase; // not used
 

--- a/torchvision/io/__init__.py
+++ b/torchvision/io/__init__.py
@@ -96,13 +96,9 @@ class VideoReader:
         stream (string, optional): descriptor of the required stream, followed by the stream id,
             in the format ``{stream_type}:{stream_id}``. Defaults to ``"video:0"``.
             Currently available options include ``['video', 'audio']``
-
-        num_threads (int, optional): number of threads used by the codec to decode video.
-            Default value (0) enables multithreading with codec-dependent heuristic. The performance
-            will depend on the version of FFMPEG codecs supported.
     """
 
-    def __init__(self, path, stream="video", num_threads=0):
+    def __init__(self, path, stream="video"):
         if not _has_video_opt():
             raise RuntimeError(
                 "Not compiled with video_reader support, "
@@ -110,7 +106,7 @@ class VideoReader:
                 + "ffmpeg (version 4.2 is currently supported) and"
                 + "build torchvision from source."
             )
-        self._c = torch.classes.torchvision.Video(path, stream, num_threads)
+        self._c = torch.classes.torchvision.Video(path, stream)
 
     def __next__(self):
         """Decodes and returns the next frame of the current stream.


### PR DESCRIPTION
Reverts pytorch/vision#3389

The PR introduced a dependency to `ATen` in `decoder`, which breaks downstream tests.

I'm reverting it for now