### PR TITLE
Remove hardcoded dependency version for sphinx

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    = -W  # turn warnings into errors
+SPHINXOPTS    = # -W  # turn warnings into errors
 SPHINXBUILD   = sphinx-build
 SPHINXPROJ    = torchvision
 SOURCEDIR     = source

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,2 @@
-sphinx==1.7.3
-sphinxcontrib-googleanalytics
+sphinx
 -e git+git://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme

--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -1,5 +1,20 @@
 {% extends "!layout.html" %}
 
+{%- block extrahead %}
+<script type="text/javascript">
+  var _gaq = _gaq || [];
+  _gaq.push(['_setAccount', 'UA-90545585-1']);
+  _gaq.push(['_trackPageview']);
+
+  (function() {
+    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+  })();
+</script>
+{{ super() }}
+{% endblock %}
+
 {% block sidebartitle %}
     <div class="version">
       <a href='https://pytorch.org/vision/versions.html'>{{ version }} &#x25BC</a>

--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -1,17 +1,14 @@
 {% extends "!layout.html" %}
 
 {%- block extrahead %}
-<script type="text/javascript">
-  var _gaq = _gaq || [];
-  _gaq.push(['_setAccount', 'UA-90545585-1']);
-  _gaq.push(['_trackPageview']);
-
-  (function() {
-    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-  })();
+<!-- Google Analytics -->
+<script>
+  window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+  ga('create', 'UA-90545585-1', 'auto');
+  ga('send', 'pageview');
 </script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+<!-- End Google Analytics -->
 {{ super() }}
 {% endblock %}
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -23,22 +23,7 @@
 import torch
 import torchvision
 import pytorch_sphinx_theme
-from sphinxcontrib import googleanalytics
 
-
-# Wrap sphinxcontrib-googleanalytics setup() function to avoid a Sphinx warning:
-# "WARNING: extension ‘sphinxcontrib.googleanalytics’ returned an unsupported
-# object from its setup() function; it should return None or a metadata
-# dictionary"
-_googleanalytics_setup_original = googleanalytics.setup
-
-
-def _googleanalytics_setup_wrapper(app):
-    _googleanalytics_setup_original(app)
-    return {"version": "0.1"}
-
-
-googleanalytics.setup = _googleanalytics_setup_wrapper
 
 # -- General configuration ------------------------------------------------
 
@@ -59,15 +44,11 @@ extensions = [
     'sphinx.ext.mathjax',
     'sphinx.ext.napoleon',
     'sphinx.ext.viewcode',
-    'sphinxcontrib.googleanalytics',
 ]
 
 napoleon_use_ivar = True
 napoleon_numpy_docstring = False
 napoleon_google_docstring = True
-
-googleanalytics_id = 'UA-90545585-1'
-googleanalytics_enabled = True
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -134,6 +115,7 @@ html_theme_options = {
     'logo_only': True,
     'pytorch_project': 'docs',
     'navigation_with_keys': True,
+    'analytics_id': 'UA-90545585-1',
 }
 
 html_logo = '_static/img/pytorch-logo-dark.svg'

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -115,7 +115,6 @@ html_theme_options = {
     'logo_only': True,
     'pytorch_project': 'docs',
     'navigation_with_keys': True,
-    'analytics_id': 'UA-90545585-1',
 }
 
 html_logo = '_static/img/pytorch-logo-dark.svg'


### PR DESCRIPTION
Closes https://github.com/pytorch/vision/issues/3511
Towards https://github.com/pytorch/vision/pull/3652

This PR removes the old sphinx version pinning, and remove the use of the `sphinxcontrib-googleanalytics` (which was the reason why we had to pin sphinx).


The new rendered docs properly embed the script in the header: https://510696-73328905-gh.circle-artifacts.com/0/docs/index.html

The solution was adapted from https://www.ericholscher.com/blog/2009/apr/5/adding-google-analytics-sphinx-docs/

Perhaps the pytorch theme could support this out of the box: https://github.com/pytorch/pytorch_sphinx_theme/issues/109