### PR TITLE
[iOS] added VisionTestApp for testing vision ops

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ gen.yml
 *.orig
 *-checkpoint.ipynb
 *.venv
+
+## Xcode User settings
+xcuserdata/

--- a/ios/VisionTestApp/Podfile
+++ b/ios/VisionTestApp/Podfile
@@ -1,0 +1,5 @@
+
+platform :ios, '12.0'
+target 'VisionTestApp' do
+  pod 'LibTorch'
+end

--- a/ios/VisionTestApp/Podfile
+++ b/ios/VisionTestApp/Podfile
@@ -1,5 +1,0 @@
-
-platform :ios, '12.0'
-target 'VisionTestApp' do
-  pod 'LibTorch'
-end

--- a/ios/VisionTestApp/VisionTestApp.xcodeproj/project.pbxproj
+++ b/ios/VisionTestApp/VisionTestApp.xcodeproj/project.pbxproj
@@ -1,0 +1,5897 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		0C12EF3D2616383D00B66C86 /* avx.py in Resources */ = {isa = PBXBuildFile; fileRef = 0C12EEF32616383C00B66C86 /* avx.py */; };
+		0C12EF3E2616383D00B66C86 /* __init__.py in Resources */ = {isa = PBXBuildFile; fileRef = 0C12EEF42616383C00B66C86 /* __init__.py */; };
+		0C12EF3F2616383D00B66C86 /* avx2.py in Resources */ = {isa = PBXBuildFile; fileRef = 0C12EEF62616383C00B66C86 /* avx2.py */; };
+		0C12EF402616383D00B66C86 /* THTensor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0C12EF192616383C00B66C86 /* THTensor.cpp */; };
+		0C12EF412616383D00B66C86 /* THTensorMath.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0C12EF1A2616383C00B66C86 /* THTensorMath.cpp */; };
+		0C12EF422616383D00B66C86 /* THStorageCopy.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0C12EF1C2616383C00B66C86 /* THStorageCopy.cpp */; };
+		0C12EF432616383D00B66C86 /* THLapack.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0C12EF212616383C00B66C86 /* THLapack.cpp */; };
+		0C12EF442616383D00B66C86 /* THStorage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0C12EF242616383C00B66C86 /* THStorage.cpp */; };
+		0C12EF452616383D00B66C86 /* THBlas.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0C12EF262616383C00B66C86 /* THBlas.cpp */; };
+		0C12EF462616383D00B66C86 /* THTensorLapack.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0C12EF272616383C00B66C86 /* THTensorLapack.cpp */; };
+		0C12EF472616383D00B66C86 /* libtorch_cpu.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 0C12EF332616383C00B66C86 /* libtorch_cpu.a */; };
+		0C12EF482616383D00B66C86 /* libtorch.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 0C12EF342616383C00B66C86 /* libtorch.a */; };
+		0C12EF492616383D00B66C86 /* libcpuinfo.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 0C12EF352616383C00B66C86 /* libcpuinfo.a */; };
+		0C12EF4A2616383D00B66C86 /* libXNNPACK.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 0C12EF362616383C00B66C86 /* libXNNPACK.a */; };
+		0C12EF4C2616383D00B66C86 /* libpthreadpool.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 0C12EF382616383C00B66C86 /* libpthreadpool.a */; };
+		0C12EF4D2616383D00B66C86 /* libc10.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 0C12EF392616383C00B66C86 /* libc10.a */; };
+		0C12EF4E2616383D00B66C86 /* libeigen_blas.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 0C12EF3A2616383C00B66C86 /* libeigen_blas.a */; };
+		0C12EF4F2616383D00B66C86 /* libclog.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 0C12EF3B2616383C00B66C86 /* libclog.a */; };
+		0C12EF502616383D00B66C86 /* libpytorch_qnnpack.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 0C12EF3C2616383C00B66C86 /* libpytorch_qnnpack.a */; };
+		0C12EF7626163B7600B66C86 /* frcnn_mnetv3.pt in Resources */ = {isa = PBXBuildFile; fileRef = 0C12EF7526163B7600B66C86 /* frcnn_mnetv3.pt */; };
+		0C12EF7A26163C7C00B66C86 /* libtorchvision_ops.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 0C12EF372616383C00B66C86 /* libtorchvision_ops.a */; };
+		0CEB0AC026151A8800F1F7D5 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 0CEB0ABF26151A8800F1F7D5 /* AppDelegate.m */; };
+		0CEB0AC626151A8800F1F7D5 /* ViewController.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0CEB0AC526151A8800F1F7D5 /* ViewController.mm */; };
+		0CEB0AC926151A8800F1F7D5 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0CEB0AC726151A8800F1F7D5 /* Main.storyboard */; };
+		0CEB0ACB26151A8900F1F7D5 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0CEB0ACA26151A8900F1F7D5 /* Assets.xcassets */; };
+		0CEB0ACE26151A8900F1F7D5 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0CEB0ACC26151A8900F1F7D5 /* LaunchScreen.storyboard */; };
+		0CEB0AD126151A8900F1F7D5 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 0CEB0AD026151A8900F1F7D5 /* main.m */; };
+		0CEB0B3A26152ED900F1F7D5 /* ModelRunner.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0CEB0B3926152ED900F1F7D5 /* ModelRunner.mm */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		0C12E78A2616383A00B66C86 /* attr.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = attr.h; sourceTree = "<group>"; };
+		0C12E78B2616383A00B66C86 /* embed.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = embed.h; sourceTree = "<group>"; };
+		0C12E78C2616383A00B66C86 /* numpy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = numpy.h; sourceTree = "<group>"; };
+		0C12E78D2616383A00B66C86 /* pybind11.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pybind11.h; sourceTree = "<group>"; };
+		0C12E78E2616383A00B66C86 /* operators.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = operators.h; sourceTree = "<group>"; };
+		0C12E78F2616383A00B66C86 /* iostream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = iostream.h; sourceTree = "<group>"; };
+		0C12E7902616383A00B66C86 /* chrono.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = chrono.h; sourceTree = "<group>"; };
+		0C12E7912616383A00B66C86 /* stl_bind.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = stl_bind.h; sourceTree = "<group>"; };
+		0C12E7922616383A00B66C86 /* buffer_info.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = buffer_info.h; sourceTree = "<group>"; };
+		0C12E7932616383A00B66C86 /* options.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = options.h; sourceTree = "<group>"; };
+		0C12E7942616383A00B66C86 /* functional.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = functional.h; sourceTree = "<group>"; };
+		0C12E7952616383A00B66C86 /* stl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = stl.h; sourceTree = "<group>"; };
+		0C12E7972616383A00B66C86 /* typeid.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = typeid.h; sourceTree = "<group>"; };
+		0C12E7982616383A00B66C86 /* descr.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = descr.h; sourceTree = "<group>"; };
+		0C12E7992616383A00B66C86 /* internals.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = internals.h; sourceTree = "<group>"; };
+		0C12E79A2616383A00B66C86 /* common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = common.h; sourceTree = "<group>"; };
+		0C12E79B2616383A00B66C86 /* class.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = class.h; sourceTree = "<group>"; };
+		0C12E79C2616383A00B66C86 /* init.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = init.h; sourceTree = "<group>"; };
+		0C12E79D2616383A00B66C86 /* common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = common.h; sourceTree = "<group>"; };
+		0C12E79E2616383A00B66C86 /* eval.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = eval.h; sourceTree = "<group>"; };
+		0C12E79F2616383A00B66C86 /* cast.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cast.h; sourceTree = "<group>"; };
+		0C12E7A02616383A00B66C86 /* eigen.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = eigen.h; sourceTree = "<group>"; };
+		0C12E7A12616383A00B66C86 /* pytypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pytypes.h; sourceTree = "<group>"; };
+		0C12E7A22616383A00B66C86 /* complex.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = complex.h; sourceTree = "<group>"; };
+		0C12E7A52616383A00B66C86 /* optical_flow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = optical_flow.h; sourceTree = "<group>"; };
+		0C12E7A62616383A00B66C86 /* video_decoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = video_decoder.h; sourceTree = "<group>"; };
+		0C12E7A72616383A00B66C86 /* video_input_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = video_input_op.h; sourceTree = "<group>"; };
+		0C12E7A82616383A00B66C86 /* video_io.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = video_io.h; sourceTree = "<group>"; };
+		0C12E7AB2616383A00B66C86 /* conv_transpose_unpool_base_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = conv_transpose_unpool_base_op.h; sourceTree = "<group>"; };
+		0C12E7AD2616383A00B66C86 /* operator_fallback_ideep.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = operator_fallback_ideep.h; sourceTree = "<group>"; };
+		0C12E7AE2616383A00B66C86 /* conv_pool_base_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = conv_pool_base_op.h; sourceTree = "<group>"; };
+		0C12E7B02616383A00B66C86 /* ideep_context.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ideep_context.h; sourceTree = "<group>"; };
+		0C12E7B12616383A00B66C86 /* ideep_operator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ideep_operator.h; sourceTree = "<group>"; };
+		0C12E7B22616383A00B66C86 /* ideep_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ideep_utils.h; sourceTree = "<group>"; };
+		0C12E7B42616383A00B66C86 /* net_async_task_graph.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = net_async_task_graph.h; sourceTree = "<group>"; };
+		0C12E7B52616383A00B66C86 /* net_simple_refcount.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = net_simple_refcount.h; sourceTree = "<group>"; };
+		0C12E7B62616383A00B66C86 /* tensor_impl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tensor_impl.h; sourceTree = "<group>"; };
+		0C12E7B72616383A00B66C86 /* plan_executor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = plan_executor.h; sourceTree = "<group>"; };
+		0C12E7B82616383A00B66C86 /* qtensor_serialization.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qtensor_serialization.h; sourceTree = "<group>"; };
+		0C12E7B92616383A00B66C86 /* context_gpu.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = context_gpu.h; sourceTree = "<group>"; };
+		0C12E7BA2616383A00B66C86 /* observer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = observer.h; sourceTree = "<group>"; };
+		0C12E7BB2616383A00B66C86 /* blob_serializer_base.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = blob_serializer_base.h; sourceTree = "<group>"; };
+		0C12E7BC2616383A00B66C86 /* memonger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = memonger.h; sourceTree = "<group>"; };
+		0C12E7BD2616383A00B66C86 /* tensor_int8.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tensor_int8.h; sourceTree = "<group>"; };
+		0C12E7BE2616383A00B66C86 /* static_tracepoint.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = static_tracepoint.h; sourceTree = "<group>"; };
+		0C12E7BF2616383A00B66C86 /* net.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = net.h; sourceTree = "<group>"; };
+		0C12E7C02616383A00B66C86 /* numa.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = numa.h; sourceTree = "<group>"; };
+		0C12E7C12616383A00B66C86 /* scope_guard.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = scope_guard.h; sourceTree = "<group>"; };
+		0C12E7C22616383A00B66C86 /* test_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = test_utils.h; sourceTree = "<group>"; };
+		0C12E7C32616383A00B66C86 /* event.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = event.h; sourceTree = "<group>"; };
+		0C12E7C42616383A00B66C86 /* types.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = types.h; sourceTree = "<group>"; };
+		0C12E7C52616383A00B66C86 /* context_base.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = context_base.h; sourceTree = "<group>"; };
+		0C12E7C62616383A00B66C86 /* operator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = operator.h; sourceTree = "<group>"; };
+		0C12E7C72616383A00B66C86 /* db.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = db.h; sourceTree = "<group>"; };
+		0C12E7C82616383A00B66C86 /* blob.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = blob.h; sourceTree = "<group>"; };
+		0C12E7C92616383A00B66C86 /* static_tracepoint_elfx86.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = static_tracepoint_elfx86.h; sourceTree = "<group>"; };
+		0C12E7CA2616383A00B66C86 /* net_async_tracing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = net_async_tracing.h; sourceTree = "<group>"; };
+		0C12E7CB2616383A00B66C86 /* flags.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = flags.h; sourceTree = "<group>"; };
+		0C12E7CC2616383A00B66C86 /* net_async_task_future.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = net_async_task_future.h; sourceTree = "<group>"; };
+		0C12E7CD2616383A00B66C86 /* operator_schema.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = operator_schema.h; sourceTree = "<group>"; };
+		0C12E7CE2616383A00B66C86 /* context.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = context.h; sourceTree = "<group>"; };
+		0C12E7CF2616383A00B66C86 /* net_async_base.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = net_async_base.h; sourceTree = "<group>"; };
+		0C12E7D02616383A00B66C86 /* prof_dag_counters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = prof_dag_counters.h; sourceTree = "<group>"; };
+		0C12E7D12616383A00B66C86 /* logging.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = logging.h; sourceTree = "<group>"; };
+		0C12E7D22616383A00B66C86 /* net_async_scheduling.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = net_async_scheduling.h; sourceTree = "<group>"; };
+		0C12E7D32616383A00B66C86 /* graph.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = graph.h; sourceTree = "<group>"; };
+		0C12E7D42616383A00B66C86 /* common_cudnn.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = common_cudnn.h; sourceTree = "<group>"; };
+		0C12E7D52616383A00B66C86 /* net_async_task.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = net_async_task.h; sourceTree = "<group>"; };
+		0C12E7D62616383A00B66C86 /* export_caffe2_op_to_c10.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = export_caffe2_op_to_c10.h; sourceTree = "<group>"; };
+		0C12E7D72616383A00B66C86 /* net_simple.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = net_simple.h; sourceTree = "<group>"; };
+		0C12E7D82616383A00B66C86 /* workspace.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = workspace.h; sourceTree = "<group>"; };
+		0C12E7D92616383A00B66C86 /* timer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = timer.h; sourceTree = "<group>"; };
+		0C12E7DA2616383A00B66C86 /* event_cpu.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = event_cpu.h; sourceTree = "<group>"; };
+		0C12E7DB2616383A00B66C86 /* common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = common.h; sourceTree = "<group>"; };
+		0C12E7DC2616383A00B66C86 /* blob_stats.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = blob_stats.h; sourceTree = "<group>"; };
+		0C12E7DD2616383A00B66C86 /* allocator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = allocator.h; sourceTree = "<group>"; };
+		0C12E7DE2616383A00B66C86 /* macros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = macros.h; sourceTree = "<group>"; };
+		0C12E7E02616383A00B66C86 /* miopen_wrapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = miopen_wrapper.h; sourceTree = "<group>"; };
+		0C12E7E12616383A00B66C86 /* common_miopen.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = common_miopen.h; sourceTree = "<group>"; };
+		0C12E7E22616383A00B66C86 /* storage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = storage.h; sourceTree = "<group>"; };
+		0C12E7E32616383A00B66C86 /* transform.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = transform.h; sourceTree = "<group>"; };
+		0C12E7E42616383A00B66C86 /* common_omp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = common_omp.h; sourceTree = "<group>"; };
+		0C12E7E52616383A00B66C86 /* export_c10_op_to_caffe2.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = export_c10_op_to_caffe2.h; sourceTree = "<group>"; };
+		0C12E7EB2616383A00B66C86 /* OpClasses.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OpClasses.h; sourceTree = "<group>"; };
+		0C12E7EC2616383A00B66C86 /* OpEnum.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OpEnum.h; sourceTree = "<group>"; };
+		0C12E7ED2616383A00B66C86 /* OpNames.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OpNames.h; sourceTree = "<group>"; };
+		0C12E7EF2616383A00B66C86 /* Compiler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Compiler.h; sourceTree = "<group>"; };
+		0C12E7F02616383A00B66C86 /* NeuralNet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NeuralNet.h; sourceTree = "<group>"; };
+		0C12E7F12616383A00B66C86 /* ControlFlow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ControlFlow.h; sourceTree = "<group>"; };
+		0C12E7F32616383A00B66C86 /* SubgraphMatcher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SubgraphMatcher.h; sourceTree = "<group>"; };
+		0C12E7F42616383A00B66C86 /* Match.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Match.h; sourceTree = "<group>"; };
+		0C12E7F62616383A00B66C86 /* Algorithms.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Algorithms.h; sourceTree = "<group>"; };
+		0C12E7F72616383A00B66C86 /* TopoSort.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TopoSort.h; sourceTree = "<group>"; };
+		0C12E7F82616383A00B66C86 /* Graph.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Graph.h; sourceTree = "<group>"; };
+		0C12E7F92616383A00B66C86 /* TarjansImpl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TarjansImpl.h; sourceTree = "<group>"; };
+		0C12E7FA2616383A00B66C86 /* BinaryMatchImpl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BinaryMatchImpl.h; sourceTree = "<group>"; };
+		0C12E7FC2616383A00B66C86 /* Dot.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Dot.h; sourceTree = "<group>"; };
+		0C12E7FE2616383A00B66C86 /* Casting.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Casting.h; sourceTree = "<group>"; };
+		0C12E7FF2616383A00B66C86 /* Common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Common.h; sourceTree = "<group>"; };
+		0C12E8012616383A00B66C86 /* test_util.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = test_util.h; sourceTree = "<group>"; };
+		0C12E8022616383A00B66C86 /* module.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = module.h; sourceTree = "<group>"; };
+		0C12E8032616383A00B66C86 /* init.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = init.h; sourceTree = "<group>"; };
+		0C12E8042616383A00B66C86 /* net_dag_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = net_dag_utils.h; sourceTree = "<group>"; };
+		0C12E8052616383A00B66C86 /* stats.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = stats.h; sourceTree = "<group>"; };
+		0C12E8062616383A00B66C86 /* tensor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tensor.h; sourceTree = "<group>"; };
+		0C12E8072616383A00B66C86 /* common_gpu.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = common_gpu.h; sourceTree = "<group>"; };
+		0C12E8082616383A00B66C86 /* qtensor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qtensor.h; sourceTree = "<group>"; };
+		0C12E8092616383A00B66C86 /* net_parallel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = net_parallel.h; sourceTree = "<group>"; };
+		0C12E80A2616383A00B66C86 /* operator_gradient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = operator_gradient.h; sourceTree = "<group>"; };
+		0C12E80B2616383A00B66C86 /* cudnn_wrappers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cudnn_wrappers.h; sourceTree = "<group>"; };
+		0C12E80C2616383A00B66C86 /* distributions_stubs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = distributions_stubs.h; sourceTree = "<group>"; };
+		0C12E80D2616383A00B66C86 /* blob_serialization.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = blob_serialization.h; sourceTree = "<group>"; };
+		0C12E80F2616383A00B66C86 /* mpi_common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mpi_common.h; sourceTree = "<group>"; };
+		0C12E8102616383A00B66C86 /* mpi_ops.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mpi_ops.h; sourceTree = "<group>"; };
+		0C12E8122616383A00B66C86 /* caffe2_pb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = caffe2_pb.h; sourceTree = "<group>"; };
+		0C12E8132616383A00B66C86 /* torch_pb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = torch_pb.h; sourceTree = "<group>"; };
+		0C12E8172616383A00B66C86 /* top_k.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = top_k.h; sourceTree = "<group>"; };
+		0C12E8182616383A00B66C86 /* channel_stats_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = channel_stats_op.h; sourceTree = "<group>"; };
+		0C12E8192616383A00B66C86 /* gru_unit_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = gru_unit_op.h; sourceTree = "<group>"; };
+		0C12E81A2616383A00B66C86 /* half_float_ops.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = half_float_ops.h; sourceTree = "<group>"; };
+		0C12E81B2616383A00B66C86 /* sqr_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = sqr_op.h; sourceTree = "<group>"; };
+		0C12E81C2616383A00B66C86 /* mean_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mean_op.h; sourceTree = "<group>"; };
+		0C12E81D2616383A00B66C86 /* thresholded_relu_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = thresholded_relu_op.h; sourceTree = "<group>"; };
+		0C12E81E2616383A00B66C86 /* ctc_greedy_decoder_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ctc_greedy_decoder_op.h; sourceTree = "<group>"; };
+		0C12E81F2616383A00B66C86 /* conv_op_cache_cudnn.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = conv_op_cache_cudnn.h; sourceTree = "<group>"; };
+		0C12E8202616383A00B66C86 /* utility_ops.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = utility_ops.h; sourceTree = "<group>"; };
+		0C12E8212616383A00B66C86 /* selu_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = selu_op.h; sourceTree = "<group>"; };
+		0C12E8222616383A00B66C86 /* map_ops.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = map_ops.h; sourceTree = "<group>"; };
+		0C12E8232616383A00B66C86 /* roi_align_rotated_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = roi_align_rotated_op.h; sourceTree = "<group>"; };
+		0C12E8242616383A00B66C86 /* fused_rowwise_random_quantization_ops.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fused_rowwise_random_quantization_ops.h; sourceTree = "<group>"; };
+		0C12E8252616383A00B66C86 /* stop_gradient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = stop_gradient.h; sourceTree = "<group>"; };
+		0C12E8262616383A00B66C86 /* batch_gather_ops.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = batch_gather_ops.h; sourceTree = "<group>"; };
+		0C12E8272616383A00B66C86 /* asin_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = asin_op.h; sourceTree = "<group>"; };
+		0C12E8282616383A00B66C86 /* cosh_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cosh_op.h; sourceTree = "<group>"; };
+		0C12E8292616383A00B66C86 /* atan_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = atan_op.h; sourceTree = "<group>"; };
+		0C12E82A2616383A00B66C86 /* reverse_packed_segs_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = reverse_packed_segs_op.h; sourceTree = "<group>"; };
+		0C12E82B2616383A00B66C86 /* given_tensor_byte_string_to_uint8_fill_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = given_tensor_byte_string_to_uint8_fill_op.h; sourceTree = "<group>"; };
+		0C12E82C2616383A00B66C86 /* ensure_clipped_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ensure_clipped_op.h; sourceTree = "<group>"; };
+		0C12E82D2616383A00B66C86 /* conv_transpose_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = conv_transpose_op.h; sourceTree = "<group>"; };
+		0C12E82E2616383A00B66C86 /* generate_proposals_op_util_nms.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = generate_proposals_op_util_nms.h; sourceTree = "<group>"; };
+		0C12E82F2616383A00B66C86 /* enforce_finite_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = enforce_finite_op.h; sourceTree = "<group>"; };
+		0C12E8302616383A00B66C86 /* conv_transpose_unpool_op_base.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = conv_transpose_unpool_op_base.h; sourceTree = "<group>"; };
+		0C12E8312616383A00B66C86 /* gather_fused_8bit_rowwise_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = gather_fused_8bit_rowwise_op.h; sourceTree = "<group>"; };
+		0C12E8322616383A00B66C86 /* batch_matmul_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = batch_matmul_op.h; sourceTree = "<group>"; };
+		0C12E8332616383A00B66C86 /* batch_bucketize_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = batch_bucketize_op.h; sourceTree = "<group>"; };
+		0C12E8342616383A00B66C86 /* softsign_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = softsign_op.h; sourceTree = "<group>"; };
+		0C12E8352616383A00B66C86 /* elementwise_logical_ops.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = elementwise_logical_ops.h; sourceTree = "<group>"; };
+		0C12E8362616383A00B66C86 /* percentile_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = percentile_op.h; sourceTree = "<group>"; };
+		0C12E8372616383A00B66C86 /* length_split_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = length_split_op.h; sourceTree = "<group>"; };
+		0C12E8382616383A00B66C86 /* locally_connected_op_impl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = locally_connected_op_impl.h; sourceTree = "<group>"; };
+		0C12E8392616383A00B66C86 /* rmac_regions_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rmac_regions_op.h; sourceTree = "<group>"; };
+		0C12E83A2616383A00B66C86 /* hard_sigmoid_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = hard_sigmoid_op.h; sourceTree = "<group>"; };
+		0C12E83B2616383A00B66C86 /* ensure_cpu_output_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ensure_cpu_output_op.h; sourceTree = "<group>"; };
+		0C12E83C2616383A00B66C86 /* batch_box_cox_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = batch_box_cox_op.h; sourceTree = "<group>"; };
+		0C12E83D2616383A00B66C86 /* ctc_beam_search_decoder_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ctc_beam_search_decoder_op.h; sourceTree = "<group>"; };
+		0C12E83E2616383A00B66C86 /* flexible_top_k.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = flexible_top_k.h; sourceTree = "<group>"; };
+		0C12E83F2616383A00B66C86 /* fully_connected_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fully_connected_op.h; sourceTree = "<group>"; };
+		0C12E8402616383A00B66C86 /* key_split_ops.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = key_split_ops.h; sourceTree = "<group>"; };
+		0C12E8412616383A00B66C86 /* reciprocal_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = reciprocal_op.h; sourceTree = "<group>"; };
+		0C12E8422616383A00B66C86 /* roi_align_gradient_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = roi_align_gradient_op.h; sourceTree = "<group>"; };
+		0C12E8432616383A00B66C86 /* group_norm_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = group_norm_op.h; sourceTree = "<group>"; };
+		0C12E8442616383A00B66C86 /* load_save_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = load_save_op.h; sourceTree = "<group>"; };
+		0C12E8452616383A00B66C86 /* cos_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cos_op.h; sourceTree = "<group>"; };
+		0C12E8462616383A00B66C86 /* expand_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = expand_op.h; sourceTree = "<group>"; };
+		0C12E8472616383A00B66C86 /* elementwise_ops.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = elementwise_ops.h; sourceTree = "<group>"; };
+		0C12E8482616383A00B66C86 /* im2col_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = im2col_op.h; sourceTree = "<group>"; };
+		0C12E8492616383A00B66C86 /* space_batch_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = space_batch_op.h; sourceTree = "<group>"; };
+		0C12E84A2616383A00B66C86 /* relu_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = relu_op.h; sourceTree = "<group>"; };
+		0C12E84B2616383A00B66C86 /* while_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = while_op.h; sourceTree = "<group>"; };
+		0C12E84C2616383A00B66C86 /* remove_data_blocks_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = remove_data_blocks_op.h; sourceTree = "<group>"; };
+		0C12E84D2616383A00B66C86 /* elementwise_mul_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = elementwise_mul_op.h; sourceTree = "<group>"; };
+		0C12E84E2616383A00B66C86 /* numpy_tile_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = numpy_tile_op.h; sourceTree = "<group>"; };
+		0C12E84F2616383A00B66C86 /* rowmul_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rowmul_op.h; sourceTree = "<group>"; };
+		0C12E8502616383A00B66C86 /* accumulate_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = accumulate_op.h; sourceTree = "<group>"; };
+		0C12E8512616383A00B66C86 /* sparse_lp_regularizer_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = sparse_lp_regularizer_op.h; sourceTree = "<group>"; };
+		0C12E8522616383A00B66C86 /* bisect_percentile_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = bisect_percentile_op.h; sourceTree = "<group>"; };
+		0C12E8532616383A00B66C86 /* tile_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tile_op.h; sourceTree = "<group>"; };
+		0C12E8542616383A00B66C86 /* gelu_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = gelu_op.h; sourceTree = "<group>"; };
+		0C12E8552616383A00B66C86 /* stats_put_ops.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = stats_put_ops.h; sourceTree = "<group>"; };
+		0C12E8562616383A00B66C86 /* given_tensor_fill_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = given_tensor_fill_op.h; sourceTree = "<group>"; };
+		0C12E8572616383A00B66C86 /* accuracy_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = accuracy_op.h; sourceTree = "<group>"; };
+		0C12E8582616383A00B66C86 /* bbox_transform_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = bbox_transform_op.h; sourceTree = "<group>"; };
+		0C12E8592616383A00B66C86 /* boolean_unmask_ops.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = boolean_unmask_ops.h; sourceTree = "<group>"; };
+		0C12E85A2616383A00B66C86 /* glu_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = glu_op.h; sourceTree = "<group>"; };
+		0C12E85B2616383A00B66C86 /* resize_3d_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = resize_3d_op.h; sourceTree = "<group>"; };
+		0C12E85C2616383A00B66C86 /* unsafe_coalesce.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = unsafe_coalesce.h; sourceTree = "<group>"; };
+		0C12E85D2616383A00B66C86 /* conv_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = conv_op.h; sourceTree = "<group>"; };
+		0C12E85E2616383A00B66C86 /* conv_op_impl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = conv_op_impl.h; sourceTree = "<group>"; };
+		0C12E85F2616383A00B66C86 /* erf_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = erf_op.h; sourceTree = "<group>"; };
+		0C12E8602616383A00B66C86 /* fused_rowwise_8bit_conversion_ops.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fused_rowwise_8bit_conversion_ops.h; sourceTree = "<group>"; };
+		0C12E8612616383A00B66C86 /* locally_connected_op_util.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = locally_connected_op_util.h; sourceTree = "<group>"; };
+		0C12E8622616383A00B66C86 /* channel_backprop_stats_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = channel_backprop_stats_op.h; sourceTree = "<group>"; };
+		0C12E8632616383A00B66C86 /* order_switch_ops.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = order_switch_ops.h; sourceTree = "<group>"; };
+		0C12E8642616383A00B66C86 /* lengths_reducer_fused_nbit_rowwise_ops.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lengths_reducer_fused_nbit_rowwise_ops.h; sourceTree = "<group>"; };
+		0C12E8652616383A00B66C86 /* lengths_reducer_fused_8bit_rowwise_ops.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lengths_reducer_fused_8bit_rowwise_ops.h; sourceTree = "<group>"; };
+		0C12E8662616383A00B66C86 /* load_save_op_util.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = load_save_op_util.h; sourceTree = "<group>"; };
+		0C12E8672616383A00B66C86 /* conv_transpose_op_impl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = conv_transpose_op_impl.h; sourceTree = "<group>"; };
+		0C12E8682616383A00B66C86 /* op_utils_cudnn.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = op_utils_cudnn.h; sourceTree = "<group>"; };
+		0C12E8692616383A00B66C86 /* prelu_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = prelu_op.h; sourceTree = "<group>"; };
+		0C12E86A2616383A00B66C86 /* box_with_nms_limit_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = box_with_nms_limit_op.h; sourceTree = "<group>"; };
+		0C12E86B2616383A00B66C86 /* fc_inference.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fc_inference.h; sourceTree = "<group>"; };
+		0C12E86C2616383A00B66C86 /* distance_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = distance_op.h; sourceTree = "<group>"; };
+		0C12E86D2616383A00B66C86 /* data_couple.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = data_couple.h; sourceTree = "<group>"; };
+		0C12E86E2616383A00B66C86 /* dataset_ops.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = dataset_ops.h; sourceTree = "<group>"; };
+		0C12E86F2616383A00B66C86 /* merge_id_lists_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = merge_id_lists_op.h; sourceTree = "<group>"; };
+		0C12E8702616383A00B66C86 /* generate_proposals_op_util_nms_gpu.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = generate_proposals_op_util_nms_gpu.h; sourceTree = "<group>"; };
+		0C12E8712616383A00B66C86 /* async_net_barrier_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = async_net_barrier_op.h; sourceTree = "<group>"; };
+		0C12E8722616383A00B66C86 /* deform_conv_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = deform_conv_op.h; sourceTree = "<group>"; };
+		0C12E8742616383A00B66C86 /* int8_relu_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = int8_relu_op.h; sourceTree = "<group>"; };
+		0C12E8752616383A00B66C86 /* int8_channel_shuffle_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = int8_channel_shuffle_op.h; sourceTree = "<group>"; };
+		0C12E8762616383A00B66C86 /* int8_concat_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = int8_concat_op.h; sourceTree = "<group>"; };
+		0C12E8772616383A00B66C86 /* int8_dequantize_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = int8_dequantize_op.h; sourceTree = "<group>"; };
+		0C12E8782616383A00B66C86 /* int8_slice_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = int8_slice_op.h; sourceTree = "<group>"; };
+		0C12E8792616383A00B66C86 /* int8_quantize_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = int8_quantize_op.h; sourceTree = "<group>"; };
+		0C12E87A2616383A00B66C86 /* int8_flatten_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = int8_flatten_op.h; sourceTree = "<group>"; };
+		0C12E87B2616383A00B66C86 /* int8_max_pool_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = int8_max_pool_op.h; sourceTree = "<group>"; };
+		0C12E87C2616383A00B66C86 /* int8_softmax_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = int8_softmax_op.h; sourceTree = "<group>"; };
+		0C12E87D2616383A00B66C86 /* int8_average_pool_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = int8_average_pool_op.h; sourceTree = "<group>"; };
+		0C12E87E2616383A00B66C86 /* int8_fc_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = int8_fc_op.h; sourceTree = "<group>"; };
+		0C12E87F2616383A00B66C86 /* int8_conv_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = int8_conv_op.h; sourceTree = "<group>"; };
+		0C12E8802616383A00B66C86 /* int8_test_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = int8_test_utils.h; sourceTree = "<group>"; };
+		0C12E8812616383A00B66C86 /* int8_roi_align_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = int8_roi_align_op.h; sourceTree = "<group>"; };
+		0C12E8822616383A00B66C86 /* int8_given_tensor_fill_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = int8_given_tensor_fill_op.h; sourceTree = "<group>"; };
+		0C12E8832616383A00B66C86 /* int8_reshape_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = int8_reshape_op.h; sourceTree = "<group>"; };
+		0C12E8842616383A00B66C86 /* int8_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = int8_utils.h; sourceTree = "<group>"; };
+		0C12E8852616383A00B66C86 /* int8_resize_nearest_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = int8_resize_nearest_op.h; sourceTree = "<group>"; };
+		0C12E8862616383A00B66C86 /* int8_sigmoid_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = int8_sigmoid_op.h; sourceTree = "<group>"; };
+		0C12E8872616383A00B66C86 /* int8_simd.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = int8_simd.h; sourceTree = "<group>"; };
+		0C12E8882616383A00B66C86 /* int8_conv_transpose_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = int8_conv_transpose_op.h; sourceTree = "<group>"; };
+		0C12E8892616383A00B66C86 /* int8_leaky_relu_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = int8_leaky_relu_op.h; sourceTree = "<group>"; };
+		0C12E88A2616383A00B66C86 /* int8_add_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = int8_add_op.h; sourceTree = "<group>"; };
+		0C12E88B2616383A00B66C86 /* int8_transpose_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = int8_transpose_op.h; sourceTree = "<group>"; };
+		0C12E88C2616383A00B66C86 /* sqrt_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = sqrt_op.h; sourceTree = "<group>"; };
+		0C12E88D2616383A00B66C86 /* elementwise_div_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = elementwise_div_op.h; sourceTree = "<group>"; };
+		0C12E88E2616383A00B66C86 /* deform_conv_op_impl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = deform_conv_op_impl.h; sourceTree = "<group>"; };
+		0C12E88F2616383A00B66C86 /* feature_maps_ops.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = feature_maps_ops.h; sourceTree = "<group>"; };
+		0C12E8902616383A00B66C86 /* text_file_reader_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = text_file_reader_utils.h; sourceTree = "<group>"; };
+		0C12E8912616383A00B66C86 /* scale_blobs_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = scale_blobs_op.h; sourceTree = "<group>"; };
+		0C12E8922616383A00B66C86 /* pool_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pool_op.h; sourceTree = "<group>"; };
+		0C12E8932616383A00B66C86 /* conv_transpose_op_mobile_impl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = conv_transpose_op_mobile_impl.h; sourceTree = "<group>"; };
+		0C12E8942616383A00B66C86 /* dense_vector_to_id_list_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = dense_vector_to_id_list_op.h; sourceTree = "<group>"; };
+		0C12E8952616383A00B66C86 /* minmax_ops.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = minmax_ops.h; sourceTree = "<group>"; };
+		0C12E8962616383A00B66C86 /* lengths_tile_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lengths_tile_op.h; sourceTree = "<group>"; };
+		0C12E8972616383A00B66C86 /* pool_op_util.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pool_op_util.h; sourceTree = "<group>"; };
+		0C12E8982616383A00B66C86 /* no_default_engine_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = no_default_engine_op.h; sourceTree = "<group>"; };
+		0C12E8992616383A00B66C86 /* onnx_while_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = onnx_while_op.h; sourceTree = "<group>"; };
+		0C12E89A2616383A00B66C86 /* reduce_front_back_sum_mean_ops.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = reduce_front_back_sum_mean_ops.h; sourceTree = "<group>"; };
+		0C12E89B2616383A00B66C86 /* roi_pool_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = roi_pool_op.h; sourceTree = "<group>"; };
+		0C12E89C2616383A00B66C86 /* flatten_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = flatten_op.h; sourceTree = "<group>"; };
+		0C12E89D2616383A00B66C86 /* self_binning_histogram_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = self_binning_histogram_op.h; sourceTree = "<group>"; };
+		0C12E89E2616383A00B66C86 /* normalize_l1_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = normalize_l1_op.h; sourceTree = "<group>"; };
+		0C12E89F2616383A00B66C86 /* pow_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pow_op.h; sourceTree = "<group>"; };
+		0C12E8A02616383A00B66C86 /* exp_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = exp_op.h; sourceTree = "<group>"; };
+		0C12E8A12616383A00B66C86 /* heatmap_max_keypoint_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = heatmap_max_keypoint_op.h; sourceTree = "<group>"; };
+		0C12E8A22616383A00B66C86 /* assert_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = assert_op.h; sourceTree = "<group>"; };
+		0C12E8A32616383A00B66C86 /* piecewise_linear_transform_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = piecewise_linear_transform_op.h; sourceTree = "<group>"; };
+		0C12E8A42616383A00B66C86 /* cbrt_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cbrt_op.h; sourceTree = "<group>"; };
+		0C12E8A52616383A00B66C86 /* weighted_sample_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = weighted_sample_op.h; sourceTree = "<group>"; };
+		0C12E8A62616383A00B66C86 /* tanh_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tanh_op.h; sourceTree = "<group>"; };
+		0C12E8A72616383A00B66C86 /* softmax_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = softmax_op.h; sourceTree = "<group>"; };
+		0C12E8A82616383A00B66C86 /* listwise_l2r_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = listwise_l2r_op.h; sourceTree = "<group>"; };
+		0C12E8A92616383A00B66C86 /* variable_length_sequence_padding.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = variable_length_sequence_padding.h; sourceTree = "<group>"; };
+		0C12E8AA2616383A00B66C86 /* elementwise_add_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = elementwise_add_op.h; sourceTree = "<group>"; };
+		0C12E8AB2616383A00B66C86 /* leaky_relu_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = leaky_relu_op.h; sourceTree = "<group>"; };
+		0C12E8AC2616383A00B66C86 /* elementwise_linear_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = elementwise_linear_op.h; sourceTree = "<group>"; };
+		0C12E8AD2616383A00B66C86 /* elu_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = elu_op.h; sourceTree = "<group>"; };
+		0C12E8AE2616383A00B66C86 /* jsd_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = jsd_op.h; sourceTree = "<group>"; };
+		0C12E8AF2616383A00B66C86 /* collect_and_distribute_fpn_rpn_proposals_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = collect_and_distribute_fpn_rpn_proposals_op.h; sourceTree = "<group>"; };
+		0C12E8B02616383A00B66C86 /* reduce_ops.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = reduce_ops.h; sourceTree = "<group>"; };
+		0C12E8B12616383A00B66C86 /* string_ops.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = string_ops.h; sourceTree = "<group>"; };
+		0C12E8B22616383A00B66C86 /* boolean_mask_ops.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = boolean_mask_ops.h; sourceTree = "<group>"; };
+		0C12E8B32616383A00B66C86 /* local_response_normalization_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = local_response_normalization_op.h; sourceTree = "<group>"; };
+		0C12E8B42616383A00B66C86 /* partition_ops.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = partition_ops.h; sourceTree = "<group>"; };
+		0C12E8B52616383A00B66C86 /* sparse_dropout_with_replacement_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = sparse_dropout_with_replacement_op.h; sourceTree = "<group>"; };
+		0C12E8B62616383A00B66C86 /* loss_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = loss_op.h; sourceTree = "<group>"; };
+		0C12E8B72616383A00B66C86 /* counter_ops.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = counter_ops.h; sourceTree = "<group>"; };
+		0C12E8B82616383A00B66C86 /* h_softmax_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = h_softmax_op.h; sourceTree = "<group>"; };
+		0C12E8B92616383A00B66C86 /* lengths_reducer_rowwise_8bit_ops.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lengths_reducer_rowwise_8bit_ops.h; sourceTree = "<group>"; };
+		0C12E8BA2616383A00B66C86 /* copy_rows_to_tensor_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = copy_rows_to_tensor_op.h; sourceTree = "<group>"; };
+		0C12E8BB2616383A00B66C86 /* moments_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = moments_op.h; sourceTree = "<group>"; };
+		0C12E8BC2616383A00B66C86 /* logit_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = logit_op.h; sourceTree = "<group>"; };
+		0C12E8BD2616383A00B66C86 /* perplexity_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = perplexity_op.h; sourceTree = "<group>"; };
+		0C12E8BE2616383A00B66C86 /* roi_align_rotated_gradient_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = roi_align_rotated_gradient_op.h; sourceTree = "<group>"; };
+		0C12E8BF2616383A00B66C86 /* ceil_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ceil_op.h; sourceTree = "<group>"; };
+		0C12E8C02616383A00B66C86 /* find_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = find_op.h; sourceTree = "<group>"; };
+		0C12E8C12616383A00B66C86 /* layer_norm_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = layer_norm_op.h; sourceTree = "<group>"; };
+		0C12E8C22616383A00B66C86 /* negate_gradient_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = negate_gradient_op.h; sourceTree = "<group>"; };
+		0C12E8C32616383A00B66C86 /* resize_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = resize_op.h; sourceTree = "<group>"; };
+		0C12E8C42616383A00B66C86 /* lengths_reducer_ops.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lengths_reducer_ops.h; sourceTree = "<group>"; };
+		0C12E8C52616383A00B66C86 /* batch_sparse_to_dense_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = batch_sparse_to_dense_op.h; sourceTree = "<group>"; };
+		0C12E8C62616383A00B66C86 /* replace_nan_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = replace_nan_op.h; sourceTree = "<group>"; };
+		0C12E8C72616383A00B66C86 /* max_pool_with_index_gpu.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = max_pool_with_index_gpu.h; sourceTree = "<group>"; };
+		0C12E8C82616383A00B66C86 /* find_duplicate_elements_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = find_duplicate_elements_op.h; sourceTree = "<group>"; };
+		0C12E8C92616383A00B66C86 /* expand_squeeze_dims_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = expand_squeeze_dims_op.h; sourceTree = "<group>"; };
+		0C12E8CA2616383A00B66C86 /* sinusoid_position_encoding_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = sinusoid_position_encoding_op.h; sourceTree = "<group>"; };
+		0C12E8CB2616383A00B66C86 /* pack_segments.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pack_segments.h; sourceTree = "<group>"; };
+		0C12E8CC2616383A00B66C86 /* softplus_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = softplus_op.h; sourceTree = "<group>"; };
+		0C12E8CD2616383A00B66C86 /* quantile_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = quantile_op.h; sourceTree = "<group>"; };
+		0C12E8CE2616383A00B66C86 /* sinh_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = sinh_op.h; sourceTree = "<group>"; };
+		0C12E8CF2616383A00B66C86 /* fused_rowwise_nbitfake_conversion_ops.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fused_rowwise_nbitfake_conversion_ops.h; sourceTree = "<group>"; };
+		0C12E8D02616383A00B66C86 /* cross_entropy_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cross_entropy_op.h; sourceTree = "<group>"; };
+		0C12E8D12616383A00B66C86 /* feed_blob_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = feed_blob_op.h; sourceTree = "<group>"; };
+		0C12E8D22616383A00B66C86 /* slice_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = slice_op.h; sourceTree = "<group>"; };
+		0C12E8D32616383A00B66C86 /* rsqrt_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rsqrt_op.h; sourceTree = "<group>"; };
+		0C12E8D42616383A00B66C86 /* free_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = free_op.h; sourceTree = "<group>"; };
+		0C12E8D52616383A00B66C86 /* square_root_divide_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = square_root_divide_op.h; sourceTree = "<group>"; };
+		0C12E8D62616383A00B66C86 /* conv_op_shared.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = conv_op_shared.h; sourceTree = "<group>"; };
+		0C12E8D72616383A00B66C86 /* apmeter_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = apmeter_op.h; sourceTree = "<group>"; };
+		0C12E8D82616383A00B66C86 /* lstm_unit_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lstm_unit_op.h; sourceTree = "<group>"; };
+		0C12E8D92616383A00B66C86 /* index_hash_ops.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = index_hash_ops.h; sourceTree = "<group>"; };
+		0C12E8DA2616383A00B66C86 /* lengths_pad_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lengths_pad_op.h; sourceTree = "<group>"; };
+		0C12E8DB2616383A00B66C86 /* elementwise_ops_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = elementwise_ops_utils.h; sourceTree = "<group>"; };
+		0C12E8DC2616383A00B66C86 /* sparse_normalize_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = sparse_normalize_op.h; sourceTree = "<group>"; };
+		0C12E8DD2616383A00B66C86 /* multi_class_accuracy_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = multi_class_accuracy_op.h; sourceTree = "<group>"; };
+		0C12E8DE2616383A00B66C86 /* cast_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cast_op.h; sourceTree = "<group>"; };
+		0C12E8DF2616383A00B66C86 /* transpose_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = transpose_op.h; sourceTree = "<group>"; };
+		0C12E8E02616383A00B66C86 /* create_scope_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = create_scope_op.h; sourceTree = "<group>"; };
+		0C12E8E12616383A00B66C86 /* zero_gradient_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = zero_gradient_op.h; sourceTree = "<group>"; };
+		0C12E8E22616383A00B66C86 /* lstm_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lstm_utils.h; sourceTree = "<group>"; };
+		0C12E8E32616383A00B66C86 /* tt_linear_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tt_linear_op.h; sourceTree = "<group>"; };
+		0C12E8E42616383A00B66C86 /* relu_n_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = relu_n_op.h; sourceTree = "<group>"; };
+		0C12E8E52616383A00B66C86 /* generate_proposals_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = generate_proposals_op.h; sourceTree = "<group>"; };
+		0C12E8E72616383A00B66C86 /* activation_ops_miopen.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = activation_ops_miopen.h; sourceTree = "<group>"; };
+		0C12E8E82616383A00B66C86 /* lpnorm_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lpnorm_op.h; sourceTree = "<group>"; };
+		0C12E8E92616383A00B66C86 /* sequence_ops.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = sequence_ops.h; sourceTree = "<group>"; };
+		0C12E8EA2616383A00B66C86 /* abs_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = abs_op.h; sourceTree = "<group>"; };
+		0C12E8EB2616383A00B66C86 /* activation_ops_cudnn.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = activation_ops_cudnn.h; sourceTree = "<group>"; };
+		0C12E8EC2616383A00B66C86 /* elementwise_op_test.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = elementwise_op_test.h; sourceTree = "<group>"; };
+		0C12E8ED2616383A00B66C86 /* inference_lstm_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = inference_lstm_op.h; sourceTree = "<group>"; };
+		0C12E8EE2616383A00B66C86 /* concat_split_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = concat_split_op.h; sourceTree = "<group>"; };
+		0C12E8EF2616383A00B66C86 /* reduction_ops.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = reduction_ops.h; sourceTree = "<group>"; };
+		0C12E8F02616383A00B66C86 /* gather_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = gather_op.h; sourceTree = "<group>"; };
+		0C12E8F12616383A00B66C86 /* log_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = log_op.h; sourceTree = "<group>"; };
+		0C12E8F22616383A00B66C86 /* conv_pool_op_base.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = conv_pool_op_base.h; sourceTree = "<group>"; };
+		0C12E8F32616383A00B66C86 /* unique_ops.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = unique_ops.h; sourceTree = "<group>"; };
+		0C12E8F42616383A00B66C86 /* elementwise_sub_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = elementwise_sub_op.h; sourceTree = "<group>"; };
+		0C12E8F52616383A00B66C86 /* segment_reduction_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = segment_reduction_op.h; sourceTree = "<group>"; };
+		0C12E8F62616383A00B66C86 /* fused_rowwise_nbit_conversion_ops.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fused_rowwise_nbit_conversion_ops.h; sourceTree = "<group>"; };
+		0C12E8F72616383A00B66C86 /* stump_func_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = stump_func_op.h; sourceTree = "<group>"; };
+		0C12E8F82616383A00B66C86 /* swish_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = swish_op.h; sourceTree = "<group>"; };
+		0C12E8F92616383A00B66C86 /* pack_rnn_sequence_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pack_rnn_sequence_op.h; sourceTree = "<group>"; };
+		0C12E8FA2616383A00B66C86 /* softmax_with_loss_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = softmax_with_loss_op.h; sourceTree = "<group>"; };
+		0C12E8FB2616383A00B66C86 /* integral_image_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = integral_image_op.h; sourceTree = "<group>"; };
+		0C12E8FC2616383A00B66C86 /* mish_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mish_op.h; sourceTree = "<group>"; };
+		0C12E8FD2616383A00B66C86 /* weighted_multi_sampling_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = weighted_multi_sampling_op.h; sourceTree = "<group>"; };
+		0C12E8FE2616383A00B66C86 /* bucketize_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = bucketize_op.h; sourceTree = "<group>"; };
+		0C12E8FF2616383A00B66C86 /* is_empty_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = is_empty_op.h; sourceTree = "<group>"; };
+		0C12E9002616383A00B66C86 /* mod_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mod_op.h; sourceTree = "<group>"; };
+		0C12E9012616383A00B66C86 /* clip_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = clip_op.h; sourceTree = "<group>"; };
+		0C12E9022616383A00B66C86 /* prepend_dim_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = prepend_dim_op.h; sourceTree = "<group>"; };
+		0C12E9032616383A00B66C86 /* copy_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = copy_op.h; sourceTree = "<group>"; };
+		0C12E9042616383A00B66C86 /* rank_loss_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rank_loss_op.h; sourceTree = "<group>"; };
+		0C12E9052616383A00B66C86 /* lengths_top_k_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lengths_top_k_op.h; sourceTree = "<group>"; };
+		0C12E9062616383A00B66C86 /* summarize_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = summarize_op.h; sourceTree = "<group>"; };
+		0C12E9072616383A00B66C86 /* one_hot_ops.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = one_hot_ops.h; sourceTree = "<group>"; };
+		0C12E9082616383A00B66C86 /* cc_bmm_bg_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cc_bmm_bg_op.h; sourceTree = "<group>"; };
+		0C12E9092616383A00B66C86 /* acos_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = acos_op.h; sourceTree = "<group>"; };
+		0C12E90A2616383A00B66C86 /* softmax_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = softmax_utils.h; sourceTree = "<group>"; };
+		0C12E90B2616383A00B66C86 /* tensor_protos_db_input.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tensor_protos_db_input.h; sourceTree = "<group>"; };
+		0C12E90C2616383A00B66C86 /* generate_proposals_op_util_boxes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = generate_proposals_op_util_boxes.h; sourceTree = "<group>"; };
+		0C12E90D2616383A00B66C86 /* conv_transpose_op_mobile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = conv_transpose_op_mobile.h; sourceTree = "<group>"; };
+		0C12E90E2616383A00B66C86 /* arg_ops.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = arg_ops.h; sourceTree = "<group>"; };
+		0C12E90F2616383A00B66C86 /* negative_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = negative_op.h; sourceTree = "<group>"; };
+		0C12E9102616383A00B66C86 /* operator_fallback_gpu.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = operator_fallback_gpu.h; sourceTree = "<group>"; };
+		0C12E9112616383A00B66C86 /* margin_ranking_criterion_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = margin_ranking_criterion_op.h; sourceTree = "<group>"; };
+		0C12E9122616383A00B66C86 /* matmul_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = matmul_op.h; sourceTree = "<group>"; };
+		0C12E9132616383A00B66C86 /* roi_align_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = roi_align_op.h; sourceTree = "<group>"; };
+		0C12E9142616383A00B66C86 /* pad_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pad_op.h; sourceTree = "<group>"; };
+		0C12E9152616383A00B66C86 /* histogram_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = histogram_op.h; sourceTree = "<group>"; };
+		0C12E9162616383A00B66C86 /* floor_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = floor_op.h; sourceTree = "<group>"; };
+		0C12E9172616383A00B66C86 /* normalize_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = normalize_op.h; sourceTree = "<group>"; };
+		0C12E9182616383A00B66C86 /* cube_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cube_op.h; sourceTree = "<group>"; };
+		0C12E9192616383A00B66C86 /* reshape_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = reshape_op.h; sourceTree = "<group>"; };
+		0C12E91A2616383A00B66C86 /* instance_norm_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = instance_norm_op.h; sourceTree = "<group>"; };
+		0C12E91B2616383A00B66C86 /* ngram_ops.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ngram_ops.h; sourceTree = "<group>"; };
+		0C12E91C2616383A00B66C86 /* if_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = if_op.h; sourceTree = "<group>"; };
+		0C12E91D2616383A00B66C86 /* reduce_front_back_max_ops.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = reduce_front_back_max_ops.h; sourceTree = "<group>"; };
+		0C12E91E2616383A00B66C86 /* reducer_functors.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = reducer_functors.h; sourceTree = "<group>"; };
+		0C12E91F2616383A00B66C86 /* affine_channel_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = affine_channel_op.h; sourceTree = "<group>"; };
+		0C12E9202616383A00B66C86 /* sigmoid_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = sigmoid_op.h; sourceTree = "<group>"; };
+		0C12E9212616383A00B66C86 /* channel_shuffle_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = channel_shuffle_op.h; sourceTree = "<group>"; };
+		0C12E9222616383A00B66C86 /* locally_connected_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = locally_connected_op.h; sourceTree = "<group>"; };
+		0C12E9232616383A00B66C86 /* conditional_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = conditional_op.h; sourceTree = "<group>"; };
+		0C12E9242616383A00B66C86 /* rms_norm_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rms_norm_op.h; sourceTree = "<group>"; };
+		0C12E9252616383A00B66C86 /* dropout_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = dropout_op.h; sourceTree = "<group>"; };
+		0C12E9262616383A00B66C86 /* gather_ranges_to_dense_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = gather_ranges_to_dense_op.h; sourceTree = "<group>"; };
+		0C12E9272616383A00B66C86 /* shape_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = shape_op.h; sourceTree = "<group>"; };
+		0C12E9282616383A00B66C86 /* index_ops.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = index_ops.h; sourceTree = "<group>"; };
+		0C12E9292616383A00B66C86 /* tan_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tan_op.h; sourceTree = "<group>"; };
+		0C12E92A2616383A00B66C86 /* scale_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = scale_op.h; sourceTree = "<group>"; };
+		0C12E92B2616383A00B66C86 /* cosine_embedding_criterion_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cosine_embedding_criterion_op.h; sourceTree = "<group>"; };
+		0C12E92C2616383A00B66C86 /* sparse_to_dense_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = sparse_to_dense_op.h; sourceTree = "<group>"; };
+		0C12E92D2616383A00B66C86 /* quant_decode_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = quant_decode_op.h; sourceTree = "<group>"; };
+		0C12E92F2616383A00B66C86 /* recurrent_network_blob_fetcher_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = recurrent_network_blob_fetcher_op.h; sourceTree = "<group>"; };
+		0C12E9302616383A00B66C86 /* recurrent_op_cudnn.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = recurrent_op_cudnn.h; sourceTree = "<group>"; };
+		0C12E9312616383A00B66C86 /* recurrent_network_executor_gpu.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = recurrent_network_executor_gpu.h; sourceTree = "<group>"; };
+		0C12E9322616383A00B66C86 /* recurrent_network_executor_incl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = recurrent_network_executor_incl.h; sourceTree = "<group>"; };
+		0C12E9342616383A00B66C86 /* recurrent_op_miopen.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = recurrent_op_miopen.h; sourceTree = "<group>"; };
+		0C12E9352616383A00B66C86 /* recurrent_network_executor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = recurrent_network_executor.h; sourceTree = "<group>"; };
+		0C12E9362616383A00B66C86 /* recurrent_network_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = recurrent_network_op.h; sourceTree = "<group>"; };
+		0C12E9372616383A00B66C86 /* sparse_to_dense_mask_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = sparse_to_dense_mask_op.h; sourceTree = "<group>"; };
+		0C12E9382616383A00B66C86 /* sin_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = sin_op.h; sourceTree = "<group>"; };
+		0C12E9392616383A00B66C86 /* upsample_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = upsample_op.h; sourceTree = "<group>"; };
+		0C12E93A2616383A00B66C86 /* filler_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = filler_op.h; sourceTree = "<group>"; };
+		0C12E93B2616383A00B66C86 /* batch_permutation_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = batch_permutation_op.h; sourceTree = "<group>"; };
+		0C12E93C2616383A00B66C86 /* spatial_softmax_with_loss_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = spatial_softmax_with_loss_op.h; sourceTree = "<group>"; };
+		0C12E93D2616383A00B66C86 /* batch_moments_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = batch_moments_op.h; sourceTree = "<group>"; };
+		0C12E93E2616383A00B66C86 /* alias_with_name.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = alias_with_name.h; sourceTree = "<group>"; };
+		0C12E93F2616383A00B66C86 /* do_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = do_op.h; sourceTree = "<group>"; };
+		0C12E9402616383A00B66C86 /* prefetch_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = prefetch_op.h; sourceTree = "<group>"; };
+		0C12E9412616383A00B66C86 /* byte_weight_dequant_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = byte_weight_dequant_op.h; sourceTree = "<group>"; };
+		0C12E9422616383A00B66C86 /* spatial_batch_norm_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = spatial_batch_norm_op.h; sourceTree = "<group>"; };
+		0C12E9442616383A00B66C86 /* helper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = helper.h; sourceTree = "<group>"; };
+		0C12E9452616383A00B66C86 /* device.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = device.h; sourceTree = "<group>"; };
+		0C12E9462616383A00B66C86 /* onnxifi_init.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = onnxifi_init.h; sourceTree = "<group>"; };
+		0C12E9472616383A00B66C86 /* backend.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = backend.h; sourceTree = "<group>"; };
+		0C12E9492616383A00B66C86 /* schema.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = schema.h; sourceTree = "<group>"; };
+		0C12E94A2616383A00B66C86 /* constants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = constants.h; sourceTree = "<group>"; };
+		0C12E94B2616383A00B66C86 /* operator_sets.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = operator_sets.h; sourceTree = "<group>"; };
+		0C12E94C2616383A00B66C86 /* backend_rep.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = backend_rep.h; sourceTree = "<group>"; };
+		0C12E94D2616383A00B66C86 /* onnx_exporter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = onnx_exporter.h; sourceTree = "<group>"; };
+		0C12E94E2616383A00B66C86 /* offline_tensor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = offline_tensor.h; sourceTree = "<group>"; };
+		0C12E94F2616383A00B66C86 /* onnxifi_graph_info.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = onnxifi_graph_info.h; sourceTree = "<group>"; };
+		0C12E9542616383A00B66C86 /* pybind_state.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pybind_state.h; sourceTree = "<group>"; };
+		0C12E9552616383A00B66C86 /* pybind_state_registry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pybind_state_registry.h; sourceTree = "<group>"; };
+		0C12E95D2616383A00B66C86 /* dlpack.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = dlpack.h; sourceTree = "<group>"; };
+		0C12E9692616383A00B66C86 /* pybind_state_dlpack.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pybind_state_dlpack.h; sourceTree = "<group>"; };
+		0C12E9712616383A00B66C86 /* redis_store_handler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = redis_store_handler.h; sourceTree = "<group>"; };
+		0C12E9722616383A00B66C86 /* file_store_handler_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = file_store_handler_op.h; sourceTree = "<group>"; };
+		0C12E9732616383A00B66C86 /* store_handler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = store_handler.h; sourceTree = "<group>"; };
+		0C12E9742616383A00B66C86 /* store_ops.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = store_ops.h; sourceTree = "<group>"; };
+		0C12E9752616383A00B66C86 /* file_store_handler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = file_store_handler.h; sourceTree = "<group>"; };
+		0C12E9762616383A00B66C86 /* redis_store_handler_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = redis_store_handler_op.h; sourceTree = "<group>"; };
+		0C12E9782616383A00B66C86 /* embedding_lookup.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = embedding_lookup.h; sourceTree = "<group>"; };
+		0C12E9792616383A00B66C86 /* fused_8bit_rowwise_embedding_lookup_idx.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fused_8bit_rowwise_embedding_lookup_idx.h; sourceTree = "<group>"; };
+		0C12E97A2616383A00B66C86 /* lstm_unit_cpu-impl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "lstm_unit_cpu-impl.h"; sourceTree = "<group>"; };
+		0C12E97B2616383A00B66C86 /* embedding_lookup_idx.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = embedding_lookup_idx.h; sourceTree = "<group>"; };
+		0C12E97C2616383A00B66C86 /* adagrad.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = adagrad.h; sourceTree = "<group>"; };
+		0C12E97D2616383A00B66C86 /* lstm_unit_cpu.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lstm_unit_cpu.h; sourceTree = "<group>"; };
+		0C12E97E2616383A00B66C86 /* cvtsh_ss_bugfix.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cvtsh_ss_bugfix.h; sourceTree = "<group>"; };
+		0C12E97F2616383A00B66C86 /* common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = common.h; sourceTree = "<group>"; };
+		0C12E9802616383A00B66C86 /* math.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = math.h; sourceTree = "<group>"; };
+		0C12E9812616383A00B66C86 /* typed_axpy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = typed_axpy.h; sourceTree = "<group>"; };
+		0C12E9822616383A00B66C86 /* fused_nbit_rowwise_conversion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fused_nbit_rowwise_conversion.h; sourceTree = "<group>"; };
+		0C12E9832616383A00B66C86 /* fused_8bit_rowwise_embedding_lookup.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fused_8bit_rowwise_embedding_lookup.h; sourceTree = "<group>"; };
+		0C12E9842616383A00B66C86 /* lstm_unit_cpu_common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lstm_unit_cpu_common.h; sourceTree = "<group>"; };
+		0C12E9872616383A00B66C86 /* fully_connected_op_decomposition.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fully_connected_op_decomposition.h; sourceTree = "<group>"; };
+		0C12E9882616383A00B66C86 /* fully_connected_op_sparse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fully_connected_op_sparse.h; sourceTree = "<group>"; };
+		0C12E9892616383A00B66C86 /* tt_contraction_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tt_contraction_op.h; sourceTree = "<group>"; };
+		0C12E98A2616383A00B66C86 /* fully_connected_op_prune.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fully_connected_op_prune.h; sourceTree = "<group>"; };
+		0C12E98B2616383A00B66C86 /* funhash_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = funhash_op.h; sourceTree = "<group>"; };
+		0C12E98C2616383A00B66C86 /* sparse_funhash_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = sparse_funhash_op.h; sourceTree = "<group>"; };
+		0C12E98D2616383A00B66C86 /* sparse_matrix_reshape_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = sparse_matrix_reshape_op.h; sourceTree = "<group>"; };
+		0C12E98E2616383A00B66C86 /* tt_pad_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tt_pad_op.h; sourceTree = "<group>"; };
+		0C12E9912616383A00B66C86 /* common_rtc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = common_rtc.h; sourceTree = "<group>"; };
+		0C12E9932616383A00B66C86 /* read_adapter_interface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = read_adapter_interface.h; sourceTree = "<group>"; };
+		0C12E9942616383A00B66C86 /* crc_alt.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = crc_alt.h; sourceTree = "<group>"; };
+		0C12E9952616383A00B66C86 /* versions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = versions.h; sourceTree = "<group>"; };
+		0C12E9962616383A00B66C86 /* inline_container.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = inline_container.h; sourceTree = "<group>"; };
+		0C12E9972616383A00B66C86 /* file_adapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = file_adapter.h; sourceTree = "<group>"; };
+		0C12E9982616383A00B66C86 /* istream_adapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = istream_adapter.h; sourceTree = "<group>"; };
+		0C12E99A2616383A00B66C86 /* filler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = filler.h; sourceTree = "<group>"; };
+		0C12E99B2616383A00B66C86 /* math-detail.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "math-detail.h"; sourceTree = "<group>"; };
+		0C12E99C2616383A00B66C86 /* signal_handler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = signal_handler.h; sourceTree = "<group>"; };
+		0C12E99D2616383A00B66C86 /* cpu_neon.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cpu_neon.h; sourceTree = "<group>"; };
+		0C12E99E2616383A00B66C86 /* conversions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = conversions.h; sourceTree = "<group>"; };
+		0C12E99F2616383A00B66C86 /* string_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = string_utils.h; sourceTree = "<group>"; };
+		0C12E9A02616383A00B66C86 /* simple_queue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = simple_queue.h; sourceTree = "<group>"; };
+		0C12E9A12616383A00B66C86 /* cpuid.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cpuid.h; sourceTree = "<group>"; };
+		0C12E9A32616383A00B66C86 /* ThreadPool.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ThreadPool.h; sourceTree = "<group>"; };
+		0C12E9A42616383A00B66C86 /* ThreadPoolCommon.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ThreadPoolCommon.h; sourceTree = "<group>"; };
+		0C12E9A52616383A00B66C86 /* pthreadpool.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pthreadpool.h; sourceTree = "<group>"; };
+		0C12E9A62616383A00B66C86 /* pthreadpool-cpp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "pthreadpool-cpp.h"; sourceTree = "<group>"; };
+		0C12E9A72616383A00B66C86 /* WorkersPool.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WorkersPool.h; sourceTree = "<group>"; };
+		0C12E9A82616383A00B66C86 /* thread_pool_guard.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = thread_pool_guard.h; sourceTree = "<group>"; };
+		0C12E9AA2616383A00B66C86 /* utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = utils.h; sourceTree = "<group>"; };
+		0C12E9AB2616383A00B66C86 /* broadcast.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = broadcast.h; sourceTree = "<group>"; };
+		0C12E9AC2616383A00B66C86 /* elementwise.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = elementwise.h; sourceTree = "<group>"; };
+		0C12E9AD2616383A00B66C86 /* half_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = half_utils.h; sourceTree = "<group>"; };
+		0C12E9AE2616383A00B66C86 /* reduce.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = reduce.h; sourceTree = "<group>"; };
+		0C12E9AF2616383A00B66C86 /* transpose.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = transpose.h; sourceTree = "<group>"; };
+		0C12E9B02616383A00B66C86 /* fixed_divisor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fixed_divisor.h; sourceTree = "<group>"; };
+		0C12E9B12616383A00B66C86 /* proto_wrap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = proto_wrap.h; sourceTree = "<group>"; };
+		0C12E9B22616383A00B66C86 /* bench_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = bench_utils.h; sourceTree = "<group>"; };
+		0C12E9B32616383A00B66C86 /* cast.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cast.h; sourceTree = "<group>"; };
+		0C12E9B52616383A00B66C86 /* murmur_hash3.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = murmur_hash3.h; sourceTree = "<group>"; };
+		0C12E9B62616383A00B66C86 /* math.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = math.h; sourceTree = "<group>"; };
+		0C12E9B72616383B00B66C86 /* eigen_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = eigen_utils.h; sourceTree = "<group>"; };
+		0C12E9B82616383B00B66C86 /* smart_tensor_printer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = smart_tensor_printer.h; sourceTree = "<group>"; };
+		0C12E9B92616383B00B66C86 /* proto_convert.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = proto_convert.h; sourceTree = "<group>"; };
+		0C12E9BA2616383B00B66C86 /* proto_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = proto_utils.h; sourceTree = "<group>"; };
+		0C12E9BB2616383B00B66C86 /* cblas.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cblas.h; sourceTree = "<group>"; };
+		0C12E9BC2616383B00B66C86 /* map_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = map_utils.h; sourceTree = "<group>"; };
+		0C12E9BD2616383B00B66C86 /* zmq_helper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = zmq_helper.h; sourceTree = "<group>"; };
+		0C12E9C12616383B00B66C86 /* ctc_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ctc_op.h; sourceTree = "<group>"; };
+		0C12E9C32616383B00B66C86 /* cuda_nccl_gpu.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cuda_nccl_gpu.h; sourceTree = "<group>"; };
+		0C12E9C92616383B00B66C86 /* allreduce_ops.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = allreduce_ops.h; sourceTree = "<group>"; };
+		0C12E9CA2616383B00B66C86 /* allgather_ops.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = allgather_ops.h; sourceTree = "<group>"; };
+		0C12E9CB2616383B00B66C86 /* context.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = context.h; sourceTree = "<group>"; };
+		0C12E9CC2616383B00B66C86 /* store_handler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = store_handler.h; sourceTree = "<group>"; };
+		0C12E9CD2616383B00B66C86 /* broadcast_ops.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = broadcast_ops.h; sourceTree = "<group>"; };
+		0C12E9CE2616383B00B66C86 /* reduce_scatter_ops.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = reduce_scatter_ops.h; sourceTree = "<group>"; };
+		0C12E9CF2616383B00B66C86 /* common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = common.h; sourceTree = "<group>"; };
+		0C12E9D02616383B00B66C86 /* common_world_ops.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = common_world_ops.h; sourceTree = "<group>"; };
+		0C12E9D12616383B00B66C86 /* barrier_ops.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = barrier_ops.h; sourceTree = "<group>"; };
+		0C12E9D32616383B00B66C86 /* sum_fp16_fake_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = sum_fp16_fake_op.h; sourceTree = "<group>"; };
+		0C12E9D42616383B00B66C86 /* lengths_reducer_fused_4bit_rowwise_fp16_fake_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lengths_reducer_fused_4bit_rowwise_fp16_fake_op.h; sourceTree = "<group>"; };
+		0C12E9D52616383B00B66C86 /* int8_dequantize_op_nnpi.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = int8_dequantize_op_nnpi.h; sourceTree = "<group>"; };
+		0C12E9D72616383B00B66C86 /* fp16_gemm_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fp16_gemm_utils.h; sourceTree = "<group>"; };
+		0C12E9D82616383B00B66C86 /* fp16_fma.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fp16_fma.h; sourceTree = "<group>"; };
+		0C12E9D92616383B00B66C86 /* fp16_fc_acc_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fp16_fc_acc_op.h; sourceTree = "<group>"; };
+		0C12E9DA2616383B00B66C86 /* layernorm_fp16_fake_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = layernorm_fp16_fake_op.h; sourceTree = "<group>"; };
+		0C12E9DB2616383B00B66C86 /* unary_fp16_fake_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = unary_fp16_fake_op.h; sourceTree = "<group>"; };
+		0C12E9DC2616383B00B66C86 /* int8_quantize_op_nnpi.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = int8_quantize_op_nnpi.h; sourceTree = "<group>"; };
+		0C12E9DD2616383B00B66C86 /* lengths_reducer_ops.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lengths_reducer_ops.h; sourceTree = "<group>"; };
+		0C12E9DE2616383B00B66C86 /* common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = common.h; sourceTree = "<group>"; };
+		0C12E9DF2616383B00B66C86 /* batch_matmul_fp16_fake_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = batch_matmul_fp16_fake_op.h; sourceTree = "<group>"; };
+		0C12E9E02616383B00B66C86 /* lengths_reducer_fused_8bit_rowwise_fp16_fake_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lengths_reducer_fused_8bit_rowwise_fp16_fake_op.h; sourceTree = "<group>"; };
+		0C12E9E12616383B00B66C86 /* spatial_batch_norm_fp16_fake_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = spatial_batch_norm_fp16_fake_op.h; sourceTree = "<group>"; };
+		0C12E9E22616383B00B66C86 /* quant_lut_fp16_fake_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = quant_lut_fp16_fake_op.h; sourceTree = "<group>"; };
+		0C12E9E32616383B00B66C86 /* int8_swish_op_nnpi.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = int8_swish_op_nnpi.h; sourceTree = "<group>"; };
+		0C12E9E72616383B00B66C86 /* context.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = context.h; sourceTree = "<group>"; };
+		0C12E9EA2616383B00B66C86 /* prof_dag_stats_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = prof_dag_stats_op.h; sourceTree = "<group>"; };
+		0C12E9EC2616383B00B66C86 /* tensorrt_tranformer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tensorrt_tranformer.h; sourceTree = "<group>"; };
+		0C12E9ED2616383B00B66C86 /* trt_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = trt_utils.h; sourceTree = "<group>"; };
+		0C12E9EE2616383B00B66C86 /* tensorrt_op_trt.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tensorrt_op_trt.h; sourceTree = "<group>"; };
+		0C12E9F02616383B00B66C86 /* shm_mutex.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = shm_mutex.h; sourceTree = "<group>"; };
+		0C12E9F32616383B00B66C86 /* aten_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = aten_op.h; sourceTree = "<group>"; };
+		0C12E9F52616383B00B66C86 /* aten_op_template.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = aten_op_template.h; sourceTree = "<group>"; };
+		0C12E9F82616383B00B66C86 /* image_input_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = image_input_op.h; sourceTree = "<group>"; };
+		0C12E9F92616383B00B66C86 /* transform_gpu.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = transform_gpu.h; sourceTree = "<group>"; };
+		0C12E9FC2616383B00B66C86 /* fbgemm_fp16_pack_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fbgemm_fp16_pack_op.h; sourceTree = "<group>"; };
+		0C12E9FD2616383B00B66C86 /* concat_dnnlowp_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = concat_dnnlowp_op.h; sourceTree = "<group>"; };
+		0C12E9FE2616383B00B66C86 /* fully_connected_dnnlowp_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fully_connected_dnnlowp_op.h; sourceTree = "<group>"; };
+		0C12E9FF2616383B00B66C86 /* int8_quant_scheme_blob_fill.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = int8_quant_scheme_blob_fill.h; sourceTree = "<group>"; };
+		0C12EA002616383B00B66C86 /* quantize_dnnlowp_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = quantize_dnnlowp_op.h; sourceTree = "<group>"; };
+		0C12EA012616383B00B66C86 /* batch_matmul_dnnlowp_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = batch_matmul_dnnlowp_op.h; sourceTree = "<group>"; };
+		0C12EA022616383B00B66C86 /* utility_dnnlowp_ops.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = utility_dnnlowp_ops.h; sourceTree = "<group>"; };
+		0C12EA032616383B00B66C86 /* activation_distribution_observer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = activation_distribution_observer.h; sourceTree = "<group>"; };
+		0C12EA042616383B00B66C86 /* compute_equalization_scale.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = compute_equalization_scale.h; sourceTree = "<group>"; };
+		0C12EA052616383B00B66C86 /* caffe2_dnnlowp_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = caffe2_dnnlowp_utils.h; sourceTree = "<group>"; };
+		0C12EA062616383B00B66C86 /* dnnlowp_partition.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = dnnlowp_partition.h; sourceTree = "<group>"; };
+		0C12EA072616383B00B66C86 /* fully_connected_fake_lowp_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fully_connected_fake_lowp_op.h; sourceTree = "<group>"; };
+		0C12EA082616383B00B66C86 /* op_wrapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = op_wrapper.h; sourceTree = "<group>"; };
+		0C12EA092616383B00B66C86 /* batch_permutation_dnnlowp_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = batch_permutation_dnnlowp_op.h; sourceTree = "<group>"; };
+		0C12EA0A2616383B00B66C86 /* conv_relu_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = conv_relu_op.h; sourceTree = "<group>"; };
+		0C12EA0B2616383B00B66C86 /* conv_pool_dnnlowp_op_base.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = conv_pool_dnnlowp_op_base.h; sourceTree = "<group>"; };
+		0C12EA0C2616383B00B66C86 /* mmio.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mmio.h; sourceTree = "<group>"; };
+		0C12EA0D2616383B00B66C86 /* lstm_unit_dnnlowp_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lstm_unit_dnnlowp_op.h; sourceTree = "<group>"; };
+		0C12EA0E2616383B00B66C86 /* fbgemm_pack_matrix_cache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fbgemm_pack_matrix_cache.h; sourceTree = "<group>"; };
+		0C12EA0F2616383B00B66C86 /* im2col_dnnlowp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = im2col_dnnlowp.h; sourceTree = "<group>"; };
+		0C12EA102616383B00B66C86 /* fbgemm_pack_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fbgemm_pack_op.h; sourceTree = "<group>"; };
+		0C12EA112616383B00B66C86 /* resize_nearest_dnnlowp_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = resize_nearest_dnnlowp_op.h; sourceTree = "<group>"; };
+		0C12EA122616383B00B66C86 /* group_norm_dnnlowp_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = group_norm_dnnlowp_op.h; sourceTree = "<group>"; };
+		0C12EA132616383B00B66C86 /* elementwise_dnnlowp_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = elementwise_dnnlowp_op.h; sourceTree = "<group>"; };
+		0C12EA142616383B00B66C86 /* fb_fc_packed_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fb_fc_packed_op.h; sourceTree = "<group>"; };
+		0C12EA152616383B00B66C86 /* relu_dnnlowp_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = relu_dnnlowp_op.h; sourceTree = "<group>"; };
+		0C12EA162616383B00B66C86 /* spatial_batch_norm_dnnlowp_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = spatial_batch_norm_dnnlowp_op.h; sourceTree = "<group>"; };
+		0C12EA172616383B00B66C86 /* dequantize_dnnlowp_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = dequantize_dnnlowp_op.h; sourceTree = "<group>"; };
+		0C12EA182616383B00B66C86 /* kl_minimization.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = kl_minimization.h; sourceTree = "<group>"; };
+		0C12EA192616383B00B66C86 /* dynamic_histogram.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = dynamic_histogram.h; sourceTree = "<group>"; };
+		0C12EA1A2616383B00B66C86 /* tanh.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tanh.h; sourceTree = "<group>"; };
+		0C12EA1B2616383B00B66C86 /* fbgemm_pack_blob.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fbgemm_pack_blob.h; sourceTree = "<group>"; };
+		0C12EA1C2616383B00B66C86 /* resize_nearest_3d_dnnlowp_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = resize_nearest_3d_dnnlowp_op.h; sourceTree = "<group>"; };
+		0C12EA1D2616383B00B66C86 /* int8_gen_quant_params.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = int8_gen_quant_params.h; sourceTree = "<group>"; };
+		0C12EA1E2616383B00B66C86 /* conv_dnnlowp_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = conv_dnnlowp_op.h; sourceTree = "<group>"; };
+		0C12EA1F2616383B00B66C86 /* sigmoid.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = sigmoid.h; sourceTree = "<group>"; };
+		0C12EA202616383B00B66C86 /* channel_shuffle_dnnlowp_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = channel_shuffle_dnnlowp_op.h; sourceTree = "<group>"; };
+		0C12EA212616383B00B66C86 /* int8_gen_quant_params_min_max.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = int8_gen_quant_params_min_max.h; sourceTree = "<group>"; };
+		0C12EA222616383B00B66C86 /* quantization_error_minimization.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = quantization_error_minimization.h; sourceTree = "<group>"; };
+		0C12EA232616383B00B66C86 /* elementwise_linear_dnnlowp_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = elementwise_linear_dnnlowp_op.h; sourceTree = "<group>"; };
+		0C12EA242616383B00B66C86 /* dnnlowp_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = dnnlowp_op.h; sourceTree = "<group>"; };
+		0C12EA252616383B00B66C86 /* l2_minimization.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = l2_minimization.h; sourceTree = "<group>"; };
+		0C12EA262616383B00B66C86 /* dnnlowp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = dnnlowp.h; sourceTree = "<group>"; };
+		0C12EA272616383B00B66C86 /* conv_dnnlowp_acc16_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = conv_dnnlowp_acc16_op.h; sourceTree = "<group>"; };
+		0C12EA282616383B00B66C86 /* transpose.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = transpose.h; sourceTree = "<group>"; };
+		0C12EA292616383B00B66C86 /* pool_dnnlowp_op_avx2.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pool_dnnlowp_op_avx2.h; sourceTree = "<group>"; };
+		0C12EA2A2616383B00B66C86 /* fully_connected_dnnlowp_acc16_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fully_connected_dnnlowp_acc16_op.h; sourceTree = "<group>"; };
+		0C12EA2C2616383B00B66C86 /* single_op_transform.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = single_op_transform.h; sourceTree = "<group>"; };
+		0C12EA2D2616383B00B66C86 /* common_subexpression_elimination.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = common_subexpression_elimination.h; sourceTree = "<group>"; };
+		0C12EA2E2616383B00B66C86 /* conv_to_nnpack_transform.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = conv_to_nnpack_transform.h; sourceTree = "<group>"; };
+		0C12EA2F2616383B00B66C86 /* pattern_net_transform.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pattern_net_transform.h; sourceTree = "<group>"; };
+		0C12EA342616383B00B66C86 /* libopencl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = libopencl.h; sourceTree = "<group>"; };
+		0C12EA362616383B00B66C86 /* cl_platform.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cl_platform.h; sourceTree = "<group>"; };
+		0C12EA372616383B00B66C86 /* opencl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = opencl.h; sourceTree = "<group>"; };
+		0C12EA382616383B00B66C86 /* cl_ext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cl_ext.h; sourceTree = "<group>"; };
+		0C12EA392616383B00B66C86 /* cl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cl.h; sourceTree = "<group>"; };
+		0C12EA3A2616383B00B66C86 /* cl_gl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cl_gl.h; sourceTree = "<group>"; };
+		0C12EA3B2616383B00B66C86 /* cl_gl_ext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cl_gl_ext.h; sourceTree = "<group>"; };
+		0C12EA3E2616383B00B66C86 /* ios_caffe_defines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ios_caffe_defines.h; sourceTree = "<group>"; };
+		0C12EA402616383B00B66C86 /* mpscnn_graph_mask.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mpscnn_graph_mask.h; sourceTree = "<group>"; };
+		0C12EA412616383B00B66C86 /* mpscnn.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mpscnn.h; sourceTree = "<group>"; };
+		0C12EA422616383B00B66C86 /* mpscnn_test.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mpscnn_test.h; sourceTree = "<group>"; };
+		0C12EA432616383B00B66C86 /* mpscnn_kernels.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mpscnn_kernels.h; sourceTree = "<group>"; };
+		0C12EA442616383B00B66C86 /* mpscnn_context.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mpscnn_context.h; sourceTree = "<group>"; };
+		0C12EA452616383B00B66C86 /* ios_caffe.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ios_caffe.h; sourceTree = "<group>"; };
+		0C12EA462616383B00B66C86 /* ios_caffe_predictor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ios_caffe_predictor.h; sourceTree = "<group>"; };
+		0C12EA482616383B00B66C86 /* snpe_ffi.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = snpe_ffi.h; sourceTree = "<group>"; };
+		0C12EA4A2616383B00B66C86 /* nnapi.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = nnapi.h; sourceTree = "<group>"; };
+		0C12EA4B2616383B00B66C86 /* NeuralNetworks.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NeuralNetworks.h; sourceTree = "<group>"; };
+		0C12EA4C2616383B00B66C86 /* dlnnapi.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = dlnnapi.h; sourceTree = "<group>"; };
+		0C12EA4E2616383B00B66C86 /* ulp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ulp.h; sourceTree = "<group>"; };
+		0C12EA4F2616383B00B66C86 /* ulp_neon.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ulp_neon.h; sourceTree = "<group>"; };
+		0C12EA522616383B00B66C86 /* libvulkan-stub.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "libvulkan-stub.h"; sourceTree = "<group>"; };
+		0C12EA542616383B00B66C86 /* vulkan.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vulkan.h; sourceTree = "<group>"; };
+		0C12EA552616383B00B66C86 /* vk_platform.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vk_platform.h; sourceTree = "<group>"; };
+		0C12EA582616383B00B66C86 /* fp16_momentum_sgd_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fp16_momentum_sgd_op.h; sourceTree = "<group>"; };
+		0C12EA592616383B00B66C86 /* rmsprop_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rmsprop_op.h; sourceTree = "<group>"; };
+		0C12EA5A2616383B00B66C86 /* lars_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lars_op.h; sourceTree = "<group>"; };
+		0C12EA5B2616383B00B66C86 /* yellowfin_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = yellowfin_op.h; sourceTree = "<group>"; };
+		0C12EA5C2616383B00B66C86 /* math_lp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = math_lp.h; sourceTree = "<group>"; };
+		0C12EA5D2616383B00B66C86 /* storm_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = storm_op.h; sourceTree = "<group>"; };
+		0C12EA5E2616383B00B66C86 /* adagrad_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = adagrad_op.h; sourceTree = "<group>"; };
+		0C12EA5F2616383B00B66C86 /* clip_tensor_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = clip_tensor_op.h; sourceTree = "<group>"; };
+		0C12EA602616383B00B66C86 /* gftrl_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = gftrl_op.h; sourceTree = "<group>"; };
+		0C12EA612616383B00B66C86 /* adadelta_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = adadelta_op.h; sourceTree = "<group>"; };
+		0C12EA622616383B00B66C86 /* learning_rate_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = learning_rate_op.h; sourceTree = "<group>"; };
+		0C12EA632616383B00B66C86 /* adagrad_fused.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = adagrad_fused.h; sourceTree = "<group>"; };
+		0C12EA642616383B00B66C86 /* adam_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = adam_op.h; sourceTree = "<group>"; };
+		0C12EA652616383B00B66C86 /* ftrl_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ftrl_op.h; sourceTree = "<group>"; };
+		0C12EA662616383B00B66C86 /* weight_scale_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = weight_scale_op.h; sourceTree = "<group>"; };
+		0C12EA672616383B00B66C86 /* learning_rate_adaption_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = learning_rate_adaption_op.h; sourceTree = "<group>"; };
+		0C12EA682616383B00B66C86 /* rowwise_counter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rowwise_counter.h; sourceTree = "<group>"; };
+		0C12EA692616383B00B66C86 /* iter_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = iter_op.h; sourceTree = "<group>"; };
+		0C12EA6A2616383B00B66C86 /* rowwise_adagrad_fused.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rowwise_adagrad_fused.h; sourceTree = "<group>"; };
+		0C12EA6B2616383B00B66C86 /* momentum_sgd_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = momentum_sgd_op.h; sourceTree = "<group>"; };
+		0C12EA6C2616383B00B66C86 /* wngrad_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = wngrad_op.h; sourceTree = "<group>"; };
+		0C12EA6D2616383B00B66C86 /* decay_adagrad_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = decay_adagrad_op.h; sourceTree = "<group>"; };
+		0C12EA6E2616383B00B66C86 /* learning_rate_functors.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = learning_rate_functors.h; sourceTree = "<group>"; };
+		0C12EA6F2616383B00B66C86 /* fp32_momentum_sgd_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fp32_momentum_sgd_op.h; sourceTree = "<group>"; };
+		0C12EA712616383B00B66C86 /* blobs_queue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = blobs_queue.h; sourceTree = "<group>"; };
+		0C12EA722616383B00B66C86 /* rebatching_queue_ops.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rebatching_queue_ops.h; sourceTree = "<group>"; };
+		0C12EA732616383B00B66C86 /* queue_ops.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = queue_ops.h; sourceTree = "<group>"; };
+		0C12EA742616383B00B66C86 /* rebatching_queue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rebatching_queue.h; sourceTree = "<group>"; };
+		0C12EA752616383B00B66C86 /* blobs_queue_db.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = blobs_queue_db.h; sourceTree = "<group>"; };
+		0C12EA772616383B00B66C86 /* create_db_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = create_db_op.h; sourceTree = "<group>"; };
+		0C12EA7B2616383B00B66C86 /* ast.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ast.h; sourceTree = "<group>"; };
+		0C12EA7C2616383B00B66C86 /* graphmatcher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = graphmatcher.h; sourceTree = "<group>"; };
+		0C12EA7D2616383B00B66C86 /* device.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = device.h; sourceTree = "<group>"; };
+		0C12EA7E2616383B00B66C86 /* annotations.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = annotations.h; sourceTree = "<group>"; };
+		0C12EA7F2616383B00B66C86 /* mobile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mobile.h; sourceTree = "<group>"; };
+		0C12EA802616383B00B66C86 /* onnxifi_transformer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = onnxifi_transformer.h; sourceTree = "<group>"; };
+		0C12EA812616383B00B66C86 /* converter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = converter.h; sourceTree = "<group>"; };
+		0C12EA822616383B00B66C86 /* backend_transformer_base.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = backend_transformer_base.h; sourceTree = "<group>"; };
+		0C12EA832616383B00B66C86 /* fakefp16_transform.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fakefp16_transform.h; sourceTree = "<group>"; };
+		0C12EA842616383B00B66C86 /* fusion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fusion.h; sourceTree = "<group>"; };
+		0C12EA852616383B00B66C86 /* shape_info.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = shape_info.h; sourceTree = "<group>"; };
+		0C12EA862616383B00B66C86 /* optimizer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = optimizer.h; sourceTree = "<group>"; };
+		0C12EA872616383B00B66C86 /* glow_net_transform.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = glow_net_transform.h; sourceTree = "<group>"; };
+		0C12EA882616383B00B66C86 /* backend_cutting.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = backend_cutting.h; sourceTree = "<group>"; };
+		0C12EA892616383B00B66C86 /* distributed.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = distributed.h; sourceTree = "<group>"; };
+		0C12EA8A2616383B00B66C86 /* onnxifi_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = onnxifi_op.h; sourceTree = "<group>"; };
+		0C12EA8B2616383B00B66C86 /* tvm_transformer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tvm_transformer.h; sourceTree = "<group>"; };
+		0C12EA8C2616383B00B66C86 /* passes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = passes.h; sourceTree = "<group>"; };
+		0C12EA8D2616383B00B66C86 /* bound_shape_inferencer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = bound_shape_inferencer.h; sourceTree = "<group>"; };
+		0C12EA8F2616383B00B66C86 /* concat_elim.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = concat_elim.h; sourceTree = "<group>"; };
+		0C12EA902616383B00B66C86 /* pointwise_elim.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pointwise_elim.h; sourceTree = "<group>"; };
+		0C12EA912616383B00B66C86 /* freeze_quantization_params.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = freeze_quantization_params.h; sourceTree = "<group>"; };
+		0C12EA922616383B00B66C86 /* in_batch_broadcast.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = in_batch_broadcast.h; sourceTree = "<group>"; };
+		0C12EA932616383B00B66C86 /* cc_amrc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cc_amrc.h; sourceTree = "<group>"; };
+		0C12EA942616383B00B66C86 /* onnx_convert.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = onnx_convert.h; sourceTree = "<group>"; };
+		0C12EA952616383B00B66C86 /* optimize_ideep.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = optimize_ideep.h; sourceTree = "<group>"; };
+		0C12EA972616383B00B66C86 /* ThreadLocalPtr.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ThreadLocalPtr.h; sourceTree = "<group>"; };
+		0C12EA982616383B00B66C86 /* InferenceGraph.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InferenceGraph.h; sourceTree = "<group>"; };
+		0C12EA992616383B00B66C86 /* predictor_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = predictor_utils.h; sourceTree = "<group>"; };
+		0C12EA9A2616383B00B66C86 /* predictor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = predictor.h; sourceTree = "<group>"; };
+		0C12EA9B2616383B00B66C86 /* predictor_config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = predictor_config.h; sourceTree = "<group>"; };
+		0C12EA9D2616383B00B66C86 /* data_filler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = data_filler.h; sourceTree = "<group>"; };
+		0C12EA9E2616383B00B66C86 /* utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = utils.h; sourceTree = "<group>"; };
+		0C12EA9F2616383B00B66C86 /* net_supplier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = net_supplier.h; sourceTree = "<group>"; };
+		0C12EAA02616383B00B66C86 /* time_profiler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = time_profiler.h; sourceTree = "<group>"; };
+		0C12EAA12616383B00B66C86 /* emulator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = emulator.h; sourceTree = "<group>"; };
+		0C12EAA22616383B00B66C86 /* output_formatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = output_formatter.h; sourceTree = "<group>"; };
+		0C12EAA32616383B00B66C86 /* std_output_formatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = std_output_formatter.h; sourceTree = "<group>"; };
+		0C12EAA42616383B00B66C86 /* benchmark.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = benchmark.h; sourceTree = "<group>"; };
+		0C12EAA52616383B00B66C86 /* profiler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = profiler.h; sourceTree = "<group>"; };
+		0C12EAA62616383B00B66C86 /* transforms.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = transforms.h; sourceTree = "<group>"; };
+		0C12EAA82616383B00B66C86 /* operator_attaching_net_observer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = operator_attaching_net_observer.h; sourceTree = "<group>"; };
+		0C12EAA92616383B00B66C86 /* time_observer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = time_observer.h; sourceTree = "<group>"; };
+		0C12EAAA2616383B00B66C86 /* runcnt_observer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = runcnt_observer.h; sourceTree = "<group>"; };
+		0C12EAAB2616383B00B66C86 /* profile_observer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = profile_observer.h; sourceTree = "<group>"; };
+		0C12EAB12616383B00B66C86 /* quant_decomp_zstd_op.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = quant_decomp_zstd_op.h; sourceTree = "<group>"; };
+		0C12EAB22616383B00B66C86 /* cpuinfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cpuinfo.h; sourceTree = "<group>"; };
+		0C12EAB52616383B00B66C86 /* Size.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Size.h; sourceTree = "<group>"; };
+		0C12EAB62616383B00B66C86 /* utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = utils.h; sourceTree = "<group>"; };
+		0C12EAB72616383B00B66C86 /* Device.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Device.h; sourceTree = "<group>"; };
+		0C12EAB92616383B00B66C86 /* init.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = init.h; sourceTree = "<group>"; };
+		0C12EABA2616383B00B66C86 /* onnx.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = onnx.h; sourceTree = "<group>"; };
+		0C12EABB2616383B00B66C86 /* Types.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Types.h; sourceTree = "<group>"; };
+		0C12EABE2616383B00B66C86 /* utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = utils.h; sourceTree = "<group>"; };
+		0C12EAC02616383B00B66C86 /* container.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = container.h; sourceTree = "<group>"; };
+		0C12EAC12616383B00B66C86 /* context.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = context.h; sourceTree = "<group>"; };
+		0C12EAC32616383B00B66C86 /* cleanup_autograd_context_req.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cleanup_autograd_context_req.h; sourceTree = "<group>"; };
+		0C12EAC42616383B00B66C86 /* cleanup_autograd_context_resp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cleanup_autograd_context_resp.h; sourceTree = "<group>"; };
+		0C12EAC52616383B00B66C86 /* rref_backward_req.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rref_backward_req.h; sourceTree = "<group>"; };
+		0C12EAC62616383B00B66C86 /* rpc_with_profiling_req.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rpc_with_profiling_req.h; sourceTree = "<group>"; };
+		0C12EAC72616383B00B66C86 /* propagate_gradients_resp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = propagate_gradients_resp.h; sourceTree = "<group>"; };
+		0C12EAC82616383B00B66C86 /* propagate_gradients_req.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = propagate_gradients_req.h; sourceTree = "<group>"; };
+		0C12EAC92616383B00B66C86 /* autograd_metadata.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = autograd_metadata.h; sourceTree = "<group>"; };
+		0C12EACA2616383B00B66C86 /* rpc_with_autograd.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rpc_with_autograd.h; sourceTree = "<group>"; };
+		0C12EACB2616383B00B66C86 /* rref_backward_resp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rref_backward_resp.h; sourceTree = "<group>"; };
+		0C12EACC2616383B00B66C86 /* rpc_with_profiling_resp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rpc_with_profiling_resp.h; sourceTree = "<group>"; };
+		0C12EACD2616383B00B66C86 /* python_autograd.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = python_autograd.h; sourceTree = "<group>"; };
+		0C12EACE2616383B00B66C86 /* autograd.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = autograd.h; sourceTree = "<group>"; };
+		0C12EAD02616383B00B66C86 /* sendrpc_backward.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = sendrpc_backward.h; sourceTree = "<group>"; };
+		0C12EAD12616383B00B66C86 /* recvrpc_backward.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = recvrpc_backward.h; sourceTree = "<group>"; };
+		0C12EAD32616383B00B66C86 /* dist_engine.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = dist_engine.h; sourceTree = "<group>"; };
+		0C12EAD62616383B00B66C86 /* RpcMetricsHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RpcMetricsHandler.h; sourceTree = "<group>"; };
+		0C12EAD72616383B00B66C86 /* utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = utils.h; sourceTree = "<group>"; };
+		0C12EAD82616383B00B66C86 /* rref_context.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rref_context.h; sourceTree = "<group>"; };
+		0C12EAD92616383B00B66C86 /* request_callback_impl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = request_callback_impl.h; sourceTree = "<group>"; };
+		0C12EADA2616383B00B66C86 /* python_resp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = python_resp.h; sourceTree = "<group>"; };
+		0C12EADB2616383B00B66C86 /* rref_impl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rref_impl.h; sourceTree = "<group>"; };
+		0C12EADC2616383B00B66C86 /* request_callback.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = request_callback.h; sourceTree = "<group>"; };
+		0C12EADD2616383B00B66C86 /* types.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = types.h; sourceTree = "<group>"; };
+		0C12EADE2616383B00B66C86 /* rref_proto.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rref_proto.h; sourceTree = "<group>"; };
+		0C12EADF2616383B00B66C86 /* py_rref.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = py_rref.h; sourceTree = "<group>"; };
+		0C12EAE02616383B00B66C86 /* rpc_agent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rpc_agent.h; sourceTree = "<group>"; };
+		0C12EAE12616383B00B66C86 /* python_functions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = python_functions.h; sourceTree = "<group>"; };
+		0C12EAE22616383B00B66C86 /* message.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = message.h; sourceTree = "<group>"; };
+		0C12EAE32616383B00B66C86 /* request_callback_no_python.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = request_callback_no_python.h; sourceTree = "<group>"; };
+		0C12EAE42616383B00B66C86 /* python_remote_call.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = python_remote_call.h; sourceTree = "<group>"; };
+		0C12EAE52616383B00B66C86 /* python_call.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = python_call.h; sourceTree = "<group>"; };
+		0C12EAE62616383B00B66C86 /* tensorpipe_agent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tensorpipe_agent.h; sourceTree = "<group>"; };
+		0C12EAE72616383B00B66C86 /* script_remote_call.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = script_remote_call.h; sourceTree = "<group>"; };
+		0C12EAE92616383B00B66C86 /* testing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = testing.h; sourceTree = "<group>"; };
+		0C12EAEA2616383B00B66C86 /* faulty_process_group_agent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = faulty_process_group_agent.h; sourceTree = "<group>"; };
+		0C12EAEB2616383B00B66C86 /* macros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = macros.h; sourceTree = "<group>"; };
+		0C12EAEC2616383B00B66C86 /* script_resp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = script_resp.h; sourceTree = "<group>"; };
+		0C12EAED2616383B00B66C86 /* rpc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rpc.h; sourceTree = "<group>"; };
+		0C12EAEE2616383B00B66C86 /* rpc_command_base.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rpc_command_base.h; sourceTree = "<group>"; };
+		0C12EAF02616383B00B66C86 /* remote_profiler_manager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = remote_profiler_manager.h; sourceTree = "<group>"; };
+		0C12EAF12616383B00B66C86 /* server_process_global_profiler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = server_process_global_profiler.h; sourceTree = "<group>"; };
+		0C12EAF22616383B00B66C86 /* script_call.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = script_call.h; sourceTree = "<group>"; };
+		0C12EAF32616383B00B66C86 /* unpickled_python_remote_call.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = unpickled_python_remote_call.h; sourceTree = "<group>"; };
+		0C12EAF42616383B00B66C86 /* torchscript_functions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = torchscript_functions.h; sourceTree = "<group>"; };
+		0C12EAF52616383B00B66C86 /* unpickled_python_call.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = unpickled_python_call.h; sourceTree = "<group>"; };
+		0C12EAF62616383B00B66C86 /* tensorpipe_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tensorpipe_utils.h; sourceTree = "<group>"; };
+		0C12EAF72616383B00B66C86 /* agent_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = agent_utils.h; sourceTree = "<group>"; };
+		0C12EAF82616383B00B66C86 /* process_group_agent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = process_group_agent.h; sourceTree = "<group>"; };
+		0C12EAF92616383B00B66C86 /* python_rpc_handler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = python_rpc_handler.h; sourceTree = "<group>"; };
+		0C12EAFB2616383B00B66C86 /* python_comm_hook.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = python_comm_hook.h; sourceTree = "<group>"; };
+		0C12EAFC2616383B00B66C86 /* c10d.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = c10d.h; sourceTree = "<group>"; };
+		0C12EAFF2616383B00B66C86 /* python_functions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = python_functions.h; sourceTree = "<group>"; };
+		0C12EB002616383B00B66C86 /* Functions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Functions.h; sourceTree = "<group>"; };
+		0C12EB012616383B00B66C86 /* variable_factories.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = variable_factories.h; sourceTree = "<group>"; };
+		0C12EB022616383B00B66C86 /* python_function.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = python_function.h; sourceTree = "<group>"; };
+		0C12EB032616383B00B66C86 /* custom_function.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = custom_function.h; sourceTree = "<group>"; };
+		0C12EB042616383B00B66C86 /* python_linalg_functions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = python_linalg_functions.h; sourceTree = "<group>"; };
+		0C12EB052616383B00B66C86 /* record_function_ops.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = record_function_ops.h; sourceTree = "<group>"; };
+		0C12EB062616383B00B66C86 /* engine.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = engine.h; sourceTree = "<group>"; };
+		0C12EB072616383B00B66C86 /* edge.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = edge.h; sourceTree = "<group>"; };
+		0C12EB082616383B00B66C86 /* saved_variable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = saved_variable.h; sourceTree = "<group>"; };
+		0C12EB092616383B00B66C86 /* python_engine.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = python_engine.h; sourceTree = "<group>"; };
+		0C12EB0A2616383B00B66C86 /* python_legacy_variable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = python_legacy_variable.h; sourceTree = "<group>"; };
+		0C12EB0B2616383B00B66C86 /* python_cpp_function.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = python_cpp_function.h; sourceTree = "<group>"; };
+		0C12EB0C2616383B00B66C86 /* python_hook.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = python_hook.h; sourceTree = "<group>"; };
+		0C12EB0D2616383B00B66C86 /* VariableTypeUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VariableTypeUtils.h; sourceTree = "<group>"; };
+		0C12EB0E2616383B00B66C86 /* python_autograd.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = python_autograd.h; sourceTree = "<group>"; };
+		0C12EB0F2616383B00B66C86 /* profiler_kineto.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = profiler_kineto.h; sourceTree = "<group>"; };
+		0C12EB102616383B00B66C86 /* variable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = variable.h; sourceTree = "<group>"; };
+		0C12EB122616383B00B66C86 /* wrap_outputs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = wrap_outputs.h; sourceTree = "<group>"; };
+		0C12EB132616383B00B66C86 /* python_arg_parsing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = python_arg_parsing.h; sourceTree = "<group>"; };
+		0C12EB142616383B00B66C86 /* grad_layout_contract.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = grad_layout_contract.h; sourceTree = "<group>"; };
+		0C12EB152616383B00B66C86 /* lambda_post_hook.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lambda_post_hook.h; sourceTree = "<group>"; };
+		0C12EB162616383B00B66C86 /* error_messages.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = error_messages.h; sourceTree = "<group>"; };
+		0C12EB172616383B00B66C86 /* python_fft_functions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = python_fft_functions.h; sourceTree = "<group>"; };
+		0C12EB182616383B00B66C86 /* python_variable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = python_variable.h; sourceTree = "<group>"; };
+		0C12EB192616383B00B66C86 /* function_hook.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = function_hook.h; sourceTree = "<group>"; };
+		0C12EB1A2616383B00B66C86 /* input_metadata.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = input_metadata.h; sourceTree = "<group>"; };
+		0C12EB1B2616383B00B66C86 /* grad_mode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = grad_mode.h; sourceTree = "<group>"; };
+		0C12EB1C2616383B00B66C86 /* symbolic.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = symbolic.h; sourceTree = "<group>"; };
+		0C12EB1D2616383B00B66C86 /* input_buffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = input_buffer.h; sourceTree = "<group>"; };
+		0C12EB1E2616383B00B66C86 /* profiler_legacy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = profiler_legacy.h; sourceTree = "<group>"; };
+		0C12EB1F2616383B00B66C86 /* autograd.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = autograd.h; sourceTree = "<group>"; };
+		0C12EB202616383B00B66C86 /* cpp_hook.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cpp_hook.h; sourceTree = "<group>"; };
+		0C12EB222616383B00B66C86 /* utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = utils.h; sourceTree = "<group>"; };
+		0C12EB232616383B00B66C86 /* pybind.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pybind.h; sourceTree = "<group>"; };
+		0C12EB242616383B00B66C86 /* comm.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = comm.h; sourceTree = "<group>"; };
+		0C12EB252616383B00B66C86 /* basic_ops.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = basic_ops.h; sourceTree = "<group>"; };
+		0C12EB262616383B00B66C86 /* accumulate_grad.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = accumulate_grad.h; sourceTree = "<group>"; };
+		0C12EB272616383B00B66C86 /* tensor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tensor.h; sourceTree = "<group>"; };
+		0C12EB282616383B00B66C86 /* python_special_functions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = python_special_functions.h; sourceTree = "<group>"; };
+		0C12EB292616383B00B66C86 /* FunctionsManual.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FunctionsManual.h; sourceTree = "<group>"; };
+		0C12EB2A2616383B00B66C86 /* forward_grad.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = forward_grad.h; sourceTree = "<group>"; };
+		0C12EB2B2616383B00B66C86 /* python_anomaly_mode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = python_anomaly_mode.h; sourceTree = "<group>"; };
+		0C12EB2C2616383B00B66C86 /* python_nn_functions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = python_nn_functions.h; sourceTree = "<group>"; };
+		0C12EB2D2616383B00B66C86 /* InferenceMode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InferenceMode.h; sourceTree = "<group>"; };
+		0C12EB2E2616383B00B66C86 /* python_variable_indexing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = python_variable_indexing.h; sourceTree = "<group>"; };
+		0C12EB2F2616383B00B66C86 /* profiler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = profiler.h; sourceTree = "<group>"; };
+		0C12EB302616383B00B66C86 /* function.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = function.h; sourceTree = "<group>"; };
+		0C12EB312616383B00B66C86 /* anomaly_mode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = anomaly_mode.h; sourceTree = "<group>"; };
+		0C12EB322616383B00B66C86 /* profiler_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = profiler_utils.h; sourceTree = "<group>"; };
+		0C12EB352616383B00B66C86 /* interpreter_impl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = interpreter_impl.h; sourceTree = "<group>"; };
+		0C12EB382616383B00B66C86 /* deploy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = deploy.h; sourceTree = "<group>"; };
+		0C12EB3A2616383B00B66C86 /* init.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = init.h; sourceTree = "<group>"; };
+		0C12EB3C2616383B00B66C86 /* utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = utils.h; sourceTree = "<group>"; };
+		0C12EB3D2616383B00B66C86 /* THCP.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = THCP.h; sourceTree = "<group>"; };
+		0C12EB3E2616383B00B66C86 /* nccl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = nccl.h; sourceTree = "<group>"; };
+		0C12EB3F2616383B00B66C86 /* python_nccl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = python_nccl.h; sourceTree = "<group>"; };
+		0C12EB402616383B00B66C86 /* device_set.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = device_set.h; sourceTree = "<group>"; };
+		0C12EB412616383B00B66C86 /* Event.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Event.h; sourceTree = "<group>"; };
+		0C12EB422616383B00B66C86 /* serialization.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = serialization.h; sourceTree = "<group>"; };
+		0C12EB432616383B00B66C86 /* python_comm.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = python_comm.h; sourceTree = "<group>"; };
+		0C12EB442616383B00B66C86 /* comm.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = comm.h; sourceTree = "<group>"; };
+		0C12EB452616383B00B66C86 /* Stream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Stream.h; sourceTree = "<group>"; };
+		0C12EB472616383B00B66C86 /* undef_macros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = undef_macros.h; sourceTree = "<group>"; };
+		0C12EB482616383B00B66C86 /* restore_macros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = restore_macros.h; sourceTree = "<group>"; };
+		0C12EB492616383B00B66C86 /* Storage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Storage.h; sourceTree = "<group>"; };
+		0C12EB4A2616383B00B66C86 /* Module.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Module.h; sourceTree = "<group>"; };
+		0C12EB4B2616383B00B66C86 /* override_macros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = override_macros.h; sourceTree = "<group>"; };
+		0C12EB4C2616383B00B66C86 /* serialization.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = serialization.h; sourceTree = "<group>"; };
+		0C12EB4D2616383B00B66C86 /* Exceptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Exceptions.h; sourceTree = "<group>"; };
+		0C12EB4E2616383B00B66C86 /* QScheme.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = QScheme.h; sourceTree = "<group>"; };
+		0C12EB502616383B00B66C86 /* object_ptr.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = object_ptr.h; sourceTree = "<group>"; };
+		0C12EB512616383B00B66C86 /* tensor_numpy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tensor_numpy.h; sourceTree = "<group>"; };
+		0C12EB522616383B00B66C86 /* tensor_dtypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tensor_dtypes.h; sourceTree = "<group>"; };
+		0C12EB532616383B00B66C86 /* python_tuples.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = python_tuples.h; sourceTree = "<group>"; };
+		0C12EB542616383B00B66C86 /* python_numbers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = python_numbers.h; sourceTree = "<group>"; };
+		0C12EB552616383B00B66C86 /* python_scalars.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = python_scalars.h; sourceTree = "<group>"; };
+		0C12EB562616383B00B66C86 /* pybind.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pybind.h; sourceTree = "<group>"; };
+		0C12EB572616383B00B66C86 /* tensor_types.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tensor_types.h; sourceTree = "<group>"; };
+		0C12EB582616383B00B66C86 /* tensor_memoryformats.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tensor_memoryformats.h; sourceTree = "<group>"; };
+		0C12EB592616383B00B66C86 /* python_arg_parser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = python_arg_parser.h; sourceTree = "<group>"; };
+		0C12EB5A2616383B00B66C86 /* cuda_lazy_init.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cuda_lazy_init.h; sourceTree = "<group>"; };
+		0C12EB5B2616383B00B66C86 /* tensor_new.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tensor_new.h; sourceTree = "<group>"; };
+		0C12EB5C2616383B00B66C86 /* tensor_qschemes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tensor_qschemes.h; sourceTree = "<group>"; };
+		0C12EB5D2616383B00B66C86 /* python_dispatch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = python_dispatch.h; sourceTree = "<group>"; };
+		0C12EB5E2616383B00B66C86 /* tensor_list.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tensor_list.h; sourceTree = "<group>"; };
+		0C12EB5F2616383B00B66C86 /* invalid_arguments.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = invalid_arguments.h; sourceTree = "<group>"; };
+		0C12EB602616383B00B66C86 /* auto_gil.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = auto_gil.h; sourceTree = "<group>"; };
+		0C12EB612616383B00B66C86 /* python_strings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = python_strings.h; sourceTree = "<group>"; };
+		0C12EB622616383B00B66C86 /* byte_order.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = byte_order.h; sourceTree = "<group>"; };
+		0C12EB632616383B00B66C86 /* pycfunction_helpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pycfunction_helpers.h; sourceTree = "<group>"; };
+		0C12EB642616383B00B66C86 /* cuda_enabled.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cuda_enabled.h; sourceTree = "<group>"; };
+		0C12EB652616383B00B66C86 /* numpy_stub.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = numpy_stub.h; sourceTree = "<group>"; };
+		0C12EB662616383B00B66C86 /* out_types.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = out_types.h; sourceTree = "<group>"; };
+		0C12EB672616383B00B66C86 /* memory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = memory.h; sourceTree = "<group>"; };
+		0C12EB682616383B00B66C86 /* tensor_layouts.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tensor_layouts.h; sourceTree = "<group>"; };
+		0C12EB692616383B00B66C86 /* structseq.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = structseq.h; sourceTree = "<group>"; };
+		0C12EB6A2616383B00B66C86 /* throughput_benchmark.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = throughput_benchmark.h; sourceTree = "<group>"; };
+		0C12EB6B2616383B00B66C86 /* disable_torch_function.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = disable_torch_function.h; sourceTree = "<group>"; };
+		0C12EB6C2616383B00B66C86 /* throughput_benchmark-inl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "throughput_benchmark-inl.h"; sourceTree = "<group>"; };
+		0C12EB6D2616383B00B66C86 /* tensor_flatten.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tensor_flatten.h; sourceTree = "<group>"; };
+		0C12EB6E2616383B00B66C86 /* tensor_apply.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tensor_apply.h; sourceTree = "<group>"; };
+		0C12EB6F2616383B00B66C86 /* init.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = init.h; sourceTree = "<group>"; };
+		0C12EB702616383B00B66C86 /* python_compat.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = python_compat.h; sourceTree = "<group>"; };
+		0C12EB712616383B00B66C86 /* disallow_copy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = disallow_copy.h; sourceTree = "<group>"; };
+		0C12EB722616383B00B66C86 /* six.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = six.h; sourceTree = "<group>"; };
+		0C12EB732616383B00B66C86 /* python_stub.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = python_stub.h; sourceTree = "<group>"; };
+		0C12EB742616383B00B66C86 /* variadic.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = variadic.h; sourceTree = "<group>"; };
+		0C12EB752616383B00B66C86 /* Stream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Stream.h; sourceTree = "<group>"; };
+		0C12EB762616383B00B66C86 /* StorageDefs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StorageDefs.h; sourceTree = "<group>"; };
+		0C12EB772616383B00B66C86 /* DataLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DataLoader.h; sourceTree = "<group>"; };
+		0C12EB782616383B00B66C86 /* THP.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = THP.h; sourceTree = "<group>"; };
+		0C12EB792616383B00B66C86 /* python_headers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = python_headers.h; sourceTree = "<group>"; };
+		0C12EB7A2616383B00B66C86 /* Layout.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Layout.h; sourceTree = "<group>"; };
+		0C12EB7B2616383B00B66C86 /* DynamicTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DynamicTypes.h; sourceTree = "<group>"; };
+		0C12EB7C2616383B00B66C86 /* copy_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = copy_utils.h; sourceTree = "<group>"; };
+		0C12EB7F2616383B00B66C86 /* jit_opt_limit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = jit_opt_limit.h; sourceTree = "<group>"; };
+		0C12EB812616383B00B66C86 /* error_report.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = error_report.h; sourceTree = "<group>"; };
+		0C12EB822616383B00B66C86 /* source_range.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = source_range.h; sourceTree = "<group>"; };
+		0C12EB832616383B00B66C86 /* edit_distance.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = edit_distance.h; sourceTree = "<group>"; };
+		0C12EB842616383B00B66C86 /* canonicalize_modified_loop.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = canonicalize_modified_loop.h; sourceTree = "<group>"; };
+		0C12EB852616383B00B66C86 /* schema_matching.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = schema_matching.h; sourceTree = "<group>"; };
+		0C12EB862616383B00B66C86 /* function_schema_parser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = function_schema_parser.h; sourceTree = "<group>"; };
+		0C12EB872616383B00B66C86 /* tree_views.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tree_views.h; sourceTree = "<group>"; };
+		0C12EB882616383B00B66C86 /* ir_emitter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ir_emitter.h; sourceTree = "<group>"; };
+		0C12EB892616383B00B66C86 /* parser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = parser.h; sourceTree = "<group>"; };
+		0C12EB8A2616383B00B66C86 /* strtod.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = strtod.h; sourceTree = "<group>"; };
+		0C12EB8B2616383B00B66C86 /* tree.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tree.h; sourceTree = "<group>"; };
+		0C12EB8C2616383B00B66C86 /* concrete_module_type.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = concrete_module_type.h; sourceTree = "<group>"; };
+		0C12EB8D2616383B00B66C86 /* builtin_functions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = builtin_functions.h; sourceTree = "<group>"; };
+		0C12EB8E2616383B00B66C86 /* exit_transforms.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = exit_transforms.h; sourceTree = "<group>"; };
+		0C12EB8F2616383B00B66C86 /* parse_string_literal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = parse_string_literal.h; sourceTree = "<group>"; };
+		0C12EB902616383B00B66C86 /* sugared_value.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = sugared_value.h; sourceTree = "<group>"; };
+		0C12EB912616383B00B66C86 /* inline_loop_condition.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = inline_loop_condition.h; sourceTree = "<group>"; };
+		0C12EB922616383B00B66C86 /* name_mangler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = name_mangler.h; sourceTree = "<group>"; };
+		0C12EB932616383B00B66C86 /* code_template.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = code_template.h; sourceTree = "<group>"; };
+		0C12EB942616383B00B66C86 /* tracer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tracer.h; sourceTree = "<group>"; };
+		0C12EB952616383B00B66C86 /* resolver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = resolver.h; sourceTree = "<group>"; };
+		0C12EB962616383B00B66C86 /* script_type_parser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = script_type_parser.h; sourceTree = "<group>"; };
+		0C12EB972616383B00B66C86 /* schema_type_parser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = schema_type_parser.h; sourceTree = "<group>"; };
+		0C12EB982616383B00B66C86 /* lexer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lexer.h; sourceTree = "<group>"; };
+		0C12EB992616383B00B66C86 /* versioned_symbols.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = versioned_symbols.h; sourceTree = "<group>"; };
+		0C12EB9A2616383B00B66C86 /* convert_to_ssa.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = convert_to_ssa.h; sourceTree = "<group>"; };
+		0C12EB9B2616383B00B66C86 /* mini_environment.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mini_environment.h; sourceTree = "<group>"; };
+		0C12EB9C2616383B00B66C86 /* parser_constants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = parser_constants.h; sourceTree = "<group>"; };
+		0C12EB9E2616383B00B66C86 /* pybind.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pybind.h; sourceTree = "<group>"; };
+		0C12EB9F2616383B00B66C86 /* python_ir.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = python_ir.h; sourceTree = "<group>"; };
+		0C12EBA02616383B00B66C86 /* script_init.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = script_init.h; sourceTree = "<group>"; };
+		0C12EBA12616383B00B66C86 /* python_tree_views.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = python_tree_views.h; sourceTree = "<group>"; };
+		0C12EBA22616383B00B66C86 /* python_ivalue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = python_ivalue.h; sourceTree = "<group>"; };
+		0C12EBA32616383B00B66C86 /* python_custom_class.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = python_custom_class.h; sourceTree = "<group>"; };
+		0C12EBA42616383B00B66C86 /* update_graph_executor_opt.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = update_graph_executor_opt.h; sourceTree = "<group>"; };
+		0C12EBA52616383B00B66C86 /* python_tracer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = python_tracer.h; sourceTree = "<group>"; };
+		0C12EBA62616383B00B66C86 /* pybind_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pybind_utils.h; sourceTree = "<group>"; };
+		0C12EBA72616383B00B66C86 /* init.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = init.h; sourceTree = "<group>"; };
+		0C12EBA82616383B00B66C86 /* python_sugared_value.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = python_sugared_value.h; sourceTree = "<group>"; };
+		0C12EBA92616383B00B66C86 /* python_arg_flatten.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = python_arg_flatten.h; sourceTree = "<group>"; };
+		0C12EBAA2616383B00B66C86 /* module_python.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = module_python.h; sourceTree = "<group>"; };
+		0C12EBAC2616383B00B66C86 /* ir_mutator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ir_mutator.h; sourceTree = "<group>"; };
+		0C12EBAD2616383B00B66C86 /* ir_simplifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ir_simplifier.h; sourceTree = "<group>"; };
+		0C12EBAE2616383B00B66C86 /* ir_visitor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ir_visitor.h; sourceTree = "<group>"; };
+		0C12EBAF2616383B00B66C86 /* llvm_jit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = llvm_jit.h; sourceTree = "<group>"; };
+		0C12EBB02616383B00B66C86 /* tensorexpr_init.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tensorexpr_init.h; sourceTree = "<group>"; };
+		0C12EBB12616383B00B66C86 /* types.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = types.h; sourceTree = "<group>"; };
+		0C12EBB22616383B00B66C86 /* mem_dependency_checker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mem_dependency_checker.h; sourceTree = "<group>"; };
+		0C12EBB32616383B00B66C86 /* ir.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ir.h; sourceTree = "<group>"; };
+		0C12EBB42616383B00B66C86 /* exceptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = exceptions.h; sourceTree = "<group>"; };
+		0C12EBB52616383B00B66C86 /* cuda_codegen.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cuda_codegen.h; sourceTree = "<group>"; };
+		0C12EBB62616383B00B66C86 /* hash_provider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = hash_provider.h; sourceTree = "<group>"; };
+		0C12EBB72616383B00B66C86 /* ir_printer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ir_printer.h; sourceTree = "<group>"; };
+		0C12EBB82616383B00B66C86 /* llvm_codegen.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = llvm_codegen.h; sourceTree = "<group>"; };
+		0C12EBB92616383B00B66C86 /* expr.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = expr.h; sourceTree = "<group>"; };
+		0C12EBBA2616383B00B66C86 /* cuda_random.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cuda_random.h; sourceTree = "<group>"; };
+		0C12EBBB2616383B00B66C86 /* execution_counter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = execution_counter.h; sourceTree = "<group>"; };
+		0C12EBBC2616383B00B66C86 /* codegen.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = codegen.h; sourceTree = "<group>"; };
+		0C12EBBD2616383B00B66C86 /* unique_name_manager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = unique_name_manager.h; sourceTree = "<group>"; };
+		0C12EBBE2616383B00B66C86 /* cpp_codegen.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cpp_codegen.h; sourceTree = "<group>"; };
+		0C12EBBF2616383B00B66C86 /* var_substitutor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = var_substitutor.h; sourceTree = "<group>"; };
+		0C12EBC02616383B00B66C86 /* eval.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = eval.h; sourceTree = "<group>"; };
+		0C12EBC12616383B00B66C86 /* bounds_inference.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = bounds_inference.h; sourceTree = "<group>"; };
+		0C12EBC22616383B00B66C86 /* intrinsic_symbols.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = intrinsic_symbols.h; sourceTree = "<group>"; };
+		0C12EBC32616383B00B66C86 /* block_codegen.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = block_codegen.h; sourceTree = "<group>"; };
+		0C12EBC42616383B00B66C86 /* external_functions_registry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = external_functions_registry.h; sourceTree = "<group>"; };
+		0C12EBC52616383B00B66C86 /* kernel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = kernel.h; sourceTree = "<group>"; };
+		0C12EBC62616383B00B66C86 /* loopnest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = loopnest.h; sourceTree = "<group>"; };
+		0C12EBC72616383B00B66C86 /* bounds_overlap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = bounds_overlap.h; sourceTree = "<group>"; };
+		0C12EBC82616383B00B66C86 /* ir_verifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ir_verifier.h; sourceTree = "<group>"; };
+		0C12EBC92616383B00B66C86 /* dim_arg.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = dim_arg.h; sourceTree = "<group>"; };
+		0C12EBCA2616383B00B66C86 /* external_functions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = external_functions.h; sourceTree = "<group>"; };
+		0C12EBCB2616383B00B66C86 /* stmt.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = stmt.h; sourceTree = "<group>"; };
+		0C12EBCC2616383B00B66C86 /* half_support.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = half_support.h; sourceTree = "<group>"; };
+		0C12EBCD2616383B00B66C86 /* registerizer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = registerizer.h; sourceTree = "<group>"; };
+		0C12EBCE2616383B00B66C86 /* reduction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = reduction.h; sourceTree = "<group>"; };
+		0C12EBCF2616383B00B66C86 /* tensor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tensor.h; sourceTree = "<group>"; };
+		0C12EBD02616383B00B66C86 /* mem_arena.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mem_arena.h; sourceTree = "<group>"; };
+		0C12EBD12616383B00B66C86 /* analysis.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = analysis.h; sourceTree = "<group>"; };
+		0C12EBD32616383B00B66C86 /* named_value.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = named_value.h; sourceTree = "<group>"; };
+		0C12EBD42616383B00B66C86 /* irparser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = irparser.h; sourceTree = "<group>"; };
+		0C12EBD52616383B00B66C86 /* ir.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ir.h; sourceTree = "<group>"; };
+		0C12EBD62616383B00B66C86 /* graph_node_list.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = graph_node_list.h; sourceTree = "<group>"; };
+		0C12EBD72616383B00B66C86 /* ir_views.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ir_views.h; sourceTree = "<group>"; };
+		0C12EBD82616383B00B66C86 /* alias_analysis.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = alias_analysis.h; sourceTree = "<group>"; };
+		0C12EBD92616383B00B66C86 /* attributes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = attributes.h; sourceTree = "<group>"; };
+		0C12EBDA2616383B00B66C86 /* type_hashing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = type_hashing.h; sourceTree = "<group>"; };
+		0C12EBDB2616383B00B66C86 /* constants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = constants.h; sourceTree = "<group>"; };
+		0C12EBDC2616383B00B66C86 /* subgraph_matcher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = subgraph_matcher.h; sourceTree = "<group>"; };
+		0C12EBDD2616383B00B66C86 /* scope.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = scope.h; sourceTree = "<group>"; };
+		0C12EBDE2616383B00B66C86 /* node_hashing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = node_hashing.h; sourceTree = "<group>"; };
+		0C12EBE02616383B00B66C86 /* cuda.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cuda.h; sourceTree = "<group>"; };
+		0C12EBE22616383B00B66C86 /* import_source.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = import_source.h; sourceTree = "<group>"; };
+		0C12EBE32616383B00B66C86 /* export.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = export.h; sourceTree = "<group>"; };
+		0C12EBE42616383B00B66C86 /* import_export_helpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = import_export_helpers.h; sourceTree = "<group>"; };
+		0C12EBE52616383B00B66C86 /* type_name_uniquer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = type_name_uniquer.h; sourceTree = "<group>"; };
+		0C12EBE62616383B00B66C86 /* pickler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pickler.h; sourceTree = "<group>"; };
+		0C12EBE72616383B00B66C86 /* python_print.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = python_print.h; sourceTree = "<group>"; };
+		0C12EBE82616383B00B66C86 /* import_legacy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = import_legacy.h; sourceTree = "<group>"; };
+		0C12EBE92616383B00B66C86 /* import_export_functions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = import_export_functions.h; sourceTree = "<group>"; };
+		0C12EBEA2616383B00B66C86 /* pickle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pickle.h; sourceTree = "<group>"; };
+		0C12EBEB2616383B00B66C86 /* import_export_constants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = import_export_constants.h; sourceTree = "<group>"; };
+		0C12EBEC2616383B00B66C86 /* source_range_serialization_impl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = source_range_serialization_impl.h; sourceTree = "<group>"; };
+		0C12EBED2616383B00B66C86 /* import.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = import.h; sourceTree = "<group>"; };
+		0C12EBEE2616383B00B66C86 /* unpickler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = unpickler.h; sourceTree = "<group>"; };
+		0C12EBEF2616383B00B66C86 /* source_range_serialization.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = source_range_serialization.h; sourceTree = "<group>"; };
+		0C12EBF02616383B00B66C86 /* onnx.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = onnx.h; sourceTree = "<group>"; };
+		0C12EBF22616383B00B66C86 /* backend_interface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = backend_interface.h; sourceTree = "<group>"; };
+		0C12EBF32616383B00B66C86 /* backend.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = backend.h; sourceTree = "<group>"; };
+		0C12EBF42616383B00B66C86 /* backend_resolver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = backend_resolver.h; sourceTree = "<group>"; };
+		0C12EBF52616383B00B66C86 /* backend_detail.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = backend_detail.h; sourceTree = "<group>"; };
+		0C12EBF62616383B00B66C86 /* backend_init.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = backend_init.h; sourceTree = "<group>"; };
+		0C12EBF82616383B00B66C86 /* slice_indices_adjust.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = slice_indices_adjust.h; sourceTree = "<group>"; };
+		0C12EBF92616383B00B66C86 /* operator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = operator.h; sourceTree = "<group>"; };
+		0C12EBFA2616383B00B66C86 /* interpreter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = interpreter.h; sourceTree = "<group>"; };
+		0C12EBFB2616383B00B66C86 /* register_ops_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = register_ops_utils.h; sourceTree = "<group>"; };
+		0C12EBFC2616383B00B66C86 /* jit_exception.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = jit_exception.h; sourceTree = "<group>"; };
+		0C12EBFD2616383B00B66C86 /* exception_message.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = exception_message.h; sourceTree = "<group>"; };
+		0C12EBFE2616383B00B66C86 /* argument_spec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = argument_spec.h; sourceTree = "<group>"; };
+		0C12EBFF2616383B00B66C86 /* logging.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = logging.h; sourceTree = "<group>"; };
+		0C12EC002616383B00B66C86 /* profiling_graph_executor_impl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = profiling_graph_executor_impl.h; sourceTree = "<group>"; };
+		0C12EC012616383B00B66C86 /* custom_operator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = custom_operator.h; sourceTree = "<group>"; };
+		0C12EC032616383B00B66C86 /* fusion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fusion.h; sourceTree = "<group>"; };
+		0C12EC042616383B00B66C86 /* passes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = passes.h; sourceTree = "<group>"; };
+		0C12EC052616383B00B66C86 /* ops.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ops.h; sourceTree = "<group>"; };
+		0C12EC062616383B00B66C86 /* impl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = impl.h; sourceTree = "<group>"; };
+		0C12EC072616383B00B66C86 /* init.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = init.h; sourceTree = "<group>"; };
+		0C12EC082616383B00B66C86 /* vararg_functions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vararg_functions.h; sourceTree = "<group>"; };
+		0C12EC092616383B00B66C86 /* symbolic_script.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = symbolic_script.h; sourceTree = "<group>"; };
+		0C12EC0A2616383B00B66C86 /* variable_tensor_list.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = variable_tensor_list.h; sourceTree = "<group>"; };
+		0C12EC0B2616383B00B66C86 /* autodiff.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = autodiff.h; sourceTree = "<group>"; };
+		0C12EC0C2616383B00B66C86 /* print_handler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = print_handler.h; sourceTree = "<group>"; };
+		0C12EC0D2616383B00B66C86 /* profiling_record.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = profiling_record.h; sourceTree = "<group>"; };
+		0C12EC0E2616383B00B66C86 /* graph_executor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = graph_executor.h; sourceTree = "<group>"; };
+		0C12EC0F2616383B00B66C86 /* operator_options.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = operator_options.h; sourceTree = "<group>"; };
+		0C12EC102616383B00B66C86 /* instruction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = instruction.h; sourceTree = "<group>"; };
+		0C12EC112616383B00B66C86 /* graph_executor_impl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = graph_executor_impl.h; sourceTree = "<group>"; };
+		0C12EC132616383B00B66C86 /* remove_expands.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = remove_expands.h; sourceTree = "<group>"; };
+		0C12EC142616383B00B66C86 /* peephole_list_idioms.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = peephole_list_idioms.h; sourceTree = "<group>"; };
+		0C12EC152616383B00B66C86 /* subgraph_rewrite.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = subgraph_rewrite.h; sourceTree = "<group>"; };
+		0C12EC162616383B00B66C86 /* fuse_relu.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fuse_relu.h; sourceTree = "<group>"; };
+		0C12EC172616383B00B66C86 /* guard_elimination.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = guard_elimination.h; sourceTree = "<group>"; };
+		0C12EC182616383B00B66C86 /* peephole_alias_sensitive.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = peephole_alias_sensitive.h; sourceTree = "<group>"; };
+		0C12EC192616383B00B66C86 /* freeze_module.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = freeze_module.h; sourceTree = "<group>"; };
+		0C12EC1A2616383B00B66C86 /* clear_undefinedness.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = clear_undefinedness.h; sourceTree = "<group>"; };
+		0C12EC1B2616383B00B66C86 /* peephole.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = peephole.h; sourceTree = "<group>"; };
+		0C12EC1C2616383B00B66C86 /* remove_dropout.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = remove_dropout.h; sourceTree = "<group>"; };
+		0C12EC1D2616383B00B66C86 /* update_differentiable_graph_requires_grad.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = update_differentiable_graph_requires_grad.h; sourceTree = "<group>"; };
+		0C12EC1E2616383B00B66C86 /* metal_rewrite.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = metal_rewrite.h; sourceTree = "<group>"; };
+		0C12EC1F2616383B00B66C86 /* liveness.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = liveness.h; sourceTree = "<group>"; };
+		0C12EC212616383B00B66C86 /* eval_peephole.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = eval_peephole.h; sourceTree = "<group>"; };
+		0C12EC222616383B00B66C86 /* function_substitution.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = function_substitution.h; sourceTree = "<group>"; };
+		0C12EC232616383B00B66C86 /* helper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = helper.h; sourceTree = "<group>"; };
+		0C12EC242616383B00B66C86 /* unpack_quantized_weights.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = unpack_quantized_weights.h; sourceTree = "<group>"; };
+		0C12EC252616383B00B66C86 /* preprocess_for_onnx.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = preprocess_for_onnx.h; sourceTree = "<group>"; };
+		0C12EC262616383B00B66C86 /* scalar_type_analysis.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = scalar_type_analysis.h; sourceTree = "<group>"; };
+		0C12EC272616383B00B66C86 /* shape_type_inference.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = shape_type_inference.h; sourceTree = "<group>"; };
+		0C12EC282616383B00B66C86 /* peephole.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = peephole.h; sourceTree = "<group>"; };
+		0C12EC292616383B00B66C86 /* eliminate_unused_items.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = eliminate_unused_items.h; sourceTree = "<group>"; };
+		0C12EC2A2616383B00B66C86 /* constant_fold.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = constant_fold.h; sourceTree = "<group>"; };
+		0C12EC2B2616383B00B66C86 /* constant_map.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = constant_map.h; sourceTree = "<group>"; };
+		0C12EC2C2616383B00B66C86 /* fixup_onnx_controlflow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fixup_onnx_controlflow.h; sourceTree = "<group>"; };
+		0C12EC2D2616383B00B66C86 /* cast_all_constant_to_floating.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cast_all_constant_to_floating.h; sourceTree = "<group>"; };
+		0C12EC2E2616383B00B66C86 /* fold_if_node.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fold_if_node.h; sourceTree = "<group>"; };
+		0C12EC2F2616383B00B66C86 /* list_model_parameters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = list_model_parameters.h; sourceTree = "<group>"; };
+		0C12EC312616383B00B66C86 /* common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = common.h; sourceTree = "<group>"; };
+		0C12EC322616383B00B66C86 /* pattern_conversion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pattern_conversion.h; sourceTree = "<group>"; };
+		0C12EC332616383B00B66C86 /* pattern_encapsulation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pattern_encapsulation.h; sourceTree = "<group>"; };
+		0C12EC342616383B00B66C86 /* remove_inplace_ops_for_onnx.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = remove_inplace_ops_for_onnx.h; sourceTree = "<group>"; };
+		0C12EC352616383B00B66C86 /* prepare_division_for_onnx.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = prepare_division_for_onnx.h; sourceTree = "<group>"; };
+		0C12EC362616383B00B66C86 /* remove_mutation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = remove_mutation.h; sourceTree = "<group>"; };
+		0C12EC372616383B00B66C86 /* common_subexpression_elimination.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = common_subexpression_elimination.h; sourceTree = "<group>"; };
+		0C12EC382616383B00B66C86 /* batch_mm.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = batch_mm.h; sourceTree = "<group>"; };
+		0C12EC392616383B00B66C86 /* constant_pooling.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = constant_pooling.h; sourceTree = "<group>"; };
+		0C12EC3A2616383B00B66C86 /* canonicalize_graph_fuser_ops.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = canonicalize_graph_fuser_ops.h; sourceTree = "<group>"; };
+		0C12EC3B2616383B00B66C86 /* fuse_linear.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fuse_linear.h; sourceTree = "<group>"; };
+		0C12EC3C2616383B00B66C86 /* annotate_warns.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = annotate_warns.h; sourceTree = "<group>"; };
+		0C12EC3D2616383B00B66C86 /* specialize_autogradzero.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = specialize_autogradzero.h; sourceTree = "<group>"; };
+		0C12EC3E2616383B00B66C86 /* prepack_folding.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = prepack_folding.h; sourceTree = "<group>"; };
+		0C12EC3F2616383B00B66C86 /* frozen_conv_folding.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = frozen_conv_folding.h; sourceTree = "<group>"; };
+		0C12EC402616383B00B66C86 /* constant_propagation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = constant_propagation.h; sourceTree = "<group>"; };
+		0C12EC412616383B00B66C86 /* insert_guards.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = insert_guards.h; sourceTree = "<group>"; };
+		0C12EC432616383B00B66C86 /* memory_dag.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = memory_dag.h; sourceTree = "<group>"; };
+		0C12EC442616383B00B66C86 /* subgraph_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = subgraph_utils.h; sourceTree = "<group>"; };
+		0C12EC452616383B00B66C86 /* check_alias_annotation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = check_alias_annotation.h; sourceTree = "<group>"; };
+		0C12EC462616383B00B66C86 /* inliner.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = inliner.h; sourceTree = "<group>"; };
+		0C12EC472616383B00B66C86 /* lower_grad_of.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lower_grad_of.h; sourceTree = "<group>"; };
+		0C12EC492616383B00B66C86 /* helper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = helper.h; sourceTree = "<group>"; };
+		0C12EC4A2616383B00B66C86 /* quantization_type.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = quantization_type.h; sourceTree = "<group>"; };
+		0C12EC4B2616383B00B66C86 /* insert_observers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = insert_observers.h; sourceTree = "<group>"; };
+		0C12EC4C2616383B00B66C86 /* dedup_module_uses.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = dedup_module_uses.h; sourceTree = "<group>"; };
+		0C12EC4D2616383B00B66C86 /* quantization_patterns.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = quantization_patterns.h; sourceTree = "<group>"; };
+		0C12EC4E2616383B00B66C86 /* finalize.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = finalize.h; sourceTree = "<group>"; };
+		0C12EC4F2616383B00B66C86 /* insert_quant_dequant.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = insert_quant_dequant.h; sourceTree = "<group>"; };
+		0C12EC502616383B00B66C86 /* fusion_passes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fusion_passes.h; sourceTree = "<group>"; };
+		0C12EC512616383B00B66C86 /* normalize_ops.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = normalize_ops.h; sourceTree = "<group>"; };
+		0C12EC522616383B00B66C86 /* vulkan_rewrite.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vulkan_rewrite.h; sourceTree = "<group>"; };
+		0C12EC532616383B00B66C86 /* erase_number_types.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = erase_number_types.h; sourceTree = "<group>"; };
+		0C12EC542616383B00B66C86 /* graph_rewrite_helper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = graph_rewrite_helper.h; sourceTree = "<group>"; };
+		0C12EC552616383B00B66C86 /* graph_fuser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = graph_fuser.h; sourceTree = "<group>"; };
+		0C12EC562616383B00B66C86 /* fold_conv_bn.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fold_conv_bn.h; sourceTree = "<group>"; };
+		0C12EC572616383B00B66C86 /* remove_redundant_profiles.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = remove_redundant_profiles.h; sourceTree = "<group>"; };
+		0C12EC582616383B00B66C86 /* inline_forked_closures.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = inline_forked_closures.h; sourceTree = "<group>"; };
+		0C12EC592616383B00B66C86 /* tensorexpr_fuser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tensorexpr_fuser.h; sourceTree = "<group>"; };
+		0C12EC5A2616383B00B66C86 /* decompose_ops.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = decompose_ops.h; sourceTree = "<group>"; };
+		0C12EC5B2616383B00B66C86 /* remove_inplace_ops.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = remove_inplace_ops.h; sourceTree = "<group>"; };
+		0C12EC5C2616383B00B66C86 /* inline_fork_wait.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = inline_fork_wait.h; sourceTree = "<group>"; };
+		0C12EC5D2616383B00B66C86 /* create_autodiff_subgraphs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = create_autodiff_subgraphs.h; sourceTree = "<group>"; };
+		0C12EC5E2616383B00B66C86 /* requires_grad_analysis.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = requires_grad_analysis.h; sourceTree = "<group>"; };
+		0C12EC5F2616383B00B66C86 /* dead_code_elimination.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = dead_code_elimination.h; sourceTree = "<group>"; };
+		0C12EC602616383B00B66C86 /* clear_profiling.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = clear_profiling.h; sourceTree = "<group>"; };
+		0C12EC612616383B00B66C86 /* create_functional_graphs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = create_functional_graphs.h; sourceTree = "<group>"; };
+		0C12EC622616383B00B66C86 /* bailout_graph.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = bailout_graph.h; sourceTree = "<group>"; };
+		0C12EC632616383B00B66C86 /* lower_tuples.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lower_tuples.h; sourceTree = "<group>"; };
+		0C12EC642616383B00B66C86 /* frozen_graph_optimizations.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = frozen_graph_optimizations.h; sourceTree = "<group>"; };
+		0C12EC652616383B00B66C86 /* frozen_ops_to_mkldnn.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = frozen_ops_to_mkldnn.h; sourceTree = "<group>"; };
+		0C12EC662616383B00B66C86 /* canonicalize.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = canonicalize.h; sourceTree = "<group>"; };
+		0C12EC672616383B00B66C86 /* hoist_conv_packed_params.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = hoist_conv_packed_params.h; sourceTree = "<group>"; };
+		0C12EC682616383B00B66C86 /* loop_unrolling.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = loop_unrolling.h; sourceTree = "<group>"; };
+		0C12EC692616383B00B66C86 /* shape_analysis.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = shape_analysis.h; sourceTree = "<group>"; };
+		0C12EC6A2616383B00B66C86 /* fixup_trace_scope_blocks.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fixup_trace_scope_blocks.h; sourceTree = "<group>"; };
+		0C12EC6B2616383B00B66C86 /* remove_exceptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = remove_exceptions.h; sourceTree = "<group>"; };
+		0C12EC6C2616383B00B66C86 /* inline_autodiff_subgraphs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = inline_autodiff_subgraphs.h; sourceTree = "<group>"; };
+		0C12EC6D2616383B00B66C86 /* inplace_check.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = inplace_check.h; sourceTree = "<group>"; };
+		0C12EC6E2616383B00B66C86 /* cuda_graph_fuser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cuda_graph_fuser.h; sourceTree = "<group>"; };
+		0C12EC6F2616383B00B66C86 /* pass_manager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pass_manager.h; sourceTree = "<group>"; };
+		0C12EC702616383B00B66C86 /* onnx.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = onnx.h; sourceTree = "<group>"; };
+		0C12EC712616383B00B66C86 /* xnnpack_rewrite.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = xnnpack_rewrite.h; sourceTree = "<group>"; };
+		0C12EC722616383B00B66C86 /* lift_closures.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lift_closures.h; sourceTree = "<group>"; };
+		0C12EC732616383B00B66C86 /* frozen_conv_add_relu_fusion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = frozen_conv_add_relu_fusion.h; sourceTree = "<group>"; };
+		0C12EC742616383B00B66C86 /* lower_graph.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lower_graph.h; sourceTree = "<group>"; };
+		0C12EC782616383B00B66C86 /* type.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = type.h; sourceTree = "<group>"; };
+		0C12EC792616383B00B66C86 /* executor_kernel_arg.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = executor_kernel_arg.h; sourceTree = "<group>"; };
+		0C12EC7A2616383B00B66C86 /* utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = utils.h; sourceTree = "<group>"; };
+		0C12EC7B2616383B00B66C86 /* kernel_ir_printer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = kernel_ir_printer.h; sourceTree = "<group>"; };
+		0C12EC7D2616383B00B66C86 /* index_compute.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = index_compute.h; sourceTree = "<group>"; };
+		0C12EC7E2616383B00B66C86 /* transform_replay.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = transform_replay.h; sourceTree = "<group>"; };
+		0C12EC7F2616383B00B66C86 /* parser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = parser.h; sourceTree = "<group>"; };
+		0C12EC802616383B00B66C86 /* executor_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = executor_utils.h; sourceTree = "<group>"; };
+		0C12EC812616383B00B66C86 /* manager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = manager.h; sourceTree = "<group>"; };
+		0C12EC822616383B00B66C86 /* scheduler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = scheduler.h; sourceTree = "<group>"; };
+		0C12EC832616383B00B66C86 /* lower_unroll.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lower_unroll.h; sourceTree = "<group>"; };
+		0C12EC852616383B00B66C86 /* ir_printer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ir_printer.h; sourceTree = "<group>"; };
+		0C12EC862616383B00B66C86 /* lower_insert_syncs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lower_insert_syncs.h; sourceTree = "<group>"; };
+		0C12EC872616383B00B66C86 /* lower2device.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lower2device.h; sourceTree = "<group>"; };
+		0C12EC882616383B00B66C86 /* predicate_compute.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = predicate_compute.h; sourceTree = "<group>"; };
+		0C12EC892616383B00B66C86 /* compute_at.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = compute_at.h; sourceTree = "<group>"; };
+		0C12EC8A2616383B00B66C86 /* ir_all_nodes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ir_all_nodes.h; sourceTree = "<group>"; };
+		0C12EC8B2616383B00B66C86 /* mutator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mutator.h; sourceTree = "<group>"; };
+		0C12EC8D2616383B00B66C86 /* documentation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = documentation.h; sourceTree = "<group>"; };
+		0C12EC8F2616383B00B66C86 /* fusion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fusion.h; sourceTree = "<group>"; };
+		0C12EC902616383B00B66C86 /* lower_loops.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lower_loops.h; sourceTree = "<group>"; };
+		0C12EC912616383B00B66C86 /* interface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = interface.h; sourceTree = "<group>"; };
+		0C12EC922616383B00B66C86 /* arith.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = arith.h; sourceTree = "<group>"; };
+		0C12EC932616383B00B66C86 /* kernel_cache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = kernel_cache.h; sourceTree = "<group>"; };
+		0C12EC942616383B00B66C86 /* codegen.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = codegen.h; sourceTree = "<group>"; };
+		0C12EC952616383B00B66C86 /* ir_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ir_utils.h; sourceTree = "<group>"; };
+		0C12EC962616383B00B66C86 /* lower_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lower_utils.h; sourceTree = "<group>"; };
+		0C12EC972616383B00B66C86 /* lower_index.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lower_index.h; sourceTree = "<group>"; };
+		0C12EC982616383B00B66C86 /* transform_rfactor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = transform_rfactor.h; sourceTree = "<group>"; };
+		0C12EC992616383B00B66C86 /* transform_iter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = transform_iter.h; sourceTree = "<group>"; };
+		0C12EC9A2616383B00B66C86 /* lower_alias_memory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lower_alias_memory.h; sourceTree = "<group>"; };
+		0C12EC9B2616383B00B66C86 /* executor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = executor.h; sourceTree = "<group>"; };
+		0C12EC9C2616383B00B66C86 /* ir_graphviz.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ir_graphviz.h; sourceTree = "<group>"; };
+		0C12EC9D2616383B00B66C86 /* ir_iostream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ir_iostream.h; sourceTree = "<group>"; };
+		0C12EC9E2616383B00B66C86 /* partition.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = partition.h; sourceTree = "<group>"; };
+		0C12EC9F2616383B00B66C86 /* shape_inference.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = shape_inference.h; sourceTree = "<group>"; };
+		0C12ECA02616383B00B66C86 /* kernel_ir_builder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = kernel_ir_builder.h; sourceTree = "<group>"; };
+		0C12ECA12616383B00B66C86 /* instrumentation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = instrumentation.h; sourceTree = "<group>"; };
+		0C12ECA22616383B00B66C86 /* kernel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = kernel.h; sourceTree = "<group>"; };
+		0C12ECA32616383B00B66C86 /* dispatch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = dispatch.h; sourceTree = "<group>"; };
+		0C12ECA42616383B00B66C86 /* lower_validation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lower_validation.h; sourceTree = "<group>"; };
+		0C12ECA52616383B00B66C86 /* ir_internal_nodes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ir_internal_nodes.h; sourceTree = "<group>"; };
+		0C12ECA62616383B00B66C86 /* lower_thread_predicate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lower_thread_predicate.h; sourceTree = "<group>"; };
+		0C12ECA72616383B00B66C86 /* ir_interface_nodes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ir_interface_nodes.h; sourceTree = "<group>"; };
+		0C12ECA82616383B00B66C86 /* ir_cloner.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ir_cloner.h; sourceTree = "<group>"; };
+		0C12ECA92616383B00B66C86 /* ir_base_nodes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ir_base_nodes.h; sourceTree = "<group>"; };
+		0C12ECAA2616383B00B66C86 /* executor_launch_params.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = executor_launch_params.h; sourceTree = "<group>"; };
+		0C12ECAB2616383B00B66C86 /* kernel_ir.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = kernel_ir.h; sourceTree = "<group>"; };
+		0C12ECAC2616383B00B66C86 /* iter_visitor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = iter_visitor.h; sourceTree = "<group>"; };
+		0C12ECAD2616383B00B66C86 /* expr_evaluator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = expr_evaluator.h; sourceTree = "<group>"; };
+		0C12ECAF2616383B00B66C86 /* tensor_info.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tensor_info.h; sourceTree = "<group>"; };
+		0C12ECB02616383B00B66C86 /* arg_spec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = arg_spec.h; sourceTree = "<group>"; };
+		0C12ECB12616383B00B66C86 /* compiler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = compiler.h; sourceTree = "<group>"; };
+		0C12ECB22616383B00B66C86 /* fallback.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fallback.h; sourceTree = "<group>"; };
+		0C12ECB42616383B00B66C86 /* temp_file.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = temp_file.h; sourceTree = "<group>"; };
+		0C12ECB52616383B00B66C86 /* fused_kernel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fused_kernel.h; sourceTree = "<group>"; };
+		0C12ECB62616383B00B66C86 /* resource_strings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = resource_strings.h; sourceTree = "<group>"; };
+		0C12ECB82616383B00B66C86 /* fused_kernel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fused_kernel.h; sourceTree = "<group>"; };
+		0C12ECB92616383B00B66C86 /* resource_strings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = resource_strings.h; sourceTree = "<group>"; };
+		0C12ECBA2616383B00B66C86 /* partition_desc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = partition_desc.h; sourceTree = "<group>"; };
+		0C12ECBB2616383B00B66C86 /* fused_kernel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fused_kernel.h; sourceTree = "<group>"; };
+		0C12ECBC2616383B00B66C86 /* kernel_spec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = kernel_spec.h; sourceTree = "<group>"; };
+		0C12ECBD2616383B00B66C86 /* interface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = interface.h; sourceTree = "<group>"; };
+		0C12ECBE2616383B00B66C86 /* kernel_cache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = kernel_cache.h; sourceTree = "<group>"; };
+		0C12ECBF2616383B00B66C86 /* codegen.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = codegen.h; sourceTree = "<group>"; };
+		0C12ECC02616383B00B66C86 /* executor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = executor.h; sourceTree = "<group>"; };
+		0C12ECC12616383B00B66C86 /* tensor_desc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tensor_desc.h; sourceTree = "<group>"; };
+		0C12ECC32616383B00B66C86 /* file_check.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = file_check.h; sourceTree = "<group>"; };
+		0C12ECC42616383B00B66C86 /* hooks_for_testing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = hooks_for_testing.h; sourceTree = "<group>"; };
+		0C12ECC52616383B00B66C86 /* jit_log.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = jit_log.h; sourceTree = "<group>"; };
+		0C12ECC72616383B00B66C86 /* observer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = observer.h; sourceTree = "<group>"; };
+		0C12ECC82616383B00B66C86 /* sequential.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = sequential.h; sourceTree = "<group>"; };
+		0C12ECC92616383B00B66C86 /* interpreter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = interpreter.h; sourceTree = "<group>"; };
+		0C12ECCA2616383B00B66C86 /* export_data.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = export_data.h; sourceTree = "<group>"; };
+		0C12ECCB2616383B00B66C86 /* method.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = method.h; sourceTree = "<group>"; };
+		0C12ECCD2616383B00B66C86 /* sgd.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = sgd.h; sourceTree = "<group>"; };
+		0C12ECCE2616383B00B66C86 /* import_data.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = import_data.h; sourceTree = "<group>"; };
+		0C12ECCF2616383B00B66C86 /* type_parser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = type_parser.h; sourceTree = "<group>"; };
+		0C12ECD02616383B00B66C86 /* import.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = import.h; sourceTree = "<group>"; };
+		0C12ECD12616383B00B66C86 /* module.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = module.h; sourceTree = "<group>"; };
+		0C12ECD22616383B00B66C86 /* function.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = function.h; sourceTree = "<group>"; };
+		0C12ECD32616383B00B66C86 /* resource_guard.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = resource_guard.h; sourceTree = "<group>"; };
+		0C12ECD52616383B00B66C86 /* function_impl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = function_impl.h; sourceTree = "<group>"; };
+		0C12ECD62616383B00B66C86 /* method.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = method.h; sourceTree = "<group>"; };
+		0C12ECD72616383B00B66C86 /* compilation_unit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = compilation_unit.h; sourceTree = "<group>"; };
+		0C12ECD82616383B00B66C86 /* object.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = object.h; sourceTree = "<group>"; };
+		0C12ECD92616383B00B66C86 /* module.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = module.h; sourceTree = "<group>"; };
+		0C12ECDA2616383B00B66C86 /* Storage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Storage.h; sourceTree = "<group>"; };
+		0C12ECDE2616383B00B66C86 /* fft.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fft.h; sourceTree = "<group>"; };
+		0C12ECDF2616383B00B66C86 /* utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = utils.h; sourceTree = "<group>"; };
+		0C12ECE02616383B00B66C86 /* version.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = version.h; sourceTree = "<group>"; };
+		0C12ECE32616383B00B66C86 /* normalization.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = normalization.h; sourceTree = "<group>"; };
+		0C12ECE42616383B00B66C86 /* rnn.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rnn.h; sourceTree = "<group>"; };
+		0C12ECE52616383B00B66C86 /* distance.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = distance.h; sourceTree = "<group>"; };
+		0C12ECE62616383B00B66C86 /* batchnorm.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = batchnorm.h; sourceTree = "<group>"; };
+		0C12ECE72616383B00B66C86 /* linear.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = linear.h; sourceTree = "<group>"; };
+		0C12ECE82616383B00B66C86 /* instancenorm.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = instancenorm.h; sourceTree = "<group>"; };
+		0C12ECE92616383B00B66C86 /* vision.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vision.h; sourceTree = "<group>"; };
+		0C12ECEA2616383B00B66C86 /* transformercoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = transformercoder.h; sourceTree = "<group>"; };
+		0C12ECEB2616383B00B66C86 /* dropout.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = dropout.h; sourceTree = "<group>"; };
+		0C12ECEC2616383B00B66C86 /* upsampling.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = upsampling.h; sourceTree = "<group>"; };
+		0C12ECED2616383B00B66C86 /* embedding.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = embedding.h; sourceTree = "<group>"; };
+		0C12ECEE2616383C00B66C86 /* fold.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fold.h; sourceTree = "<group>"; };
+		0C12ECEF2616383C00B66C86 /* activation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = activation.h; sourceTree = "<group>"; };
+		0C12ECF02616383C00B66C86 /* transformer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = transformer.h; sourceTree = "<group>"; };
+		0C12ECF12616383C00B66C86 /* pooling.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pooling.h; sourceTree = "<group>"; };
+		0C12ECF22616383C00B66C86 /* transformerlayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = transformerlayer.h; sourceTree = "<group>"; };
+		0C12ECF32616383C00B66C86 /* adaptive.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = adaptive.h; sourceTree = "<group>"; };
+		0C12ECF42616383C00B66C86 /* conv.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = conv.h; sourceTree = "<group>"; };
+		0C12ECF52616383C00B66C86 /* padding.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = padding.h; sourceTree = "<group>"; };
+		0C12ECF62616383C00B66C86 /* pixelshuffle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pixelshuffle.h; sourceTree = "<group>"; };
+		0C12ECF72616383C00B66C86 /* loss.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = loss.h; sourceTree = "<group>"; };
+		0C12ECF82616383C00B66C86 /* utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = utils.h; sourceTree = "<group>"; };
+		0C12ECFA2616383C00B66C86 /* data_parallel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = data_parallel.h; sourceTree = "<group>"; };
+		0C12ECFB2616383C00B66C86 /* pimpl-inl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "pimpl-inl.h"; sourceTree = "<group>"; };
+		0C12ECFD2616383C00B66C86 /* rnn.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rnn.h; sourceTree = "<group>"; };
+		0C12ECFE2616383C00B66C86 /* clip_grad.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = clip_grad.h; sourceTree = "<group>"; };
+		0C12ECFF2616383C00B66C86 /* convert_parameters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = convert_parameters.h; sourceTree = "<group>"; };
+		0C12ED002616383C00B66C86 /* options.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = options.h; sourceTree = "<group>"; };
+		0C12ED012616383C00B66C86 /* functional.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = functional.h; sourceTree = "<group>"; };
+		0C12ED022616383C00B66C86 /* modules.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = modules.h; sourceTree = "<group>"; };
+		0C12ED032616383C00B66C86 /* pimpl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pimpl.h; sourceTree = "<group>"; };
+		0C12ED042616383C00B66C86 /* module.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = module.h; sourceTree = "<group>"; };
+		0C12ED062616383C00B66C86 /* normalization.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = normalization.h; sourceTree = "<group>"; };
+		0C12ED072616383C00B66C86 /* utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = utils.h; sourceTree = "<group>"; };
+		0C12ED082616383C00B66C86 /* rnn.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rnn.h; sourceTree = "<group>"; };
+		0C12ED092616383C00B66C86 /* distance.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = distance.h; sourceTree = "<group>"; };
+		0C12ED0A2616383C00B66C86 /* batchnorm.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = batchnorm.h; sourceTree = "<group>"; };
+		0C12ED0B2616383C00B66C86 /* linear.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = linear.h; sourceTree = "<group>"; };
+		0C12ED0C2616383C00B66C86 /* instancenorm.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = instancenorm.h; sourceTree = "<group>"; };
+		0C12ED0D2616383C00B66C86 /* transformercoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = transformercoder.h; sourceTree = "<group>"; };
+		0C12ED0E2616383C00B66C86 /* _functions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _functions.h; sourceTree = "<group>"; };
+		0C12ED102616383C00B66C86 /* named_any.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = named_any.h; sourceTree = "<group>"; };
+		0C12ED112616383C00B66C86 /* any_value.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = any_value.h; sourceTree = "<group>"; };
+		0C12ED122616383C00B66C86 /* modulelist.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = modulelist.h; sourceTree = "<group>"; };
+		0C12ED132616383C00B66C86 /* moduledict.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = moduledict.h; sourceTree = "<group>"; };
+		0C12ED142616383C00B66C86 /* sequential.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = sequential.h; sourceTree = "<group>"; };
+		0C12ED152616383C00B66C86 /* functional.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = functional.h; sourceTree = "<group>"; };
+		0C12ED162616383C00B66C86 /* parameterlist.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = parameterlist.h; sourceTree = "<group>"; };
+		0C12ED172616383C00B66C86 /* parameterdict.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = parameterdict.h; sourceTree = "<group>"; };
+		0C12ED182616383C00B66C86 /* any.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = any.h; sourceTree = "<group>"; };
+		0C12ED192616383C00B66C86 /* any_module_holder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = any_module_holder.h; sourceTree = "<group>"; };
+		0C12ED1A2616383C00B66C86 /* dropout.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = dropout.h; sourceTree = "<group>"; };
+		0C12ED1B2616383C00B66C86 /* common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = common.h; sourceTree = "<group>"; };
+		0C12ED1C2616383C00B66C86 /* upsampling.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = upsampling.h; sourceTree = "<group>"; };
+		0C12ED1D2616383C00B66C86 /* embedding.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = embedding.h; sourceTree = "<group>"; };
+		0C12ED1E2616383C00B66C86 /* fold.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fold.h; sourceTree = "<group>"; };
+		0C12ED1F2616383C00B66C86 /* activation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = activation.h; sourceTree = "<group>"; };
+		0C12ED202616383C00B66C86 /* transformer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = transformer.h; sourceTree = "<group>"; };
+		0C12ED212616383C00B66C86 /* pooling.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pooling.h; sourceTree = "<group>"; };
+		0C12ED222616383C00B66C86 /* transformerlayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = transformerlayer.h; sourceTree = "<group>"; };
+		0C12ED232616383C00B66C86 /* adaptive.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = adaptive.h; sourceTree = "<group>"; };
+		0C12ED242616383C00B66C86 /* conv.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = conv.h; sourceTree = "<group>"; };
+		0C12ED252616383C00B66C86 /* padding.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = padding.h; sourceTree = "<group>"; };
+		0C12ED262616383C00B66C86 /* pixelshuffle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pixelshuffle.h; sourceTree = "<group>"; };
+		0C12ED272616383C00B66C86 /* loss.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = loss.h; sourceTree = "<group>"; };
+		0C12ED282616383C00B66C86 /* init.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = init.h; sourceTree = "<group>"; };
+		0C12ED292616383C00B66C86 /* cloneable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cloneable.h; sourceTree = "<group>"; };
+		0C12ED2B2616383C00B66C86 /* normalization.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = normalization.h; sourceTree = "<group>"; };
+		0C12ED2C2616383C00B66C86 /* distance.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = distance.h; sourceTree = "<group>"; };
+		0C12ED2D2616383C00B66C86 /* batchnorm.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = batchnorm.h; sourceTree = "<group>"; };
+		0C12ED2E2616383C00B66C86 /* linear.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = linear.h; sourceTree = "<group>"; };
+		0C12ED2F2616383C00B66C86 /* instancenorm.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = instancenorm.h; sourceTree = "<group>"; };
+		0C12ED302616383C00B66C86 /* vision.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vision.h; sourceTree = "<group>"; };
+		0C12ED312616383C00B66C86 /* dropout.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = dropout.h; sourceTree = "<group>"; };
+		0C12ED322616383C00B66C86 /* upsampling.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = upsampling.h; sourceTree = "<group>"; };
+		0C12ED332616383C00B66C86 /* embedding.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = embedding.h; sourceTree = "<group>"; };
+		0C12ED342616383C00B66C86 /* fold.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fold.h; sourceTree = "<group>"; };
+		0C12ED352616383C00B66C86 /* activation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = activation.h; sourceTree = "<group>"; };
+		0C12ED362616383C00B66C86 /* pooling.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pooling.h; sourceTree = "<group>"; };
+		0C12ED372616383C00B66C86 /* conv.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = conv.h; sourceTree = "<group>"; };
+		0C12ED382616383C00B66C86 /* padding.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = padding.h; sourceTree = "<group>"; };
+		0C12ED392616383C00B66C86 /* pixelshuffle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pixelshuffle.h; sourceTree = "<group>"; };
+		0C12ED3A2616383C00B66C86 /* loss.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = loss.h; sourceTree = "<group>"; };
+		0C12ED3C2616383C00B66C86 /* init.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = init.h; sourceTree = "<group>"; };
+		0C12ED3D2616383C00B66C86 /* enum.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = enum.h; sourceTree = "<group>"; };
+		0C12ED3E2616383C00B66C86 /* types.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = types.h; sourceTree = "<group>"; };
+		0C12ED3F2616383C00B66C86 /* all.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = all.h; sourceTree = "<group>"; };
+		0C12ED402616383C00B66C86 /* data.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = data.h; sourceTree = "<group>"; };
+		0C12ED412616383C00B66C86 /* arg.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = arg.h; sourceTree = "<group>"; };
+		0C12ED432616383C00B66C86 /* rmsprop.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rmsprop.h; sourceTree = "<group>"; };
+		0C12ED442616383C00B66C86 /* lbfgs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lbfgs.h; sourceTree = "<group>"; };
+		0C12ED452616383C00B66C86 /* optimizer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = optimizer.h; sourceTree = "<group>"; };
+		0C12ED462616383C00B66C86 /* adagrad.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = adagrad.h; sourceTree = "<group>"; };
+		0C12ED472616383C00B66C86 /* sgd.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = sgd.h; sourceTree = "<group>"; };
+		0C12ED482616383C00B66C86 /* serialize.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = serialize.h; sourceTree = "<group>"; };
+		0C12ED492616383C00B66C86 /* adamw.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = adamw.h; sourceTree = "<group>"; };
+		0C12ED4B2616383C00B66C86 /* lr_scheduler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lr_scheduler.h; sourceTree = "<group>"; };
+		0C12ED4C2616383C00B66C86 /* step_lr.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = step_lr.h; sourceTree = "<group>"; };
+		0C12ED4D2616383C00B66C86 /* adam.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = adam.h; sourceTree = "<group>"; };
+		0C12ED4F2616383C00B66C86 /* archive.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = archive.h; sourceTree = "<group>"; };
+		0C12ED502616383C00B66C86 /* input-archive.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "input-archive.h"; sourceTree = "<group>"; };
+		0C12ED512616383C00B66C86 /* output-archive.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "output-archive.h"; sourceTree = "<group>"; };
+		0C12ED522616383C00B66C86 /* tensor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tensor.h; sourceTree = "<group>"; };
+		0C12ED532616383C00B66C86 /* torch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = torch.h; sourceTree = "<group>"; };
+		0C12ED542616383C00B66C86 /* optim.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = optim.h; sourceTree = "<group>"; };
+		0C12ED552616383C00B66C86 /* jit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = jit.h; sourceTree = "<group>"; };
+		0C12ED572616383C00B66C86 /* static.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = static.h; sourceTree = "<group>"; };
+		0C12ED582616383C00B66C86 /* TensorDataContainer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TensorDataContainer.h; sourceTree = "<group>"; };
+		0C12ED592616383C00B66C86 /* nn.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = nn.h; sourceTree = "<group>"; };
+		0C12ED5A2616383C00B66C86 /* ordered_dict.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ordered_dict.h; sourceTree = "<group>"; };
+		0C12ED5B2616383C00B66C86 /* cuda.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cuda.h; sourceTree = "<group>"; };
+		0C12ED5C2616383C00B66C86 /* autograd.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = autograd.h; sourceTree = "<group>"; };
+		0C12ED5D2616383C00B66C86 /* linalg.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = linalg.h; sourceTree = "<group>"; };
+		0C12ED5E2616383C00B66C86 /* special.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = special.h; sourceTree = "<group>"; };
+		0C12ED5F2616383C00B66C86 /* python.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = python.h; sourceTree = "<group>"; };
+		0C12ED602616383C00B66C86 /* serialize.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = serialize.h; sourceTree = "<group>"; };
+		0C12ED622616383C00B66C86 /* example.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = example.h; sourceTree = "<group>"; };
+		0C12ED632616383C00B66C86 /* dataloader_options.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = dataloader_options.h; sourceTree = "<group>"; };
+		0C12ED652616383C00B66C86 /* mnist.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mnist.h; sourceTree = "<group>"; };
+		0C12ED662616383C00B66C86 /* shared.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = shared.h; sourceTree = "<group>"; };
+		0C12ED672616383C00B66C86 /* map.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = map.h; sourceTree = "<group>"; };
+		0C12ED682616383C00B66C86 /* chunk.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = chunk.h; sourceTree = "<group>"; };
+		0C12ED692616383C00B66C86 /* stateful.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = stateful.h; sourceTree = "<group>"; };
+		0C12ED6A2616383C00B66C86 /* tensor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tensor.h; sourceTree = "<group>"; };
+		0C12ED6B2616383C00B66C86 /* base.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = base.h; sourceTree = "<group>"; };
+		0C12ED6C2616383C00B66C86 /* worker_exception.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = worker_exception.h; sourceTree = "<group>"; };
+		0C12ED6D2616383C00B66C86 /* dataloader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = dataloader.h; sourceTree = "<group>"; };
+		0C12ED6F2616383C00B66C86 /* data_shuttle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = data_shuttle.h; sourceTree = "<group>"; };
+		0C12ED702616383C00B66C86 /* sequencers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = sequencers.h; sourceTree = "<group>"; };
+		0C12ED712616383C00B66C86 /* queue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = queue.h; sourceTree = "<group>"; };
+		0C12ED722616383C00B66C86 /* samplers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = samplers.h; sourceTree = "<group>"; };
+		0C12ED742616383C00B66C86 /* lambda.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lambda.h; sourceTree = "<group>"; };
+		0C12ED752616383C00B66C86 /* stack.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = stack.h; sourceTree = "<group>"; };
+		0C12ED762616383C00B66C86 /* collate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = collate.h; sourceTree = "<group>"; };
+		0C12ED772616383C00B66C86 /* tensor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tensor.h; sourceTree = "<group>"; };
+		0C12ED782616383C00B66C86 /* base.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = base.h; sourceTree = "<group>"; };
+		0C12ED7A2616383C00B66C86 /* sequential.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = sequential.h; sourceTree = "<group>"; };
+		0C12ED7B2616383C00B66C86 /* custom_batch_request.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = custom_batch_request.h; sourceTree = "<group>"; };
+		0C12ED7C2616383C00B66C86 /* stream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = stream.h; sourceTree = "<group>"; };
+		0C12ED7D2616383C00B66C86 /* distributed.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = distributed.h; sourceTree = "<group>"; };
+		0C12ED7E2616383C00B66C86 /* serialize.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = serialize.h; sourceTree = "<group>"; };
+		0C12ED7F2616383C00B66C86 /* random.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = random.h; sourceTree = "<group>"; };
+		0C12ED802616383C00B66C86 /* base.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = base.h; sourceTree = "<group>"; };
+		0C12ED812616383C00B66C86 /* datasets.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = datasets.h; sourceTree = "<group>"; };
+		0C12ED822616383C00B66C86 /* transforms.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = transforms.h; sourceTree = "<group>"; };
+		0C12ED832616383C00B66C86 /* iterator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = iterator.h; sourceTree = "<group>"; };
+		0C12ED852616383C00B66C86 /* stateless.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = stateless.h; sourceTree = "<group>"; };
+		0C12ED862616383C00B66C86 /* stateful.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = stateful.h; sourceTree = "<group>"; };
+		0C12ED872616383C00B66C86 /* base.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = base.h; sourceTree = "<group>"; };
+		0C12ED882616383C00B66C86 /* expanding_array.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = expanding_array.h; sourceTree = "<group>"; };
+		0C12ED952616383C00B66C86 /* MemoryFormat.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MemoryFormat.h; sourceTree = "<group>"; };
+		0C12ED972616383C00B66C86 /* utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = utils.h; sourceTree = "<group>"; };
+		0C12ED982616383C00B66C86 /* serialization.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = serialization.h; sourceTree = "<group>"; };
+		0C12ED992616383C00B66C86 /* Storage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Storage.h; sourceTree = "<group>"; };
+		0C12ED9B2616383C00B66C86 /* python_tensor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = python_tensor.h; sourceTree = "<group>"; };
+		0C12ED9C2616383C00B66C86 /* WindowsTorchApiMacro.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WindowsTorchApiMacro.h; sourceTree = "<group>"; };
+		0C12ED9D2616383C00B66C86 /* Dtype.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Dtype.h; sourceTree = "<group>"; };
+		0C12ED9E2616383C00B66C86 /* Module.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Module.h; sourceTree = "<group>"; };
+		0C12ED9F2616383C00B66C86 /* THP_export.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = THP_export.h; sourceTree = "<group>"; };
+		0C12EDA02616383C00B66C86 /* python_dimname.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = python_dimname.h; sourceTree = "<group>"; };
+		0C12EDA12616383C00B66C86 /* CudaIPCTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CudaIPCTypes.h; sourceTree = "<group>"; };
+		0C12EDA22616383C00B66C86 /* Generator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Generator.h; sourceTree = "<group>"; };
+		0C12EDA32616383C00B66C86 /* TypeInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TypeInfo.h; sourceTree = "<group>"; };
+		0C12EDA42616383C00B66C86 /* PythonTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PythonTypes.h; sourceTree = "<group>"; };
+		0C12EDA52616383C00B66C86 /* script.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = script.h; sourceTree = "<group>"; };
+		0C12EDA62616383C00B66C86 /* library.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = library.h; sourceTree = "<group>"; };
+		0C12EDA72616383C00B66C86 /* custom_class_detail.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = custom_class_detail.h; sourceTree = "<group>"; };
+		0C12EDA82616383C00B66C86 /* custom_class.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = custom_class.h; sourceTree = "<group>"; };
+		0C12EDA92616383C00B66C86 /* extension.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = extension.h; sourceTree = "<group>"; };
+		0C12EDAA2616383C00B66C86 /* xnnpack.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = xnnpack.h; sourceTree = "<group>"; };
+		0C12EDAB2616383C00B66C86 /* fp16.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fp16.h; sourceTree = "<group>"; };
+		0C12EDAC2616383C00B66C86 /* qnnpack_func.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qnnpack_func.h; sourceTree = "<group>"; };
+		0C12EDAD2616383C00B66C86 /* pthreadpool.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pthreadpool.h; sourceTree = "<group>"; };
+		0C12EDAE2616383C00B66C86 /* clog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = clog.h; sourceTree = "<group>"; };
+		0C12EDB02616383C00B66C86 /* Formatting.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Formatting.h; sourceTree = "<group>"; };
+		0C12EDB12616383C00B66C86 /* CPUFunctions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CPUFunctions.h; sourceTree = "<group>"; };
+		0C12EDB22616383C00B66C86 /* MetaFunctions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MetaFunctions.h; sourceTree = "<group>"; };
+		0C12EDB32616383C00B66C86 /* Utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Utils.h; sourceTree = "<group>"; };
+		0C12EDB42616383C00B66C86 /* CUDAGeneratorImpl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CUDAGeneratorImpl.h; sourceTree = "<group>"; };
+		0C12EDB52616383C00B66C86 /* TensorOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TensorOptions.h; sourceTree = "<group>"; };
+		0C12EDB62616383C00B66C86 /* TensorUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TensorUtils.h; sourceTree = "<group>"; };
+		0C12EDB72616383C00B66C86 /* MemoryOverlap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MemoryOverlap.h; sourceTree = "<group>"; };
+		0C12EDB82616383C00B66C86 /* InitialTensorOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InitialTensorOptions.h; sourceTree = "<group>"; };
+		0C12EDB92616383C00B66C86 /* Version.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Version.h; sourceTree = "<group>"; };
+		0C12EDBA2616383C00B66C86 /* DLConvertor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DLConvertor.h; sourceTree = "<group>"; };
+		0C12EDBB2616383C00B66C86 /* Device.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Device.h; sourceTree = "<group>"; };
+		0C12EDBD2616383C00B66C86 /* Dict_inl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Dict_inl.h; sourceTree = "<group>"; };
+		0C12EDBE2616383C00B66C86 /* Formatting.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Formatting.h; sourceTree = "<group>"; };
+		0C12EDBF2616383C00B66C86 /* TensorBody.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TensorBody.h; sourceTree = "<group>"; };
+		0C12EDC12616383C00B66C86 /* adaption.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = adaption.h; sourceTree = "<group>"; };
+		0C12EDC22616383C00B66C86 /* op_allowlist.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = op_allowlist.h; sourceTree = "<group>"; };
+		0C12EDC32616383C00B66C86 /* op_registration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = op_registration.h; sourceTree = "<group>"; };
+		0C12EDC42616383C00B66C86 /* infer_schema.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = infer_schema.h; sourceTree = "<group>"; };
+		0C12EDC52616383C00B66C86 /* jit_type_base.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = jit_type_base.h; sourceTree = "<group>"; };
+		0C12EDC62616383C00B66C86 /* typeid.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = typeid.h; sourceTree = "<group>"; };
+		0C12EDC72616383C00B66C86 /* rref_interface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rref_interface.h; sourceTree = "<group>"; };
+		0C12EDC82616383C00B66C86 /* Range.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Range.h; sourceTree = "<group>"; };
+		0C12EDC92616383C00B66C86 /* interned_strings_class.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = interned_strings_class.h; sourceTree = "<group>"; };
+		0C12EDCA2616383C00B66C86 /* operator_name.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = operator_name.h; sourceTree = "<group>"; };
+		0C12EDCB2616383C00B66C86 /* DeprecatedTypePropertiesRegistry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DeprecatedTypePropertiesRegistry.h; sourceTree = "<group>"; };
+		0C12EDCC2616383C00B66C86 /* Backtrace.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Backtrace.h; sourceTree = "<group>"; };
+		0C12EDCD2616383C00B66C86 /* TransformationHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TransformationHelper.h; sourceTree = "<group>"; };
+		0C12EDCE2616383C00B66C86 /* blob.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = blob.h; sourceTree = "<group>"; };
+		0C12EDCF2616383C00B66C86 /* function_schema.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = function_schema.h; sourceTree = "<group>"; };
+		0C12EDD12616383C00B66C86 /* OperatorOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OperatorOptions.h; sourceTree = "<group>"; };
+		0C12EDD22616383C00B66C86 /* RegistrationHandleRAII.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RegistrationHandleRAII.h; sourceTree = "<group>"; };
+		0C12EDD32616383C00B66C86 /* ObservedOperators.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ObservedOperators.h; sourceTree = "<group>"; };
+		0C12EDD42616383C00B66C86 /* DispatchKeyExtractor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DispatchKeyExtractor.h; sourceTree = "<group>"; };
+		0C12EDD52616383C00B66C86 /* Dispatcher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Dispatcher.h; sourceTree = "<group>"; };
+		0C12EDD62616383C00B66C86 /* CppSignature.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CppSignature.h; sourceTree = "<group>"; };
+		0C12EDD72616383C00B66C86 /* OperatorEntry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OperatorEntry.h; sourceTree = "<group>"; };
+		0C12EDD82616383C00B66C86 /* MT19937RNGEngine.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MT19937RNGEngine.h; sourceTree = "<group>"; };
+		0C12EDD92616383C00B66C86 /* ivalue_to.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ivalue_to.h; sourceTree = "<group>"; };
+		0C12EDDA2616383C00B66C86 /* aten_interned_strings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = aten_interned_strings.h; sourceTree = "<group>"; };
+		0C12EDDB2616383C00B66C86 /* LegacyTypeDispatch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LegacyTypeDispatch.h; sourceTree = "<group>"; };
+		0C12EDDC2616383C00B66C86 /* function_schema_inl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = function_schema_inl.h; sourceTree = "<group>"; };
+		0C12EDDD2616383C00B66C86 /* qualified_name.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qualified_name.h; sourceTree = "<group>"; };
+		0C12EDDE2616383C00B66C86 /* UndefinedTensorImpl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UndefinedTensorImpl.h; sourceTree = "<group>"; };
+		0C12EDDF2616383C00B66C86 /* NamedTensor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NamedTensor.h; sourceTree = "<group>"; };
+		0C12EDE02616383C00B66C86 /* Scalar.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Scalar.h; sourceTree = "<group>"; };
+		0C12EDE12616383C00B66C86 /* functional.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = functional.h; sourceTree = "<group>"; };
+		0C12EDE22616383C00B66C86 /* DeprecatedTypeProperties.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DeprecatedTypeProperties.h; sourceTree = "<group>"; };
+		0C12EDE32616383C00B66C86 /* interned_strings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = interned_strings.h; sourceTree = "<group>"; };
+		0C12EDE42616383C00B66C86 /* List.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = List.h; sourceTree = "<group>"; };
+		0C12EDE52616383C00B66C86 /* ATenOpList.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ATenOpList.h; sourceTree = "<group>"; };
+		0C12EDE62616383C00B66C86 /* Dict.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Dict.h; sourceTree = "<group>"; };
+		0C12EDE72616383C00B66C86 /* grad_mode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = grad_mode.h; sourceTree = "<group>"; };
+		0C12EDE82616383C00B66C86 /* DistributionsHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DistributionsHelper.h; sourceTree = "<group>"; };
+		0C12EDE92616383C00B66C86 /* Macros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Macros.h; sourceTree = "<group>"; };
+		0C12EDEA2616383C00B66C86 /* VariableHooksInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VariableHooksInterface.h; sourceTree = "<group>"; };
+		0C12EDEB2616383C00B66C86 /* ScalarType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ScalarType.h; sourceTree = "<group>"; };
+		0C12EDEC2616383C00B66C86 /* Array.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Array.h; sourceTree = "<group>"; };
+		0C12EDED2616383C00B66C86 /* stack.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = stack.h; sourceTree = "<group>"; };
+		0C12EDEE2616383C00B66C86 /* ATenGeneral.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ATenGeneral.h; sourceTree = "<group>"; };
+		0C12EDEF2616383C00B66C86 /* UnsafeFromTH.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UnsafeFromTH.h; sourceTree = "<group>"; };
+		0C12EDF02616383C00B66C86 /* QuantizerBase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = QuantizerBase.h; sourceTree = "<group>"; };
+		0C12EDF12616383C00B66C86 /* alias_info.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = alias_info.h; sourceTree = "<group>"; };
+		0C12EDF22616383C00B66C86 /* List_inl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = List_inl.h; sourceTree = "<group>"; };
+		0C12EDF32616383C00B66C86 /* jit_type.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = jit_type.h; sourceTree = "<group>"; };
+		0C12EDF42616383C00B66C86 /* ivalue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ivalue.h; sourceTree = "<group>"; };
+		0C12EDF52616383C00B66C86 /* Dimname.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Dimname.h; sourceTree = "<group>"; };
+		0C12EDF62616383C00B66C86 /* Vitals.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Vitals.h; sourceTree = "<group>"; };
+		0C12EDF92616383C00B66C86 /* make_boxed_from_unboxed_functor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = make_boxed_from_unboxed_functor.h; sourceTree = "<group>"; };
+		0C12EDFA2616383C00B66C86 /* boxing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = boxing.h; sourceTree = "<group>"; };
+		0C12EDFB2616383C00B66C86 /* test_helpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = test_helpers.h; sourceTree = "<group>"; };
+		0C12EDFC2616383C00B66C86 /* WrapFunctionIntoFunctor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WrapFunctionIntoFunctor.h; sourceTree = "<group>"; };
+		0C12EDFD2616383C00B66C86 /* WrapFunctionIntoRuntimeFunctor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WrapFunctionIntoRuntimeFunctor.h; sourceTree = "<group>"; };
+		0C12EDFE2616383C00B66C86 /* KernelFunction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KernelFunction.h; sourceTree = "<group>"; };
+		0C12EDFF2616383C00B66C86 /* KernelFunction_impl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KernelFunction_impl.h; sourceTree = "<group>"; };
+		0C12EE002616383C00B66C86 /* builtin_function.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = builtin_function.h; sourceTree = "<group>"; };
+		0C12EE012616383C00B66C86 /* DimVector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DimVector.h; sourceTree = "<group>"; };
+		0C12EE022616383C00B66C86 /* Reduction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Reduction.h; sourceTree = "<group>"; };
+		0C12EE032616383C00B66C86 /* Tensor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Tensor.h; sourceTree = "<group>"; };
+		0C12EE042616383C00B66C86 /* function.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = function.h; sourceTree = "<group>"; };
+		0C12EE052616383C00B66C86 /* Generator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Generator.h; sourceTree = "<group>"; };
+		0C12EE062616383C00B66C86 /* PhiloxRNGEngine.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PhiloxRNGEngine.h; sourceTree = "<group>"; };
+		0C12EE072616383C00B66C86 /* TensorAccessor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TensorAccessor.h; sourceTree = "<group>"; };
+		0C12EE082616383C00B66C86 /* ivalue_inl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ivalue_inl.h; sourceTree = "<group>"; };
+		0C12EE092616383C00B66C86 /* Variadic.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Variadic.h; sourceTree = "<group>"; };
+		0C12EE0A2616383C00B66C86 /* VmapMode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VmapMode.h; sourceTree = "<group>"; };
+		0C12EE0B2616383C00B66C86 /* BatchedFallback.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BatchedFallback.h; sourceTree = "<group>"; };
+		0C12EE0C2616383C00B66C86 /* dlpack.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = dlpack.h; sourceTree = "<group>"; };
+		0C12EE0D2616383C00B66C86 /* Config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Config.h; sourceTree = "<group>"; };
+		0C12EE0E2616383C00B66C86 /* SparseTensorUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SparseTensorUtils.h; sourceTree = "<group>"; };
+		0C12EE0F2616383C00B66C86 /* Backtrace.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Backtrace.h; sourceTree = "<group>"; };
+		0C12EE122616383C00B66C86 /* vec256_bfloat16.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vec256_bfloat16.h; sourceTree = "<group>"; };
+		0C12EE132616383C00B66C86 /* vec256_float_neon.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vec256_float_neon.h; sourceTree = "<group>"; };
+		0C12EE142616383C00B66C86 /* missing_vst1_neon.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = missing_vst1_neon.h; sourceTree = "<group>"; };
+		0C12EE152616383C00B66C86 /* vec256_qint.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vec256_qint.h; sourceTree = "<group>"; };
+		0C12EE162616383C00B66C86 /* intrinsics.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = intrinsics.h; sourceTree = "<group>"; };
+		0C12EE172616383C00B66C86 /* functional.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = functional.h; sourceTree = "<group>"; };
+		0C12EE182616383C00B66C86 /* vec256_complex_float.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vec256_complex_float.h; sourceTree = "<group>"; };
+		0C12EE192616383C00B66C86 /* vec256_double.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vec256_double.h; sourceTree = "<group>"; };
+		0C12EE1A2616383C00B66C86 /* vec256_base.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vec256_base.h; sourceTree = "<group>"; };
+		0C12EE1B2616383C00B66C86 /* vec256_float.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vec256_float.h; sourceTree = "<group>"; };
+		0C12EE1C2616383C00B66C86 /* missing_vld1_neon.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = missing_vld1_neon.h; sourceTree = "<group>"; };
+		0C12EE1D2616383C00B66C86 /* vec256.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vec256.h; sourceTree = "<group>"; };
+		0C12EE1E2616383C00B66C86 /* vec256_int.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vec256_int.h; sourceTree = "<group>"; };
+		0C12EE1F2616383C00B66C86 /* vec256_complex_double.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vec256_complex_double.h; sourceTree = "<group>"; };
+		0C12EE202616383C00B66C86 /* FlushDenormal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FlushDenormal.h; sourceTree = "<group>"; };
+		0C12EE212616383C00B66C86 /* vml.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vml.h; sourceTree = "<group>"; };
+		0C12EE222616383C00B66C86 /* TracerMode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TracerMode.h; sourceTree = "<group>"; };
+		0C12EE232616383C00B66C86 /* Backend.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Backend.h; sourceTree = "<group>"; };
+		0C12EE242616383C00B66C86 /* RegistrationDeclarations.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RegistrationDeclarations.h; sourceTree = "<group>"; };
+		0C12EE252616383C00B66C86 /* CompositeImplicitAutogradFunctions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CompositeImplicitAutogradFunctions.h; sourceTree = "<group>"; };
+		0C12EE262616383C00B66C86 /* PTThreadPool.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PTThreadPool.h; sourceTree = "<group>"; };
+		0C12EE272616383C00B66C86 /* OpaqueTensorImpl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OpaqueTensorImpl.h; sourceTree = "<group>"; };
+		0C12EE282616383C00B66C86 /* LegacyTHFunctionsCPU.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LegacyTHFunctionsCPU.h; sourceTree = "<group>"; };
+		0C12EE2A2616383C00B66C86 /* QTensorImpl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = QTensorImpl.h; sourceTree = "<group>"; };
+		0C12EE2B2616383C00B66C86 /* Quantizer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Quantizer.h; sourceTree = "<group>"; };
+		0C12EE2C2616383C00B66C86 /* record_function.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = record_function.h; sourceTree = "<group>"; };
+		0C12EE2D2616383C00B66C86 /* WrapDimUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WrapDimUtils.h; sourceTree = "<group>"; };
+		0C12EE2E2616383C00B66C86 /* RedispatchFunctions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RedispatchFunctions.h; sourceTree = "<group>"; };
+		0C12EE2F2616383C00B66C86 /* Context.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Context.h; sourceTree = "<group>"; };
+		0C12EE302616383C00B66C86 /* div_rtn.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = div_rtn.h; sourceTree = "<group>"; };
+		0C12EE312616383C00B66C86 /* ExpandUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ExpandUtils.h; sourceTree = "<group>"; };
+		0C12EE322616383C00B66C86 /* TypeDefault.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TypeDefault.h; sourceTree = "<group>"; };
+		0C12EE332616383C00B66C86 /* CPUFixedAllocator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CPUFixedAllocator.h; sourceTree = "<group>"; };
+		0C12EE342616383C00B66C86 /* NamedTensor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NamedTensor.h; sourceTree = "<group>"; };
+		0C12EE352616383C00B66C86 /* Scalar.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Scalar.h; sourceTree = "<group>"; };
+		0C12EE362616383C00B66C86 /* ParallelNativeTBB.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ParallelNativeTBB.h; sourceTree = "<group>"; };
+		0C12EE372616383C00B66C86 /* ArrayRef.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ArrayRef.h; sourceTree = "<group>"; };
+		0C12EE382616383C00B66C86 /* SequenceNumber.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SequenceNumber.h; sourceTree = "<group>"; };
+		0C12EE392616383C00B66C86 /* MatrixRef.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MatrixRef.h; sourceTree = "<group>"; };
+		0C12EE3A2616383C00B66C86 /* CompositeExplicitAutogradFunctions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CompositeExplicitAutogradFunctions.h; sourceTree = "<group>"; };
+		0C12EE3B2616383C00B66C86 /* NumericUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NumericUtils.h; sourceTree = "<group>"; };
+		0C12EE3C2616383C00B66C86 /* ATen.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ATen.h; sourceTree = "<group>"; };
+		0C12EE3D2616383C00B66C86 /* TensorNames.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TensorNames.h; sourceTree = "<group>"; };
+		0C12EE3E2616383C00B66C86 /* TensorMeta.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TensorMeta.h; sourceTree = "<group>"; };
+		0C12EE3F2616383C00B66C86 /* TensorIndexing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TensorIndexing.h; sourceTree = "<group>"; };
+		0C12EE402616383C00B66C86 /* Layout.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Layout.h; sourceTree = "<group>"; };
+		0C12EE412616383C00B66C86 /* SparseTensorImpl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SparseTensorImpl.h; sourceTree = "<group>"; };
+		0C12EE432616383C00B66C86 /* CUDAHooksInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CUDAHooksInterface.h; sourceTree = "<group>"; };
+		0C12EE442616383C00B66C86 /* FunctionTraits.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FunctionTraits.h; sourceTree = "<group>"; };
+		0C12EE452616383C00B66C86 /* HIPHooksInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HIPHooksInterface.h; sourceTree = "<group>"; };
+		0C12EE462616383C00B66C86 /* WrapDimUtilsMulti.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WrapDimUtilsMulti.h; sourceTree = "<group>"; };
+		0C12EE472616383C00B66C86 /* TensorOperators.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TensorOperators.h; sourceTree = "<group>"; };
+		0C12EE482616383C00B66C86 /* ScalarType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ScalarType.h; sourceTree = "<group>"; };
+		0C12EE492616383C00B66C86 /* cpp_custom_type_hack.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cpp_custom_type_hack.h; sourceTree = "<group>"; };
+		0C12EE4A2616383C00B66C86 /* VmapTransforms.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VmapTransforms.h; sourceTree = "<group>"; };
+		0C12EE4B2616383C00B66C86 /* Storage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Storage.h; sourceTree = "<group>"; };
+		0C12EE4C2616383C00B66C86 /* DeviceGuard.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DeviceGuard.h; sourceTree = "<group>"; };
+		0C12EE4D2616383C00B66C86 /* ParallelNative.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ParallelNative.h; sourceTree = "<group>"; };
+		0C12EE4E2616383C00B66C86 /* Dispatch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Dispatch.h; sourceTree = "<group>"; };
+		0C12EE4F2616383C00B66C86 /* CPUGeneratorImpl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CPUGeneratorImpl.h; sourceTree = "<group>"; };
+		0C12EE502616383C00B66C86 /* Functions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Functions.h; sourceTree = "<group>"; };
+		0C12EE512616383C00B66C86 /* ParallelOpenMP.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ParallelOpenMP.h; sourceTree = "<group>"; };
+		0C12EE522616383C00B66C86 /* BatchedTensorImpl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BatchedTensorImpl.h; sourceTree = "<group>"; };
+		0C12EE532616383C00B66C86 /* CPUApplyUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CPUApplyUtils.h; sourceTree = "<group>"; };
+		0C12EE542616383C00B66C86 /* ThreadLocalState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ThreadLocalState.h; sourceTree = "<group>"; };
+		0C12EE552616383C00B66C86 /* ScalarOps.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ScalarOps.h; sourceTree = "<group>"; };
+		0C12EE562616383C00B66C86 /* NativeFunctions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NativeFunctions.h; sourceTree = "<group>"; };
+		0C12EE572616383C00B66C86 /* DynamicLibrary.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DynamicLibrary.h; sourceTree = "<group>"; };
+		0C12EE582616383C00B66C86 /* TensorGeometry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TensorGeometry.h; sourceTree = "<group>"; };
+		0C12EE592616383C00B66C86 /* TensorIterator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TensorIterator.h; sourceTree = "<group>"; };
+		0C12EE5A2616383C00B66C86 /* NamedTensorUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NamedTensorUtils.h; sourceTree = "<group>"; };
+		0C12EE5B2616383C00B66C86 /* Dimname.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Dimname.h; sourceTree = "<group>"; };
+		0C12EE5C2616383C00B66C86 /* autocast_mode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = autocast_mode.h; sourceTree = "<group>"; };
+		0C12EE5D2616383C00B66C86 /* Parallel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Parallel.h; sourceTree = "<group>"; };
+		0C12EE5E2616383C00B66C86 /* DimVector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DimVector.h; sourceTree = "<group>"; };
+		0C12EE5F2616383C00B66C86 /* InferSize.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InferSize.h; sourceTree = "<group>"; };
+		0C12EE602616383C00B66C86 /* SmallVector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SmallVector.h; sourceTree = "<group>"; };
+		0C12EE612616383C00B66C86 /* Tensor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Tensor.h; sourceTree = "<group>"; };
+		0C12EE622616383C00B66C86 /* Generator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Generator.h; sourceTree = "<group>"; };
+		0C12EE632616383C00B66C86 /* AccumulateType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AccumulateType.h; sourceTree = "<group>"; };
+		0C12EE642616383C00B66C86 /* TensorAccessor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TensorAccessor.h; sourceTree = "<group>"; };
+		0C12EE652616383C00B66C86 /* LegacyTHFunctionsCUDA.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LegacyTHFunctionsCUDA.h; sourceTree = "<group>"; };
+		0C12EE6A2616383C00B66C86 /* InlineStreamGuard.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InlineStreamGuard.h; sourceTree = "<group>"; };
+		0C12EE6B2616383C00B66C86 /* SizesAndStrides.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SizesAndStrides.h; sourceTree = "<group>"; };
+		0C12EE6C2616383C00B66C86 /* InlineDeviceGuard.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InlineDeviceGuard.h; sourceTree = "<group>"; };
+		0C12EE6D2616383C00B66C86 /* LocalDispatchKeySet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LocalDispatchKeySet.h; sourceTree = "<group>"; };
+		0C12EE6E2616383C00B66C86 /* VirtualGuardImpl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VirtualGuardImpl.h; sourceTree = "<group>"; };
+		0C12EE6F2616383C00B66C86 /* InlineEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InlineEvent.h; sourceTree = "<group>"; };
+		0C12EE702616383C00B66C86 /* DeviceGuardImplInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DeviceGuardImplInterface.h; sourceTree = "<group>"; };
+		0C12EE712616383C00B66C86 /* FakeGuardImpl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FakeGuardImpl.h; sourceTree = "<group>"; };
+		0C12EE722616383C00B66C86 /* QEngine.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = QEngine.h; sourceTree = "<group>"; };
+		0C12EE732616383C00B66C86 /* TensorOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TensorOptions.h; sourceTree = "<group>"; };
+		0C12EE742616383C00B66C86 /* Device.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Device.h; sourceTree = "<group>"; };
+		0C12EE752616383C00B66C86 /* CPUAllocator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CPUAllocator.h; sourceTree = "<group>"; };
+		0C12EE762616383C00B66C86 /* DefaultDtype.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DefaultDtype.h; sourceTree = "<group>"; };
+		0C12EE772616383C00B66C86 /* DefaultTensorOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DefaultTensorOptions.h; sourceTree = "<group>"; };
+		0C12EE782616383C00B66C86 /* Event.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Event.h; sourceTree = "<group>"; };
+		0C12EE792616383C00B66C86 /* Backend.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Backend.h; sourceTree = "<group>"; };
+		0C12EE7A2616383C00B66C86 /* CompileTimeFunctionPointer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CompileTimeFunctionPointer.h; sourceTree = "<group>"; };
+		0C12EE7B2616383C00B66C86 /* WrapDimMinimal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WrapDimMinimal.h; sourceTree = "<group>"; };
+		0C12EE7C2616383C00B66C86 /* QScheme.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = QScheme.h; sourceTree = "<group>"; };
+		0C12EE7D2616383C00B66C86 /* Stream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Stream.h; sourceTree = "<group>"; };
+		0C12EE7E2616383C00B66C86 /* UndefinedTensorImpl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UndefinedTensorImpl.h; sourceTree = "<group>"; };
+		0C12EE7F2616383C00B66C86 /* Scalar.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Scalar.h; sourceTree = "<group>"; };
+		0C12EE802616383C00B66C86 /* thread_pool.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = thread_pool.h; sourceTree = "<group>"; };
+		0C12EE812616383C00B66C86 /* CopyBytes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CopyBytes.h; sourceTree = "<group>"; };
+		0C12EE822616383C00B66C86 /* StreamGuard.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StreamGuard.h; sourceTree = "<group>"; };
+		0C12EE832616383C00B66C86 /* Layout.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Layout.h; sourceTree = "<group>"; };
+		0C12EE842616383C00B66C86 /* GeneratorImpl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GeneratorImpl.h; sourceTree = "<group>"; };
+		0C12EE852616383C00B66C86 /* DispatchKeySet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DispatchKeySet.h; sourceTree = "<group>"; };
+		0C12EE862616383C00B66C86 /* Allocator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Allocator.h; sourceTree = "<group>"; };
+		0C12EE872616383C00B66C86 /* TensorImpl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TensorImpl.h; sourceTree = "<group>"; };
+		0C12EE882616383C00B66C86 /* ScalarType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ScalarType.h; sourceTree = "<group>"; };
+		0C12EE892616383C00B66C86 /* Storage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Storage.h; sourceTree = "<group>"; };
+		0C12EE8A2616383C00B66C86 /* DeviceType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DeviceType.h; sourceTree = "<group>"; };
+		0C12EE8B2616383C00B66C86 /* DeviceGuard.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DeviceGuard.h; sourceTree = "<group>"; };
+		0C12EE8C2616383C00B66C86 /* StorageImpl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StorageImpl.h; sourceTree = "<group>"; };
+		0C12EE8D2616383C00B66C86 /* MemoryFormat.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MemoryFormat.h; sourceTree = "<group>"; };
+		0C12EE8E2616383C00B66C86 /* DispatchKey.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DispatchKey.h; sourceTree = "<group>"; };
+		0C12EE8F2616383C00B66C86 /* ScalarTypeToTypeMeta.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ScalarTypeToTypeMeta.h; sourceTree = "<group>"; };
+		0C12EE902616383C00B66C86 /* InferenceMode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InferenceMode.h; sourceTree = "<group>"; };
+		0C12EE952616383C00B66C86 /* complex_test_common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = complex_test_common.h; sourceTree = "<group>"; };
+		0C12EE962616383C00B66C86 /* complex_math_test_common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = complex_math_test_common.h; sourceTree = "<group>"; };
+		0C12EE972616383C00B66C86 /* Macros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Macros.h; sourceTree = "<group>"; };
+		0C12EE992616383C00B66C86 /* Type.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Type.h; sourceTree = "<group>"; };
+		0C12EE9A2616383C00B66C86 /* order_preserving_flat_hash_map.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = order_preserving_flat_hash_map.h; sourceTree = "<group>"; };
+		0C12EE9B2616383C00B66C86 /* reverse_iterator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = reverse_iterator.h; sourceTree = "<group>"; };
+		0C12EE9C2616383C00B66C86 /* quint4x2.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = quint4x2.h; sourceTree = "<group>"; };
+		0C12EE9D2616383C00B66C86 /* Half.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Half.h; sourceTree = "<group>"; };
+		0C12EE9E2616383C00B66C86 /* flat_hash_map.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = flat_hash_map.h; sourceTree = "<group>"; };
+		0C12EE9F2616383C00B66C86 /* llvmMathExtras.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = llvmMathExtras.h; sourceTree = "<group>"; };
+		0C12EEA02616383C00B66C86 /* math_compat.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = math_compat.h; sourceTree = "<group>"; };
+		0C12EEA12616383C00B66C86 /* Bitset.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Bitset.h; sourceTree = "<group>"; };
+		0C12EEA22616383C00B66C86 /* typeid.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = typeid.h; sourceTree = "<group>"; };
+		0C12EEA32616383C00B66C86 /* intrusive_ptr.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = intrusive_ptr.h; sourceTree = "<group>"; };
+		0C12EEA42616383C00B66C86 /* string_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = string_utils.h; sourceTree = "<group>"; };
+		0C12EEA52616383C00B66C86 /* win32-headers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "win32-headers.h"; sourceTree = "<group>"; };
+		0C12EEA62616383C00B66C86 /* AlignOf.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AlignOf.h; sourceTree = "<group>"; };
+		0C12EEA72616383C00B66C86 /* numa.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = numa.h; sourceTree = "<group>"; };
+		0C12EEA82616383C00B66C86 /* qint32.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qint32.h; sourceTree = "<group>"; };
+		0C12EEA92616383C00B66C86 /* MaybeOwned.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MaybeOwned.h; sourceTree = "<group>"; };
+		0C12EEAA2616383C00B66C86 /* Half-inl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "Half-inl.h"; sourceTree = "<group>"; };
+		0C12EEAB2616383C00B66C86 /* TypeTraits.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TypeTraits.h; sourceTree = "<group>"; };
+		0C12EEAC2616383C00B66C86 /* FunctionRef.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FunctionRef.h; sourceTree = "<group>"; };
+		0C12EEAD2616383C00B66C86 /* Backtrace.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Backtrace.h; sourceTree = "<group>"; };
+		0C12EEAE2616383C00B66C86 /* BFloat16-inl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "BFloat16-inl.h"; sourceTree = "<group>"; };
+		0C12EEAF2616383C00B66C86 /* in_place.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = in_place.h; sourceTree = "<group>"; };
+		0C12EEB02616383C00B66C86 /* ConstexprCrc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ConstexprCrc.h; sourceTree = "<group>"; };
+		0C12EEB12616383C00B66C86 /* IdWrapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IdWrapper.h; sourceTree = "<group>"; };
+		0C12EEB22616383C00B66C86 /* Flags.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Flags.h; sourceTree = "<group>"; };
+		0C12EEB32616383C00B66C86 /* overloaded.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = overloaded.h; sourceTree = "<group>"; };
+		0C12EEB42616383C00B66C86 /* quint8.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = quint8.h; sourceTree = "<group>"; };
+		0C12EEB52616383C00B66C86 /* StringUtil.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StringUtil.h; sourceTree = "<group>"; };
+		0C12EEB62616383C00B66C86 /* Logging.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Logging.h; sourceTree = "<group>"; };
+		0C12EEB72616383C00B66C86 /* MathConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MathConstants.h; sourceTree = "<group>"; };
+		0C12EEB82616383C00B66C86 /* Registry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Registry.h; sourceTree = "<group>"; };
+		0C12EEB92616383C00B66C86 /* Optional.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Optional.h; sourceTree = "<group>"; };
+		0C12EEBA2616383C00B66C86 /* tempfile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tempfile.h; sourceTree = "<group>"; };
+		0C12EEBB2616383C00B66C86 /* ArrayRef.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ArrayRef.h; sourceTree = "<group>"; };
+		0C12EEBC2616383C00B66C86 /* thread_name.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = thread_name.h; sourceTree = "<group>"; };
+		0C12EEBD2616383C00B66C86 /* Unicode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Unicode.h; sourceTree = "<group>"; };
+		0C12EEBE2616383C00B66C86 /* TypeCast.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TypeCast.h; sourceTree = "<group>"; };
+		0C12EEBF2616383C00B66C86 /* sparse_bitset.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = sparse_bitset.h; sourceTree = "<group>"; };
+		0C12EEC02616383C00B66C86 /* BFloat16.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BFloat16.h; sourceTree = "<group>"; };
+		0C12EEC12616383C00B66C86 /* TypeList.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TypeList.h; sourceTree = "<group>"; };
+		0C12EEC22616383C00B66C86 /* TypeIndex.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TypeIndex.h; sourceTree = "<group>"; };
+		0C12EEC32616383C00B66C86 /* Array.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Array.h; sourceTree = "<group>"; };
+		0C12EEC42616383C00B66C86 /* logging_is_google_glog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = logging_is_google_glog.h; sourceTree = "<group>"; };
+		0C12EEC52616383C00B66C86 /* Metaprogramming.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Metaprogramming.h; sourceTree = "<group>"; };
+		0C12EEC62616383C00B66C86 /* either.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = either.h; sourceTree = "<group>"; };
+		0C12EEC72616383C00B66C86 /* BFloat16-math.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "BFloat16-math.h"; sourceTree = "<group>"; };
+		0C12EEC82616383C00B66C86 /* Deprecated.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Deprecated.h; sourceTree = "<group>"; };
+		0C12EEC92616383C00B66C86 /* irange.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = irange.h; sourceTree = "<group>"; };
+		0C12EECA2616383C00B66C86 /* LeftRight.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LeftRight.h; sourceTree = "<group>"; };
+		0C12EECB2616383C00B66C86 /* qint8.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qint8.h; sourceTree = "<group>"; };
+		0C12EECC2616383C00B66C86 /* complex_math.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = complex_math.h; sourceTree = "<group>"; };
+		0C12EECD2616383C00B66C86 /* logging_is_not_google_glog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = logging_is_not_google_glog.h; sourceTree = "<group>"; };
+		0C12EECE2616383C00B66C86 /* Exception.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Exception.h; sourceTree = "<group>"; };
+		0C12EECF2616383C00B66C86 /* UniqueVoidPtr.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UniqueVoidPtr.h; sourceTree = "<group>"; };
+		0C12EED02616383C00B66C86 /* ThreadLocalDebugInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ThreadLocalDebugInfo.h; sourceTree = "<group>"; };
+		0C12EED12616383C00B66C86 /* accumulate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = accumulate.h; sourceTree = "<group>"; };
+		0C12EED22616383C00B66C86 /* C++17.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "C++17.h"; sourceTree = "<group>"; };
+		0C12EED32616383C00B66C86 /* SmallVector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SmallVector.h; sourceTree = "<group>"; };
+		0C12EED42616383C00B66C86 /* hash.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = hash.h; sourceTree = "<group>"; };
+		0C12EED52616383C00B66C86 /* python_stub.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = python_stub.h; sourceTree = "<group>"; };
+		0C12EED62616383C00B66C86 /* complex.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = complex.h; sourceTree = "<group>"; };
+		0C12EED72616383C00B66C86 /* string_view.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = string_view.h; sourceTree = "<group>"; };
+		0C12EED82616383C00B66C86 /* variant.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = variant.h; sourceTree = "<group>"; };
+		0C12EED92616383C00B66C86 /* complex_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = complex_utils.h; sourceTree = "<group>"; };
+		0C12EEDC2616383C00B66C86 /* CUDATest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CUDATest.h; sourceTree = "<group>"; };
+		0C12EEDD2616383C00B66C86 /* CUDAGuardImpl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CUDAGuardImpl.h; sourceTree = "<group>"; };
+		0C12EEDE2616383C00B66C86 /* CUDAMathCompat.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CUDAMathCompat.h; sourceTree = "<group>"; };
+		0C12EEE12616383C00B66C86 /* CUDAStream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CUDAStream.h; sourceTree = "<group>"; };
+		0C12EEE22616383C00B66C86 /* CUDAGuard.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CUDAGuard.h; sourceTree = "<group>"; };
+		0C12EEE32616383C00B66C86 /* CUDAGraphsC10Utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CUDAGraphsC10Utils.h; sourceTree = "<group>"; };
+		0C12EEE42616383C00B66C86 /* CUDAMacros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CUDAMacros.h; sourceTree = "<group>"; };
+		0C12EEE52616383C00B66C86 /* CUDAFunctions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CUDAFunctions.h; sourceTree = "<group>"; };
+		0C12EEE62616383C00B66C86 /* CUDAException.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CUDAException.h; sourceTree = "<group>"; };
+		0C12EEE72616383C00B66C86 /* CUDACachingAllocator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CUDACachingAllocator.h; sourceTree = "<group>"; };
+		0C12EEE92616383C00B66C86 /* cmake_macros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cmake_macros.h; sourceTree = "<group>"; };
+		0C12EEEA2616383C00B66C86 /* Export.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Export.h; sourceTree = "<group>"; };
+		0C12EEEB2616383C00B66C86 /* Macros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Macros.h; sourceTree = "<group>"; };
+		0C12EEED2616383C00B66C86 /* CPUCachingAllocator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CPUCachingAllocator.h; sourceTree = "<group>"; };
+		0C12EEEE2616383C00B66C86 /* CPUProfilingAllocator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CPUProfilingAllocator.h; sourceTree = "<group>"; };
+		0C12EEF02616383C00B66C86 /* psimd.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = psimd.h; sourceTree = "<group>"; };
+		0C12EEF12616383C00B66C86 /* fxdiv.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fxdiv.h; sourceTree = "<group>"; };
+		0C12EEF32616383C00B66C86 /* avx.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; path = avx.py; sourceTree = "<group>"; };
+		0C12EEF42616383C00B66C86 /* __init__.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; path = __init__.py; sourceTree = "<group>"; };
+		0C12EEF52616383C00B66C86 /* fp16.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fp16.h; sourceTree = "<group>"; };
+		0C12EEF62616383C00B66C86 /* avx2.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; path = avx2.py; sourceTree = "<group>"; };
+		0C12EEF72616383C00B66C86 /* psimd.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = psimd.h; sourceTree = "<group>"; };
+		0C12EEF82616383C00B66C86 /* bitcasts.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = bitcasts.h; sourceTree = "<group>"; };
+		0C12EEFB2616383C00B66C86 /* THCUNN.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = THCUNN.h; sourceTree = "<group>"; };
+		0C12EEFD2616383C00B66C86 /* THTensorDimApply.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = THTensorDimApply.h; sourceTree = "<group>"; };
+		0C12EEFE2616383C00B66C86 /* THBlas.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = THBlas.h; sourceTree = "<group>"; };
+		0C12EEFF2616383C00B66C86 /* THGenerateQUInt8Type.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = THGenerateQUInt8Type.h; sourceTree = "<group>"; };
+		0C12EF002616383C00B66C86 /* THGenerateQInt8Type.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = THGenerateQInt8Type.h; sourceTree = "<group>"; };
+		0C12EF012616383C00B66C86 /* THGenerateComplexTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = THGenerateComplexTypes.h; sourceTree = "<group>"; };
+		0C12EF022616383C00B66C86 /* THGenerateFloatType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = THGenerateFloatType.h; sourceTree = "<group>"; };
+		0C12EF032616383C00B66C86 /* THGenerateQInt32Type.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = THGenerateQInt32Type.h; sourceTree = "<group>"; };
+		0C12EF042616383C00B66C86 /* THGenerateDoubleType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = THGenerateDoubleType.h; sourceTree = "<group>"; };
+		0C12EF052616383C00B66C86 /* THGenerateShortType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = THGenerateShortType.h; sourceTree = "<group>"; };
+		0C12EF062616383C00B66C86 /* THGenerateIntTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = THGenerateIntTypes.h; sourceTree = "<group>"; };
+		0C12EF072616383C00B66C86 /* THGenerateLongType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = THGenerateLongType.h; sourceTree = "<group>"; };
+		0C12EF082616383C00B66C86 /* THGenerateComplexFloatType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = THGenerateComplexFloatType.h; sourceTree = "<group>"; };
+		0C12EF092616383C00B66C86 /* THAllocator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = THAllocator.h; sourceTree = "<group>"; };
+		0C12EF0A2616383C00B66C86 /* THGenerateCharType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = THGenerateCharType.h; sourceTree = "<group>"; };
+		0C12EF0B2616383C00B66C86 /* THStorage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = THStorage.h; sourceTree = "<group>"; };
+		0C12EF0C2616383C00B66C86 /* THHalf.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = THHalf.h; sourceTree = "<group>"; };
+		0C12EF0D2616383C00B66C86 /* THGenerateHalfType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = THGenerateHalfType.h; sourceTree = "<group>"; };
+		0C12EF0E2616383C00B66C86 /* THGenerateIntType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = THGenerateIntType.h; sourceTree = "<group>"; };
+		0C12EF0F2616383C00B66C86 /* THVector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = THVector.h; sourceTree = "<group>"; };
+		0C12EF102616383C00B66C86 /* THGeneral.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = THGeneral.h; sourceTree = "<group>"; };
+		0C12EF112616383C00B66C86 /* THGenerateBoolType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = THGenerateBoolType.h; sourceTree = "<group>"; };
+		0C12EF122616383C00B66C86 /* THLapack.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = THLapack.h; sourceTree = "<group>"; };
+		0C12EF132616383C00B66C86 /* THGenerateComplexDoubleType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = THGenerateComplexDoubleType.h; sourceTree = "<group>"; };
+		0C12EF142616383C00B66C86 /* THGenerateBFloat16Type.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = THGenerateBFloat16Type.h; sourceTree = "<group>"; };
+		0C12EF152616383C00B66C86 /* THGenerateQTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = THGenerateQTypes.h; sourceTree = "<group>"; };
+		0C12EF162616383C00B66C86 /* THGenerateFloatTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = THGenerateFloatTypes.h; sourceTree = "<group>"; };
+		0C12EF182616383C00B66C86 /* THBlas.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = THBlas.h; sourceTree = "<group>"; };
+		0C12EF192616383C00B66C86 /* THTensor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = THTensor.cpp; sourceTree = "<group>"; };
+		0C12EF1A2616383C00B66C86 /* THTensorMath.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = THTensorMath.cpp; sourceTree = "<group>"; };
+		0C12EF1B2616383C00B66C86 /* THTensorMath.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = THTensorMath.h; sourceTree = "<group>"; };
+		0C12EF1C2616383C00B66C86 /* THStorageCopy.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = THStorageCopy.cpp; sourceTree = "<group>"; };
+		0C12EF1D2616383C00B66C86 /* THTensorFastGetSet.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = THTensorFastGetSet.hpp; sourceTree = "<group>"; };
+		0C12EF1E2616383C00B66C86 /* THStorage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = THStorage.h; sourceTree = "<group>"; };
+		0C12EF1F2616383C00B66C86 /* THTensorLapack.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = THTensorLapack.h; sourceTree = "<group>"; };
+		0C12EF202616383C00B66C86 /* THVector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = THVector.h; sourceTree = "<group>"; };
+		0C12EF212616383C00B66C86 /* THLapack.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = THLapack.cpp; sourceTree = "<group>"; };
+		0C12EF222616383C00B66C86 /* THStorageCopy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = THStorageCopy.h; sourceTree = "<group>"; };
+		0C12EF232616383C00B66C86 /* THLapack.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = THLapack.h; sourceTree = "<group>"; };
+		0C12EF242616383C00B66C86 /* THStorage.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = THStorage.cpp; sourceTree = "<group>"; };
+		0C12EF252616383C00B66C86 /* THTensor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = THTensor.h; sourceTree = "<group>"; };
+		0C12EF262616383C00B66C86 /* THBlas.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = THBlas.cpp; sourceTree = "<group>"; };
+		0C12EF272616383C00B66C86 /* THTensorLapack.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = THTensorLapack.cpp; sourceTree = "<group>"; };
+		0C12EF282616383C00B66C86 /* THTensor.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = THTensor.hpp; sourceTree = "<group>"; };
+		0C12EF292616383C00B66C86 /* THTensor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = THTensor.h; sourceTree = "<group>"; };
+		0C12EF2A2616383C00B66C86 /* TH.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TH.h; sourceTree = "<group>"; };
+		0C12EF2B2616383C00B66C86 /* THTensorApply.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = THTensorApply.h; sourceTree = "<group>"; };
+		0C12EF2C2616383C00B66C86 /* THStorageFunctions.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = THStorageFunctions.hpp; sourceTree = "<group>"; };
+		0C12EF2D2616383C00B66C86 /* THGenerateAllTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = THGenerateAllTypes.h; sourceTree = "<group>"; };
+		0C12EF2E2616383C00B66C86 /* THTensor.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = THTensor.hpp; sourceTree = "<group>"; };
+		0C12EF2F2616383C00B66C86 /* THGenerateByteType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = THGenerateByteType.h; sourceTree = "<group>"; };
+		0C12EF302616383C00B66C86 /* THStorageFunctions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = THStorageFunctions.h; sourceTree = "<group>"; };
+		0C12EF312616383C00B66C86 /* THGenerateQUInt4x2Type.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = THGenerateQUInt4x2Type.h; sourceTree = "<group>"; };
+		0C12EF332616383C00B66C86 /* libtorch_cpu.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libtorch_cpu.a; sourceTree = "<group>"; };
+		0C12EF342616383C00B66C86 /* libtorch.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libtorch.a; sourceTree = "<group>"; };
+		0C12EF352616383C00B66C86 /* libcpuinfo.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libcpuinfo.a; sourceTree = "<group>"; };
+		0C12EF362616383C00B66C86 /* libXNNPACK.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libXNNPACK.a; sourceTree = "<group>"; };
+		0C12EF372616383C00B66C86 /* libtorchvision_ops.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libtorchvision_ops.a; sourceTree = "<group>"; };
+		0C12EF382616383C00B66C86 /* libpthreadpool.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libpthreadpool.a; sourceTree = "<group>"; };
+		0C12EF392616383C00B66C86 /* libc10.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libc10.a; sourceTree = "<group>"; };
+		0C12EF3A2616383C00B66C86 /* libeigen_blas.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libeigen_blas.a; sourceTree = "<group>"; };
+		0C12EF3B2616383C00B66C86 /* libclog.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libclog.a; sourceTree = "<group>"; };
+		0C12EF3C2616383C00B66C86 /* libpytorch_qnnpack.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libpytorch_qnnpack.a; sourceTree = "<group>"; };
+		0C12EF7526163B7600B66C86 /* frcnn_mnetv3.pt */ = {isa = PBXFileReference; lastKnownFileType = file; path = frcnn_mnetv3.pt; sourceTree = "<group>"; };
+		0CEB0ABB26151A8800F1F7D5 /* VisionTestApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = VisionTestApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		0CEB0ABE26151A8800F1F7D5 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
+		0CEB0ABF26151A8800F1F7D5 /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
+		0CEB0AC426151A8800F1F7D5 /* ViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ViewController.h; sourceTree = "<group>"; };
+		0CEB0AC526151A8800F1F7D5 /* ViewController.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ViewController.mm; sourceTree = "<group>"; };
+		0CEB0AC826151A8800F1F7D5 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		0CEB0ACA26151A8900F1F7D5 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		0CEB0ACD26151A8900F1F7D5 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		0CEB0ACF26151A8900F1F7D5 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		0CEB0AD026151A8900F1F7D5 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		0CEB0B3826152ED900F1F7D5 /* ModelRunner.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ModelRunner.h; sourceTree = "<group>"; };
+		0CEB0B3926152ED900F1F7D5 /* ModelRunner.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ModelRunner.mm; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		0CEB0AB826151A8800F1F7D5 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0C12EF502616383D00B66C86 /* libpytorch_qnnpack.a in Frameworks */,
+				0C12EF4C2616383D00B66C86 /* libpthreadpool.a in Frameworks */,
+				0C12EF4F2616383D00B66C86 /* libclog.a in Frameworks */,
+				0C12EF482616383D00B66C86 /* libtorch.a in Frameworks */,
+				0C12EF4A2616383D00B66C86 /* libXNNPACK.a in Frameworks */,
+				0C12EF472616383D00B66C86 /* libtorch_cpu.a in Frameworks */,
+				0C12EF7A26163C7C00B66C86 /* libtorchvision_ops.a in Frameworks */,
+				0C12EF492616383D00B66C86 /* libcpuinfo.a in Frameworks */,
+				0C12EF4E2616383D00B66C86 /* libeigen_blas.a in Frameworks */,
+				0C12EF4D2616383D00B66C86 /* libc10.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		0C12E7872616383A00B66C86 /* install */ = {
+			isa = PBXGroup;
+			children = (
+				0C12E7882616383A00B66C86 /* include */,
+				0C12EF322616383C00B66C86 /* lib */,
+			);
+			path = install;
+			sourceTree = "<group>";
+		};
+		0C12E7882616383A00B66C86 /* include */ = {
+			isa = PBXGroup;
+			children = (
+				0C12E7892616383A00B66C86 /* pybind11 */,
+				0C12E7A32616383A00B66C86 /* caffe2 */,
+				0C12EAB22616383B00B66C86 /* cpuinfo.h */,
+				0C12EAB32616383B00B66C86 /* torch */,
+				0C12EDAA2616383C00B66C86 /* xnnpack.h */,
+				0C12EDAB2616383C00B66C86 /* fp16.h */,
+				0C12EDAC2616383C00B66C86 /* qnnpack_func.h */,
+				0C12EDAD2616383C00B66C86 /* pthreadpool.h */,
+				0C12EDAE2616383C00B66C86 /* clog.h */,
+				0C12EDAF2616383C00B66C86 /* ATen */,
+				0C12EE662616383C00B66C86 /* c10 */,
+				0C12EEF02616383C00B66C86 /* psimd.h */,
+				0C12EEF12616383C00B66C86 /* fxdiv.h */,
+				0C12EEF22616383C00B66C86 /* fp16 */,
+				0C12EEF92616383C00B66C86 /* THCUNN */,
+				0C12EEFC2616383C00B66C86 /* TH */,
+			);
+			path = include;
+			sourceTree = "<group>";
+		};
+		0C12E7892616383A00B66C86 /* pybind11 */ = {
+			isa = PBXGroup;
+			children = (
+				0C12E78A2616383A00B66C86 /* attr.h */,
+				0C12E78B2616383A00B66C86 /* embed.h */,
+				0C12E78C2616383A00B66C86 /* numpy.h */,
+				0C12E78D2616383A00B66C86 /* pybind11.h */,
+				0C12E78E2616383A00B66C86 /* operators.h */,
+				0C12E78F2616383A00B66C86 /* iostream.h */,
+				0C12E7902616383A00B66C86 /* chrono.h */,
+				0C12E7912616383A00B66C86 /* stl_bind.h */,
+				0C12E7922616383A00B66C86 /* buffer_info.h */,
+				0C12E7932616383A00B66C86 /* options.h */,
+				0C12E7942616383A00B66C86 /* functional.h */,
+				0C12E7952616383A00B66C86 /* stl.h */,
+				0C12E7962616383A00B66C86 /* detail */,
+				0C12E79D2616383A00B66C86 /* common.h */,
+				0C12E79E2616383A00B66C86 /* eval.h */,
+				0C12E79F2616383A00B66C86 /* cast.h */,
+				0C12E7A02616383A00B66C86 /* eigen.h */,
+				0C12E7A12616383A00B66C86 /* pytypes.h */,
+				0C12E7A22616383A00B66C86 /* complex.h */,
+			);
+			path = pybind11;
+			sourceTree = "<group>";
+		};
+		0C12E7962616383A00B66C86 /* detail */ = {
+			isa = PBXGroup;
+			children = (
+				0C12E7972616383A00B66C86 /* typeid.h */,
+				0C12E7982616383A00B66C86 /* descr.h */,
+				0C12E7992616383A00B66C86 /* internals.h */,
+				0C12E79A2616383A00B66C86 /* common.h */,
+				0C12E79B2616383A00B66C86 /* class.h */,
+				0C12E79C2616383A00B66C86 /* init.h */,
+			);
+			path = detail;
+			sourceTree = "<group>";
+		};
+		0C12E7A32616383A00B66C86 /* caffe2 */ = {
+			isa = PBXGroup;
+			children = (
+				0C12E7A42616383A00B66C86 /* video */,
+				0C12E7A92616383A00B66C86 /* ideep */,
+				0C12E7B32616383A00B66C86 /* core */,
+				0C12E80E2616383A00B66C86 /* mpi */,
+				0C12E8112616383A00B66C86 /* proto */,
+				0C12E8142616383A00B66C86 /* test */,
+				0C12E8162616383A00B66C86 /* operators */,
+				0C12E9432616383A00B66C86 /* onnx */,
+				0C12E9502616383A00B66C86 /* python */,
+				0C12E9702616383A00B66C86 /* distributed */,
+				0C12E9772616383A00B66C86 /* perfkernels */,
+				0C12E9852616383A00B66C86 /* experiments */,
+				0C12E9902616383A00B66C86 /* cuda_rtc */,
+				0C12E9922616383A00B66C86 /* serialize */,
+				0C12E9992616383A00B66C86 /* utils */,
+				0C12E9BE2616383B00B66C86 /* contrib */,
+				0C12E9F72616383B00B66C86 /* image */,
+				0C12E9FA2616383B00B66C86 /* quantization */,
+				0C12EA2B2616383B00B66C86 /* transforms */,
+				0C12EA302616383B00B66C86 /* mobile */,
+				0C12EA572616383B00B66C86 /* sgd */,
+				0C12EA702616383B00B66C86 /* queue */,
+				0C12EA762616383B00B66C86 /* db */,
+				0C12EA782616383B00B66C86 /* opt */,
+				0C12EA962616383B00B66C86 /* predictor */,
+				0C12EAA72616383B00B66C86 /* observers */,
+				0C12EAAC2616383B00B66C86 /* share */,
+			);
+			path = caffe2;
+			sourceTree = "<group>";
+		};
+		0C12E7A42616383A00B66C86 /* video */ = {
+			isa = PBXGroup;
+			children = (
+				0C12E7A52616383A00B66C86 /* optical_flow.h */,
+				0C12E7A62616383A00B66C86 /* video_decoder.h */,
+				0C12E7A72616383A00B66C86 /* video_input_op.h */,
+				0C12E7A82616383A00B66C86 /* video_io.h */,
+			);
+			path = video;
+			sourceTree = "<group>";
+		};
+		0C12E7A92616383A00B66C86 /* ideep */ = {
+			isa = PBXGroup;
+			children = (
+				0C12E7AA2616383A00B66C86 /* operators */,
+				0C12E7AF2616383A00B66C86 /* utils */,
+				0C12E7B22616383A00B66C86 /* ideep_utils.h */,
+			);
+			path = ideep;
+			sourceTree = "<group>";
+		};
+		0C12E7AA2616383A00B66C86 /* operators */ = {
+			isa = PBXGroup;
+			children = (
+				0C12E7AB2616383A00B66C86 /* conv_transpose_unpool_base_op.h */,
+				0C12E7AC2616383A00B66C86 /* quantization */,
+				0C12E7AD2616383A00B66C86 /* operator_fallback_ideep.h */,
+				0C12E7AE2616383A00B66C86 /* conv_pool_base_op.h */,
+			);
+			path = operators;
+			sourceTree = "<group>";
+		};
+		0C12E7AC2616383A00B66C86 /* quantization */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = quantization;
+			sourceTree = "<group>";
+		};
+		0C12E7AF2616383A00B66C86 /* utils */ = {
+			isa = PBXGroup;
+			children = (
+				0C12E7B02616383A00B66C86 /* ideep_context.h */,
+				0C12E7B12616383A00B66C86 /* ideep_operator.h */,
+			);
+			path = utils;
+			sourceTree = "<group>";
+		};
+		0C12E7B32616383A00B66C86 /* core */ = {
+			isa = PBXGroup;
+			children = (
+				0C12E7B42616383A00B66C86 /* net_async_task_graph.h */,
+				0C12E7B52616383A00B66C86 /* net_simple_refcount.h */,
+				0C12E7B62616383A00B66C86 /* tensor_impl.h */,
+				0C12E7B72616383A00B66C86 /* plan_executor.h */,
+				0C12E7B82616383A00B66C86 /* qtensor_serialization.h */,
+				0C12E7B92616383A00B66C86 /* context_gpu.h */,
+				0C12E7BA2616383A00B66C86 /* observer.h */,
+				0C12E7BB2616383A00B66C86 /* blob_serializer_base.h */,
+				0C12E7BC2616383A00B66C86 /* memonger.h */,
+				0C12E7BD2616383A00B66C86 /* tensor_int8.h */,
+				0C12E7BE2616383A00B66C86 /* static_tracepoint.h */,
+				0C12E7BF2616383A00B66C86 /* net.h */,
+				0C12E7C02616383A00B66C86 /* numa.h */,
+				0C12E7C12616383A00B66C86 /* scope_guard.h */,
+				0C12E7C22616383A00B66C86 /* test_utils.h */,
+				0C12E7C32616383A00B66C86 /* event.h */,
+				0C12E7C42616383A00B66C86 /* types.h */,
+				0C12E7C52616383A00B66C86 /* context_base.h */,
+				0C12E7C62616383A00B66C86 /* operator.h */,
+				0C12E7C72616383A00B66C86 /* db.h */,
+				0C12E7C82616383A00B66C86 /* blob.h */,
+				0C12E7C92616383A00B66C86 /* static_tracepoint_elfx86.h */,
+				0C12E7CA2616383A00B66C86 /* net_async_tracing.h */,
+				0C12E7CB2616383A00B66C86 /* flags.h */,
+				0C12E7CC2616383A00B66C86 /* net_async_task_future.h */,
+				0C12E7CD2616383A00B66C86 /* operator_schema.h */,
+				0C12E7CE2616383A00B66C86 /* context.h */,
+				0C12E7CF2616383A00B66C86 /* net_async_base.h */,
+				0C12E7D02616383A00B66C86 /* prof_dag_counters.h */,
+				0C12E7D12616383A00B66C86 /* logging.h */,
+				0C12E7D22616383A00B66C86 /* net_async_scheduling.h */,
+				0C12E7D32616383A00B66C86 /* graph.h */,
+				0C12E7D42616383A00B66C86 /* common_cudnn.h */,
+				0C12E7D52616383A00B66C86 /* net_async_task.h */,
+				0C12E7D62616383A00B66C86 /* export_caffe2_op_to_c10.h */,
+				0C12E7D72616383A00B66C86 /* net_simple.h */,
+				0C12E7D82616383A00B66C86 /* workspace.h */,
+				0C12E7D92616383A00B66C86 /* timer.h */,
+				0C12E7DA2616383A00B66C86 /* event_cpu.h */,
+				0C12E7DB2616383A00B66C86 /* common.h */,
+				0C12E7DC2616383A00B66C86 /* blob_stats.h */,
+				0C12E7DD2616383A00B66C86 /* allocator.h */,
+				0C12E7DE2616383A00B66C86 /* macros.h */,
+				0C12E7DF2616383A00B66C86 /* hip */,
+				0C12E7E22616383A00B66C86 /* storage.h */,
+				0C12E7E32616383A00B66C86 /* transform.h */,
+				0C12E7E42616383A00B66C86 /* common_omp.h */,
+				0C12E7E52616383A00B66C86 /* export_c10_op_to_caffe2.h */,
+				0C12E7E62616383A00B66C86 /* nomnigraph */,
+				0C12E8022616383A00B66C86 /* module.h */,
+				0C12E8032616383A00B66C86 /* init.h */,
+				0C12E8042616383A00B66C86 /* net_dag_utils.h */,
+				0C12E8052616383A00B66C86 /* stats.h */,
+				0C12E8062616383A00B66C86 /* tensor.h */,
+				0C12E8072616383A00B66C86 /* common_gpu.h */,
+				0C12E8082616383A00B66C86 /* qtensor.h */,
+				0C12E8092616383A00B66C86 /* net_parallel.h */,
+				0C12E80A2616383A00B66C86 /* operator_gradient.h */,
+				0C12E80B2616383A00B66C86 /* cudnn_wrappers.h */,
+				0C12E80C2616383A00B66C86 /* distributions_stubs.h */,
+				0C12E80D2616383A00B66C86 /* blob_serialization.h */,
+			);
+			path = core;
+			sourceTree = "<group>";
+		};
+		0C12E7DF2616383A00B66C86 /* hip */ = {
+			isa = PBXGroup;
+			children = (
+				0C12E7E02616383A00B66C86 /* miopen_wrapper.h */,
+				0C12E7E12616383A00B66C86 /* common_miopen.h */,
+			);
+			path = hip;
+			sourceTree = "<group>";
+		};
+		0C12E7E62616383A00B66C86 /* nomnigraph */ = {
+			isa = PBXGroup;
+			children = (
+				0C12E7E72616383A00B66C86 /* Representations */,
+				0C12E7E82616383A00B66C86 /* include */,
+				0C12E8002616383A00B66C86 /* tests */,
+			);
+			path = nomnigraph;
+			sourceTree = "<group>";
+		};
+		0C12E7E72616383A00B66C86 /* Representations */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Representations;
+			sourceTree = "<group>";
+		};
+		0C12E7E82616383A00B66C86 /* include */ = {
+			isa = PBXGroup;
+			children = (
+				0C12E7E92616383A00B66C86 /* nomnigraph */,
+			);
+			path = include;
+			sourceTree = "<group>";
+		};
+		0C12E7E92616383A00B66C86 /* nomnigraph */ = {
+			isa = PBXGroup;
+			children = (
+				0C12E7EA2616383A00B66C86 /* Generated */,
+				0C12E7EE2616383A00B66C86 /* Representations */,
+				0C12E7F22616383A00B66C86 /* Transformations */,
+				0C12E7F52616383A00B66C86 /* Graph */,
+				0C12E7FB2616383A00B66C86 /* Converters */,
+				0C12E7FD2616383A00B66C86 /* Support */,
+			);
+			path = nomnigraph;
+			sourceTree = "<group>";
+		};
+		0C12E7EA2616383A00B66C86 /* Generated */ = {
+			isa = PBXGroup;
+			children = (
+				0C12E7EB2616383A00B66C86 /* OpClasses.h */,
+				0C12E7EC2616383A00B66C86 /* OpEnum.h */,
+				0C12E7ED2616383A00B66C86 /* OpNames.h */,
+			);
+			path = Generated;
+			sourceTree = "<group>";
+		};
+		0C12E7EE2616383A00B66C86 /* Representations */ = {
+			isa = PBXGroup;
+			children = (
+				0C12E7EF2616383A00B66C86 /* Compiler.h */,
+				0C12E7F02616383A00B66C86 /* NeuralNet.h */,
+				0C12E7F12616383A00B66C86 /* ControlFlow.h */,
+			);
+			path = Representations;
+			sourceTree = "<group>";
+		};
+		0C12E7F22616383A00B66C86 /* Transformations */ = {
+			isa = PBXGroup;
+			children = (
+				0C12E7F32616383A00B66C86 /* SubgraphMatcher.h */,
+				0C12E7F42616383A00B66C86 /* Match.h */,
+			);
+			path = Transformations;
+			sourceTree = "<group>";
+		};
+		0C12E7F52616383A00B66C86 /* Graph */ = {
+			isa = PBXGroup;
+			children = (
+				0C12E7F62616383A00B66C86 /* Algorithms.h */,
+				0C12E7F72616383A00B66C86 /* TopoSort.h */,
+				0C12E7F82616383A00B66C86 /* Graph.h */,
+				0C12E7F92616383A00B66C86 /* TarjansImpl.h */,
+				0C12E7FA2616383A00B66C86 /* BinaryMatchImpl.h */,
+			);
+			path = Graph;
+			sourceTree = "<group>";
+		};
+		0C12E7FB2616383A00B66C86 /* Converters */ = {
+			isa = PBXGroup;
+			children = (
+				0C12E7FC2616383A00B66C86 /* Dot.h */,
+			);
+			path = Converters;
+			sourceTree = "<group>";
+		};
+		0C12E7FD2616383A00B66C86 /* Support */ = {
+			isa = PBXGroup;
+			children = (
+				0C12E7FE2616383A00B66C86 /* Casting.h */,
+				0C12E7FF2616383A00B66C86 /* Common.h */,
+			);
+			path = Support;
+			sourceTree = "<group>";
+		};
+		0C12E8002616383A00B66C86 /* tests */ = {
+			isa = PBXGroup;
+			children = (
+				0C12E8012616383A00B66C86 /* test_util.h */,
+			);
+			path = tests;
+			sourceTree = "<group>";
+		};
+		0C12E80E2616383A00B66C86 /* mpi */ = {
+			isa = PBXGroup;
+			children = (
+				0C12E80F2616383A00B66C86 /* mpi_common.h */,
+				0C12E8102616383A00B66C86 /* mpi_ops.h */,
+			);
+			path = mpi;
+			sourceTree = "<group>";
+		};
+		0C12E8112616383A00B66C86 /* proto */ = {
+			isa = PBXGroup;
+			children = (
+				0C12E8122616383A00B66C86 /* caffe2_pb.h */,
+				0C12E8132616383A00B66C86 /* torch_pb.h */,
+			);
+			path = proto;
+			sourceTree = "<group>";
+		};
+		0C12E8142616383A00B66C86 /* test */ = {
+			isa = PBXGroup;
+			children = (
+				0C12E8152616383A00B66C86 /* assets */,
+			);
+			path = test;
+			sourceTree = "<group>";
+		};
+		0C12E8152616383A00B66C86 /* assets */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = assets;
+			sourceTree = "<group>";
+		};
+		0C12E8162616383A00B66C86 /* operators */ = {
+			isa = PBXGroup;
+			children = (
+				0C12E8172616383A00B66C86 /* top_k.h */,
+				0C12E8182616383A00B66C86 /* channel_stats_op.h */,
+				0C12E8192616383A00B66C86 /* gru_unit_op.h */,
+				0C12E81A2616383A00B66C86 /* half_float_ops.h */,
+				0C12E81B2616383A00B66C86 /* sqr_op.h */,
+				0C12E81C2616383A00B66C86 /* mean_op.h */,
+				0C12E81D2616383A00B66C86 /* thresholded_relu_op.h */,
+				0C12E81E2616383A00B66C86 /* ctc_greedy_decoder_op.h */,
+				0C12E81F2616383A00B66C86 /* conv_op_cache_cudnn.h */,
+				0C12E8202616383A00B66C86 /* utility_ops.h */,
+				0C12E8212616383A00B66C86 /* selu_op.h */,
+				0C12E8222616383A00B66C86 /* map_ops.h */,
+				0C12E8232616383A00B66C86 /* roi_align_rotated_op.h */,
+				0C12E8242616383A00B66C86 /* fused_rowwise_random_quantization_ops.h */,
+				0C12E8252616383A00B66C86 /* stop_gradient.h */,
+				0C12E8262616383A00B66C86 /* batch_gather_ops.h */,
+				0C12E8272616383A00B66C86 /* asin_op.h */,
+				0C12E8282616383A00B66C86 /* cosh_op.h */,
+				0C12E8292616383A00B66C86 /* atan_op.h */,
+				0C12E82A2616383A00B66C86 /* reverse_packed_segs_op.h */,
+				0C12E82B2616383A00B66C86 /* given_tensor_byte_string_to_uint8_fill_op.h */,
+				0C12E82C2616383A00B66C86 /* ensure_clipped_op.h */,
+				0C12E82D2616383A00B66C86 /* conv_transpose_op.h */,
+				0C12E82E2616383A00B66C86 /* generate_proposals_op_util_nms.h */,
+				0C12E82F2616383A00B66C86 /* enforce_finite_op.h */,
+				0C12E8302616383A00B66C86 /* conv_transpose_unpool_op_base.h */,
+				0C12E8312616383A00B66C86 /* gather_fused_8bit_rowwise_op.h */,
+				0C12E8322616383A00B66C86 /* batch_matmul_op.h */,
+				0C12E8332616383A00B66C86 /* batch_bucketize_op.h */,
+				0C12E8342616383A00B66C86 /* softsign_op.h */,
+				0C12E8352616383A00B66C86 /* elementwise_logical_ops.h */,
+				0C12E8362616383A00B66C86 /* percentile_op.h */,
+				0C12E8372616383A00B66C86 /* length_split_op.h */,
+				0C12E8382616383A00B66C86 /* locally_connected_op_impl.h */,
+				0C12E8392616383A00B66C86 /* rmac_regions_op.h */,
+				0C12E83A2616383A00B66C86 /* hard_sigmoid_op.h */,
+				0C12E83B2616383A00B66C86 /* ensure_cpu_output_op.h */,
+				0C12E83C2616383A00B66C86 /* batch_box_cox_op.h */,
+				0C12E83D2616383A00B66C86 /* ctc_beam_search_decoder_op.h */,
+				0C12E83E2616383A00B66C86 /* flexible_top_k.h */,
+				0C12E83F2616383A00B66C86 /* fully_connected_op.h */,
+				0C12E8402616383A00B66C86 /* key_split_ops.h */,
+				0C12E8412616383A00B66C86 /* reciprocal_op.h */,
+				0C12E8422616383A00B66C86 /* roi_align_gradient_op.h */,
+				0C12E8432616383A00B66C86 /* group_norm_op.h */,
+				0C12E8442616383A00B66C86 /* load_save_op.h */,
+				0C12E8452616383A00B66C86 /* cos_op.h */,
+				0C12E8462616383A00B66C86 /* expand_op.h */,
+				0C12E8472616383A00B66C86 /* elementwise_ops.h */,
+				0C12E8482616383A00B66C86 /* im2col_op.h */,
+				0C12E8492616383A00B66C86 /* space_batch_op.h */,
+				0C12E84A2616383A00B66C86 /* relu_op.h */,
+				0C12E84B2616383A00B66C86 /* while_op.h */,
+				0C12E84C2616383A00B66C86 /* remove_data_blocks_op.h */,
+				0C12E84D2616383A00B66C86 /* elementwise_mul_op.h */,
+				0C12E84E2616383A00B66C86 /* numpy_tile_op.h */,
+				0C12E84F2616383A00B66C86 /* rowmul_op.h */,
+				0C12E8502616383A00B66C86 /* accumulate_op.h */,
+				0C12E8512616383A00B66C86 /* sparse_lp_regularizer_op.h */,
+				0C12E8522616383A00B66C86 /* bisect_percentile_op.h */,
+				0C12E8532616383A00B66C86 /* tile_op.h */,
+				0C12E8542616383A00B66C86 /* gelu_op.h */,
+				0C12E8552616383A00B66C86 /* stats_put_ops.h */,
+				0C12E8562616383A00B66C86 /* given_tensor_fill_op.h */,
+				0C12E8572616383A00B66C86 /* accuracy_op.h */,
+				0C12E8582616383A00B66C86 /* bbox_transform_op.h */,
+				0C12E8592616383A00B66C86 /* boolean_unmask_ops.h */,
+				0C12E85A2616383A00B66C86 /* glu_op.h */,
+				0C12E85B2616383A00B66C86 /* resize_3d_op.h */,
+				0C12E85C2616383A00B66C86 /* unsafe_coalesce.h */,
+				0C12E85D2616383A00B66C86 /* conv_op.h */,
+				0C12E85E2616383A00B66C86 /* conv_op_impl.h */,
+				0C12E85F2616383A00B66C86 /* erf_op.h */,
+				0C12E8602616383A00B66C86 /* fused_rowwise_8bit_conversion_ops.h */,
+				0C12E8612616383A00B66C86 /* locally_connected_op_util.h */,
+				0C12E8622616383A00B66C86 /* channel_backprop_stats_op.h */,
+				0C12E8632616383A00B66C86 /* order_switch_ops.h */,
+				0C12E8642616383A00B66C86 /* lengths_reducer_fused_nbit_rowwise_ops.h */,
+				0C12E8652616383A00B66C86 /* lengths_reducer_fused_8bit_rowwise_ops.h */,
+				0C12E8662616383A00B66C86 /* load_save_op_util.h */,
+				0C12E8672616383A00B66C86 /* conv_transpose_op_impl.h */,
+				0C12E8682616383A00B66C86 /* op_utils_cudnn.h */,
+				0C12E8692616383A00B66C86 /* prelu_op.h */,
+				0C12E86A2616383A00B66C86 /* box_with_nms_limit_op.h */,
+				0C12E86B2616383A00B66C86 /* fc_inference.h */,
+				0C12E86C2616383A00B66C86 /* distance_op.h */,
+				0C12E86D2616383A00B66C86 /* data_couple.h */,
+				0C12E86E2616383A00B66C86 /* dataset_ops.h */,
+				0C12E86F2616383A00B66C86 /* merge_id_lists_op.h */,
+				0C12E8702616383A00B66C86 /* generate_proposals_op_util_nms_gpu.h */,
+				0C12E8712616383A00B66C86 /* async_net_barrier_op.h */,
+				0C12E8722616383A00B66C86 /* deform_conv_op.h */,
+				0C12E8732616383A00B66C86 /* quantized */,
+				0C12E88C2616383A00B66C86 /* sqrt_op.h */,
+				0C12E88D2616383A00B66C86 /* elementwise_div_op.h */,
+				0C12E88E2616383A00B66C86 /* deform_conv_op_impl.h */,
+				0C12E88F2616383A00B66C86 /* feature_maps_ops.h */,
+				0C12E8902616383A00B66C86 /* text_file_reader_utils.h */,
+				0C12E8912616383A00B66C86 /* scale_blobs_op.h */,
+				0C12E8922616383A00B66C86 /* pool_op.h */,
+				0C12E8932616383A00B66C86 /* conv_transpose_op_mobile_impl.h */,
+				0C12E8942616383A00B66C86 /* dense_vector_to_id_list_op.h */,
+				0C12E8952616383A00B66C86 /* minmax_ops.h */,
+				0C12E8962616383A00B66C86 /* lengths_tile_op.h */,
+				0C12E8972616383A00B66C86 /* pool_op_util.h */,
+				0C12E8982616383A00B66C86 /* no_default_engine_op.h */,
+				0C12E8992616383A00B66C86 /* onnx_while_op.h */,
+				0C12E89A2616383A00B66C86 /* reduce_front_back_sum_mean_ops.h */,
+				0C12E89B2616383A00B66C86 /* roi_pool_op.h */,
+				0C12E89C2616383A00B66C86 /* flatten_op.h */,
+				0C12E89D2616383A00B66C86 /* self_binning_histogram_op.h */,
+				0C12E89E2616383A00B66C86 /* normalize_l1_op.h */,
+				0C12E89F2616383A00B66C86 /* pow_op.h */,
+				0C12E8A02616383A00B66C86 /* exp_op.h */,
+				0C12E8A12616383A00B66C86 /* heatmap_max_keypoint_op.h */,
+				0C12E8A22616383A00B66C86 /* assert_op.h */,
+				0C12E8A32616383A00B66C86 /* piecewise_linear_transform_op.h */,
+				0C12E8A42616383A00B66C86 /* cbrt_op.h */,
+				0C12E8A52616383A00B66C86 /* weighted_sample_op.h */,
+				0C12E8A62616383A00B66C86 /* tanh_op.h */,
+				0C12E8A72616383A00B66C86 /* softmax_op.h */,
+				0C12E8A82616383A00B66C86 /* listwise_l2r_op.h */,
+				0C12E8A92616383A00B66C86 /* variable_length_sequence_padding.h */,
+				0C12E8AA2616383A00B66C86 /* elementwise_add_op.h */,
+				0C12E8AB2616383A00B66C86 /* leaky_relu_op.h */,
+				0C12E8AC2616383A00B66C86 /* elementwise_linear_op.h */,
+				0C12E8AD2616383A00B66C86 /* elu_op.h */,
+				0C12E8AE2616383A00B66C86 /* jsd_op.h */,
+				0C12E8AF2616383A00B66C86 /* collect_and_distribute_fpn_rpn_proposals_op.h */,
+				0C12E8B02616383A00B66C86 /* reduce_ops.h */,
+				0C12E8B12616383A00B66C86 /* string_ops.h */,
+				0C12E8B22616383A00B66C86 /* boolean_mask_ops.h */,
+				0C12E8B32616383A00B66C86 /* local_response_normalization_op.h */,
+				0C12E8B42616383A00B66C86 /* partition_ops.h */,
+				0C12E8B52616383A00B66C86 /* sparse_dropout_with_replacement_op.h */,
+				0C12E8B62616383A00B66C86 /* loss_op.h */,
+				0C12E8B72616383A00B66C86 /* counter_ops.h */,
+				0C12E8B82616383A00B66C86 /* h_softmax_op.h */,
+				0C12E8B92616383A00B66C86 /* lengths_reducer_rowwise_8bit_ops.h */,
+				0C12E8BA2616383A00B66C86 /* copy_rows_to_tensor_op.h */,
+				0C12E8BB2616383A00B66C86 /* moments_op.h */,
+				0C12E8BC2616383A00B66C86 /* logit_op.h */,
+				0C12E8BD2616383A00B66C86 /* perplexity_op.h */,
+				0C12E8BE2616383A00B66C86 /* roi_align_rotated_gradient_op.h */,
+				0C12E8BF2616383A00B66C86 /* ceil_op.h */,
+				0C12E8C02616383A00B66C86 /* find_op.h */,
+				0C12E8C12616383A00B66C86 /* layer_norm_op.h */,
+				0C12E8C22616383A00B66C86 /* negate_gradient_op.h */,
+				0C12E8C32616383A00B66C86 /* resize_op.h */,
+				0C12E8C42616383A00B66C86 /* lengths_reducer_ops.h */,
+				0C12E8C52616383A00B66C86 /* batch_sparse_to_dense_op.h */,
+				0C12E8C62616383A00B66C86 /* replace_nan_op.h */,
+				0C12E8C72616383A00B66C86 /* max_pool_with_index_gpu.h */,
+				0C12E8C82616383A00B66C86 /* find_duplicate_elements_op.h */,
+				0C12E8C92616383A00B66C86 /* expand_squeeze_dims_op.h */,
+				0C12E8CA2616383A00B66C86 /* sinusoid_position_encoding_op.h */,
+				0C12E8CB2616383A00B66C86 /* pack_segments.h */,
+				0C12E8CC2616383A00B66C86 /* softplus_op.h */,
+				0C12E8CD2616383A00B66C86 /* quantile_op.h */,
+				0C12E8CE2616383A00B66C86 /* sinh_op.h */,
+				0C12E8CF2616383A00B66C86 /* fused_rowwise_nbitfake_conversion_ops.h */,
+				0C12E8D02616383A00B66C86 /* cross_entropy_op.h */,
+				0C12E8D12616383A00B66C86 /* feed_blob_op.h */,
+				0C12E8D22616383A00B66C86 /* slice_op.h */,
+				0C12E8D32616383A00B66C86 /* rsqrt_op.h */,
+				0C12E8D42616383A00B66C86 /* free_op.h */,
+				0C12E8D52616383A00B66C86 /* square_root_divide_op.h */,
+				0C12E8D62616383A00B66C86 /* conv_op_shared.h */,
+				0C12E8D72616383A00B66C86 /* apmeter_op.h */,
+				0C12E8D82616383A00B66C86 /* lstm_unit_op.h */,
+				0C12E8D92616383A00B66C86 /* index_hash_ops.h */,
+				0C12E8DA2616383A00B66C86 /* lengths_pad_op.h */,
+				0C12E8DB2616383A00B66C86 /* elementwise_ops_utils.h */,
+				0C12E8DC2616383A00B66C86 /* sparse_normalize_op.h */,
+				0C12E8DD2616383A00B66C86 /* multi_class_accuracy_op.h */,
+				0C12E8DE2616383A00B66C86 /* cast_op.h */,
+				0C12E8DF2616383A00B66C86 /* transpose_op.h */,
+				0C12E8E02616383A00B66C86 /* create_scope_op.h */,
+				0C12E8E12616383A00B66C86 /* zero_gradient_op.h */,
+				0C12E8E22616383A00B66C86 /* lstm_utils.h */,
+				0C12E8E32616383A00B66C86 /* tt_linear_op.h */,
+				0C12E8E42616383A00B66C86 /* relu_n_op.h */,
+				0C12E8E52616383A00B66C86 /* generate_proposals_op.h */,
+				0C12E8E62616383A00B66C86 /* hip */,
+				0C12E8E82616383A00B66C86 /* lpnorm_op.h */,
+				0C12E8E92616383A00B66C86 /* sequence_ops.h */,
+				0C12E8EA2616383A00B66C86 /* abs_op.h */,
+				0C12E8EB2616383A00B66C86 /* activation_ops_cudnn.h */,
+				0C12E8EC2616383A00B66C86 /* elementwise_op_test.h */,
+				0C12E8ED2616383A00B66C86 /* inference_lstm_op.h */,
+				0C12E8EE2616383A00B66C86 /* concat_split_op.h */,
+				0C12E8EF2616383A00B66C86 /* reduction_ops.h */,
+				0C12E8F02616383A00B66C86 /* gather_op.h */,
+				0C12E8F12616383A00B66C86 /* log_op.h */,
+				0C12E8F22616383A00B66C86 /* conv_pool_op_base.h */,
+				0C12E8F32616383A00B66C86 /* unique_ops.h */,
+				0C12E8F42616383A00B66C86 /* elementwise_sub_op.h */,
+				0C12E8F52616383A00B66C86 /* segment_reduction_op.h */,
+				0C12E8F62616383A00B66C86 /* fused_rowwise_nbit_conversion_ops.h */,
+				0C12E8F72616383A00B66C86 /* stump_func_op.h */,
+				0C12E8F82616383A00B66C86 /* swish_op.h */,
+				0C12E8F92616383A00B66C86 /* pack_rnn_sequence_op.h */,
+				0C12E8FA2616383A00B66C86 /* softmax_with_loss_op.h */,
+				0C12E8FB2616383A00B66C86 /* integral_image_op.h */,
+				0C12E8FC2616383A00B66C86 /* mish_op.h */,
+				0C12E8FD2616383A00B66C86 /* weighted_multi_sampling_op.h */,
+				0C12E8FE2616383A00B66C86 /* bucketize_op.h */,
+				0C12E8FF2616383A00B66C86 /* is_empty_op.h */,
+				0C12E9002616383A00B66C86 /* mod_op.h */,
+				0C12E9012616383A00B66C86 /* clip_op.h */,
+				0C12E9022616383A00B66C86 /* prepend_dim_op.h */,
+				0C12E9032616383A00B66C86 /* copy_op.h */,
+				0C12E9042616383A00B66C86 /* rank_loss_op.h */,
+				0C12E9052616383A00B66C86 /* lengths_top_k_op.h */,
+				0C12E9062616383A00B66C86 /* summarize_op.h */,
+				0C12E9072616383A00B66C86 /* one_hot_ops.h */,
+				0C12E9082616383A00B66C86 /* cc_bmm_bg_op.h */,
+				0C12E9092616383A00B66C86 /* acos_op.h */,
+				0C12E90A2616383A00B66C86 /* softmax_utils.h */,
+				0C12E90B2616383A00B66C86 /* tensor_protos_db_input.h */,
+				0C12E90C2616383A00B66C86 /* generate_proposals_op_util_boxes.h */,
+				0C12E90D2616383A00B66C86 /* conv_transpose_op_mobile.h */,
+				0C12E90E2616383A00B66C86 /* arg_ops.h */,
+				0C12E90F2616383A00B66C86 /* negative_op.h */,
+				0C12E9102616383A00B66C86 /* operator_fallback_gpu.h */,
+				0C12E9112616383A00B66C86 /* margin_ranking_criterion_op.h */,
+				0C12E9122616383A00B66C86 /* matmul_op.h */,
+				0C12E9132616383A00B66C86 /* roi_align_op.h */,
+				0C12E9142616383A00B66C86 /* pad_op.h */,
+				0C12E9152616383A00B66C86 /* histogram_op.h */,
+				0C12E9162616383A00B66C86 /* floor_op.h */,
+				0C12E9172616383A00B66C86 /* normalize_op.h */,
+				0C12E9182616383A00B66C86 /* cube_op.h */,
+				0C12E9192616383A00B66C86 /* reshape_op.h */,
+				0C12E91A2616383A00B66C86 /* instance_norm_op.h */,
+				0C12E91B2616383A00B66C86 /* ngram_ops.h */,
+				0C12E91C2616383A00B66C86 /* if_op.h */,
+				0C12E91D2616383A00B66C86 /* reduce_front_back_max_ops.h */,
+				0C12E91E2616383A00B66C86 /* reducer_functors.h */,
+				0C12E91F2616383A00B66C86 /* affine_channel_op.h */,
+				0C12E9202616383A00B66C86 /* sigmoid_op.h */,
+				0C12E9212616383A00B66C86 /* channel_shuffle_op.h */,
+				0C12E9222616383A00B66C86 /* locally_connected_op.h */,
+				0C12E9232616383A00B66C86 /* conditional_op.h */,
+				0C12E9242616383A00B66C86 /* rms_norm_op.h */,
+				0C12E9252616383A00B66C86 /* dropout_op.h */,
+				0C12E9262616383A00B66C86 /* gather_ranges_to_dense_op.h */,
+				0C12E9272616383A00B66C86 /* shape_op.h */,
+				0C12E9282616383A00B66C86 /* index_ops.h */,
+				0C12E9292616383A00B66C86 /* tan_op.h */,
+				0C12E92A2616383A00B66C86 /* scale_op.h */,
+				0C12E92B2616383A00B66C86 /* cosine_embedding_criterion_op.h */,
+				0C12E92C2616383A00B66C86 /* sparse_to_dense_op.h */,
+				0C12E92D2616383A00B66C86 /* quant_decode_op.h */,
+				0C12E92E2616383A00B66C86 /* rnn */,
+				0C12E9372616383A00B66C86 /* sparse_to_dense_mask_op.h */,
+				0C12E9382616383A00B66C86 /* sin_op.h */,
+				0C12E9392616383A00B66C86 /* upsample_op.h */,
+				0C12E93A2616383A00B66C86 /* filler_op.h */,
+				0C12E93B2616383A00B66C86 /* batch_permutation_op.h */,
+				0C12E93C2616383A00B66C86 /* spatial_softmax_with_loss_op.h */,
+				0C12E93D2616383A00B66C86 /* batch_moments_op.h */,
+				0C12E93E2616383A00B66C86 /* alias_with_name.h */,
+				0C12E93F2616383A00B66C86 /* do_op.h */,
+				0C12E9402616383A00B66C86 /* prefetch_op.h */,
+				0C12E9412616383A00B66C86 /* byte_weight_dequant_op.h */,
+				0C12E9422616383A00B66C86 /* spatial_batch_norm_op.h */,
+			);
+			path = operators;
+			sourceTree = "<group>";
+		};
+		0C12E8732616383A00B66C86 /* quantized */ = {
+			isa = PBXGroup;
+			children = (
+				0C12E8742616383A00B66C86 /* int8_relu_op.h */,
+				0C12E8752616383A00B66C86 /* int8_channel_shuffle_op.h */,
+				0C12E8762616383A00B66C86 /* int8_concat_op.h */,
+				0C12E8772616383A00B66C86 /* int8_dequantize_op.h */,
+				0C12E8782616383A00B66C86 /* int8_slice_op.h */,
+				0C12E8792616383A00B66C86 /* int8_quantize_op.h */,
+				0C12E87A2616383A00B66C86 /* int8_flatten_op.h */,
+				0C12E87B2616383A00B66C86 /* int8_max_pool_op.h */,
+				0C12E87C2616383A00B66C86 /* int8_softmax_op.h */,
+				0C12E87D2616383A00B66C86 /* int8_average_pool_op.h */,
+				0C12E87E2616383A00B66C86 /* int8_fc_op.h */,
+				0C12E87F2616383A00B66C86 /* int8_conv_op.h */,
+				0C12E8802616383A00B66C86 /* int8_test_utils.h */,
+				0C12E8812616383A00B66C86 /* int8_roi_align_op.h */,
+				0C12E8822616383A00B66C86 /* int8_given_tensor_fill_op.h */,
+				0C12E8832616383A00B66C86 /* int8_reshape_op.h */,
+				0C12E8842616383A00B66C86 /* int8_utils.h */,
+				0C12E8852616383A00B66C86 /* int8_resize_nearest_op.h */,
+				0C12E8862616383A00B66C86 /* int8_sigmoid_op.h */,
+				0C12E8872616383A00B66C86 /* int8_simd.h */,
+				0C12E8882616383A00B66C86 /* int8_conv_transpose_op.h */,
+				0C12E8892616383A00B66C86 /* int8_leaky_relu_op.h */,
+				0C12E88A2616383A00B66C86 /* int8_add_op.h */,
+				0C12E88B2616383A00B66C86 /* int8_transpose_op.h */,
+			);
+			path = quantized;
+			sourceTree = "<group>";
+		};
+		0C12E8E62616383A00B66C86 /* hip */ = {
+			isa = PBXGroup;
+			children = (
+				0C12E8E72616383A00B66C86 /* activation_ops_miopen.h */,
+			);
+			path = hip;
+			sourceTree = "<group>";
+		};
+		0C12E92E2616383A00B66C86 /* rnn */ = {
+			isa = PBXGroup;
+			children = (
+				0C12E92F2616383A00B66C86 /* recurrent_network_blob_fetcher_op.h */,
+				0C12E9302616383A00B66C86 /* recurrent_op_cudnn.h */,
+				0C12E9312616383A00B66C86 /* recurrent_network_executor_gpu.h */,
+				0C12E9322616383A00B66C86 /* recurrent_network_executor_incl.h */,
+				0C12E9332616383A00B66C86 /* hip */,
+				0C12E9352616383A00B66C86 /* recurrent_network_executor.h */,
+				0C12E9362616383A00B66C86 /* recurrent_network_op.h */,
+			);
+			path = rnn;
+			sourceTree = "<group>";
+		};
+		0C12E9332616383A00B66C86 /* hip */ = {
+			isa = PBXGroup;
+			children = (
+				0C12E9342616383A00B66C86 /* recurrent_op_miopen.h */,
+			);
+			path = hip;
+			sourceTree = "<group>";
+		};
+		0C12E9432616383A00B66C86 /* onnx */ = {
+			isa = PBXGroup;
+			children = (
+				0C12E9442616383A00B66C86 /* helper.h */,
+				0C12E9452616383A00B66C86 /* device.h */,
+				0C12E9462616383A00B66C86 /* onnxifi_init.h */,
+				0C12E9472616383A00B66C86 /* backend.h */,
+				0C12E9482616383A00B66C86 /* torch_ops */,
+				0C12E94C2616383A00B66C86 /* backend_rep.h */,
+				0C12E94D2616383A00B66C86 /* onnx_exporter.h */,
+				0C12E94E2616383A00B66C86 /* offline_tensor.h */,
+				0C12E94F2616383A00B66C86 /* onnxifi_graph_info.h */,
+			);
+			path = onnx;
+			sourceTree = "<group>";
+		};
+		0C12E9482616383A00B66C86 /* torch_ops */ = {
+			isa = PBXGroup;
+			children = (
+				0C12E9492616383A00B66C86 /* schema.h */,
+				0C12E94A2616383A00B66C86 /* constants.h */,
+				0C12E94B2616383A00B66C86 /* operator_sets.h */,
+			);
+			path = torch_ops;
+			sourceTree = "<group>";
+		};
+		0C12E9502616383A00B66C86 /* python */ = {
+			isa = PBXGroup;
+			children = (
+				0C12E9512616383A00B66C86 /* serialized_test */,
+				0C12E9542616383A00B66C86 /* pybind_state.h */,
+				0C12E9552616383A00B66C86 /* pybind_state_registry.h */,
+				0C12E9562616383A00B66C86 /* ideep */,
+				0C12E9572616383A00B66C86 /* mint */,
+				0C12E95B2616383A00B66C86 /* layers */,
+				0C12E95C2616383A00B66C86 /* test */,
+				0C12E95D2616383A00B66C86 /* dlpack.h */,
+				0C12E95E2616383A00B66C86 /* onnx */,
+				0C12E9612616383A00B66C86 /* trt */,
+				0C12E9632616383A00B66C86 /* operator_test */,
+				0C12E9642616383A00B66C86 /* models */,
+				0C12E9662616383A00B66C86 /* docs */,
+				0C12E9672616383A00B66C86 /* fakelowp */,
+				0C12E9682616383A00B66C86 /* modeling */,
+				0C12E9692616383A00B66C86 /* pybind_state_dlpack.h */,
+				0C12E96A2616383A00B66C86 /* mkl */,
+				0C12E96B2616383A00B66C86 /* examples */,
+				0C12E96C2616383A00B66C86 /* benchmarks */,
+				0C12E96D2616383A00B66C86 /* predictor */,
+				0C12E96E2616383A00B66C86 /* helpers */,
+				0C12E96F2616383A00B66C86 /* rnn */,
+			);
+			path = python;
+			sourceTree = "<group>";
+		};
+		0C12E9512616383A00B66C86 /* serialized_test */ = {
+			isa = PBXGroup;
+			children = (
+				0C12E9522616383A00B66C86 /* data */,
+			);
+			path = serialized_test;
+			sourceTree = "<group>";
+		};
+		0C12E9522616383A00B66C86 /* data */ = {
+			isa = PBXGroup;
+			children = (
+				0C12E9532616383A00B66C86 /* operator_test */,
+			);
+			path = data;
+			sourceTree = "<group>";
+		};
+		0C12E9532616383A00B66C86 /* operator_test */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = operator_test;
+			sourceTree = "<group>";
+		};
+		0C12E9562616383A00B66C86 /* ideep */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = ideep;
+			sourceTree = "<group>";
+		};
+		0C12E9572616383A00B66C86 /* mint */ = {
+			isa = PBXGroup;
+			children = (
+				0C12E9582616383A00B66C86 /* static */,
+				0C12E95A2616383A00B66C86 /* templates */,
+			);
+			path = mint;
+			sourceTree = "<group>";
+		};
+		0C12E9582616383A00B66C86 /* static */ = {
+			isa = PBXGroup;
+			children = (
+				0C12E9592616383A00B66C86 /* css */,
+			);
+			path = static;
+			sourceTree = "<group>";
+		};
+		0C12E9592616383A00B66C86 /* css */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = css;
+			sourceTree = "<group>";
+		};
+		0C12E95A2616383A00B66C86 /* templates */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = templates;
+			sourceTree = "<group>";
+		};
+		0C12E95B2616383A00B66C86 /* layers */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = layers;
+			sourceTree = "<group>";
+		};
+		0C12E95C2616383A00B66C86 /* test */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = test;
+			sourceTree = "<group>";
+		};
+		0C12E95E2616383A00B66C86 /* onnx */ = {
+			isa = PBXGroup;
+			children = (
+				0C12E95F2616383A00B66C86 /* bin */,
+				0C12E9602616383A00B66C86 /* tests */,
+			);
+			path = onnx;
+			sourceTree = "<group>";
+		};
+		0C12E95F2616383A00B66C86 /* bin */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = bin;
+			sourceTree = "<group>";
+		};
+		0C12E9602616383A00B66C86 /* tests */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = tests;
+			sourceTree = "<group>";
+		};
+		0C12E9612616383A00B66C86 /* trt */ = {
+			isa = PBXGroup;
+			children = (
+				0C12E9622616383A00B66C86 /* data */,
+			);
+			path = trt;
+			sourceTree = "<group>";
+		};
+		0C12E9622616383A00B66C86 /* data */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = data;
+			sourceTree = "<group>";
+		};
+		0C12E9632616383A00B66C86 /* operator_test */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = operator_test;
+			sourceTree = "<group>";
+		};
+		0C12E9642616383A00B66C86 /* models */ = {
+			isa = PBXGroup;
+			children = (
+				0C12E9652616383A00B66C86 /* seq2seq */,
+			);
+			path = models;
+			sourceTree = "<group>";
+		};
+		0C12E9652616383A00B66C86 /* seq2seq */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = seq2seq;
+			sourceTree = "<group>";
+		};
+		0C12E9662616383A00B66C86 /* docs */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = docs;
+			sourceTree = "<group>";
+		};
+		0C12E9672616383A00B66C86 /* fakelowp */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = fakelowp;
+			sourceTree = "<group>";
+		};
+		0C12E9682616383A00B66C86 /* modeling */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = modeling;
+			sourceTree = "<group>";
+		};
+		0C12E96A2616383A00B66C86 /* mkl */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = mkl;
+			sourceTree = "<group>";
+		};
+		0C12E96B2616383A00B66C86 /* examples */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = examples;
+			sourceTree = "<group>";
+		};
+		0C12E96C2616383A00B66C86 /* benchmarks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = benchmarks;
+			sourceTree = "<group>";
+		};
+		0C12E96D2616383A00B66C86 /* predictor */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = predictor;
+			sourceTree = "<group>";
+		};
+		0C12E96E2616383A00B66C86 /* helpers */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = helpers;
+			sourceTree = "<group>";
+		};
+		0C12E96F2616383A00B66C86 /* rnn */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = rnn;
+			sourceTree = "<group>";
+		};
+		0C12E9702616383A00B66C86 /* distributed */ = {
+			isa = PBXGroup;
+			children = (
+				0C12E9712616383A00B66C86 /* redis_store_handler.h */,
+				0C12E9722616383A00B66C86 /* file_store_handler_op.h */,
+				0C12E9732616383A00B66C86 /* store_handler.h */,
+				0C12E9742616383A00B66C86 /* store_ops.h */,
+				0C12E9752616383A00B66C86 /* file_store_handler.h */,
+				0C12E9762616383A00B66C86 /* redis_store_handler_op.h */,
+			);
+			path = distributed;
+			sourceTree = "<group>";
+		};
+		0C12E9772616383A00B66C86 /* perfkernels */ = {
+			isa = PBXGroup;
+			children = (
+				0C12E9782616383A00B66C86 /* embedding_lookup.h */,
+				0C12E9792616383A00B66C86 /* fused_8bit_rowwise_embedding_lookup_idx.h */,
+				0C12E97A2616383A00B66C86 /* lstm_unit_cpu-impl.h */,
+				0C12E97B2616383A00B66C86 /* embedding_lookup_idx.h */,
+				0C12E97C2616383A00B66C86 /* adagrad.h */,
+				0C12E97D2616383A00B66C86 /* lstm_unit_cpu.h */,
+				0C12E97E2616383A00B66C86 /* cvtsh_ss_bugfix.h */,
+				0C12E97F2616383A00B66C86 /* common.h */,
+				0C12E9802616383A00B66C86 /* math.h */,
+				0C12E9812616383A00B66C86 /* typed_axpy.h */,
+				0C12E9822616383A00B66C86 /* fused_nbit_rowwise_conversion.h */,
+				0C12E9832616383A00B66C86 /* fused_8bit_rowwise_embedding_lookup.h */,
+				0C12E9842616383A00B66C86 /* lstm_unit_cpu_common.h */,
+			);
+			path = perfkernels;
+			sourceTree = "<group>";
+		};
+		0C12E9852616383A00B66C86 /* experiments */ = {
+			isa = PBXGroup;
+			children = (
+				0C12E9862616383A00B66C86 /* operators */,
+				0C12E98F2616383A00B66C86 /* python */,
+			);
+			path = experiments;
+			sourceTree = "<group>";
+		};
+		0C12E9862616383A00B66C86 /* operators */ = {
+			isa = PBXGroup;
+			children = (
+				0C12E9872616383A00B66C86 /* fully_connected_op_decomposition.h */,
+				0C12E9882616383A00B66C86 /* fully_connected_op_sparse.h */,
+				0C12E9892616383A00B66C86 /* tt_contraction_op.h */,
+				0C12E98A2616383A00B66C86 /* fully_connected_op_prune.h */,
+				0C12E98B2616383A00B66C86 /* funhash_op.h */,
+				0C12E98C2616383A00B66C86 /* sparse_funhash_op.h */,
+				0C12E98D2616383A00B66C86 /* sparse_matrix_reshape_op.h */,
+				0C12E98E2616383A00B66C86 /* tt_pad_op.h */,
+			);
+			path = operators;
+			sourceTree = "<group>";
+		};
+		0C12E98F2616383A00B66C86 /* python */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = python;
+			sourceTree = "<group>";
+		};
+		0C12E9902616383A00B66C86 /* cuda_rtc */ = {
+			isa = PBXGroup;
+			children = (
+				0C12E9912616383A00B66C86 /* common_rtc.h */,
+			);
+			path = cuda_rtc;
+			sourceTree = "<group>";
+		};
+		0C12E9922616383A00B66C86 /* serialize */ = {
+			isa = PBXGroup;
+			children = (
+				0C12E9932616383A00B66C86 /* read_adapter_interface.h */,
+				0C12E9942616383A00B66C86 /* crc_alt.h */,
+				0C12E9952616383A00B66C86 /* versions.h */,
+				0C12E9962616383A00B66C86 /* inline_container.h */,
+				0C12E9972616383A00B66C86 /* file_adapter.h */,
+				0C12E9982616383A00B66C86 /* istream_adapter.h */,
+			);
+			path = serialize;
+			sourceTree = "<group>";
+		};
+		0C12E9992616383A00B66C86 /* utils */ = {
+			isa = PBXGroup;
+			children = (
+				0C12E99A2616383A00B66C86 /* filler.h */,
+				0C12E99B2616383A00B66C86 /* math-detail.h */,
+				0C12E99C2616383A00B66C86 /* signal_handler.h */,
+				0C12E99D2616383A00B66C86 /* cpu_neon.h */,
+				0C12E99E2616383A00B66C86 /* conversions.h */,
+				0C12E99F2616383A00B66C86 /* string_utils.h */,
+				0C12E9A02616383A00B66C86 /* simple_queue.h */,
+				0C12E9A12616383A00B66C86 /* cpuid.h */,
+				0C12E9A22616383A00B66C86 /* threadpool */,
+				0C12E9A92616383A00B66C86 /* math */,
+				0C12E9B02616383A00B66C86 /* fixed_divisor.h */,
+				0C12E9B12616383A00B66C86 /* proto_wrap.h */,
+				0C12E9B22616383A00B66C86 /* bench_utils.h */,
+				0C12E9B32616383A00B66C86 /* cast.h */,
+				0C12E9B42616383A00B66C86 /* hip */,
+				0C12E9B52616383A00B66C86 /* murmur_hash3.h */,
+				0C12E9B62616383A00B66C86 /* math.h */,
+				0C12E9B72616383B00B66C86 /* eigen_utils.h */,
+				0C12E9B82616383B00B66C86 /* smart_tensor_printer.h */,
+				0C12E9B92616383B00B66C86 /* proto_convert.h */,
+				0C12E9BA2616383B00B66C86 /* proto_utils.h */,
+				0C12E9BB2616383B00B66C86 /* cblas.h */,
+				0C12E9BC2616383B00B66C86 /* map_utils.h */,
+				0C12E9BD2616383B00B66C86 /* zmq_helper.h */,
+			);
+			path = utils;
+			sourceTree = "<group>";
+		};
+		0C12E9A22616383A00B66C86 /* threadpool */ = {
+			isa = PBXGroup;
+			children = (
+				0C12E9A32616383A00B66C86 /* ThreadPool.h */,
+				0C12E9A42616383A00B66C86 /* ThreadPoolCommon.h */,
+				0C12E9A52616383A00B66C86 /* pthreadpool.h */,
+				0C12E9A62616383A00B66C86 /* pthreadpool-cpp.h */,
+				0C12E9A72616383A00B66C86 /* WorkersPool.h */,
+				0C12E9A82616383A00B66C86 /* thread_pool_guard.h */,
+			);
+			path = threadpool;
+			sourceTree = "<group>";
+		};
+		0C12E9A92616383A00B66C86 /* math */ = {
+			isa = PBXGroup;
+			children = (
+				0C12E9AA2616383A00B66C86 /* utils.h */,
+				0C12E9AB2616383A00B66C86 /* broadcast.h */,
+				0C12E9AC2616383A00B66C86 /* elementwise.h */,
+				0C12E9AD2616383A00B66C86 /* half_utils.h */,
+				0C12E9AE2616383A00B66C86 /* reduce.h */,
+				0C12E9AF2616383A00B66C86 /* transpose.h */,
+			);
+			path = math;
+			sourceTree = "<group>";
+		};
+		0C12E9B42616383A00B66C86 /* hip */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = hip;
+			sourceTree = "<group>";
+		};
+		0C12E9BE2616383B00B66C86 /* contrib */ = {
+			isa = PBXGroup;
+			children = (
+				0C12E9BF2616383B00B66C86 /* nnpack */,
+				0C12E9C02616383B00B66C86 /* warpctc */,
+				0C12E9C22616383B00B66C86 /* nccl */,
+				0C12E9C42616383B00B66C86 /* ideep */,
+				0C12E9C52616383B00B66C86 /* docker-ubuntu-14.04 */,
+				0C12E9C62616383B00B66C86 /* playground */,
+				0C12E9C82616383B00B66C86 /* gloo */,
+				0C12E9D22616383B00B66C86 /* fakelowp */,
+				0C12E9E42616383B00B66C86 /* script */,
+				0C12E9E62616383B00B66C86 /* opencl */,
+				0C12E9E92616383B00B66C86 /* prof */,
+				0C12E9EB2616383B00B66C86 /* tensorrt */,
+				0C12E9EF2616383B00B66C86 /* shm_mutex */,
+				0C12E9F12616383B00B66C86 /* tensorboard */,
+				0C12E9F22616383B00B66C86 /* aten */,
+				0C12E9F62616383B00B66C86 /* pytorch */,
+			);
+			path = contrib;
+			sourceTree = "<group>";
+		};
+		0C12E9BF2616383B00B66C86 /* nnpack */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = nnpack;
+			sourceTree = "<group>";
+		};
+		0C12E9C02616383B00B66C86 /* warpctc */ = {
+			isa = PBXGroup;
+			children = (
+				0C12E9C12616383B00B66C86 /* ctc_op.h */,
+			);
+			path = warpctc;
+			sourceTree = "<group>";
+		};
+		0C12E9C22616383B00B66C86 /* nccl */ = {
+			isa = PBXGroup;
+			children = (
+				0C12E9C32616383B00B66C86 /* cuda_nccl_gpu.h */,
+			);
+			path = nccl;
+			sourceTree = "<group>";
+		};
+		0C12E9C42616383B00B66C86 /* ideep */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = ideep;
+			sourceTree = "<group>";
+		};
+		0C12E9C52616383B00B66C86 /* docker-ubuntu-14.04 */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = "docker-ubuntu-14.04";
+			sourceTree = "<group>";
+		};
+		0C12E9C62616383B00B66C86 /* playground */ = {
+			isa = PBXGroup;
+			children = (
+				0C12E9C72616383B00B66C86 /* resnetdemo */,
+			);
+			path = playground;
+			sourceTree = "<group>";
+		};
+		0C12E9C72616383B00B66C86 /* resnetdemo */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = resnetdemo;
+			sourceTree = "<group>";
+		};
+		0C12E9C82616383B00B66C86 /* gloo */ = {
+			isa = PBXGroup;
+			children = (
+				0C12E9C92616383B00B66C86 /* allreduce_ops.h */,
+				0C12E9CA2616383B00B66C86 /* allgather_ops.h */,
+				0C12E9CB2616383B00B66C86 /* context.h */,
+				0C12E9CC2616383B00B66C86 /* store_handler.h */,
+				0C12E9CD2616383B00B66C86 /* broadcast_ops.h */,
+				0C12E9CE2616383B00B66C86 /* reduce_scatter_ops.h */,
+				0C12E9CF2616383B00B66C86 /* common.h */,
+				0C12E9D02616383B00B66C86 /* common_world_ops.h */,
+				0C12E9D12616383B00B66C86 /* barrier_ops.h */,
+			);
+			path = gloo;
+			sourceTree = "<group>";
+		};
+		0C12E9D22616383B00B66C86 /* fakelowp */ = {
+			isa = PBXGroup;
+			children = (
+				0C12E9D32616383B00B66C86 /* sum_fp16_fake_op.h */,
+				0C12E9D42616383B00B66C86 /* lengths_reducer_fused_4bit_rowwise_fp16_fake_op.h */,
+				0C12E9D52616383B00B66C86 /* int8_dequantize_op_nnpi.h */,
+				0C12E9D62616383B00B66C86 /* test */,
+				0C12E9D72616383B00B66C86 /* fp16_gemm_utils.h */,
+				0C12E9D82616383B00B66C86 /* fp16_fma.h */,
+				0C12E9D92616383B00B66C86 /* fp16_fc_acc_op.h */,
+				0C12E9DA2616383B00B66C86 /* layernorm_fp16_fake_op.h */,
+				0C12E9DB2616383B00B66C86 /* unary_fp16_fake_op.h */,
+				0C12E9DC2616383B00B66C86 /* int8_quantize_op_nnpi.h */,
+				0C12E9DD2616383B00B66C86 /* lengths_reducer_ops.h */,
+				0C12E9DE2616383B00B66C86 /* common.h */,
+				0C12E9DF2616383B00B66C86 /* batch_matmul_fp16_fake_op.h */,
+				0C12E9E02616383B00B66C86 /* lengths_reducer_fused_8bit_rowwise_fp16_fake_op.h */,
+				0C12E9E12616383B00B66C86 /* spatial_batch_norm_fp16_fake_op.h */,
+				0C12E9E22616383B00B66C86 /* quant_lut_fp16_fake_op.h */,
+				0C12E9E32616383B00B66C86 /* int8_swish_op_nnpi.h */,
+			);
+			path = fakelowp;
+			sourceTree = "<group>";
+		};
+		0C12E9D62616383B00B66C86 /* test */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = test;
+			sourceTree = "<group>";
+		};
+		0C12E9E42616383B00B66C86 /* script */ = {
+			isa = PBXGroup;
+			children = (
+				0C12E9E52616383B00B66C86 /* examples */,
+			);
+			path = script;
+			sourceTree = "<group>";
+		};
+		0C12E9E52616383B00B66C86 /* examples */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = examples;
+			sourceTree = "<group>";
+		};
+		0C12E9E62616383B00B66C86 /* opencl */ = {
+			isa = PBXGroup;
+			children = (
+				0C12E9E72616383B00B66C86 /* context.h */,
+				0C12E9E82616383B00B66C86 /* OpenCL */,
+			);
+			path = opencl;
+			sourceTree = "<group>";
+		};
+		0C12E9E82616383B00B66C86 /* OpenCL */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = OpenCL;
+			sourceTree = "<group>";
+		};
+		0C12E9E92616383B00B66C86 /* prof */ = {
+			isa = PBXGroup;
+			children = (
+				0C12E9EA2616383B00B66C86 /* prof_dag_stats_op.h */,
+			);
+			path = prof;
+			sourceTree = "<group>";
+		};
+		0C12E9EB2616383B00B66C86 /* tensorrt */ = {
+			isa = PBXGroup;
+			children = (
+				0C12E9EC2616383B00B66C86 /* tensorrt_tranformer.h */,
+				0C12E9ED2616383B00B66C86 /* trt_utils.h */,
+				0C12E9EE2616383B00B66C86 /* tensorrt_op_trt.h */,
+			);
+			path = tensorrt;
+			sourceTree = "<group>";
+		};
+		0C12E9EF2616383B00B66C86 /* shm_mutex */ = {
+			isa = PBXGroup;
+			children = (
+				0C12E9F02616383B00B66C86 /* shm_mutex.h */,
+			);
+			path = shm_mutex;
+			sourceTree = "<group>";
+		};
+		0C12E9F12616383B00B66C86 /* tensorboard */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = tensorboard;
+			sourceTree = "<group>";
+		};
+		0C12E9F22616383B00B66C86 /* aten */ = {
+			isa = PBXGroup;
+			children = (
+				0C12E9F32616383B00B66C86 /* aten_op.h */,
+				0C12E9F42616383B00B66C86 /* docs */,
+				0C12E9F52616383B00B66C86 /* aten_op_template.h */,
+			);
+			path = aten;
+			sourceTree = "<group>";
+		};
+		0C12E9F42616383B00B66C86 /* docs */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = docs;
+			sourceTree = "<group>";
+		};
+		0C12E9F62616383B00B66C86 /* pytorch */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = pytorch;
+			sourceTree = "<group>";
+		};
+		0C12E9F72616383B00B66C86 /* image */ = {
+			isa = PBXGroup;
+			children = (
+				0C12E9F82616383B00B66C86 /* image_input_op.h */,
+				0C12E9F92616383B00B66C86 /* transform_gpu.h */,
+			);
+			path = image;
+			sourceTree = "<group>";
+		};
+		0C12E9FA2616383B00B66C86 /* quantization */ = {
+			isa = PBXGroup;
+			children = (
+				0C12E9FB2616383B00B66C86 /* server */,
+			);
+			path = quantization;
+			sourceTree = "<group>";
+		};
+		0C12E9FB2616383B00B66C86 /* server */ = {
+			isa = PBXGroup;
+			children = (
+				0C12E9FC2616383B00B66C86 /* fbgemm_fp16_pack_op.h */,
+				0C12E9FD2616383B00B66C86 /* concat_dnnlowp_op.h */,
+				0C12E9FE2616383B00B66C86 /* fully_connected_dnnlowp_op.h */,
+				0C12E9FF2616383B00B66C86 /* int8_quant_scheme_blob_fill.h */,
+				0C12EA002616383B00B66C86 /* quantize_dnnlowp_op.h */,
+				0C12EA012616383B00B66C86 /* batch_matmul_dnnlowp_op.h */,
+				0C12EA022616383B00B66C86 /* utility_dnnlowp_ops.h */,
+				0C12EA032616383B00B66C86 /* activation_distribution_observer.h */,
+				0C12EA042616383B00B66C86 /* compute_equalization_scale.h */,
+				0C12EA052616383B00B66C86 /* caffe2_dnnlowp_utils.h */,
+				0C12EA062616383B00B66C86 /* dnnlowp_partition.h */,
+				0C12EA072616383B00B66C86 /* fully_connected_fake_lowp_op.h */,
+				0C12EA082616383B00B66C86 /* op_wrapper.h */,
+				0C12EA092616383B00B66C86 /* batch_permutation_dnnlowp_op.h */,
+				0C12EA0A2616383B00B66C86 /* conv_relu_op.h */,
+				0C12EA0B2616383B00B66C86 /* conv_pool_dnnlowp_op_base.h */,
+				0C12EA0C2616383B00B66C86 /* mmio.h */,
+				0C12EA0D2616383B00B66C86 /* lstm_unit_dnnlowp_op.h */,
+				0C12EA0E2616383B00B66C86 /* fbgemm_pack_matrix_cache.h */,
+				0C12EA0F2616383B00B66C86 /* im2col_dnnlowp.h */,
+				0C12EA102616383B00B66C86 /* fbgemm_pack_op.h */,
+				0C12EA112616383B00B66C86 /* resize_nearest_dnnlowp_op.h */,
+				0C12EA122616383B00B66C86 /* group_norm_dnnlowp_op.h */,
+				0C12EA132616383B00B66C86 /* elementwise_dnnlowp_op.h */,
+				0C12EA142616383B00B66C86 /* fb_fc_packed_op.h */,
+				0C12EA152616383B00B66C86 /* relu_dnnlowp_op.h */,
+				0C12EA162616383B00B66C86 /* spatial_batch_norm_dnnlowp_op.h */,
+				0C12EA172616383B00B66C86 /* dequantize_dnnlowp_op.h */,
+				0C12EA182616383B00B66C86 /* kl_minimization.h */,
+				0C12EA192616383B00B66C86 /* dynamic_histogram.h */,
+				0C12EA1A2616383B00B66C86 /* tanh.h */,
+				0C12EA1B2616383B00B66C86 /* fbgemm_pack_blob.h */,
+				0C12EA1C2616383B00B66C86 /* resize_nearest_3d_dnnlowp_op.h */,
+				0C12EA1D2616383B00B66C86 /* int8_gen_quant_params.h */,
+				0C12EA1E2616383B00B66C86 /* conv_dnnlowp_op.h */,
+				0C12EA1F2616383B00B66C86 /* sigmoid.h */,
+				0C12EA202616383B00B66C86 /* channel_shuffle_dnnlowp_op.h */,
+				0C12EA212616383B00B66C86 /* int8_gen_quant_params_min_max.h */,
+				0C12EA222616383B00B66C86 /* quantization_error_minimization.h */,
+				0C12EA232616383B00B66C86 /* elementwise_linear_dnnlowp_op.h */,
+				0C12EA242616383B00B66C86 /* dnnlowp_op.h */,
+				0C12EA252616383B00B66C86 /* l2_minimization.h */,
+				0C12EA262616383B00B66C86 /* dnnlowp.h */,
+				0C12EA272616383B00B66C86 /* conv_dnnlowp_acc16_op.h */,
+				0C12EA282616383B00B66C86 /* transpose.h */,
+				0C12EA292616383B00B66C86 /* pool_dnnlowp_op_avx2.h */,
+				0C12EA2A2616383B00B66C86 /* fully_connected_dnnlowp_acc16_op.h */,
+			);
+			path = server;
+			sourceTree = "<group>";
+		};
+		0C12EA2B2616383B00B66C86 /* transforms */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EA2C2616383B00B66C86 /* single_op_transform.h */,
+				0C12EA2D2616383B00B66C86 /* common_subexpression_elimination.h */,
+				0C12EA2E2616383B00B66C86 /* conv_to_nnpack_transform.h */,
+				0C12EA2F2616383B00B66C86 /* pattern_net_transform.h */,
+			);
+			path = transforms;
+			sourceTree = "<group>";
+		};
+		0C12EA302616383B00B66C86 /* mobile */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EA312616383B00B66C86 /* contrib */,
+			);
+			path = mobile;
+			sourceTree = "<group>";
+		};
+		0C12EA312616383B00B66C86 /* contrib */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EA322616383B00B66C86 /* libopencl-stub */,
+				0C12EA3D2616383B00B66C86 /* ios */,
+				0C12EA472616383B00B66C86 /* snpe */,
+				0C12EA492616383B00B66C86 /* nnapi */,
+				0C12EA4D2616383B00B66C86 /* ulp2 */,
+				0C12EA502616383B00B66C86 /* libvulkan-stub */,
+			);
+			path = contrib;
+			sourceTree = "<group>";
+		};
+		0C12EA322616383B00B66C86 /* libopencl-stub */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EA332616383B00B66C86 /* include */,
+				0C12EA3C2616383B00B66C86 /* src */,
+			);
+			path = "libopencl-stub";
+			sourceTree = "<group>";
+		};
+		0C12EA332616383B00B66C86 /* include */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EA342616383B00B66C86 /* libopencl.h */,
+				0C12EA352616383B00B66C86 /* CL */,
+			);
+			path = include;
+			sourceTree = "<group>";
+		};
+		0C12EA352616383B00B66C86 /* CL */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EA362616383B00B66C86 /* cl_platform.h */,
+				0C12EA372616383B00B66C86 /* opencl.h */,
+				0C12EA382616383B00B66C86 /* cl_ext.h */,
+				0C12EA392616383B00B66C86 /* cl.h */,
+				0C12EA3A2616383B00B66C86 /* cl_gl.h */,
+				0C12EA3B2616383B00B66C86 /* cl_gl_ext.h */,
+			);
+			path = CL;
+			sourceTree = "<group>";
+		};
+		0C12EA3C2616383B00B66C86 /* src */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = src;
+			sourceTree = "<group>";
+		};
+		0C12EA3D2616383B00B66C86 /* ios */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EA3E2616383B00B66C86 /* ios_caffe_defines.h */,
+				0C12EA3F2616383B00B66C86 /* mpscnn */,
+				0C12EA452616383B00B66C86 /* ios_caffe.h */,
+				0C12EA462616383B00B66C86 /* ios_caffe_predictor.h */,
+			);
+			path = ios;
+			sourceTree = "<group>";
+		};
+		0C12EA3F2616383B00B66C86 /* mpscnn */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EA402616383B00B66C86 /* mpscnn_graph_mask.h */,
+				0C12EA412616383B00B66C86 /* mpscnn.h */,
+				0C12EA422616383B00B66C86 /* mpscnn_test.h */,
+				0C12EA432616383B00B66C86 /* mpscnn_kernels.h */,
+				0C12EA442616383B00B66C86 /* mpscnn_context.h */,
+			);
+			path = mpscnn;
+			sourceTree = "<group>";
+		};
+		0C12EA472616383B00B66C86 /* snpe */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EA482616383B00B66C86 /* snpe_ffi.h */,
+			);
+			path = snpe;
+			sourceTree = "<group>";
+		};
+		0C12EA492616383B00B66C86 /* nnapi */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EA4A2616383B00B66C86 /* nnapi.h */,
+				0C12EA4B2616383B00B66C86 /* NeuralNetworks.h */,
+				0C12EA4C2616383B00B66C86 /* dlnnapi.h */,
+			);
+			path = nnapi;
+			sourceTree = "<group>";
+		};
+		0C12EA4D2616383B00B66C86 /* ulp2 */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EA4E2616383B00B66C86 /* ulp.h */,
+				0C12EA4F2616383B00B66C86 /* ulp_neon.h */,
+			);
+			path = ulp2;
+			sourceTree = "<group>";
+		};
+		0C12EA502616383B00B66C86 /* libvulkan-stub */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EA512616383B00B66C86 /* include */,
+				0C12EA562616383B00B66C86 /* src */,
+			);
+			path = "libvulkan-stub";
+			sourceTree = "<group>";
+		};
+		0C12EA512616383B00B66C86 /* include */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EA522616383B00B66C86 /* libvulkan-stub.h */,
+				0C12EA532616383B00B66C86 /* vulkan */,
+			);
+			path = include;
+			sourceTree = "<group>";
+		};
+		0C12EA532616383B00B66C86 /* vulkan */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EA542616383B00B66C86 /* vulkan.h */,
+				0C12EA552616383B00B66C86 /* vk_platform.h */,
+			);
+			path = vulkan;
+			sourceTree = "<group>";
+		};
+		0C12EA562616383B00B66C86 /* src */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = src;
+			sourceTree = "<group>";
+		};
+		0C12EA572616383B00B66C86 /* sgd */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EA582616383B00B66C86 /* fp16_momentum_sgd_op.h */,
+				0C12EA592616383B00B66C86 /* rmsprop_op.h */,
+				0C12EA5A2616383B00B66C86 /* lars_op.h */,
+				0C12EA5B2616383B00B66C86 /* yellowfin_op.h */,
+				0C12EA5C2616383B00B66C86 /* math_lp.h */,
+				0C12EA5D2616383B00B66C86 /* storm_op.h */,
+				0C12EA5E2616383B00B66C86 /* adagrad_op.h */,
+				0C12EA5F2616383B00B66C86 /* clip_tensor_op.h */,
+				0C12EA602616383B00B66C86 /* gftrl_op.h */,
+				0C12EA612616383B00B66C86 /* adadelta_op.h */,
+				0C12EA622616383B00B66C86 /* learning_rate_op.h */,
+				0C12EA632616383B00B66C86 /* adagrad_fused.h */,
+				0C12EA642616383B00B66C86 /* adam_op.h */,
+				0C12EA652616383B00B66C86 /* ftrl_op.h */,
+				0C12EA662616383B00B66C86 /* weight_scale_op.h */,
+				0C12EA672616383B00B66C86 /* learning_rate_adaption_op.h */,
+				0C12EA682616383B00B66C86 /* rowwise_counter.h */,
+				0C12EA692616383B00B66C86 /* iter_op.h */,
+				0C12EA6A2616383B00B66C86 /* rowwise_adagrad_fused.h */,
+				0C12EA6B2616383B00B66C86 /* momentum_sgd_op.h */,
+				0C12EA6C2616383B00B66C86 /* wngrad_op.h */,
+				0C12EA6D2616383B00B66C86 /* decay_adagrad_op.h */,
+				0C12EA6E2616383B00B66C86 /* learning_rate_functors.h */,
+				0C12EA6F2616383B00B66C86 /* fp32_momentum_sgd_op.h */,
+			);
+			path = sgd;
+			sourceTree = "<group>";
+		};
+		0C12EA702616383B00B66C86 /* queue */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EA712616383B00B66C86 /* blobs_queue.h */,
+				0C12EA722616383B00B66C86 /* rebatching_queue_ops.h */,
+				0C12EA732616383B00B66C86 /* queue_ops.h */,
+				0C12EA742616383B00B66C86 /* rebatching_queue.h */,
+				0C12EA752616383B00B66C86 /* blobs_queue_db.h */,
+			);
+			path = queue;
+			sourceTree = "<group>";
+		};
+		0C12EA762616383B00B66C86 /* db */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EA772616383B00B66C86 /* create_db_op.h */,
+			);
+			path = db;
+			sourceTree = "<group>";
+		};
+		0C12EA782616383B00B66C86 /* opt */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EA792616383B00B66C86 /* nql */,
+				0C12EA7D2616383B00B66C86 /* device.h */,
+				0C12EA7E2616383B00B66C86 /* annotations.h */,
+				0C12EA7F2616383B00B66C86 /* mobile.h */,
+				0C12EA802616383B00B66C86 /* onnxifi_transformer.h */,
+				0C12EA812616383B00B66C86 /* converter.h */,
+				0C12EA822616383B00B66C86 /* backend_transformer_base.h */,
+				0C12EA832616383B00B66C86 /* fakefp16_transform.h */,
+				0C12EA842616383B00B66C86 /* fusion.h */,
+				0C12EA852616383B00B66C86 /* shape_info.h */,
+				0C12EA862616383B00B66C86 /* optimizer.h */,
+				0C12EA872616383B00B66C86 /* glow_net_transform.h */,
+				0C12EA882616383B00B66C86 /* backend_cutting.h */,
+				0C12EA892616383B00B66C86 /* distributed.h */,
+				0C12EA8A2616383B00B66C86 /* onnxifi_op.h */,
+				0C12EA8B2616383B00B66C86 /* tvm_transformer.h */,
+				0C12EA8C2616383B00B66C86 /* passes.h */,
+				0C12EA8D2616383B00B66C86 /* bound_shape_inferencer.h */,
+				0C12EA8E2616383B00B66C86 /* custom */,
+				0C12EA942616383B00B66C86 /* onnx_convert.h */,
+				0C12EA952616383B00B66C86 /* optimize_ideep.h */,
+			);
+			path = opt;
+			sourceTree = "<group>";
+		};
+		0C12EA792616383B00B66C86 /* nql */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EA7A2616383B00B66C86 /* tests */,
+				0C12EA7B2616383B00B66C86 /* ast.h */,
+				0C12EA7C2616383B00B66C86 /* graphmatcher.h */,
+			);
+			path = nql;
+			sourceTree = "<group>";
+		};
+		0C12EA7A2616383B00B66C86 /* tests */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = tests;
+			sourceTree = "<group>";
+		};
+		0C12EA8E2616383B00B66C86 /* custom */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EA8F2616383B00B66C86 /* concat_elim.h */,
+				0C12EA902616383B00B66C86 /* pointwise_elim.h */,
+				0C12EA912616383B00B66C86 /* freeze_quantization_params.h */,
+				0C12EA922616383B00B66C86 /* in_batch_broadcast.h */,
+				0C12EA932616383B00B66C86 /* cc_amrc.h */,
+			);
+			path = custom;
+			sourceTree = "<group>";
+		};
+		0C12EA962616383B00B66C86 /* predictor */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EA972616383B00B66C86 /* ThreadLocalPtr.h */,
+				0C12EA982616383B00B66C86 /* InferenceGraph.h */,
+				0C12EA992616383B00B66C86 /* predictor_utils.h */,
+				0C12EA9A2616383B00B66C86 /* predictor.h */,
+				0C12EA9B2616383B00B66C86 /* predictor_config.h */,
+				0C12EA9C2616383B00B66C86 /* emulator */,
+				0C12EAA62616383B00B66C86 /* transforms.h */,
+			);
+			path = predictor;
+			sourceTree = "<group>";
+		};
+		0C12EA9C2616383B00B66C86 /* emulator */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EA9D2616383B00B66C86 /* data_filler.h */,
+				0C12EA9E2616383B00B66C86 /* utils.h */,
+				0C12EA9F2616383B00B66C86 /* net_supplier.h */,
+				0C12EAA02616383B00B66C86 /* time_profiler.h */,
+				0C12EAA12616383B00B66C86 /* emulator.h */,
+				0C12EAA22616383B00B66C86 /* output_formatter.h */,
+				0C12EAA32616383B00B66C86 /* std_output_formatter.h */,
+				0C12EAA42616383B00B66C86 /* benchmark.h */,
+				0C12EAA52616383B00B66C86 /* profiler.h */,
+			);
+			path = emulator;
+			sourceTree = "<group>";
+		};
+		0C12EAA72616383B00B66C86 /* observers */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EAA82616383B00B66C86 /* operator_attaching_net_observer.h */,
+				0C12EAA92616383B00B66C86 /* time_observer.h */,
+				0C12EAAA2616383B00B66C86 /* runcnt_observer.h */,
+				0C12EAAB2616383B00B66C86 /* profile_observer.h */,
+			);
+			path = observers;
+			sourceTree = "<group>";
+		};
+		0C12EAAC2616383B00B66C86 /* share */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EAAD2616383B00B66C86 /* contrib */,
+			);
+			path = share;
+			sourceTree = "<group>";
+		};
+		0C12EAAD2616383B00B66C86 /* contrib */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EAAE2616383B00B66C86 /* nnpack */,
+				0C12EAAF2616383B00B66C86 /* depthwise */,
+				0C12EAB02616383B00B66C86 /* zstd */,
+			);
+			path = contrib;
+			sourceTree = "<group>";
+		};
+		0C12EAAE2616383B00B66C86 /* nnpack */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = nnpack;
+			sourceTree = "<group>";
+		};
+		0C12EAAF2616383B00B66C86 /* depthwise */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = depthwise;
+			sourceTree = "<group>";
+		};
+		0C12EAB02616383B00B66C86 /* zstd */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EAB12616383B00B66C86 /* quant_decomp_zstd_op.h */,
+			);
+			path = zstd;
+			sourceTree = "<group>";
+		};
+		0C12EAB32616383B00B66C86 /* torch */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EAB42616383B00B66C86 /* csrc */,
+				0C12EDA52616383C00B66C86 /* script.h */,
+				0C12EDA62616383C00B66C86 /* library.h */,
+				0C12EDA72616383C00B66C86 /* custom_class_detail.h */,
+				0C12EDA82616383C00B66C86 /* custom_class.h */,
+				0C12EDA92616383C00B66C86 /* extension.h */,
+			);
+			path = torch;
+			sourceTree = "<group>";
+		};
+		0C12EAB42616383B00B66C86 /* csrc */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EAB52616383B00B66C86 /* Size.h */,
+				0C12EAB62616383B00B66C86 /* utils.h */,
+				0C12EAB72616383B00B66C86 /* Device.h */,
+				0C12EAB82616383B00B66C86 /* onnx */,
+				0C12EABB2616383B00B66C86 /* Types.h */,
+				0C12EABC2616383B00B66C86 /* distributed */,
+				0C12EAFD2616383B00B66C86 /* autograd */,
+				0C12EB332616383B00B66C86 /* deploy */,
+				0C12EB392616383B00B66C86 /* multiprocessing */,
+				0C12EB3B2616383B00B66C86 /* cuda */,
+				0C12EB4C2616383B00B66C86 /* serialization.h */,
+				0C12EB4D2616383B00B66C86 /* Exceptions.h */,
+				0C12EB4E2616383B00B66C86 /* QScheme.h */,
+				0C12EB4F2616383B00B66C86 /* utils */,
+				0C12EB752616383B00B66C86 /* Stream.h */,
+				0C12EB762616383B00B66C86 /* StorageDefs.h */,
+				0C12EB772616383B00B66C86 /* DataLoader.h */,
+				0C12EB782616383B00B66C86 /* THP.h */,
+				0C12EB792616383B00B66C86 /* python_headers.h */,
+				0C12EB7A2616383B00B66C86 /* Layout.h */,
+				0C12EB7B2616383B00B66C86 /* DynamicTypes.h */,
+				0C12EB7C2616383B00B66C86 /* copy_utils.h */,
+				0C12EB7D2616383B00B66C86 /* jit */,
+				0C12ECDA2616383B00B66C86 /* Storage.h */,
+				0C12ECDB2616383B00B66C86 /* api */,
+				0C12ED952616383C00B66C86 /* MemoryFormat.h */,
+				0C12ED962616383C00B66C86 /* generic */,
+				0C12ED9A2616383C00B66C86 /* tensor */,
+				0C12ED9C2616383C00B66C86 /* WindowsTorchApiMacro.h */,
+				0C12ED9D2616383C00B66C86 /* Dtype.h */,
+				0C12ED9E2616383C00B66C86 /* Module.h */,
+				0C12ED9F2616383C00B66C86 /* THP_export.h */,
+				0C12EDA02616383C00B66C86 /* python_dimname.h */,
+				0C12EDA12616383C00B66C86 /* CudaIPCTypes.h */,
+				0C12EDA22616383C00B66C86 /* Generator.h */,
+				0C12EDA32616383C00B66C86 /* TypeInfo.h */,
+				0C12EDA42616383C00B66C86 /* PythonTypes.h */,
+			);
+			path = csrc;
+			sourceTree = "<group>";
+		};
+		0C12EAB82616383B00B66C86 /* onnx */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EAB92616383B00B66C86 /* init.h */,
+				0C12EABA2616383B00B66C86 /* onnx.h */,
+			);
+			path = onnx;
+			sourceTree = "<group>";
+		};
+		0C12EABC2616383B00B66C86 /* distributed */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EABD2616383B00B66C86 /* autograd */,
+				0C12EAD42616383B00B66C86 /* rpc */,
+				0C12EAFA2616383B00B66C86 /* c10d */,
+			);
+			path = distributed;
+			sourceTree = "<group>";
+		};
+		0C12EABD2616383B00B66C86 /* autograd */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EABE2616383B00B66C86 /* utils.h */,
+				0C12EABF2616383B00B66C86 /* context */,
+				0C12EAC22616383B00B66C86 /* rpc_messages */,
+				0C12EACD2616383B00B66C86 /* python_autograd.h */,
+				0C12EACE2616383B00B66C86 /* autograd.h */,
+				0C12EACF2616383B00B66C86 /* functions */,
+				0C12EAD22616383B00B66C86 /* engine */,
+			);
+			path = autograd;
+			sourceTree = "<group>";
+		};
+		0C12EABF2616383B00B66C86 /* context */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EAC02616383B00B66C86 /* container.h */,
+				0C12EAC12616383B00B66C86 /* context.h */,
+			);
+			path = context;
+			sourceTree = "<group>";
+		};
+		0C12EAC22616383B00B66C86 /* rpc_messages */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EAC32616383B00B66C86 /* cleanup_autograd_context_req.h */,
+				0C12EAC42616383B00B66C86 /* cleanup_autograd_context_resp.h */,
+				0C12EAC52616383B00B66C86 /* rref_backward_req.h */,
+				0C12EAC62616383B00B66C86 /* rpc_with_profiling_req.h */,
+				0C12EAC72616383B00B66C86 /* propagate_gradients_resp.h */,
+				0C12EAC82616383B00B66C86 /* propagate_gradients_req.h */,
+				0C12EAC92616383B00B66C86 /* autograd_metadata.h */,
+				0C12EACA2616383B00B66C86 /* rpc_with_autograd.h */,
+				0C12EACB2616383B00B66C86 /* rref_backward_resp.h */,
+				0C12EACC2616383B00B66C86 /* rpc_with_profiling_resp.h */,
+			);
+			path = rpc_messages;
+			sourceTree = "<group>";
+		};
+		0C12EACF2616383B00B66C86 /* functions */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EAD02616383B00B66C86 /* sendrpc_backward.h */,
+				0C12EAD12616383B00B66C86 /* recvrpc_backward.h */,
+			);
+			path = functions;
+			sourceTree = "<group>";
+		};
+		0C12EAD22616383B00B66C86 /* engine */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EAD32616383B00B66C86 /* dist_engine.h */,
+			);
+			path = engine;
+			sourceTree = "<group>";
+		};
+		0C12EAD42616383B00B66C86 /* rpc */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EAD52616383B00B66C86 /* metrics */,
+				0C12EAD72616383B00B66C86 /* utils.h */,
+				0C12EAD82616383B00B66C86 /* rref_context.h */,
+				0C12EAD92616383B00B66C86 /* request_callback_impl.h */,
+				0C12EADA2616383B00B66C86 /* python_resp.h */,
+				0C12EADB2616383B00B66C86 /* rref_impl.h */,
+				0C12EADC2616383B00B66C86 /* request_callback.h */,
+				0C12EADD2616383B00B66C86 /* types.h */,
+				0C12EADE2616383B00B66C86 /* rref_proto.h */,
+				0C12EADF2616383B00B66C86 /* py_rref.h */,
+				0C12EAE02616383B00B66C86 /* rpc_agent.h */,
+				0C12EAE12616383B00B66C86 /* python_functions.h */,
+				0C12EAE22616383B00B66C86 /* message.h */,
+				0C12EAE32616383B00B66C86 /* request_callback_no_python.h */,
+				0C12EAE42616383B00B66C86 /* python_remote_call.h */,
+				0C12EAE52616383B00B66C86 /* python_call.h */,
+				0C12EAE62616383B00B66C86 /* tensorpipe_agent.h */,
+				0C12EAE72616383B00B66C86 /* script_remote_call.h */,
+				0C12EAE82616383B00B66C86 /* testing */,
+				0C12EAEB2616383B00B66C86 /* macros.h */,
+				0C12EAEC2616383B00B66C86 /* script_resp.h */,
+				0C12EAED2616383B00B66C86 /* rpc.h */,
+				0C12EAEE2616383B00B66C86 /* rpc_command_base.h */,
+				0C12EAEF2616383B00B66C86 /* profiler */,
+				0C12EAF22616383B00B66C86 /* script_call.h */,
+				0C12EAF32616383B00B66C86 /* unpickled_python_remote_call.h */,
+				0C12EAF42616383B00B66C86 /* torchscript_functions.h */,
+				0C12EAF52616383B00B66C86 /* unpickled_python_call.h */,
+				0C12EAF62616383B00B66C86 /* tensorpipe_utils.h */,
+				0C12EAF72616383B00B66C86 /* agent_utils.h */,
+				0C12EAF82616383B00B66C86 /* process_group_agent.h */,
+				0C12EAF92616383B00B66C86 /* python_rpc_handler.h */,
+			);
+			path = rpc;
+			sourceTree = "<group>";
+		};
+		0C12EAD52616383B00B66C86 /* metrics */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EAD62616383B00B66C86 /* RpcMetricsHandler.h */,
+			);
+			path = metrics;
+			sourceTree = "<group>";
+		};
+		0C12EAE82616383B00B66C86 /* testing */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EAE92616383B00B66C86 /* testing.h */,
+				0C12EAEA2616383B00B66C86 /* faulty_process_group_agent.h */,
+			);
+			path = testing;
+			sourceTree = "<group>";
+		};
+		0C12EAEF2616383B00B66C86 /* profiler */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EAF02616383B00B66C86 /* remote_profiler_manager.h */,
+				0C12EAF12616383B00B66C86 /* server_process_global_profiler.h */,
+			);
+			path = profiler;
+			sourceTree = "<group>";
+		};
+		0C12EAFA2616383B00B66C86 /* c10d */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EAFB2616383B00B66C86 /* python_comm_hook.h */,
+				0C12EAFC2616383B00B66C86 /* c10d.h */,
+			);
+			path = c10d;
+			sourceTree = "<group>";
+		};
+		0C12EAFD2616383B00B66C86 /* autograd */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EAFE2616383B00B66C86 /* generated */,
+				0C12EB022616383B00B66C86 /* python_function.h */,
+				0C12EB032616383B00B66C86 /* custom_function.h */,
+				0C12EB042616383B00B66C86 /* python_linalg_functions.h */,
+				0C12EB052616383B00B66C86 /* record_function_ops.h */,
+				0C12EB062616383B00B66C86 /* engine.h */,
+				0C12EB072616383B00B66C86 /* edge.h */,
+				0C12EB082616383B00B66C86 /* saved_variable.h */,
+				0C12EB092616383B00B66C86 /* python_engine.h */,
+				0C12EB0A2616383B00B66C86 /* python_legacy_variable.h */,
+				0C12EB0B2616383B00B66C86 /* python_cpp_function.h */,
+				0C12EB0C2616383B00B66C86 /* python_hook.h */,
+				0C12EB0D2616383B00B66C86 /* VariableTypeUtils.h */,
+				0C12EB0E2616383B00B66C86 /* python_autograd.h */,
+				0C12EB0F2616383B00B66C86 /* profiler_kineto.h */,
+				0C12EB102616383B00B66C86 /* variable.h */,
+				0C12EB112616383B00B66C86 /* utils */,
+				0C12EB172616383B00B66C86 /* python_fft_functions.h */,
+				0C12EB182616383B00B66C86 /* python_variable.h */,
+				0C12EB192616383B00B66C86 /* function_hook.h */,
+				0C12EB1A2616383B00B66C86 /* input_metadata.h */,
+				0C12EB1B2616383B00B66C86 /* grad_mode.h */,
+				0C12EB1C2616383B00B66C86 /* symbolic.h */,
+				0C12EB1D2616383B00B66C86 /* input_buffer.h */,
+				0C12EB1E2616383B00B66C86 /* profiler_legacy.h */,
+				0C12EB1F2616383B00B66C86 /* autograd.h */,
+				0C12EB202616383B00B66C86 /* cpp_hook.h */,
+				0C12EB212616383B00B66C86 /* functions */,
+				0C12EB282616383B00B66C86 /* python_special_functions.h */,
+				0C12EB292616383B00B66C86 /* FunctionsManual.h */,
+				0C12EB2A2616383B00B66C86 /* forward_grad.h */,
+				0C12EB2B2616383B00B66C86 /* python_anomaly_mode.h */,
+				0C12EB2C2616383B00B66C86 /* python_nn_functions.h */,
+				0C12EB2D2616383B00B66C86 /* InferenceMode.h */,
+				0C12EB2E2616383B00B66C86 /* python_variable_indexing.h */,
+				0C12EB2F2616383B00B66C86 /* profiler.h */,
+				0C12EB302616383B00B66C86 /* function.h */,
+				0C12EB312616383B00B66C86 /* anomaly_mode.h */,
+				0C12EB322616383B00B66C86 /* profiler_utils.h */,
+			);
+			path = autograd;
+			sourceTree = "<group>";
+		};
+		0C12EAFE2616383B00B66C86 /* generated */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EAFF2616383B00B66C86 /* python_functions.h */,
+				0C12EB002616383B00B66C86 /* Functions.h */,
+				0C12EB012616383B00B66C86 /* variable_factories.h */,
+			);
+			path = generated;
+			sourceTree = "<group>";
+		};
+		0C12EB112616383B00B66C86 /* utils */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EB122616383B00B66C86 /* wrap_outputs.h */,
+				0C12EB132616383B00B66C86 /* python_arg_parsing.h */,
+				0C12EB142616383B00B66C86 /* grad_layout_contract.h */,
+				0C12EB152616383B00B66C86 /* lambda_post_hook.h */,
+				0C12EB162616383B00B66C86 /* error_messages.h */,
+			);
+			path = utils;
+			sourceTree = "<group>";
+		};
+		0C12EB212616383B00B66C86 /* functions */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EB222616383B00B66C86 /* utils.h */,
+				0C12EB232616383B00B66C86 /* pybind.h */,
+				0C12EB242616383B00B66C86 /* comm.h */,
+				0C12EB252616383B00B66C86 /* basic_ops.h */,
+				0C12EB262616383B00B66C86 /* accumulate_grad.h */,
+				0C12EB272616383B00B66C86 /* tensor.h */,
+			);
+			path = functions;
+			sourceTree = "<group>";
+		};
+		0C12EB332616383B00B66C86 /* deploy */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EB342616383B00B66C86 /* interpreter */,
+				0C12EB372616383B00B66C86 /* example */,
+				0C12EB382616383B00B66C86 /* deploy.h */,
+			);
+			path = deploy;
+			sourceTree = "<group>";
+		};
+		0C12EB342616383B00B66C86 /* interpreter */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EB352616383B00B66C86 /* interpreter_impl.h */,
+				0C12EB362616383B00B66C86 /* third_party */,
+			);
+			path = interpreter;
+			sourceTree = "<group>";
+		};
+		0C12EB362616383B00B66C86 /* third_party */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = third_party;
+			sourceTree = "<group>";
+		};
+		0C12EB372616383B00B66C86 /* example */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = example;
+			sourceTree = "<group>";
+		};
+		0C12EB392616383B00B66C86 /* multiprocessing */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EB3A2616383B00B66C86 /* init.h */,
+			);
+			path = multiprocessing;
+			sourceTree = "<group>";
+		};
+		0C12EB3B2616383B00B66C86 /* cuda */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EB3C2616383B00B66C86 /* utils.h */,
+				0C12EB3D2616383B00B66C86 /* THCP.h */,
+				0C12EB3E2616383B00B66C86 /* nccl.h */,
+				0C12EB3F2616383B00B66C86 /* python_nccl.h */,
+				0C12EB402616383B00B66C86 /* device_set.h */,
+				0C12EB412616383B00B66C86 /* Event.h */,
+				0C12EB422616383B00B66C86 /* serialization.h */,
+				0C12EB432616383B00B66C86 /* python_comm.h */,
+				0C12EB442616383B00B66C86 /* comm.h */,
+				0C12EB452616383B00B66C86 /* Stream.h */,
+				0C12EB462616383B00B66C86 /* shared */,
+				0C12EB472616383B00B66C86 /* undef_macros.h */,
+				0C12EB482616383B00B66C86 /* restore_macros.h */,
+				0C12EB492616383B00B66C86 /* Storage.h */,
+				0C12EB4A2616383B00B66C86 /* Module.h */,
+				0C12EB4B2616383B00B66C86 /* override_macros.h */,
+			);
+			path = cuda;
+			sourceTree = "<group>";
+		};
+		0C12EB462616383B00B66C86 /* shared */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = shared;
+			sourceTree = "<group>";
+		};
+		0C12EB4F2616383B00B66C86 /* utils */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EB502616383B00B66C86 /* object_ptr.h */,
+				0C12EB512616383B00B66C86 /* tensor_numpy.h */,
+				0C12EB522616383B00B66C86 /* tensor_dtypes.h */,
+				0C12EB532616383B00B66C86 /* python_tuples.h */,
+				0C12EB542616383B00B66C86 /* python_numbers.h */,
+				0C12EB552616383B00B66C86 /* python_scalars.h */,
+				0C12EB562616383B00B66C86 /* pybind.h */,
+				0C12EB572616383B00B66C86 /* tensor_types.h */,
+				0C12EB582616383B00B66C86 /* tensor_memoryformats.h */,
+				0C12EB592616383B00B66C86 /* python_arg_parser.h */,
+				0C12EB5A2616383B00B66C86 /* cuda_lazy_init.h */,
+				0C12EB5B2616383B00B66C86 /* tensor_new.h */,
+				0C12EB5C2616383B00B66C86 /* tensor_qschemes.h */,
+				0C12EB5D2616383B00B66C86 /* python_dispatch.h */,
+				0C12EB5E2616383B00B66C86 /* tensor_list.h */,
+				0C12EB5F2616383B00B66C86 /* invalid_arguments.h */,
+				0C12EB602616383B00B66C86 /* auto_gil.h */,
+				0C12EB612616383B00B66C86 /* python_strings.h */,
+				0C12EB622616383B00B66C86 /* byte_order.h */,
+				0C12EB632616383B00B66C86 /* pycfunction_helpers.h */,
+				0C12EB642616383B00B66C86 /* cuda_enabled.h */,
+				0C12EB652616383B00B66C86 /* numpy_stub.h */,
+				0C12EB662616383B00B66C86 /* out_types.h */,
+				0C12EB672616383B00B66C86 /* memory.h */,
+				0C12EB682616383B00B66C86 /* tensor_layouts.h */,
+				0C12EB692616383B00B66C86 /* structseq.h */,
+				0C12EB6A2616383B00B66C86 /* throughput_benchmark.h */,
+				0C12EB6B2616383B00B66C86 /* disable_torch_function.h */,
+				0C12EB6C2616383B00B66C86 /* throughput_benchmark-inl.h */,
+				0C12EB6D2616383B00B66C86 /* tensor_flatten.h */,
+				0C12EB6E2616383B00B66C86 /* tensor_apply.h */,
+				0C12EB6F2616383B00B66C86 /* init.h */,
+				0C12EB702616383B00B66C86 /* python_compat.h */,
+				0C12EB712616383B00B66C86 /* disallow_copy.h */,
+				0C12EB722616383B00B66C86 /* six.h */,
+				0C12EB732616383B00B66C86 /* python_stub.h */,
+				0C12EB742616383B00B66C86 /* variadic.h */,
+			);
+			path = utils;
+			sourceTree = "<group>";
+		};
+		0C12EB7D2616383B00B66C86 /* jit */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EB7E2616383B00B66C86 /* generated */,
+				0C12EB7F2616383B00B66C86 /* jit_opt_limit.h */,
+				0C12EB802616383B00B66C86 /* frontend */,
+				0C12EB9D2616383B00B66C86 /* python */,
+				0C12EBAB2616383B00B66C86 /* tensorexpr */,
+				0C12EBD22616383B00B66C86 /* ir */,
+				0C12EBDF2616383B00B66C86 /* cuda */,
+				0C12EBE12616383B00B66C86 /* serialization */,
+				0C12EBF12616383B00B66C86 /* backends */,
+				0C12EBF72616383B00B66C86 /* runtime */,
+				0C12EC122616383B00B66C86 /* passes */,
+				0C12EC752616383B00B66C86 /* docs */,
+				0C12EC762616383B00B66C86 /* codegen */,
+				0C12ECC22616383B00B66C86 /* testing */,
+				0C12ECC52616383B00B66C86 /* jit_log.h */,
+				0C12ECC62616383B00B66C86 /* mobile */,
+				0C12ECD32616383B00B66C86 /* resource_guard.h */,
+				0C12ECD42616383B00B66C86 /* api */,
+			);
+			path = jit;
+			sourceTree = "<group>";
+		};
+		0C12EB7E2616383B00B66C86 /* generated */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = generated;
+			sourceTree = "<group>";
+		};
+		0C12EB802616383B00B66C86 /* frontend */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EB812616383B00B66C86 /* error_report.h */,
+				0C12EB822616383B00B66C86 /* source_range.h */,
+				0C12EB832616383B00B66C86 /* edit_distance.h */,
+				0C12EB842616383B00B66C86 /* canonicalize_modified_loop.h */,
+				0C12EB852616383B00B66C86 /* schema_matching.h */,
+				0C12EB862616383B00B66C86 /* function_schema_parser.h */,
+				0C12EB872616383B00B66C86 /* tree_views.h */,
+				0C12EB882616383B00B66C86 /* ir_emitter.h */,
+				0C12EB892616383B00B66C86 /* parser.h */,
+				0C12EB8A2616383B00B66C86 /* strtod.h */,
+				0C12EB8B2616383B00B66C86 /* tree.h */,
+				0C12EB8C2616383B00B66C86 /* concrete_module_type.h */,
+				0C12EB8D2616383B00B66C86 /* builtin_functions.h */,
+				0C12EB8E2616383B00B66C86 /* exit_transforms.h */,
+				0C12EB8F2616383B00B66C86 /* parse_string_literal.h */,
+				0C12EB902616383B00B66C86 /* sugared_value.h */,
+				0C12EB912616383B00B66C86 /* inline_loop_condition.h */,
+				0C12EB922616383B00B66C86 /* name_mangler.h */,
+				0C12EB932616383B00B66C86 /* code_template.h */,
+				0C12EB942616383B00B66C86 /* tracer.h */,
+				0C12EB952616383B00B66C86 /* resolver.h */,
+				0C12EB962616383B00B66C86 /* script_type_parser.h */,
+				0C12EB972616383B00B66C86 /* schema_type_parser.h */,
+				0C12EB982616383B00B66C86 /* lexer.h */,
+				0C12EB992616383B00B66C86 /* versioned_symbols.h */,
+				0C12EB9A2616383B00B66C86 /* convert_to_ssa.h */,
+				0C12EB9B2616383B00B66C86 /* mini_environment.h */,
+				0C12EB9C2616383B00B66C86 /* parser_constants.h */,
+			);
+			path = frontend;
+			sourceTree = "<group>";
+		};
+		0C12EB9D2616383B00B66C86 /* python */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EB9E2616383B00B66C86 /* pybind.h */,
+				0C12EB9F2616383B00B66C86 /* python_ir.h */,
+				0C12EBA02616383B00B66C86 /* script_init.h */,
+				0C12EBA12616383B00B66C86 /* python_tree_views.h */,
+				0C12EBA22616383B00B66C86 /* python_ivalue.h */,
+				0C12EBA32616383B00B66C86 /* python_custom_class.h */,
+				0C12EBA42616383B00B66C86 /* update_graph_executor_opt.h */,
+				0C12EBA52616383B00B66C86 /* python_tracer.h */,
+				0C12EBA62616383B00B66C86 /* pybind_utils.h */,
+				0C12EBA72616383B00B66C86 /* init.h */,
+				0C12EBA82616383B00B66C86 /* python_sugared_value.h */,
+				0C12EBA92616383B00B66C86 /* python_arg_flatten.h */,
+				0C12EBAA2616383B00B66C86 /* module_python.h */,
+			);
+			path = python;
+			sourceTree = "<group>";
+		};
+		0C12EBAB2616383B00B66C86 /* tensorexpr */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EBAC2616383B00B66C86 /* ir_mutator.h */,
+				0C12EBAD2616383B00B66C86 /* ir_simplifier.h */,
+				0C12EBAE2616383B00B66C86 /* ir_visitor.h */,
+				0C12EBAF2616383B00B66C86 /* llvm_jit.h */,
+				0C12EBB02616383B00B66C86 /* tensorexpr_init.h */,
+				0C12EBB12616383B00B66C86 /* types.h */,
+				0C12EBB22616383B00B66C86 /* mem_dependency_checker.h */,
+				0C12EBB32616383B00B66C86 /* ir.h */,
+				0C12EBB42616383B00B66C86 /* exceptions.h */,
+				0C12EBB52616383B00B66C86 /* cuda_codegen.h */,
+				0C12EBB62616383B00B66C86 /* hash_provider.h */,
+				0C12EBB72616383B00B66C86 /* ir_printer.h */,
+				0C12EBB82616383B00B66C86 /* llvm_codegen.h */,
+				0C12EBB92616383B00B66C86 /* expr.h */,
+				0C12EBBA2616383B00B66C86 /* cuda_random.h */,
+				0C12EBBB2616383B00B66C86 /* execution_counter.h */,
+				0C12EBBC2616383B00B66C86 /* codegen.h */,
+				0C12EBBD2616383B00B66C86 /* unique_name_manager.h */,
+				0C12EBBE2616383B00B66C86 /* cpp_codegen.h */,
+				0C12EBBF2616383B00B66C86 /* var_substitutor.h */,
+				0C12EBC02616383B00B66C86 /* eval.h */,
+				0C12EBC12616383B00B66C86 /* bounds_inference.h */,
+				0C12EBC22616383B00B66C86 /* intrinsic_symbols.h */,
+				0C12EBC32616383B00B66C86 /* block_codegen.h */,
+				0C12EBC42616383B00B66C86 /* external_functions_registry.h */,
+				0C12EBC52616383B00B66C86 /* kernel.h */,
+				0C12EBC62616383B00B66C86 /* loopnest.h */,
+				0C12EBC72616383B00B66C86 /* bounds_overlap.h */,
+				0C12EBC82616383B00B66C86 /* ir_verifier.h */,
+				0C12EBC92616383B00B66C86 /* dim_arg.h */,
+				0C12EBCA2616383B00B66C86 /* external_functions.h */,
+				0C12EBCB2616383B00B66C86 /* stmt.h */,
+				0C12EBCC2616383B00B66C86 /* half_support.h */,
+				0C12EBCD2616383B00B66C86 /* registerizer.h */,
+				0C12EBCE2616383B00B66C86 /* reduction.h */,
+				0C12EBCF2616383B00B66C86 /* tensor.h */,
+				0C12EBD02616383B00B66C86 /* mem_arena.h */,
+				0C12EBD12616383B00B66C86 /* analysis.h */,
+			);
+			path = tensorexpr;
+			sourceTree = "<group>";
+		};
+		0C12EBD22616383B00B66C86 /* ir */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EBD32616383B00B66C86 /* named_value.h */,
+				0C12EBD42616383B00B66C86 /* irparser.h */,
+				0C12EBD52616383B00B66C86 /* ir.h */,
+				0C12EBD62616383B00B66C86 /* graph_node_list.h */,
+				0C12EBD72616383B00B66C86 /* ir_views.h */,
+				0C12EBD82616383B00B66C86 /* alias_analysis.h */,
+				0C12EBD92616383B00B66C86 /* attributes.h */,
+				0C12EBDA2616383B00B66C86 /* type_hashing.h */,
+				0C12EBDB2616383B00B66C86 /* constants.h */,
+				0C12EBDC2616383B00B66C86 /* subgraph_matcher.h */,
+				0C12EBDD2616383B00B66C86 /* scope.h */,
+				0C12EBDE2616383B00B66C86 /* node_hashing.h */,
+			);
+			path = ir;
+			sourceTree = "<group>";
+		};
+		0C12EBDF2616383B00B66C86 /* cuda */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EBE02616383B00B66C86 /* cuda.h */,
+			);
+			path = cuda;
+			sourceTree = "<group>";
+		};
+		0C12EBE12616383B00B66C86 /* serialization */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EBE22616383B00B66C86 /* import_source.h */,
+				0C12EBE32616383B00B66C86 /* export.h */,
+				0C12EBE42616383B00B66C86 /* import_export_helpers.h */,
+				0C12EBE52616383B00B66C86 /* type_name_uniquer.h */,
+				0C12EBE62616383B00B66C86 /* pickler.h */,
+				0C12EBE72616383B00B66C86 /* python_print.h */,
+				0C12EBE82616383B00B66C86 /* import_legacy.h */,
+				0C12EBE92616383B00B66C86 /* import_export_functions.h */,
+				0C12EBEA2616383B00B66C86 /* pickle.h */,
+				0C12EBEB2616383B00B66C86 /* import_export_constants.h */,
+				0C12EBEC2616383B00B66C86 /* source_range_serialization_impl.h */,
+				0C12EBED2616383B00B66C86 /* import.h */,
+				0C12EBEE2616383B00B66C86 /* unpickler.h */,
+				0C12EBEF2616383B00B66C86 /* source_range_serialization.h */,
+				0C12EBF02616383B00B66C86 /* onnx.h */,
+			);
+			path = serialization;
+			sourceTree = "<group>";
+		};
+		0C12EBF12616383B00B66C86 /* backends */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EBF22616383B00B66C86 /* backend_interface.h */,
+				0C12EBF32616383B00B66C86 /* backend.h */,
+				0C12EBF42616383B00B66C86 /* backend_resolver.h */,
+				0C12EBF52616383B00B66C86 /* backend_detail.h */,
+				0C12EBF62616383B00B66C86 /* backend_init.h */,
+			);
+			path = backends;
+			sourceTree = "<group>";
+		};
+		0C12EBF72616383B00B66C86 /* runtime */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EBF82616383B00B66C86 /* slice_indices_adjust.h */,
+				0C12EBF92616383B00B66C86 /* operator.h */,
+				0C12EBFA2616383B00B66C86 /* interpreter.h */,
+				0C12EBFB2616383B00B66C86 /* register_ops_utils.h */,
+				0C12EBFC2616383B00B66C86 /* jit_exception.h */,
+				0C12EBFD2616383B00B66C86 /* exception_message.h */,
+				0C12EBFE2616383B00B66C86 /* argument_spec.h */,
+				0C12EBFF2616383B00B66C86 /* logging.h */,
+				0C12EC002616383B00B66C86 /* profiling_graph_executor_impl.h */,
+				0C12EC012616383B00B66C86 /* custom_operator.h */,
+				0C12EC022616383B00B66C86 /* static */,
+				0C12EC082616383B00B66C86 /* vararg_functions.h */,
+				0C12EC092616383B00B66C86 /* symbolic_script.h */,
+				0C12EC0A2616383B00B66C86 /* variable_tensor_list.h */,
+				0C12EC0B2616383B00B66C86 /* autodiff.h */,
+				0C12EC0C2616383B00B66C86 /* print_handler.h */,
+				0C12EC0D2616383B00B66C86 /* profiling_record.h */,
+				0C12EC0E2616383B00B66C86 /* graph_executor.h */,
+				0C12EC0F2616383B00B66C86 /* operator_options.h */,
+				0C12EC102616383B00B66C86 /* instruction.h */,
+				0C12EC112616383B00B66C86 /* graph_executor_impl.h */,
+			);
+			path = runtime;
+			sourceTree = "<group>";
+		};
+		0C12EC022616383B00B66C86 /* static */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EC032616383B00B66C86 /* fusion.h */,
+				0C12EC042616383B00B66C86 /* passes.h */,
+				0C12EC052616383B00B66C86 /* ops.h */,
+				0C12EC062616383B00B66C86 /* impl.h */,
+				0C12EC072616383B00B66C86 /* init.h */,
+			);
+			path = static;
+			sourceTree = "<group>";
+		};
+		0C12EC122616383B00B66C86 /* passes */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EC132616383B00B66C86 /* remove_expands.h */,
+				0C12EC142616383B00B66C86 /* peephole_list_idioms.h */,
+				0C12EC152616383B00B66C86 /* subgraph_rewrite.h */,
+				0C12EC162616383B00B66C86 /* fuse_relu.h */,
+				0C12EC172616383B00B66C86 /* guard_elimination.h */,
+				0C12EC182616383B00B66C86 /* peephole_alias_sensitive.h */,
+				0C12EC192616383B00B66C86 /* freeze_module.h */,
+				0C12EC1A2616383B00B66C86 /* clear_undefinedness.h */,
+				0C12EC1B2616383B00B66C86 /* peephole.h */,
+				0C12EC1C2616383B00B66C86 /* remove_dropout.h */,
+				0C12EC1D2616383B00B66C86 /* update_differentiable_graph_requires_grad.h */,
+				0C12EC1E2616383B00B66C86 /* metal_rewrite.h */,
+				0C12EC1F2616383B00B66C86 /* liveness.h */,
+				0C12EC202616383B00B66C86 /* onnx */,
+				0C12EC362616383B00B66C86 /* remove_mutation.h */,
+				0C12EC372616383B00B66C86 /* common_subexpression_elimination.h */,
+				0C12EC382616383B00B66C86 /* batch_mm.h */,
+				0C12EC392616383B00B66C86 /* constant_pooling.h */,
+				0C12EC3A2616383B00B66C86 /* canonicalize_graph_fuser_ops.h */,
+				0C12EC3B2616383B00B66C86 /* fuse_linear.h */,
+				0C12EC3C2616383B00B66C86 /* annotate_warns.h */,
+				0C12EC3D2616383B00B66C86 /* specialize_autogradzero.h */,
+				0C12EC3E2616383B00B66C86 /* prepack_folding.h */,
+				0C12EC3F2616383B00B66C86 /* frozen_conv_folding.h */,
+				0C12EC402616383B00B66C86 /* constant_propagation.h */,
+				0C12EC412616383B00B66C86 /* insert_guards.h */,
+				0C12EC422616383B00B66C86 /* utils */,
+				0C12EC462616383B00B66C86 /* inliner.h */,
+				0C12EC472616383B00B66C86 /* lower_grad_of.h */,
+				0C12EC482616383B00B66C86 /* quantization */,
+				0C12EC512616383B00B66C86 /* normalize_ops.h */,
+				0C12EC522616383B00B66C86 /* vulkan_rewrite.h */,
+				0C12EC532616383B00B66C86 /* erase_number_types.h */,
+				0C12EC542616383B00B66C86 /* graph_rewrite_helper.h */,
+				0C12EC552616383B00B66C86 /* graph_fuser.h */,
+				0C12EC562616383B00B66C86 /* fold_conv_bn.h */,
+				0C12EC572616383B00B66C86 /* remove_redundant_profiles.h */,
+				0C12EC582616383B00B66C86 /* inline_forked_closures.h */,
+				0C12EC592616383B00B66C86 /* tensorexpr_fuser.h */,
+				0C12EC5A2616383B00B66C86 /* decompose_ops.h */,
+				0C12EC5B2616383B00B66C86 /* remove_inplace_ops.h */,
+				0C12EC5C2616383B00B66C86 /* inline_fork_wait.h */,
+				0C12EC5D2616383B00B66C86 /* create_autodiff_subgraphs.h */,
+				0C12EC5E2616383B00B66C86 /* requires_grad_analysis.h */,
+				0C12EC5F2616383B00B66C86 /* dead_code_elimination.h */,
+				0C12EC602616383B00B66C86 /* clear_profiling.h */,
+				0C12EC612616383B00B66C86 /* create_functional_graphs.h */,
+				0C12EC622616383B00B66C86 /* bailout_graph.h */,
+				0C12EC632616383B00B66C86 /* lower_tuples.h */,
+				0C12EC642616383B00B66C86 /* frozen_graph_optimizations.h */,
+				0C12EC652616383B00B66C86 /* frozen_ops_to_mkldnn.h */,
+				0C12EC662616383B00B66C86 /* canonicalize.h */,
+				0C12EC672616383B00B66C86 /* hoist_conv_packed_params.h */,
+				0C12EC682616383B00B66C86 /* loop_unrolling.h */,
+				0C12EC692616383B00B66C86 /* shape_analysis.h */,
+				0C12EC6A2616383B00B66C86 /* fixup_trace_scope_blocks.h */,
+				0C12EC6B2616383B00B66C86 /* remove_exceptions.h */,
+				0C12EC6C2616383B00B66C86 /* inline_autodiff_subgraphs.h */,
+				0C12EC6D2616383B00B66C86 /* inplace_check.h */,
+				0C12EC6E2616383B00B66C86 /* cuda_graph_fuser.h */,
+				0C12EC6F2616383B00B66C86 /* pass_manager.h */,
+				0C12EC702616383B00B66C86 /* onnx.h */,
+				0C12EC712616383B00B66C86 /* xnnpack_rewrite.h */,
+				0C12EC722616383B00B66C86 /* lift_closures.h */,
+				0C12EC732616383B00B66C86 /* frozen_conv_add_relu_fusion.h */,
+				0C12EC742616383B00B66C86 /* lower_graph.h */,
+			);
+			path = passes;
+			sourceTree = "<group>";
+		};
+		0C12EC202616383B00B66C86 /* onnx */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EC212616383B00B66C86 /* eval_peephole.h */,
+				0C12EC222616383B00B66C86 /* function_substitution.h */,
+				0C12EC232616383B00B66C86 /* helper.h */,
+				0C12EC242616383B00B66C86 /* unpack_quantized_weights.h */,
+				0C12EC252616383B00B66C86 /* preprocess_for_onnx.h */,
+				0C12EC262616383B00B66C86 /* scalar_type_analysis.h */,
+				0C12EC272616383B00B66C86 /* shape_type_inference.h */,
+				0C12EC282616383B00B66C86 /* peephole.h */,
+				0C12EC292616383B00B66C86 /* eliminate_unused_items.h */,
+				0C12EC2A2616383B00B66C86 /* constant_fold.h */,
+				0C12EC2B2616383B00B66C86 /* constant_map.h */,
+				0C12EC2C2616383B00B66C86 /* fixup_onnx_controlflow.h */,
+				0C12EC2D2616383B00B66C86 /* cast_all_constant_to_floating.h */,
+				0C12EC2E2616383B00B66C86 /* fold_if_node.h */,
+				0C12EC2F2616383B00B66C86 /* list_model_parameters.h */,
+				0C12EC302616383B00B66C86 /* pattern_conversion */,
+				0C12EC342616383B00B66C86 /* remove_inplace_ops_for_onnx.h */,
+				0C12EC352616383B00B66C86 /* prepare_division_for_onnx.h */,
+			);
+			path = onnx;
+			sourceTree = "<group>";
+		};
+		0C12EC302616383B00B66C86 /* pattern_conversion */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EC312616383B00B66C86 /* common.h */,
+				0C12EC322616383B00B66C86 /* pattern_conversion.h */,
+				0C12EC332616383B00B66C86 /* pattern_encapsulation.h */,
+			);
+			path = pattern_conversion;
+			sourceTree = "<group>";
+		};
+		0C12EC422616383B00B66C86 /* utils */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EC432616383B00B66C86 /* memory_dag.h */,
+				0C12EC442616383B00B66C86 /* subgraph_utils.h */,
+				0C12EC452616383B00B66C86 /* check_alias_annotation.h */,
+			);
+			path = utils;
+			sourceTree = "<group>";
+		};
+		0C12EC482616383B00B66C86 /* quantization */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EC492616383B00B66C86 /* helper.h */,
+				0C12EC4A2616383B00B66C86 /* quantization_type.h */,
+				0C12EC4B2616383B00B66C86 /* insert_observers.h */,
+				0C12EC4C2616383B00B66C86 /* dedup_module_uses.h */,
+				0C12EC4D2616383B00B66C86 /* quantization_patterns.h */,
+				0C12EC4E2616383B00B66C86 /* finalize.h */,
+				0C12EC4F2616383B00B66C86 /* insert_quant_dequant.h */,
+				0C12EC502616383B00B66C86 /* fusion_passes.h */,
+			);
+			path = quantization;
+			sourceTree = "<group>";
+		};
+		0C12EC752616383B00B66C86 /* docs */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = docs;
+			sourceTree = "<group>";
+		};
+		0C12EC762616383B00B66C86 /* codegen */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EC772616383B00B66C86 /* cuda */,
+				0C12ECAE2616383B00B66C86 /* fuser */,
+			);
+			path = codegen;
+			sourceTree = "<group>";
+		};
+		0C12EC772616383B00B66C86 /* cuda */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EC782616383B00B66C86 /* type.h */,
+				0C12EC792616383B00B66C86 /* executor_kernel_arg.h */,
+				0C12EC7A2616383B00B66C86 /* utils.h */,
+				0C12EC7B2616383B00B66C86 /* kernel_ir_printer.h */,
+				0C12EC7C2616383B00B66C86 /* tools */,
+				0C12EC7D2616383B00B66C86 /* index_compute.h */,
+				0C12EC7E2616383B00B66C86 /* transform_replay.h */,
+				0C12EC7F2616383B00B66C86 /* parser.h */,
+				0C12EC802616383B00B66C86 /* executor_utils.h */,
+				0C12EC812616383B00B66C86 /* manager.h */,
+				0C12EC822616383B00B66C86 /* scheduler.h */,
+				0C12EC832616383B00B66C86 /* lower_unroll.h */,
+				0C12EC842616383B00B66C86 /* runtime */,
+				0C12EC852616383B00B66C86 /* ir_printer.h */,
+				0C12EC862616383B00B66C86 /* lower_insert_syncs.h */,
+				0C12EC872616383B00B66C86 /* lower2device.h */,
+				0C12EC882616383B00B66C86 /* predicate_compute.h */,
+				0C12EC892616383B00B66C86 /* compute_at.h */,
+				0C12EC8A2616383B00B66C86 /* ir_all_nodes.h */,
+				0C12EC8B2616383B00B66C86 /* mutator.h */,
+				0C12EC8C2616383B00B66C86 /* docs */,
+				0C12EC8F2616383B00B66C86 /* fusion.h */,
+				0C12EC902616383B00B66C86 /* lower_loops.h */,
+				0C12EC912616383B00B66C86 /* interface.h */,
+				0C12EC922616383B00B66C86 /* arith.h */,
+				0C12EC932616383B00B66C86 /* kernel_cache.h */,
+				0C12EC942616383B00B66C86 /* codegen.h */,
+				0C12EC952616383B00B66C86 /* ir_utils.h */,
+				0C12EC962616383B00B66C86 /* lower_utils.h */,
+				0C12EC972616383B00B66C86 /* lower_index.h */,
+				0C12EC982616383B00B66C86 /* transform_rfactor.h */,
+				0C12EC992616383B00B66C86 /* transform_iter.h */,
+				0C12EC9A2616383B00B66C86 /* lower_alias_memory.h */,
+				0C12EC9B2616383B00B66C86 /* executor.h */,
+				0C12EC9C2616383B00B66C86 /* ir_graphviz.h */,
+				0C12EC9D2616383B00B66C86 /* ir_iostream.h */,
+				0C12EC9E2616383B00B66C86 /* partition.h */,
+				0C12EC9F2616383B00B66C86 /* shape_inference.h */,
+				0C12ECA02616383B00B66C86 /* kernel_ir_builder.h */,
+				0C12ECA12616383B00B66C86 /* instrumentation.h */,
+				0C12ECA22616383B00B66C86 /* kernel.h */,
+				0C12ECA32616383B00B66C86 /* dispatch.h */,
+				0C12ECA42616383B00B66C86 /* lower_validation.h */,
+				0C12ECA52616383B00B66C86 /* ir_internal_nodes.h */,
+				0C12ECA62616383B00B66C86 /* lower_thread_predicate.h */,
+				0C12ECA72616383B00B66C86 /* ir_interface_nodes.h */,
+				0C12ECA82616383B00B66C86 /* ir_cloner.h */,
+				0C12ECA92616383B00B66C86 /* ir_base_nodes.h */,
+				0C12ECAA2616383B00B66C86 /* executor_launch_params.h */,
+				0C12ECAB2616383B00B66C86 /* kernel_ir.h */,
+				0C12ECAC2616383B00B66C86 /* iter_visitor.h */,
+				0C12ECAD2616383B00B66C86 /* expr_evaluator.h */,
+			);
+			path = cuda;
+			sourceTree = "<group>";
+		};
+		0C12EC7C2616383B00B66C86 /* tools */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = tools;
+			sourceTree = "<group>";
+		};
+		0C12EC842616383B00B66C86 /* runtime */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = runtime;
+			sourceTree = "<group>";
+		};
+		0C12EC8C2616383B00B66C86 /* docs */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EC8D2616383B00B66C86 /* documentation.h */,
+				0C12EC8E2616383B00B66C86 /* images */,
+			);
+			path = docs;
+			sourceTree = "<group>";
+		};
+		0C12EC8E2616383B00B66C86 /* images */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = images;
+			sourceTree = "<group>";
+		};
+		0C12ECAE2616383B00B66C86 /* fuser */ = {
+			isa = PBXGroup;
+			children = (
+				0C12ECAF2616383B00B66C86 /* tensor_info.h */,
+				0C12ECB02616383B00B66C86 /* arg_spec.h */,
+				0C12ECB12616383B00B66C86 /* compiler.h */,
+				0C12ECB22616383B00B66C86 /* fallback.h */,
+				0C12ECB32616383B00B66C86 /* cpu */,
+				0C12ECB72616383B00B66C86 /* cuda */,
+				0C12ECBA2616383B00B66C86 /* partition_desc.h */,
+				0C12ECBB2616383B00B66C86 /* fused_kernel.h */,
+				0C12ECBC2616383B00B66C86 /* kernel_spec.h */,
+				0C12ECBD2616383B00B66C86 /* interface.h */,
+				0C12ECBE2616383B00B66C86 /* kernel_cache.h */,
+				0C12ECBF2616383B00B66C86 /* codegen.h */,
+				0C12ECC02616383B00B66C86 /* executor.h */,
+				0C12ECC12616383B00B66C86 /* tensor_desc.h */,
+			);
+			path = fuser;
+			sourceTree = "<group>";
+		};
+		0C12ECB32616383B00B66C86 /* cpu */ = {
+			isa = PBXGroup;
+			children = (
+				0C12ECB42616383B00B66C86 /* temp_file.h */,
+				0C12ECB52616383B00B66C86 /* fused_kernel.h */,
+				0C12ECB62616383B00B66C86 /* resource_strings.h */,
+			);
+			path = cpu;
+			sourceTree = "<group>";
+		};
+		0C12ECB72616383B00B66C86 /* cuda */ = {
+			isa = PBXGroup;
+			children = (
+				0C12ECB82616383B00B66C86 /* fused_kernel.h */,
+				0C12ECB92616383B00B66C86 /* resource_strings.h */,
+			);
+			path = cuda;
+			sourceTree = "<group>";
+		};
+		0C12ECC22616383B00B66C86 /* testing */ = {
+			isa = PBXGroup;
+			children = (
+				0C12ECC32616383B00B66C86 /* file_check.h */,
+				0C12ECC42616383B00B66C86 /* hooks_for_testing.h */,
+			);
+			path = testing;
+			sourceTree = "<group>";
+		};
+		0C12ECC62616383B00B66C86 /* mobile */ = {
+			isa = PBXGroup;
+			children = (
+				0C12ECC72616383B00B66C86 /* observer.h */,
+				0C12ECC82616383B00B66C86 /* sequential.h */,
+				0C12ECC92616383B00B66C86 /* interpreter.h */,
+				0C12ECCA2616383B00B66C86 /* export_data.h */,
+				0C12ECCB2616383B00B66C86 /* method.h */,
+				0C12ECCC2616383B00B66C86 /* optim */,
+				0C12ECCE2616383B00B66C86 /* import_data.h */,
+				0C12ECCF2616383B00B66C86 /* type_parser.h */,
+				0C12ECD02616383B00B66C86 /* import.h */,
+				0C12ECD12616383B00B66C86 /* module.h */,
+				0C12ECD22616383B00B66C86 /* function.h */,
+			);
+			path = mobile;
+			sourceTree = "<group>";
+		};
+		0C12ECCC2616383B00B66C86 /* optim */ = {
+			isa = PBXGroup;
+			children = (
+				0C12ECCD2616383B00B66C86 /* sgd.h */,
+			);
+			path = optim;
+			sourceTree = "<group>";
+		};
+		0C12ECD42616383B00B66C86 /* api */ = {
+			isa = PBXGroup;
+			children = (
+				0C12ECD52616383B00B66C86 /* function_impl.h */,
+				0C12ECD62616383B00B66C86 /* method.h */,
+				0C12ECD72616383B00B66C86 /* compilation_unit.h */,
+				0C12ECD82616383B00B66C86 /* object.h */,
+				0C12ECD92616383B00B66C86 /* module.h */,
+			);
+			path = api;
+			sourceTree = "<group>";
+		};
+		0C12ECDB2616383B00B66C86 /* api */ = {
+			isa = PBXGroup;
+			children = (
+				0C12ECDC2616383B00B66C86 /* include */,
+				0C12ED892616383C00B66C86 /* src */,
+			);
+			path = api;
+			sourceTree = "<group>";
+		};
+		0C12ECDC2616383B00B66C86 /* include */ = {
+			isa = PBXGroup;
+			children = (
+				0C12ECDD2616383B00B66C86 /* torch */,
+			);
+			path = include;
+			sourceTree = "<group>";
+		};
+		0C12ECDD2616383B00B66C86 /* torch */ = {
+			isa = PBXGroup;
+			children = (
+				0C12ECDE2616383B00B66C86 /* fft.h */,
+				0C12ECDF2616383B00B66C86 /* utils.h */,
+				0C12ECE02616383B00B66C86 /* version.h */,
+				0C12ECE12616383B00B66C86 /* nn */,
+				0C12ED3B2616383C00B66C86 /* python */,
+				0C12ED3D2616383C00B66C86 /* enum.h */,
+				0C12ED3E2616383C00B66C86 /* types.h */,
+				0C12ED3F2616383C00B66C86 /* all.h */,
+				0C12ED402616383C00B66C86 /* data.h */,
+				0C12ED412616383C00B66C86 /* arg.h */,
+				0C12ED422616383C00B66C86 /* optim */,
+				0C12ED4E2616383C00B66C86 /* serialize */,
+				0C12ED532616383C00B66C86 /* torch.h */,
+				0C12ED542616383C00B66C86 /* optim.h */,
+				0C12ED552616383C00B66C86 /* jit.h */,
+				0C12ED562616383C00B66C86 /* detail */,
+				0C12ED592616383C00B66C86 /* nn.h */,
+				0C12ED5A2616383C00B66C86 /* ordered_dict.h */,
+				0C12ED5B2616383C00B66C86 /* cuda.h */,
+				0C12ED5C2616383C00B66C86 /* autograd.h */,
+				0C12ED5D2616383C00B66C86 /* linalg.h */,
+				0C12ED5E2616383C00B66C86 /* special.h */,
+				0C12ED5F2616383C00B66C86 /* python.h */,
+				0C12ED602616383C00B66C86 /* serialize.h */,
+				0C12ED612616383C00B66C86 /* data */,
+				0C12ED882616383C00B66C86 /* expanding_array.h */,
+			);
+			path = torch;
+			sourceTree = "<group>";
+		};
+		0C12ECE12616383B00B66C86 /* nn */ = {
+			isa = PBXGroup;
+			children = (
+				0C12ECE22616383B00B66C86 /* options */,
+				0C12ECF82616383C00B66C86 /* utils.h */,
+				0C12ECF92616383C00B66C86 /* parallel */,
+				0C12ECFB2616383C00B66C86 /* pimpl-inl.h */,
+				0C12ECFC2616383C00B66C86 /* utils */,
+				0C12ED002616383C00B66C86 /* options.h */,
+				0C12ED012616383C00B66C86 /* functional.h */,
+				0C12ED022616383C00B66C86 /* modules.h */,
+				0C12ED032616383C00B66C86 /* pimpl.h */,
+				0C12ED042616383C00B66C86 /* module.h */,
+				0C12ED052616383C00B66C86 /* modules */,
+				0C12ED282616383C00B66C86 /* init.h */,
+				0C12ED292616383C00B66C86 /* cloneable.h */,
+				0C12ED2A2616383C00B66C86 /* functional */,
+			);
+			path = nn;
+			sourceTree = "<group>";
+		};
+		0C12ECE22616383B00B66C86 /* options */ = {
+			isa = PBXGroup;
+			children = (
+				0C12ECE32616383B00B66C86 /* normalization.h */,
+				0C12ECE42616383B00B66C86 /* rnn.h */,
+				0C12ECE52616383B00B66C86 /* distance.h */,
+				0C12ECE62616383B00B66C86 /* batchnorm.h */,
+				0C12ECE72616383B00B66C86 /* linear.h */,
+				0C12ECE82616383B00B66C86 /* instancenorm.h */,
+				0C12ECE92616383B00B66C86 /* vision.h */,
+				0C12ECEA2616383B00B66C86 /* transformercoder.h */,
+				0C12ECEB2616383B00B66C86 /* dropout.h */,
+				0C12ECEC2616383B00B66C86 /* upsampling.h */,
+				0C12ECED2616383B00B66C86 /* embedding.h */,
+				0C12ECEE2616383C00B66C86 /* fold.h */,
+				0C12ECEF2616383C00B66C86 /* activation.h */,
+				0C12ECF02616383C00B66C86 /* transformer.h */,
+				0C12ECF12616383C00B66C86 /* pooling.h */,
+				0C12ECF22616383C00B66C86 /* transformerlayer.h */,
+				0C12ECF32616383C00B66C86 /* adaptive.h */,
+				0C12ECF42616383C00B66C86 /* conv.h */,
+				0C12ECF52616383C00B66C86 /* padding.h */,
+				0C12ECF62616383C00B66C86 /* pixelshuffle.h */,
+				0C12ECF72616383C00B66C86 /* loss.h */,
+			);
+			path = options;
+			sourceTree = "<group>";
+		};
+		0C12ECF92616383C00B66C86 /* parallel */ = {
+			isa = PBXGroup;
+			children = (
+				0C12ECFA2616383C00B66C86 /* data_parallel.h */,
+			);
+			path = parallel;
+			sourceTree = "<group>";
+		};
+		0C12ECFC2616383C00B66C86 /* utils */ = {
+			isa = PBXGroup;
+			children = (
+				0C12ECFD2616383C00B66C86 /* rnn.h */,
+				0C12ECFE2616383C00B66C86 /* clip_grad.h */,
+				0C12ECFF2616383C00B66C86 /* convert_parameters.h */,
+			);
+			path = utils;
+			sourceTree = "<group>";
+		};
+		0C12ED052616383C00B66C86 /* modules */ = {
+			isa = PBXGroup;
+			children = (
+				0C12ED062616383C00B66C86 /* normalization.h */,
+				0C12ED072616383C00B66C86 /* utils.h */,
+				0C12ED082616383C00B66C86 /* rnn.h */,
+				0C12ED092616383C00B66C86 /* distance.h */,
+				0C12ED0A2616383C00B66C86 /* batchnorm.h */,
+				0C12ED0B2616383C00B66C86 /* linear.h */,
+				0C12ED0C2616383C00B66C86 /* instancenorm.h */,
+				0C12ED0D2616383C00B66C86 /* transformercoder.h */,
+				0C12ED0E2616383C00B66C86 /* _functions.h */,
+				0C12ED0F2616383C00B66C86 /* container */,
+				0C12ED1A2616383C00B66C86 /* dropout.h */,
+				0C12ED1B2616383C00B66C86 /* common.h */,
+				0C12ED1C2616383C00B66C86 /* upsampling.h */,
+				0C12ED1D2616383C00B66C86 /* embedding.h */,
+				0C12ED1E2616383C00B66C86 /* fold.h */,
+				0C12ED1F2616383C00B66C86 /* activation.h */,
+				0C12ED202616383C00B66C86 /* transformer.h */,
+				0C12ED212616383C00B66C86 /* pooling.h */,
+				0C12ED222616383C00B66C86 /* transformerlayer.h */,
+				0C12ED232616383C00B66C86 /* adaptive.h */,
+				0C12ED242616383C00B66C86 /* conv.h */,
+				0C12ED252616383C00B66C86 /* padding.h */,
+				0C12ED262616383C00B66C86 /* pixelshuffle.h */,
+				0C12ED272616383C00B66C86 /* loss.h */,
+			);
+			path = modules;
+			sourceTree = "<group>";
+		};
+		0C12ED0F2616383C00B66C86 /* container */ = {
+			isa = PBXGroup;
+			children = (
+				0C12ED102616383C00B66C86 /* named_any.h */,
+				0C12ED112616383C00B66C86 /* any_value.h */,
+				0C12ED122616383C00B66C86 /* modulelist.h */,
+				0C12ED132616383C00B66C86 /* moduledict.h */,
+				0C12ED142616383C00B66C86 /* sequential.h */,
+				0C12ED152616383C00B66C86 /* functional.h */,
+				0C12ED162616383C00B66C86 /* parameterlist.h */,
+				0C12ED172616383C00B66C86 /* parameterdict.h */,
+				0C12ED182616383C00B66C86 /* any.h */,
+				0C12ED192616383C00B66C86 /* any_module_holder.h */,
+			);
+			path = container;
+			sourceTree = "<group>";
+		};
+		0C12ED2A2616383C00B66C86 /* functional */ = {
+			isa = PBXGroup;
+			children = (
+				0C12ED2B2616383C00B66C86 /* normalization.h */,
+				0C12ED2C2616383C00B66C86 /* distance.h */,
+				0C12ED2D2616383C00B66C86 /* batchnorm.h */,
+				0C12ED2E2616383C00B66C86 /* linear.h */,
+				0C12ED2F2616383C00B66C86 /* instancenorm.h */,
+				0C12ED302616383C00B66C86 /* vision.h */,
+				0C12ED312616383C00B66C86 /* dropout.h */,
+				0C12ED322616383C00B66C86 /* upsampling.h */,
+				0C12ED332616383C00B66C86 /* embedding.h */,
+				0C12ED342616383C00B66C86 /* fold.h */,
+				0C12ED352616383C00B66C86 /* activation.h */,
+				0C12ED362616383C00B66C86 /* pooling.h */,
+				0C12ED372616383C00B66C86 /* conv.h */,
+				0C12ED382616383C00B66C86 /* padding.h */,
+				0C12ED392616383C00B66C86 /* pixelshuffle.h */,
+				0C12ED3A2616383C00B66C86 /* loss.h */,
+			);
+			path = functional;
+			sourceTree = "<group>";
+		};
+		0C12ED3B2616383C00B66C86 /* python */ = {
+			isa = PBXGroup;
+			children = (
+				0C12ED3C2616383C00B66C86 /* init.h */,
+			);
+			path = python;
+			sourceTree = "<group>";
+		};
+		0C12ED422616383C00B66C86 /* optim */ = {
+			isa = PBXGroup;
+			children = (
+				0C12ED432616383C00B66C86 /* rmsprop.h */,
+				0C12ED442616383C00B66C86 /* lbfgs.h */,
+				0C12ED452616383C00B66C86 /* optimizer.h */,
+				0C12ED462616383C00B66C86 /* adagrad.h */,
+				0C12ED472616383C00B66C86 /* sgd.h */,
+				0C12ED482616383C00B66C86 /* serialize.h */,
+				0C12ED492616383C00B66C86 /* adamw.h */,
+				0C12ED4A2616383C00B66C86 /* schedulers */,
+				0C12ED4D2616383C00B66C86 /* adam.h */,
+			);
+			path = optim;
+			sourceTree = "<group>";
+		};
+		0C12ED4A2616383C00B66C86 /* schedulers */ = {
+			isa = PBXGroup;
+			children = (
+				0C12ED4B2616383C00B66C86 /* lr_scheduler.h */,
+				0C12ED4C2616383C00B66C86 /* step_lr.h */,
+			);
+			path = schedulers;
+			sourceTree = "<group>";
+		};
+		0C12ED4E2616383C00B66C86 /* serialize */ = {
+			isa = PBXGroup;
+			children = (
+				0C12ED4F2616383C00B66C86 /* archive.h */,
+				0C12ED502616383C00B66C86 /* input-archive.h */,
+				0C12ED512616383C00B66C86 /* output-archive.h */,
+				0C12ED522616383C00B66C86 /* tensor.h */,
+			);
+			path = serialize;
+			sourceTree = "<group>";
+		};
+		0C12ED562616383C00B66C86 /* detail */ = {
+			isa = PBXGroup;
+			children = (
+				0C12ED572616383C00B66C86 /* static.h */,
+				0C12ED582616383C00B66C86 /* TensorDataContainer.h */,
+			);
+			path = detail;
+			sourceTree = "<group>";
+		};
+		0C12ED612616383C00B66C86 /* data */ = {
+			isa = PBXGroup;
+			children = (
+				0C12ED622616383C00B66C86 /* example.h */,
+				0C12ED632616383C00B66C86 /* dataloader_options.h */,
+				0C12ED642616383C00B66C86 /* datasets */,
+				0C12ED6C2616383C00B66C86 /* worker_exception.h */,
+				0C12ED6D2616383C00B66C86 /* dataloader.h */,
+				0C12ED6E2616383C00B66C86 /* detail */,
+				0C12ED722616383C00B66C86 /* samplers.h */,
+				0C12ED732616383C00B66C86 /* transforms */,
+				0C12ED792616383C00B66C86 /* samplers */,
+				0C12ED812616383C00B66C86 /* datasets.h */,
+				0C12ED822616383C00B66C86 /* transforms.h */,
+				0C12ED832616383C00B66C86 /* iterator.h */,
+				0C12ED842616383C00B66C86 /* dataloader */,
+			);
+			path = data;
+			sourceTree = "<group>";
+		};
+		0C12ED642616383C00B66C86 /* datasets */ = {
+			isa = PBXGroup;
+			children = (
+				0C12ED652616383C00B66C86 /* mnist.h */,
+				0C12ED662616383C00B66C86 /* shared.h */,
+				0C12ED672616383C00B66C86 /* map.h */,
+				0C12ED682616383C00B66C86 /* chunk.h */,
+				0C12ED692616383C00B66C86 /* stateful.h */,
+				0C12ED6A2616383C00B66C86 /* tensor.h */,
+				0C12ED6B2616383C00B66C86 /* base.h */,
+			);
+			path = datasets;
+			sourceTree = "<group>";
+		};
+		0C12ED6E2616383C00B66C86 /* detail */ = {
+			isa = PBXGroup;
+			children = (
+				0C12ED6F2616383C00B66C86 /* data_shuttle.h */,
+				0C12ED702616383C00B66C86 /* sequencers.h */,
+				0C12ED712616383C00B66C86 /* queue.h */,
+			);
+			path = detail;
+			sourceTree = "<group>";
+		};
+		0C12ED732616383C00B66C86 /* transforms */ = {
+			isa = PBXGroup;
+			children = (
+				0C12ED742616383C00B66C86 /* lambda.h */,
+				0C12ED752616383C00B66C86 /* stack.h */,
+				0C12ED762616383C00B66C86 /* collate.h */,
+				0C12ED772616383C00B66C86 /* tensor.h */,
+				0C12ED782616383C00B66C86 /* base.h */,
+			);
+			path = transforms;
+			sourceTree = "<group>";
+		};
+		0C12ED792616383C00B66C86 /* samplers */ = {
+			isa = PBXGroup;
+			children = (
+				0C12ED7A2616383C00B66C86 /* sequential.h */,
+				0C12ED7B2616383C00B66C86 /* custom_batch_request.h */,
+				0C12ED7C2616383C00B66C86 /* stream.h */,
+				0C12ED7D2616383C00B66C86 /* distributed.h */,
+				0C12ED7E2616383C00B66C86 /* serialize.h */,
+				0C12ED7F2616383C00B66C86 /* random.h */,
+				0C12ED802616383C00B66C86 /* base.h */,
+			);
+			path = samplers;
+			sourceTree = "<group>";
+		};
+		0C12ED842616383C00B66C86 /* dataloader */ = {
+			isa = PBXGroup;
+			children = (
+				0C12ED852616383C00B66C86 /* stateless.h */,
+				0C12ED862616383C00B66C86 /* stateful.h */,
+				0C12ED872616383C00B66C86 /* base.h */,
+			);
+			path = dataloader;
+			sourceTree = "<group>";
+		};
+		0C12ED892616383C00B66C86 /* src */ = {
+			isa = PBXGroup;
+			children = (
+				0C12ED8A2616383C00B66C86 /* nn */,
+				0C12ED8E2616383C00B66C86 /* python */,
+				0C12ED8F2616383C00B66C86 /* optim */,
+				0C12ED912616383C00B66C86 /* serialize */,
+				0C12ED922616383C00B66C86 /* data */,
+			);
+			path = src;
+			sourceTree = "<group>";
+		};
+		0C12ED8A2616383C00B66C86 /* nn */ = {
+			isa = PBXGroup;
+			children = (
+				0C12ED8B2616383C00B66C86 /* options */,
+				0C12ED8C2616383C00B66C86 /* modules */,
+			);
+			path = nn;
+			sourceTree = "<group>";
+		};
+		0C12ED8B2616383C00B66C86 /* options */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = options;
+			sourceTree = "<group>";
+		};
+		0C12ED8C2616383C00B66C86 /* modules */ = {
+			isa = PBXGroup;
+			children = (
+				0C12ED8D2616383C00B66C86 /* container */,
+			);
+			path = modules;
+			sourceTree = "<group>";
+		};
+		0C12ED8D2616383C00B66C86 /* container */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = container;
+			sourceTree = "<group>";
+		};
+		0C12ED8E2616383C00B66C86 /* python */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = python;
+			sourceTree = "<group>";
+		};
+		0C12ED8F2616383C00B66C86 /* optim */ = {
+			isa = PBXGroup;
+			children = (
+				0C12ED902616383C00B66C86 /* schedulers */,
+			);
+			path = optim;
+			sourceTree = "<group>";
+		};
+		0C12ED902616383C00B66C86 /* schedulers */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = schedulers;
+			sourceTree = "<group>";
+		};
+		0C12ED912616383C00B66C86 /* serialize */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = serialize;
+			sourceTree = "<group>";
+		};
+		0C12ED922616383C00B66C86 /* data */ = {
+			isa = PBXGroup;
+			children = (
+				0C12ED932616383C00B66C86 /* datasets */,
+				0C12ED942616383C00B66C86 /* samplers */,
+			);
+			path = data;
+			sourceTree = "<group>";
+		};
+		0C12ED932616383C00B66C86 /* datasets */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = datasets;
+			sourceTree = "<group>";
+		};
+		0C12ED942616383C00B66C86 /* samplers */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = samplers;
+			sourceTree = "<group>";
+		};
+		0C12ED962616383C00B66C86 /* generic */ = {
+			isa = PBXGroup;
+			children = (
+				0C12ED972616383C00B66C86 /* utils.h */,
+				0C12ED982616383C00B66C86 /* serialization.h */,
+				0C12ED992616383C00B66C86 /* Storage.h */,
+			);
+			path = generic;
+			sourceTree = "<group>";
+		};
+		0C12ED9A2616383C00B66C86 /* tensor */ = {
+			isa = PBXGroup;
+			children = (
+				0C12ED9B2616383C00B66C86 /* python_tensor.h */,
+			);
+			path = tensor;
+			sourceTree = "<group>";
+		};
+		0C12EDAF2616383C00B66C86 /* ATen */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EDB02616383C00B66C86 /* Formatting.h */,
+				0C12EDB12616383C00B66C86 /* CPUFunctions.h */,
+				0C12EDB22616383C00B66C86 /* MetaFunctions.h */,
+				0C12EDB32616383C00B66C86 /* Utils.h */,
+				0C12EDB42616383C00B66C86 /* CUDAGeneratorImpl.h */,
+				0C12EDB52616383C00B66C86 /* TensorOptions.h */,
+				0C12EDB62616383C00B66C86 /* TensorUtils.h */,
+				0C12EDB72616383C00B66C86 /* MemoryOverlap.h */,
+				0C12EDB82616383C00B66C86 /* InitialTensorOptions.h */,
+				0C12EDB92616383C00B66C86 /* Version.h */,
+				0C12EDBA2616383C00B66C86 /* DLConvertor.h */,
+				0C12EDBB2616383C00B66C86 /* Device.h */,
+				0C12EDBC2616383C00B66C86 /* core */,
+				0C12EE0A2616383C00B66C86 /* VmapMode.h */,
+				0C12EE0B2616383C00B66C86 /* BatchedFallback.h */,
+				0C12EE0C2616383C00B66C86 /* dlpack.h */,
+				0C12EE0D2616383C00B66C86 /* Config.h */,
+				0C12EE0E2616383C00B66C86 /* SparseTensorUtils.h */,
+				0C12EE0F2616383C00B66C86 /* Backtrace.h */,
+				0C12EE102616383C00B66C86 /* cpu */,
+				0C12EE222616383C00B66C86 /* TracerMode.h */,
+				0C12EE232616383C00B66C86 /* Backend.h */,
+				0C12EE242616383C00B66C86 /* RegistrationDeclarations.h */,
+				0C12EE252616383C00B66C86 /* CompositeImplicitAutogradFunctions.h */,
+				0C12EE262616383C00B66C86 /* PTThreadPool.h */,
+				0C12EE272616383C00B66C86 /* OpaqueTensorImpl.h */,
+				0C12EE282616383C00B66C86 /* LegacyTHFunctionsCPU.h */,
+				0C12EE292616383C00B66C86 /* quantized */,
+				0C12EE2C2616383C00B66C86 /* record_function.h */,
+				0C12EE2D2616383C00B66C86 /* WrapDimUtils.h */,
+				0C12EE2E2616383C00B66C86 /* RedispatchFunctions.h */,
+				0C12EE2F2616383C00B66C86 /* Context.h */,
+				0C12EE302616383C00B66C86 /* div_rtn.h */,
+				0C12EE312616383C00B66C86 /* ExpandUtils.h */,
+				0C12EE322616383C00B66C86 /* TypeDefault.h */,
+				0C12EE332616383C00B66C86 /* CPUFixedAllocator.h */,
+				0C12EE342616383C00B66C86 /* NamedTensor.h */,
+				0C12EE352616383C00B66C86 /* Scalar.h */,
+				0C12EE362616383C00B66C86 /* ParallelNativeTBB.h */,
+				0C12EE372616383C00B66C86 /* ArrayRef.h */,
+				0C12EE382616383C00B66C86 /* SequenceNumber.h */,
+				0C12EE392616383C00B66C86 /* MatrixRef.h */,
+				0C12EE3A2616383C00B66C86 /* CompositeExplicitAutogradFunctions.h */,
+				0C12EE3B2616383C00B66C86 /* NumericUtils.h */,
+				0C12EE3C2616383C00B66C86 /* ATen.h */,
+				0C12EE3D2616383C00B66C86 /* TensorNames.h */,
+				0C12EE3E2616383C00B66C86 /* TensorMeta.h */,
+				0C12EE3F2616383C00B66C86 /* TensorIndexing.h */,
+				0C12EE402616383C00B66C86 /* Layout.h */,
+				0C12EE412616383C00B66C86 /* SparseTensorImpl.h */,
+				0C12EE422616383C00B66C86 /* detail */,
+				0C12EE462616383C00B66C86 /* WrapDimUtilsMulti.h */,
+				0C12EE472616383C00B66C86 /* TensorOperators.h */,
+				0C12EE482616383C00B66C86 /* ScalarType.h */,
+				0C12EE492616383C00B66C86 /* cpp_custom_type_hack.h */,
+				0C12EE4A2616383C00B66C86 /* VmapTransforms.h */,
+				0C12EE4B2616383C00B66C86 /* Storage.h */,
+				0C12EE4C2616383C00B66C86 /* DeviceGuard.h */,
+				0C12EE4D2616383C00B66C86 /* ParallelNative.h */,
+				0C12EE4E2616383C00B66C86 /* Dispatch.h */,
+				0C12EE4F2616383C00B66C86 /* CPUGeneratorImpl.h */,
+				0C12EE502616383C00B66C86 /* Functions.h */,
+				0C12EE512616383C00B66C86 /* ParallelOpenMP.h */,
+				0C12EE522616383C00B66C86 /* BatchedTensorImpl.h */,
+				0C12EE532616383C00B66C86 /* CPUApplyUtils.h */,
+				0C12EE542616383C00B66C86 /* ThreadLocalState.h */,
+				0C12EE552616383C00B66C86 /* ScalarOps.h */,
+				0C12EE562616383C00B66C86 /* NativeFunctions.h */,
+				0C12EE572616383C00B66C86 /* DynamicLibrary.h */,
+				0C12EE582616383C00B66C86 /* TensorGeometry.h */,
+				0C12EE592616383C00B66C86 /* TensorIterator.h */,
+				0C12EE5A2616383C00B66C86 /* NamedTensorUtils.h */,
+				0C12EE5B2616383C00B66C86 /* Dimname.h */,
+				0C12EE5C2616383C00B66C86 /* autocast_mode.h */,
+				0C12EE5D2616383C00B66C86 /* Parallel.h */,
+				0C12EE5E2616383C00B66C86 /* DimVector.h */,
+				0C12EE5F2616383C00B66C86 /* InferSize.h */,
+				0C12EE602616383C00B66C86 /* SmallVector.h */,
+				0C12EE612616383C00B66C86 /* Tensor.h */,
+				0C12EE622616383C00B66C86 /* Generator.h */,
+				0C12EE632616383C00B66C86 /* AccumulateType.h */,
+				0C12EE642616383C00B66C86 /* TensorAccessor.h */,
+				0C12EE652616383C00B66C86 /* LegacyTHFunctionsCUDA.h */,
+			);
+			path = ATen;
+			sourceTree = "<group>";
+		};
+		0C12EDBC2616383C00B66C86 /* core */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EDBD2616383C00B66C86 /* Dict_inl.h */,
+				0C12EDBE2616383C00B66C86 /* Formatting.h */,
+				0C12EDBF2616383C00B66C86 /* TensorBody.h */,
+				0C12EDC02616383C00B66C86 /* op_registration */,
+				0C12EDC52616383C00B66C86 /* jit_type_base.h */,
+				0C12EDC62616383C00B66C86 /* typeid.h */,
+				0C12EDC72616383C00B66C86 /* rref_interface.h */,
+				0C12EDC82616383C00B66C86 /* Range.h */,
+				0C12EDC92616383C00B66C86 /* interned_strings_class.h */,
+				0C12EDCA2616383C00B66C86 /* operator_name.h */,
+				0C12EDCB2616383C00B66C86 /* DeprecatedTypePropertiesRegistry.h */,
+				0C12EDCC2616383C00B66C86 /* Backtrace.h */,
+				0C12EDCD2616383C00B66C86 /* TransformationHelper.h */,
+				0C12EDCE2616383C00B66C86 /* blob.h */,
+				0C12EDCF2616383C00B66C86 /* function_schema.h */,
+				0C12EDD02616383C00B66C86 /* dispatch */,
+				0C12EDD82616383C00B66C86 /* MT19937RNGEngine.h */,
+				0C12EDD92616383C00B66C86 /* ivalue_to.h */,
+				0C12EDDA2616383C00B66C86 /* aten_interned_strings.h */,
+				0C12EDDB2616383C00B66C86 /* LegacyTypeDispatch.h */,
+				0C12EDDC2616383C00B66C86 /* function_schema_inl.h */,
+				0C12EDDD2616383C00B66C86 /* qualified_name.h */,
+				0C12EDDE2616383C00B66C86 /* UndefinedTensorImpl.h */,
+				0C12EDDF2616383C00B66C86 /* NamedTensor.h */,
+				0C12EDE02616383C00B66C86 /* Scalar.h */,
+				0C12EDE12616383C00B66C86 /* functional.h */,
+				0C12EDE22616383C00B66C86 /* DeprecatedTypeProperties.h */,
+				0C12EDE32616383C00B66C86 /* interned_strings.h */,
+				0C12EDE42616383C00B66C86 /* List.h */,
+				0C12EDE52616383C00B66C86 /* ATenOpList.h */,
+				0C12EDE62616383C00B66C86 /* Dict.h */,
+				0C12EDE72616383C00B66C86 /* grad_mode.h */,
+				0C12EDE82616383C00B66C86 /* DistributionsHelper.h */,
+				0C12EDE92616383C00B66C86 /* Macros.h */,
+				0C12EDEA2616383C00B66C86 /* VariableHooksInterface.h */,
+				0C12EDEB2616383C00B66C86 /* ScalarType.h */,
+				0C12EDEC2616383C00B66C86 /* Array.h */,
+				0C12EDED2616383C00B66C86 /* stack.h */,
+				0C12EDEE2616383C00B66C86 /* ATenGeneral.h */,
+				0C12EDEF2616383C00B66C86 /* UnsafeFromTH.h */,
+				0C12EDF02616383C00B66C86 /* QuantizerBase.h */,
+				0C12EDF12616383C00B66C86 /* alias_info.h */,
+				0C12EDF22616383C00B66C86 /* List_inl.h */,
+				0C12EDF32616383C00B66C86 /* jit_type.h */,
+				0C12EDF42616383C00B66C86 /* ivalue.h */,
+				0C12EDF52616383C00B66C86 /* Dimname.h */,
+				0C12EDF62616383C00B66C86 /* Vitals.h */,
+				0C12EDF72616383C00B66C86 /* boxing */,
+				0C12EE002616383C00B66C86 /* builtin_function.h */,
+				0C12EE012616383C00B66C86 /* DimVector.h */,
+				0C12EE022616383C00B66C86 /* Reduction.h */,
+				0C12EE032616383C00B66C86 /* Tensor.h */,
+				0C12EE042616383C00B66C86 /* function.h */,
+				0C12EE052616383C00B66C86 /* Generator.h */,
+				0C12EE062616383C00B66C86 /* PhiloxRNGEngine.h */,
+				0C12EE072616383C00B66C86 /* TensorAccessor.h */,
+				0C12EE082616383C00B66C86 /* ivalue_inl.h */,
+				0C12EE092616383C00B66C86 /* Variadic.h */,
+			);
+			path = core;
+			sourceTree = "<group>";
+		};
+		0C12EDC02616383C00B66C86 /* op_registration */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EDC12616383C00B66C86 /* adaption.h */,
+				0C12EDC22616383C00B66C86 /* op_allowlist.h */,
+				0C12EDC32616383C00B66C86 /* op_registration.h */,
+				0C12EDC42616383C00B66C86 /* infer_schema.h */,
+			);
+			path = op_registration;
+			sourceTree = "<group>";
+		};
+		0C12EDD02616383C00B66C86 /* dispatch */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EDD12616383C00B66C86 /* OperatorOptions.h */,
+				0C12EDD22616383C00B66C86 /* RegistrationHandleRAII.h */,
+				0C12EDD32616383C00B66C86 /* ObservedOperators.h */,
+				0C12EDD42616383C00B66C86 /* DispatchKeyExtractor.h */,
+				0C12EDD52616383C00B66C86 /* Dispatcher.h */,
+				0C12EDD62616383C00B66C86 /* CppSignature.h */,
+				0C12EDD72616383C00B66C86 /* OperatorEntry.h */,
+			);
+			path = dispatch;
+			sourceTree = "<group>";
+		};
+		0C12EDF72616383C00B66C86 /* boxing */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EDF82616383C00B66C86 /* impl */,
+				0C12EDFE2616383C00B66C86 /* KernelFunction.h */,
+				0C12EDFF2616383C00B66C86 /* KernelFunction_impl.h */,
+			);
+			path = boxing;
+			sourceTree = "<group>";
+		};
+		0C12EDF82616383C00B66C86 /* impl */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EDF92616383C00B66C86 /* make_boxed_from_unboxed_functor.h */,
+				0C12EDFA2616383C00B66C86 /* boxing.h */,
+				0C12EDFB2616383C00B66C86 /* test_helpers.h */,
+				0C12EDFC2616383C00B66C86 /* WrapFunctionIntoFunctor.h */,
+				0C12EDFD2616383C00B66C86 /* WrapFunctionIntoRuntimeFunctor.h */,
+			);
+			path = impl;
+			sourceTree = "<group>";
+		};
+		0C12EE102616383C00B66C86 /* cpu */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EE112616383C00B66C86 /* vec256 */,
+				0C12EE202616383C00B66C86 /* FlushDenormal.h */,
+				0C12EE212616383C00B66C86 /* vml.h */,
+			);
+			path = cpu;
+			sourceTree = "<group>";
+		};
+		0C12EE112616383C00B66C86 /* vec256 */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EE122616383C00B66C86 /* vec256_bfloat16.h */,
+				0C12EE132616383C00B66C86 /* vec256_float_neon.h */,
+				0C12EE142616383C00B66C86 /* missing_vst1_neon.h */,
+				0C12EE152616383C00B66C86 /* vec256_qint.h */,
+				0C12EE162616383C00B66C86 /* intrinsics.h */,
+				0C12EE172616383C00B66C86 /* functional.h */,
+				0C12EE182616383C00B66C86 /* vec256_complex_float.h */,
+				0C12EE192616383C00B66C86 /* vec256_double.h */,
+				0C12EE1A2616383C00B66C86 /* vec256_base.h */,
+				0C12EE1B2616383C00B66C86 /* vec256_float.h */,
+				0C12EE1C2616383C00B66C86 /* missing_vld1_neon.h */,
+				0C12EE1D2616383C00B66C86 /* vec256.h */,
+				0C12EE1E2616383C00B66C86 /* vec256_int.h */,
+				0C12EE1F2616383C00B66C86 /* vec256_complex_double.h */,
+			);
+			path = vec256;
+			sourceTree = "<group>";
+		};
+		0C12EE292616383C00B66C86 /* quantized */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EE2A2616383C00B66C86 /* QTensorImpl.h */,
+				0C12EE2B2616383C00B66C86 /* Quantizer.h */,
+			);
+			path = quantized;
+			sourceTree = "<group>";
+		};
+		0C12EE422616383C00B66C86 /* detail */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EE432616383C00B66C86 /* CUDAHooksInterface.h */,
+				0C12EE442616383C00B66C86 /* FunctionTraits.h */,
+				0C12EE452616383C00B66C86 /* HIPHooksInterface.h */,
+			);
+			path = detail;
+			sourceTree = "<group>";
+		};
+		0C12EE662616383C00B66C86 /* c10 */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EE672616383C00B66C86 /* benchmark */,
+				0C12EE682616383C00B66C86 /* core */,
+				0C12EE912616383C00B66C86 /* test */,
+				0C12EE982616383C00B66C86 /* util */,
+				0C12EEDA2616383C00B66C86 /* cuda */,
+				0C12EEE82616383C00B66C86 /* macros */,
+				0C12EEEC2616383C00B66C86 /* mobile */,
+				0C12EEEF2616383C00B66C86 /* hip */,
+			);
+			path = c10;
+			sourceTree = "<group>";
+		};
+		0C12EE672616383C00B66C86 /* benchmark */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = benchmark;
+			sourceTree = "<group>";
+		};
+		0C12EE682616383C00B66C86 /* core */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EE692616383C00B66C86 /* impl */,
+				0C12EE722616383C00B66C86 /* QEngine.h */,
+				0C12EE732616383C00B66C86 /* TensorOptions.h */,
+				0C12EE742616383C00B66C86 /* Device.h */,
+				0C12EE752616383C00B66C86 /* CPUAllocator.h */,
+				0C12EE762616383C00B66C86 /* DefaultDtype.h */,
+				0C12EE772616383C00B66C86 /* DefaultTensorOptions.h */,
+				0C12EE782616383C00B66C86 /* Event.h */,
+				0C12EE792616383C00B66C86 /* Backend.h */,
+				0C12EE7A2616383C00B66C86 /* CompileTimeFunctionPointer.h */,
+				0C12EE7B2616383C00B66C86 /* WrapDimMinimal.h */,
+				0C12EE7C2616383C00B66C86 /* QScheme.h */,
+				0C12EE7D2616383C00B66C86 /* Stream.h */,
+				0C12EE7E2616383C00B66C86 /* UndefinedTensorImpl.h */,
+				0C12EE7F2616383C00B66C86 /* Scalar.h */,
+				0C12EE802616383C00B66C86 /* thread_pool.h */,
+				0C12EE812616383C00B66C86 /* CopyBytes.h */,
+				0C12EE822616383C00B66C86 /* StreamGuard.h */,
+				0C12EE832616383C00B66C86 /* Layout.h */,
+				0C12EE842616383C00B66C86 /* GeneratorImpl.h */,
+				0C12EE852616383C00B66C86 /* DispatchKeySet.h */,
+				0C12EE862616383C00B66C86 /* Allocator.h */,
+				0C12EE872616383C00B66C86 /* TensorImpl.h */,
+				0C12EE882616383C00B66C86 /* ScalarType.h */,
+				0C12EE892616383C00B66C86 /* Storage.h */,
+				0C12EE8A2616383C00B66C86 /* DeviceType.h */,
+				0C12EE8B2616383C00B66C86 /* DeviceGuard.h */,
+				0C12EE8C2616383C00B66C86 /* StorageImpl.h */,
+				0C12EE8D2616383C00B66C86 /* MemoryFormat.h */,
+				0C12EE8E2616383C00B66C86 /* DispatchKey.h */,
+				0C12EE8F2616383C00B66C86 /* ScalarTypeToTypeMeta.h */,
+				0C12EE902616383C00B66C86 /* InferenceMode.h */,
+			);
+			path = core;
+			sourceTree = "<group>";
+		};
+		0C12EE692616383C00B66C86 /* impl */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EE6A2616383C00B66C86 /* InlineStreamGuard.h */,
+				0C12EE6B2616383C00B66C86 /* SizesAndStrides.h */,
+				0C12EE6C2616383C00B66C86 /* InlineDeviceGuard.h */,
+				0C12EE6D2616383C00B66C86 /* LocalDispatchKeySet.h */,
+				0C12EE6E2616383C00B66C86 /* VirtualGuardImpl.h */,
+				0C12EE6F2616383C00B66C86 /* InlineEvent.h */,
+				0C12EE702616383C00B66C86 /* DeviceGuardImplInterface.h */,
+				0C12EE712616383C00B66C86 /* FakeGuardImpl.h */,
+			);
+			path = impl;
+			sourceTree = "<group>";
+		};
+		0C12EE912616383C00B66C86 /* test */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EE922616383C00B66C86 /* core */,
+				0C12EE942616383C00B66C86 /* util */,
+			);
+			path = test;
+			sourceTree = "<group>";
+		};
+		0C12EE922616383C00B66C86 /* core */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EE932616383C00B66C86 /* impl */,
+			);
+			path = core;
+			sourceTree = "<group>";
+		};
+		0C12EE932616383C00B66C86 /* impl */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = impl;
+			sourceTree = "<group>";
+		};
+		0C12EE942616383C00B66C86 /* util */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EE952616383C00B66C86 /* complex_test_common.h */,
+				0C12EE962616383C00B66C86 /* complex_math_test_common.h */,
+				0C12EE972616383C00B66C86 /* Macros.h */,
+			);
+			path = util;
+			sourceTree = "<group>";
+		};
+		0C12EE982616383C00B66C86 /* util */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EE992616383C00B66C86 /* Type.h */,
+				0C12EE9A2616383C00B66C86 /* order_preserving_flat_hash_map.h */,
+				0C12EE9B2616383C00B66C86 /* reverse_iterator.h */,
+				0C12EE9C2616383C00B66C86 /* quint4x2.h */,
+				0C12EE9D2616383C00B66C86 /* Half.h */,
+				0C12EE9E2616383C00B66C86 /* flat_hash_map.h */,
+				0C12EE9F2616383C00B66C86 /* llvmMathExtras.h */,
+				0C12EEA02616383C00B66C86 /* math_compat.h */,
+				0C12EEA12616383C00B66C86 /* Bitset.h */,
+				0C12EEA22616383C00B66C86 /* typeid.h */,
+				0C12EEA32616383C00B66C86 /* intrusive_ptr.h */,
+				0C12EEA42616383C00B66C86 /* string_utils.h */,
+				0C12EEA52616383C00B66C86 /* win32-headers.h */,
+				0C12EEA62616383C00B66C86 /* AlignOf.h */,
+				0C12EEA72616383C00B66C86 /* numa.h */,
+				0C12EEA82616383C00B66C86 /* qint32.h */,
+				0C12EEA92616383C00B66C86 /* MaybeOwned.h */,
+				0C12EEAA2616383C00B66C86 /* Half-inl.h */,
+				0C12EEAB2616383C00B66C86 /* TypeTraits.h */,
+				0C12EEAC2616383C00B66C86 /* FunctionRef.h */,
+				0C12EEAD2616383C00B66C86 /* Backtrace.h */,
+				0C12EEAE2616383C00B66C86 /* BFloat16-inl.h */,
+				0C12EEAF2616383C00B66C86 /* in_place.h */,
+				0C12EEB02616383C00B66C86 /* ConstexprCrc.h */,
+				0C12EEB12616383C00B66C86 /* IdWrapper.h */,
+				0C12EEB22616383C00B66C86 /* Flags.h */,
+				0C12EEB32616383C00B66C86 /* overloaded.h */,
+				0C12EEB42616383C00B66C86 /* quint8.h */,
+				0C12EEB52616383C00B66C86 /* StringUtil.h */,
+				0C12EEB62616383C00B66C86 /* Logging.h */,
+				0C12EEB72616383C00B66C86 /* MathConstants.h */,
+				0C12EEB82616383C00B66C86 /* Registry.h */,
+				0C12EEB92616383C00B66C86 /* Optional.h */,
+				0C12EEBA2616383C00B66C86 /* tempfile.h */,
+				0C12EEBB2616383C00B66C86 /* ArrayRef.h */,
+				0C12EEBC2616383C00B66C86 /* thread_name.h */,
+				0C12EEBD2616383C00B66C86 /* Unicode.h */,
+				0C12EEBE2616383C00B66C86 /* TypeCast.h */,
+				0C12EEBF2616383C00B66C86 /* sparse_bitset.h */,
+				0C12EEC02616383C00B66C86 /* BFloat16.h */,
+				0C12EEC12616383C00B66C86 /* TypeList.h */,
+				0C12EEC22616383C00B66C86 /* TypeIndex.h */,
+				0C12EEC32616383C00B66C86 /* Array.h */,
+				0C12EEC42616383C00B66C86 /* logging_is_google_glog.h */,
+				0C12EEC52616383C00B66C86 /* Metaprogramming.h */,
+				0C12EEC62616383C00B66C86 /* either.h */,
+				0C12EEC72616383C00B66C86 /* BFloat16-math.h */,
+				0C12EEC82616383C00B66C86 /* Deprecated.h */,
+				0C12EEC92616383C00B66C86 /* irange.h */,
+				0C12EECA2616383C00B66C86 /* LeftRight.h */,
+				0C12EECB2616383C00B66C86 /* qint8.h */,
+				0C12EECC2616383C00B66C86 /* complex_math.h */,
+				0C12EECD2616383C00B66C86 /* logging_is_not_google_glog.h */,
+				0C12EECE2616383C00B66C86 /* Exception.h */,
+				0C12EECF2616383C00B66C86 /* UniqueVoidPtr.h */,
+				0C12EED02616383C00B66C86 /* ThreadLocalDebugInfo.h */,
+				0C12EED12616383C00B66C86 /* accumulate.h */,
+				0C12EED22616383C00B66C86 /* C++17.h */,
+				0C12EED32616383C00B66C86 /* SmallVector.h */,
+				0C12EED42616383C00B66C86 /* hash.h */,
+				0C12EED52616383C00B66C86 /* python_stub.h */,
+				0C12EED62616383C00B66C86 /* complex.h */,
+				0C12EED72616383C00B66C86 /* string_view.h */,
+				0C12EED82616383C00B66C86 /* variant.h */,
+				0C12EED92616383C00B66C86 /* complex_utils.h */,
+			);
+			path = util;
+			sourceTree = "<group>";
+		};
+		0C12EEDA2616383C00B66C86 /* cuda */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EEDB2616383C00B66C86 /* impl */,
+				0C12EEDE2616383C00B66C86 /* CUDAMathCompat.h */,
+				0C12EEDF2616383C00B66C86 /* test */,
+				0C12EEE12616383C00B66C86 /* CUDAStream.h */,
+				0C12EEE22616383C00B66C86 /* CUDAGuard.h */,
+				0C12EEE32616383C00B66C86 /* CUDAGraphsC10Utils.h */,
+				0C12EEE42616383C00B66C86 /* CUDAMacros.h */,
+				0C12EEE52616383C00B66C86 /* CUDAFunctions.h */,
+				0C12EEE62616383C00B66C86 /* CUDAException.h */,
+				0C12EEE72616383C00B66C86 /* CUDACachingAllocator.h */,
+			);
+			path = cuda;
+			sourceTree = "<group>";
+		};
+		0C12EEDB2616383C00B66C86 /* impl */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EEDC2616383C00B66C86 /* CUDATest.h */,
+				0C12EEDD2616383C00B66C86 /* CUDAGuardImpl.h */,
+			);
+			path = impl;
+			sourceTree = "<group>";
+		};
+		0C12EEDF2616383C00B66C86 /* test */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EEE02616383C00B66C86 /* impl */,
+			);
+			path = test;
+			sourceTree = "<group>";
+		};
+		0C12EEE02616383C00B66C86 /* impl */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = impl;
+			sourceTree = "<group>";
+		};
+		0C12EEE82616383C00B66C86 /* macros */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EEE92616383C00B66C86 /* cmake_macros.h */,
+				0C12EEEA2616383C00B66C86 /* Export.h */,
+				0C12EEEB2616383C00B66C86 /* Macros.h */,
+			);
+			path = macros;
+			sourceTree = "<group>";
+		};
+		0C12EEEC2616383C00B66C86 /* mobile */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EEED2616383C00B66C86 /* CPUCachingAllocator.h */,
+				0C12EEEE2616383C00B66C86 /* CPUProfilingAllocator.h */,
+			);
+			path = mobile;
+			sourceTree = "<group>";
+		};
+		0C12EEEF2616383C00B66C86 /* hip */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = hip;
+			sourceTree = "<group>";
+		};
+		0C12EEF22616383C00B66C86 /* fp16 */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EEF32616383C00B66C86 /* avx.py */,
+				0C12EEF42616383C00B66C86 /* __init__.py */,
+				0C12EEF52616383C00B66C86 /* fp16.h */,
+				0C12EEF62616383C00B66C86 /* avx2.py */,
+				0C12EEF72616383C00B66C86 /* psimd.h */,
+				0C12EEF82616383C00B66C86 /* bitcasts.h */,
+			);
+			path = fp16;
+			sourceTree = "<group>";
+		};
+		0C12EEF92616383C00B66C86 /* THCUNN */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EEFA2616383C00B66C86 /* generic */,
+			);
+			path = THCUNN;
+			sourceTree = "<group>";
+		};
+		0C12EEFA2616383C00B66C86 /* generic */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EEFB2616383C00B66C86 /* THCUNN.h */,
+			);
+			path = generic;
+			sourceTree = "<group>";
+		};
+		0C12EEFC2616383C00B66C86 /* TH */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EEFD2616383C00B66C86 /* THTensorDimApply.h */,
+				0C12EEFE2616383C00B66C86 /* THBlas.h */,
+				0C12EEFF2616383C00B66C86 /* THGenerateQUInt8Type.h */,
+				0C12EF002616383C00B66C86 /* THGenerateQInt8Type.h */,
+				0C12EF012616383C00B66C86 /* THGenerateComplexTypes.h */,
+				0C12EF022616383C00B66C86 /* THGenerateFloatType.h */,
+				0C12EF032616383C00B66C86 /* THGenerateQInt32Type.h */,
+				0C12EF042616383C00B66C86 /* THGenerateDoubleType.h */,
+				0C12EF052616383C00B66C86 /* THGenerateShortType.h */,
+				0C12EF062616383C00B66C86 /* THGenerateIntTypes.h */,
+				0C12EF072616383C00B66C86 /* THGenerateLongType.h */,
+				0C12EF082616383C00B66C86 /* THGenerateComplexFloatType.h */,
+				0C12EF092616383C00B66C86 /* THAllocator.h */,
+				0C12EF0A2616383C00B66C86 /* THGenerateCharType.h */,
+				0C12EF0B2616383C00B66C86 /* THStorage.h */,
+				0C12EF0C2616383C00B66C86 /* THHalf.h */,
+				0C12EF0D2616383C00B66C86 /* THGenerateHalfType.h */,
+				0C12EF0E2616383C00B66C86 /* THGenerateIntType.h */,
+				0C12EF0F2616383C00B66C86 /* THVector.h */,
+				0C12EF102616383C00B66C86 /* THGeneral.h */,
+				0C12EF112616383C00B66C86 /* THGenerateBoolType.h */,
+				0C12EF122616383C00B66C86 /* THLapack.h */,
+				0C12EF132616383C00B66C86 /* THGenerateComplexDoubleType.h */,
+				0C12EF142616383C00B66C86 /* THGenerateBFloat16Type.h */,
+				0C12EF152616383C00B66C86 /* THGenerateQTypes.h */,
+				0C12EF162616383C00B66C86 /* THGenerateFloatTypes.h */,
+				0C12EF172616383C00B66C86 /* generic */,
+				0C12EF292616383C00B66C86 /* THTensor.h */,
+				0C12EF2A2616383C00B66C86 /* TH.h */,
+				0C12EF2B2616383C00B66C86 /* THTensorApply.h */,
+				0C12EF2C2616383C00B66C86 /* THStorageFunctions.hpp */,
+				0C12EF2D2616383C00B66C86 /* THGenerateAllTypes.h */,
+				0C12EF2E2616383C00B66C86 /* THTensor.hpp */,
+				0C12EF2F2616383C00B66C86 /* THGenerateByteType.h */,
+				0C12EF302616383C00B66C86 /* THStorageFunctions.h */,
+				0C12EF312616383C00B66C86 /* THGenerateQUInt4x2Type.h */,
+			);
+			path = TH;
+			sourceTree = "<group>";
+		};
+		0C12EF172616383C00B66C86 /* generic */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EF182616383C00B66C86 /* THBlas.h */,
+				0C12EF192616383C00B66C86 /* THTensor.cpp */,
+				0C12EF1A2616383C00B66C86 /* THTensorMath.cpp */,
+				0C12EF1B2616383C00B66C86 /* THTensorMath.h */,
+				0C12EF1C2616383C00B66C86 /* THStorageCopy.cpp */,
+				0C12EF1D2616383C00B66C86 /* THTensorFastGetSet.hpp */,
+				0C12EF1E2616383C00B66C86 /* THStorage.h */,
+				0C12EF1F2616383C00B66C86 /* THTensorLapack.h */,
+				0C12EF202616383C00B66C86 /* THVector.h */,
+				0C12EF212616383C00B66C86 /* THLapack.cpp */,
+				0C12EF222616383C00B66C86 /* THStorageCopy.h */,
+				0C12EF232616383C00B66C86 /* THLapack.h */,
+				0C12EF242616383C00B66C86 /* THStorage.cpp */,
+				0C12EF252616383C00B66C86 /* THTensor.h */,
+				0C12EF262616383C00B66C86 /* THBlas.cpp */,
+				0C12EF272616383C00B66C86 /* THTensorLapack.cpp */,
+				0C12EF282616383C00B66C86 /* THTensor.hpp */,
+			);
+			path = generic;
+			sourceTree = "<group>";
+		};
+		0C12EF322616383C00B66C86 /* lib */ = {
+			isa = PBXGroup;
+			children = (
+				0C12EF332616383C00B66C86 /* libtorch_cpu.a */,
+				0C12EF342616383C00B66C86 /* libtorch.a */,
+				0C12EF352616383C00B66C86 /* libcpuinfo.a */,
+				0C12EF362616383C00B66C86 /* libXNNPACK.a */,
+				0C12EF372616383C00B66C86 /* libtorchvision_ops.a */,
+				0C12EF382616383C00B66C86 /* libpthreadpool.a */,
+				0C12EF392616383C00B66C86 /* libc10.a */,
+				0C12EF3A2616383C00B66C86 /* libeigen_blas.a */,
+				0C12EF3B2616383C00B66C86 /* libclog.a */,
+				0C12EF3C2616383C00B66C86 /* libpytorch_qnnpack.a */,
+			);
+			path = lib;
+			sourceTree = "<group>";
+		};
+		0C12EF6F26163A4C00B66C86 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		0CEB0AB226151A8800F1F7D5 = {
+			isa = PBXGroup;
+			children = (
+				0C12E7872616383A00B66C86 /* install */,
+				0CEB0ABD26151A8800F1F7D5 /* VisionTestApp */,
+				0CEB0ABC26151A8800F1F7D5 /* Products */,
+				0C12EF6F26163A4C00B66C86 /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		0CEB0ABC26151A8800F1F7D5 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				0CEB0ABB26151A8800F1F7D5 /* VisionTestApp.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		0CEB0ABD26151A8800F1F7D5 /* VisionTestApp */ = {
+			isa = PBXGroup;
+			children = (
+				0CEB0B3826152ED900F1F7D5 /* ModelRunner.h */,
+				0CEB0B3926152ED900F1F7D5 /* ModelRunner.mm */,
+				0CEB0ABE26151A8800F1F7D5 /* AppDelegate.h */,
+				0CEB0ABF26151A8800F1F7D5 /* AppDelegate.m */,
+				0CEB0AC426151A8800F1F7D5 /* ViewController.h */,
+				0CEB0AC526151A8800F1F7D5 /* ViewController.mm */,
+				0CEB0AC726151A8800F1F7D5 /* Main.storyboard */,
+				0CEB0ACA26151A8900F1F7D5 /* Assets.xcassets */,
+				0CEB0ACC26151A8900F1F7D5 /* LaunchScreen.storyboard */,
+				0CEB0ACF26151A8900F1F7D5 /* Info.plist */,
+				0CEB0AD026151A8900F1F7D5 /* main.m */,
+				0C12EF7526163B7600B66C86 /* frcnn_mnetv3.pt */,
+			);
+			path = VisionTestApp;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		0CEB0ABA26151A8800F1F7D5 /* VisionTestApp */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 0CEB0AEA26151A8900F1F7D5 /* Build configuration list for PBXNativeTarget "VisionTestApp" */;
+			buildPhases = (
+				0CEB0AB726151A8800F1F7D5 /* Sources */,
+				0CEB0AB826151A8800F1F7D5 /* Frameworks */,
+				0CEB0AB926151A8800F1F7D5 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = VisionTestApp;
+			productName = VisionTestApp;
+			productReference = 0CEB0ABB26151A8800F1F7D5 /* VisionTestApp.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		0CEB0AB326151A8800F1F7D5 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1240;
+				TargetAttributes = {
+					0CEB0ABA26151A8800F1F7D5 = {
+						CreatedOnToolsVersion = 12.4;
+					};
+				};
+			};
+			buildConfigurationList = 0CEB0AB626151A8800F1F7D5 /* Build configuration list for PBXProject "VisionTestApp" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 0CEB0AB226151A8800F1F7D5;
+			productRefGroup = 0CEB0ABC26151A8800F1F7D5 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				0CEB0ABA26151A8800F1F7D5 /* VisionTestApp */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		0CEB0AB926151A8800F1F7D5 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0C12EF3D2616383D00B66C86 /* avx.py in Resources */,
+				0CEB0ACE26151A8900F1F7D5 /* LaunchScreen.storyboard in Resources */,
+				0C12EF3F2616383D00B66C86 /* avx2.py in Resources */,
+				0C12EF7626163B7600B66C86 /* frcnn_mnetv3.pt in Resources */,
+				0CEB0ACB26151A8900F1F7D5 /* Assets.xcassets in Resources */,
+				0C12EF3E2616383D00B66C86 /* __init__.py in Resources */,
+				0CEB0AC926151A8800F1F7D5 /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		0CEB0AB726151A8800F1F7D5 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0CEB0AC626151A8800F1F7D5 /* ViewController.mm in Sources */,
+				0CEB0AC026151A8800F1F7D5 /* AppDelegate.m in Sources */,
+				0C12EF412616383D00B66C86 /* THTensorMath.cpp in Sources */,
+				0C12EF422616383D00B66C86 /* THStorageCopy.cpp in Sources */,
+				0C12EF462616383D00B66C86 /* THTensorLapack.cpp in Sources */,
+				0CEB0AD126151A8900F1F7D5 /* main.m in Sources */,
+				0C12EF432616383D00B66C86 /* THLapack.cpp in Sources */,
+				0C12EF402616383D00B66C86 /* THTensor.cpp in Sources */,
+				0C12EF442616383D00B66C86 /* THStorage.cpp in Sources */,
+				0CEB0B3A26152ED900F1F7D5 /* ModelRunner.mm in Sources */,
+				0C12EF452616383D00B66C86 /* THBlas.cpp in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXVariantGroup section */
+		0CEB0AC726151A8800F1F7D5 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				0CEB0AC826151A8800F1F7D5 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		0CEB0ACC26151A8900F1F7D5 /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				0CEB0ACD26151A8900F1F7D5 /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		0CEB0AE826151A8900F1F7D5 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_BITCODE = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				LIBRARY_SEARCH_PATHS = "";
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_LDFLAGS = "";
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		0CEB0AE926151A8900F1F7D5 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_BITCODE = NO;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				LIBRARY_SEARCH_PATHS = "";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				OTHER_LDFLAGS = "";
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		0CEB0AEB26151A8900F1F7D5 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				ENABLE_BITCODE = NO;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/install/include",
+				);
+				INFOPLIST_FILE = VisionTestApp/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/VisionTestApp",
+					"$(PROJECT_DIR)",
+					"$(PROJECT_DIR)/install/lib",
+				);
+				OTHER_LDFLAGS = (
+					"-all_load",
+					"$(inherited)",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.pytorch.ios.VisionTestApp.VisionTestApp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		0CEB0AEC26151A8900F1F7D5 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				ENABLE_BITCODE = NO;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/install/include",
+				);
+				INFOPLIST_FILE = VisionTestApp/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/VisionTestApp",
+					"$(PROJECT_DIR)",
+					"$(PROJECT_DIR)/install/lib",
+				);
+				OTHER_LDFLAGS = (
+					"-all_load",
+					"$(inherited)",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.pytorch.ios.VisionTestApp.VisionTestApp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		0CEB0AB626151A8800F1F7D5 /* Build configuration list for PBXProject "VisionTestApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0CEB0AE826151A8900F1F7D5 /* Debug */,
+				0CEB0AE926151A8900F1F7D5 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		0CEB0AEA26151A8900F1F7D5 /* Build configuration list for PBXNativeTarget "VisionTestApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0CEB0AEB26151A8900F1F7D5 /* Debug */,
+				0CEB0AEC26151A8900F1F7D5 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 0CEB0AB326151A8800F1F7D5 /* Project object */;
+}

--- a/ios/VisionTestApp/VisionTestApp.xcodeproj/project.pbxproj
+++ b/ios/VisionTestApp/VisionTestApp.xcodeproj/project.pbxproj
@@ -5829,8 +5829,26 @@
 					"$(PROJECT_DIR)/install/lib",
 				);
 				OTHER_LDFLAGS = (
-					"-all_load",
 					"$(inherited)",
+					"-ObjC",
+					"-l\"XNNPACK\"",
+					"-l\"c++\"",
+					"-l\"c10\"",
+					"-l\"clog\"",
+					"-l\"cpuinfo\"",
+					"-l\"eigen_blas\"",
+					"-l\"pthreadpool\"",
+					"-l\"pytorch_qnnpack\"",
+					"-l\"stdc++\"",
+					"-l\"torch\"",
+					"-l\"torch_cpu\"",
+					"-l\"torchvision_ops\"",
+					"-force_load",
+					"$(PROJECT_DIR)/install/lib/libtorch.a",
+					"-force_load",
+					"$(PROJECT_DIR)/install/lib/libtorch_cpu.a",
+					"-force_load",
+					"$(PROJECT_DIR)/install/lib/libtorchvision_ops.a",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.pytorch.ios.VisionTestApp.VisionTestApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -5861,8 +5879,26 @@
 					"$(PROJECT_DIR)/install/lib",
 				);
 				OTHER_LDFLAGS = (
-					"-all_load",
 					"$(inherited)",
+					"-ObjC",
+					"-l\"XNNPACK\"",
+					"-l\"c++\"",
+					"-l\"c10\"",
+					"-l\"clog\"",
+					"-l\"cpuinfo\"",
+					"-l\"eigen_blas\"",
+					"-l\"pthreadpool\"",
+					"-l\"pytorch_qnnpack\"",
+					"-l\"stdc++\"",
+					"-l\"torch\"",
+					"-l\"torch_cpu\"",
+					"-l\"torchvision_ops\"",
+					"-force_load",
+					"$(PROJECT_DIR)/install/lib/libtorch.a",
+					"-force_load",
+					"$(PROJECT_DIR)/install/lib/libtorch_cpu.a",
+					"-force_load",
+					"$(PROJECT_DIR)/install/lib/libtorchvision_ops.a",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.pytorch.ios.VisionTestApp.VisionTestApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/ios/VisionTestApp/VisionTestApp.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/ios/VisionTestApp/VisionTestApp.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/ios/VisionTestApp/VisionTestApp.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ios/VisionTestApp/VisionTestApp.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/ios/VisionTestApp/VisionTestApp/AppDelegate.h
+++ b/ios/VisionTestApp/VisionTestApp/AppDelegate.h
@@ -1,0 +1,7 @@
+#import <UIKit/UIKit.h>
+
+@interface AppDelegate : UIResponder <UIApplicationDelegate>
+
+@property(strong, nonatomic) UIWindow *window;
+
+@end

--- a/ios/VisionTestApp/VisionTestApp/AppDelegate.m
+++ b/ios/VisionTestApp/VisionTestApp/AppDelegate.m
@@ -1,0 +1,44 @@
+
+#import "AppDelegate.h"
+
+@interface AppDelegate ()
+
+@end
+
+@implementation AppDelegate
+
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+    // Override point for customization after application launch.
+    return YES;
+}
+
+
+- (void)applicationWillResignActive:(UIApplication *)application {
+    // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
+    // Use this method to pause ongoing tasks, disable timers, and invalidate graphics rendering callbacks. Games should use this method to pause the game.
+}
+
+
+- (void)applicationDidEnterBackground:(UIApplication *)application {
+    // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
+    // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
+}
+
+
+- (void)applicationWillEnterForeground:(UIApplication *)application {
+    // Called as part of the transition from the background to the active state; here you can undo many of the changes made on entering the background.
+}
+
+
+- (void)applicationDidBecomeActive:(UIApplication *)application {
+    // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
+}
+
+
+- (void)applicationWillTerminate:(UIApplication *)application {
+    // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
+}
+
+
+@end

--- a/ios/VisionTestApp/VisionTestApp/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/ios/VisionTestApp/VisionTestApp/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/VisionTestApp/VisionTestApp/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/ios/VisionTestApp/VisionTestApp/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/VisionTestApp/VisionTestApp/Assets.xcassets/Contents.json
+++ b/ios/VisionTestApp/VisionTestApp/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/VisionTestApp/VisionTestApp/Base.lproj/LaunchScreen.storyboard
+++ b/ios/VisionTestApp/VisionTestApp/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/ios/VisionTestApp/VisionTestApp/Base.lproj/Main.storyboard
+++ b/ios/VisionTestApp/VisionTestApp/Base.lproj/Main.storyboard
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="C8u-kp-ZGJ">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Test Vision Ops-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="gaT-0L-TqB">
+                                <rect key="frame" x="20" y="88" width="374" height="774"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <color key="textColor" systemColor="labelColor"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                            </textView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="gaT-0L-TqB" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="20" id="3b1-x4-VD4"/>
+                            <constraint firstItem="gaT-0L-TqB" firstAttribute="bottom" secondItem="6Tk-OE-BBY" secondAttribute="bottom" id="URh-hA-LJV"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="gaT-0L-TqB" secondAttribute="trailing" constant="20" id="avy-0f-meB"/>
+                            <constraint firstItem="gaT-0L-TqB" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" id="d1Q-UA-AUb"/>
+                        </constraints>
+                    </view>
+                    <navigationItem key="navigationItem" title="Test Vision Ops" id="QV8-E1-9z9">
+                        <barButtonItem key="rightBarButtonItem" title="Redo" id="ZQ5-yr-k4l">
+                            <connections>
+                                <action selector="rerun:" destination="BYZ-38-t0r" id="F5t-Nr-XmE"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
+                    <connections>
+                        <outlet property="textView" destination="gaT-0L-TqB" id="lMF-Rf-ics"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1047.8260869565217" y="137.94642857142856"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="LxF-da-Ea2">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="C8u-kp-ZGJ" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="SkD-La-Hwl">
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="BYZ-38-t0r" kind="relationship" relationship="rootViewController" id="s4b-GK-ujM"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="tCY-46-VMM" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="137.68115942028987" y="137.94642857142856"/>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="labelColor">
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/ios/VisionTestApp/VisionTestApp/Info.plist
+++ b/ios/VisionTestApp/VisionTestApp/Info.plist
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/ios/VisionTestApp/VisionTestApp/ModelRunner.h
+++ b/ios/VisionTestApp/VisionTestApp/ModelRunner.h
@@ -1,0 +1,13 @@
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ModelRunner : NSObject
+
++ (NSString* )run;
++ (BOOL)setUp;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/VisionTestApp/VisionTestApp/ModelRunner.mm
+++ b/ios/VisionTestApp/VisionTestApp/ModelRunner.mm
@@ -1,0 +1,73 @@
+
+#import "ModelRunner.h"
+#include <string>
+#include <vector>
+#include "ATen/ATen.h"
+#include "caffe2/core/timer.h"
+#include "caffe2/utils/string_utils.h"
+#include "torch/csrc/autograd/grad_mode.h"
+#include "torch/csrc/jit/serialization/import.h"
+#include "torch/script.h"
+
+static NSString *model_name = @"frcnn_mnetv3";
+static NSString *model_suffix = @"pt";
+static NSString *model_path = nil;
+static int warmup = 5;
+static int iter = 20;
+
+@implementation ModelRunner
+
++ (NSString *)run {
+  std::vector<std::string> logs;
+#define UI_LOG(fmt, ...)                                          \
+  {                                                               \
+    NSString* log = [NSString stringWithFormat:fmt, __VA_ARGS__]; \
+    NSLog(@"%@", log);                                            \
+    logs.push_back(log.UTF8String);                               \
+  }
+  
+  auto module = torch::jit::load(std::string(model_path.UTF8String));
+  module.eval();
+  
+  std::vector<c10::IValue> inputs;
+  auto img_tensor = torch::ones({3, 224, 224}, at::ScalarType::Float);
+  inputs.push_back(c10::List<at::Tensor>(img_tensor));
+  torch::autograd::AutoGradMode guard(false);
+  at::AutoNonVariableTypeMode nonVarTypeModeGuard(true);
+  
+  UI_LOG(@"Running warmup runs...", nil);
+  for (int i = 0; i < warmup; ++i) {
+    module.forward(inputs);
+  }
+  UI_LOG(@"Warmup runs finished.\nMain runs...", nil);
+  caffe2::Timer timer;
+  auto millis = timer.MilliSeconds();
+  for (int i = 0; i < iter; ++i) {
+    module.forward(inputs);
+  }
+  millis = timer.MilliSeconds();
+  UI_LOG(@"Main run finished. \nMilliseconds per iter: %.3f", millis / iter, nil);
+  UI_LOG(@"Iters per second: : %.3f", 1000.0 * iter / millis, nil);
+  UI_LOG(@"Done.", nil);
+  
+  std::cout << module.forward(inputs) << std::endl;
+  
+  NSString* log_text = @"";
+  for (auto& msg : logs) {
+    log_text = [log_text stringByAppendingString:[NSString stringWithUTF8String:msg.c_str()]];
+    log_text = [log_text stringByAppendingString:@"\n"];
+  }
+  return log_text;
+}
+
++ (BOOL)setUp {
+  model_path = [[NSBundle mainBundle] pathForResource:model_name ofType:model_suffix];
+  if (![[NSFileManager defaultManager] fileExistsAtPath:model_path]) {
+    NSLog(@"Invalid model path!");
+    model_path = nil;
+    return NO;
+  }
+  return YES;
+}
+
+@end

--- a/ios/VisionTestApp/VisionTestApp/ViewController.h
+++ b/ios/VisionTestApp/VisionTestApp/ViewController.h
@@ -1,0 +1,8 @@
+
+#import <UIKit/UIKit.h>
+
+@interface ViewController : UIViewController
+
+
+@end
+

--- a/ios/VisionTestApp/VisionTestApp/ViewController.mm
+++ b/ios/VisionTestApp/VisionTestApp/ViewController.mm
@@ -1,0 +1,44 @@
+
+#import "ViewController.h"
+#include <torch/script.h>
+#import "ModelRunner.h"
+
+@interface ViewController ()
+@property (weak, nonatomic) IBOutlet UITextView *textView;
+@end
+
+static NSString const *config_error_msg = @"Wrong model configurations... Please fix and click \"Redo\"";
+
+@implementation ViewController
+
+- (void)viewDidLoad {
+  [super viewDidLoad];
+  if ([ModelRunner setUp]) {
+    [self testModel];
+  } else {
+    self.textView.text = [config_error_msg copy];
+  }
+}
+
+
+- (IBAction)rerun:(id)sender {
+  self.textView.text = @"";
+  if (![ModelRunner setUp]) {
+    self.textView.text = [config_error_msg copy];
+    return;
+  }
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [self testModel];
+  });
+}
+
+- (void)testModel {
+  dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+    NSString *text = [ModelRunner run];
+    dispatch_async(dispatch_get_main_queue(), ^{
+      self.textView.text = [self.textView.text stringByAppendingString:text];
+    });
+  });
+}
+
+@end

--- a/ios/VisionTestApp/VisionTestApp/main.m
+++ b/ios/VisionTestApp/VisionTestApp/main.m
@@ -1,0 +1,18 @@
+//
+//  main.m
+//  VisionTestApp
+//
+//  Created by Yuchen Huang on 3/31/21.
+//
+
+#import <UIKit/UIKit.h>
+#import "AppDelegate.h"
+
+int main(int argc, char * argv[]) {
+  NSString * appDelegateClassName;
+  @autoreleasepool {
+      // Setup code that might create autoreleased objects goes here.
+      appDelegateClassName = NSStringFromClass([AppDelegate class]);
+  }
+  return UIApplicationMain(argc, argv, nil, appDelegateClassName);
+}

--- a/ios/VisionTestApp/clean.sh
+++ b/ios/VisionTestApp/clean.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 set -ex -o pipefail
 
+TEST_APP_PATH=$(dirname $(realpath $0))
+cd ${TEST_APP_PATH}
+
 rm -rf ./install
 rm ./VisionTestApp/*.pt

--- a/ios/VisionTestApp/clean.sh
+++ b/ios/VisionTestApp/clean.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -ex -o pipefail
+
+rm -rf ./install
+rm ./VisionTestApp/*.pt

--- a/ios/VisionTestApp/make_assets.py
+++ b/ios/VisionTestApp/make_assets.py
@@ -1,0 +1,17 @@
+import torch
+import torchvision
+from torch.utils.mobile_optimizer import optimize_for_mobile
+
+print(torch.__version__)
+
+model = torchvision.models.detection.fasterrcnn_mobilenet_v3_large_320_fpn(
+    pretrained=True,
+    box_score_thresh=0.7,
+    rpn_post_nms_top_n_test=100,
+    rpn_score_thresh=0.4,
+    rpn_pre_nms_top_n_test=150)
+
+model.eval()
+script_model = torch.jit.script(model)
+opt_script_model = optimize_for_mobile(script_model)
+opt_script_model.save("VisionTestApp/frcnn_mnetv3.pt")

--- a/ios/VisionTestApp/setup.sh
+++ b/ios/VisionTestApp/setup.sh
@@ -4,6 +4,9 @@ set -ex -o pipefail
 echo ""
 echo "DIR: $(pwd)"
 
+TEST_APP_PATH=$(dirname $(realpath $0))
+cd ${TEST_APP_PATH}
+
 PYTORCH_IOS_NIGHTLY_NAME=libtorch_ios_nightly_build.zip
 VISION_IOS_NIGHTLY_NAME=libtorchvision_ops_ios_nightly_build.zip
 
@@ -27,4 +30,4 @@ rm -rf ./*.zip
 echo "Generating the vision model..."
 python ./make_assets.py
 
-echo "Done."
+echo "Finished project setups."

--- a/ios/VisionTestApp/setup.sh
+++ b/ios/VisionTestApp/setup.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -ex -o pipefail
+
+echo ""
+echo "DIR: $(pwd)"
+
+PYTORCH_IOS_NIGHTLY_NAME=libtorch_ios_nightly_build.zip
+VISION_IOS_NIGHTLY_NAME=libtorchvision_ops_ios_nightly_build.zip
+
+echo "Downloading torch libs and vision libs..."
+wget https://ossci-ios-build.s3.amazonaws.com/${PYTORCH_IOS_NIGHTLY_NAME}
+wget https://ossci-ios-build.s3.amazonaws.com/${VISION_IOS_NIGHTLY_NAME}
+
+mkdir -p ./library/torch
+mkdir -p ./library/vision
+
+echo "Unziping torch libs and vision libs..."
+unzip -d ./library/torch ./${PYTORCH_IOS_NIGHTLY_NAME}
+unzip -d ./library/vision ./${VISION_IOS_NIGHTLY_NAME}
+
+cp ./library/vision/install/lib/*.a ./library/torch/install/lib
+cp -r ./library/torch/install .
+
+rm -rf ./library
+rm -rf ./*.zip
+
+echo "Generating the vision model..."
+python ./make_assets.py
+
+echo "Done."


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#3629 [iOS] added VisionTestApp for testing vision ops**

### How to build & run the test app via Xcode
- `cd` to `ios/VisionTestApp`
- run `./setup.sh` (this step requires your `wget` is pre-installed and make sure your Python torch and Python vision are up to date so that the model is able to be generated)
- open `VisionTestApp.xcodeproj` using Xcode
- build & run (supports both simulators and real devices)
- check if the benchmark results can be displayed on the view
- if you want to check in some code, make sure you run `./clean.sh` before commit so that the model file and static libs will not be committed