### PR TITLE
Unify onnx and JIT resize implementations

### DIFF
--- a/torchvision/models/detection/transform.py
+++ b/torchvision/models/detection/transform.py
@@ -35,11 +35,10 @@ def _resize_image_and_masks_onnx(image, self_min_size, self_max_size, target):
 def _resize_image_and_masks(image, self_min_size, self_max_size, target):
     # type: (Tensor, float, float, Optional[Dict[str, Tensor]]) -> Tuple[Tensor, Optional[Dict[str, Tensor]]]
     im_shape = torch.tensor(image.shape[-2:])
-    min_size = float(torch.min(im_shape))
-    max_size = float(torch.max(im_shape))
-    scale_factor = self_min_size / min_size
-    if max_size * scale_factor > self_max_size:
-        scale_factor = self_max_size / max_size
+    min_size = torch.min(im_shape).to(dtype=torch.float32)
+    max_size = torch.max(im_shape).to(dtype=torch.float32)
+    scale_factor = torch.min(self_min_size / min_size, self_max_size / max_size).item()
+
     image = torch.nn.functional.interpolate(
         image[None], scale_factor=scale_factor, mode='bilinear', recompute_scale_factor=True,
         align_corners=False)[0]


### PR DESCRIPTION
This PR unifies the two separate implementations of resize used by ONNX and JIT. 

Unfortunately a workaround is necessary related to how we handle the `scale_factor` because:
- The interpolate method needs it to be a float.
- ONNX needs it to be a tensor so that the variable is in the computation graph.
- JIT complains about its type if ONNX passes a tensor.

To resolve the problem we introduce a conditional fake cast to fool JIT and stop it from complaining about the ONNX branch.