### PR TITLE
packaging: Remove pin for jpeg, numpy

### DIFF
--- a/packaging/torchvision/meta.yaml
+++ b/packaging/torchvision/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - libpng
     - ffmpeg >=4.2  # [not win]
     - jpeg
-    - pillow >=4.1.1
+    - pillow >=5.3.0
     {{ environ.get('CONDA_PYTORCH_CONSTRAINT') }}
     {{ environ.get('CONDA_CUDATOOLKIT_CONSTRAINT') }}
 

--- a/packaging/torchvision/meta.yaml
+++ b/packaging/torchvision/meta.yaml
@@ -9,14 +9,13 @@ requirements:
   build:
     - {{ compiler('c') }} # [win]
     - libpng
-    - jpeg <=9b
+    - jpeg
     # NOTE: The only ffmpeg version that we build is actually 4.2
     - ffmpeg >=4.2  # [not win]
 
   host:
     - python
     - setuptools
-    - defaults::numpy >=1.11
     {{ environ.get('CONDA_PYTORCH_BUILD_CONSTRAINT') }}
     {{ environ.get('CONDA_CUDATOOLKIT_CONSTRAINT') }}
     {{ environ.get('CONDA_CPUONLY_FEATURE') }}
@@ -25,9 +24,8 @@ requirements:
     - python
     - libpng
     - ffmpeg >=4.2  # [not win]
-    - jpeg <=9b
+    - jpeg
     - pillow >=4.1.1
-    - defaults::numpy >=1.11
     {{ environ.get('CONDA_PYTORCH_CONSTRAINT') }}
     {{ environ.get('CONDA_CUDATOOLKIT_CONSTRAINT') }}
 
@@ -53,7 +51,7 @@ test:
     - pytest
     - scipy
     - av >=8.0.1
-    - jpeg <=9b
+    - jpeg
     - ca-certificates
 
 


### PR DESCRIPTION
These may no longer be necessary due to the default anaconda channel
having the necessary packages now.

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>