### PR TITLE
Put back error on warnings for sphinx

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    = # -W  # turn warnings into errors
+SPHINXOPTS    = -W  # turn warnings into errors
 SPHINXBUILD   = sphinx-build
 SPHINXPROJ    = torchvision
 SOURCEDIR     = source

--- a/torchvision/ops/deform_conv.py
+++ b/torchvision/ops/deform_conv.py
@@ -29,23 +29,20 @@ def deform_conv2d(
 
     Args:
         input (Tensor[batch_size, in_channels, in_height, in_width]): input tensor
-        offset (Tensor[batch_size, 2 * offset_groups * kernel_height * kernel_width,
-            out_height, out_width]): offsets to be applied for each position in the
-            convolution kernel.
-        weight (Tensor[out_channels, in_channels // groups, kernel_height, kernel_width]):
-            convolution weights, split into groups of size (in_channels // groups)
+        offset (Tensor[batch_size, 2 * offset_groups * kernel_height * kernel_width, out_height, out_width]):
+            offsets to be applied for each position in the convolution kernel.
+        weight (Tensor[out_channels, in_channels // groups, kernel_height, kernel_width]): convolution weights,
+            split into groups of size (in_channels // groups)
         bias (Tensor[out_channels]): optional bias of shape (out_channels,). Default: None
         stride (int or Tuple[int, int]): distance between convolution centers. Default: 1
         padding (int or Tuple[int, int]): height/width of padding of zeroes around
             each image. Default: 0
         dilation (int or Tuple[int, int]): the spacing between kernel elements. Default: 1
-        mask (Tensor[batch_size, offset_groups * kernel_height * kernel_width,
-            out_height, out_width]): masks to be applied for each position in the
-            convolution kernel. Default: None
+        mask (Tensor[batch_size, offset_groups * kernel_height * kernel_width, out_height, out_width]):
+            masks to be applied for each position in the convolution kernel. Default: None
 
     Returns:
         Tensor[batch_sz, out_channels, out_h, out_w]: result of convolution
-
 
     Examples::
         >>> input = torch.rand(4, 3, 10, 10)

--- a/torchvision/transforms/functional.py
+++ b/torchvision/transforms/functional.py
@@ -744,8 +744,8 @@ def adjust_brightness(img: Tensor, brightness_factor: float) -> Tensor:
 
     Args:
         img (PIL Image or Tensor): Image to be adjusted.
-        If img is torch Tensor, it is expected to be in [..., 1 or 3, H, W] format,
-        where ... means it can have an arbitrary number of leading dimensions.
+            If img is torch Tensor, it is expected to be in [..., 1 or 3, H, W] format,
+            where ... means it can have an arbitrary number of leading dimensions.
         brightness_factor (float):  How much to adjust the brightness. Can be
             any non negative number. 0 gives a black image, 1 gives the
             original image while 2 increases the brightness by a factor of 2.
@@ -764,8 +764,8 @@ def adjust_contrast(img: Tensor, contrast_factor: float) -> Tensor:
 
     Args:
         img (PIL Image or Tensor): Image to be adjusted.
-        If img is torch Tensor, it is expected to be in [..., 3, H, W] format,
-        where ... means it can have an arbitrary number of leading dimensions.
+            If img is torch Tensor, it is expected to be in [..., 3, H, W] format,
+            where ... means it can have an arbitrary number of leading dimensions.
         contrast_factor (float): How much to adjust the contrast. Can be any
             non negative number. 0 gives a solid gray image, 1 gives the
             original image while 2 increases the contrast by a factor of 2.
@@ -784,8 +784,8 @@ def adjust_saturation(img: Tensor, saturation_factor: float) -> Tensor:
 
     Args:
         img (PIL Image or Tensor): Image to be adjusted.
-        If img is torch Tensor, it is expected to be in [..., 3, H, W] format,
-        where ... means it can have an arbitrary number of leading dimensions.
+            If img is torch Tensor, it is expected to be in [..., 3, H, W] format,
+            where ... means it can have an arbitrary number of leading dimensions.
         saturation_factor (float):  How much to adjust the saturation. 0 will
             give a black and white image, 1 will give the original image while
             2 will enhance the saturation by a factor of 2.
@@ -815,9 +815,9 @@ def adjust_hue(img: Tensor, hue_factor: float) -> Tensor:
 
     Args:
         img (PIL Image or Tensor): Image to be adjusted.
-        If img is torch Tensor, it is expected to be in [..., 3, H, W] format,
-        where ... means it can have an arbitrary number of leading dimensions.
-        If img is PIL Image mode "1", "L", "I", "F" and modes with transparency (alpha channel) are not supported.
+            If img is torch Tensor, it is expected to be in [..., 3, H, W] format,
+            where ... means it can have an arbitrary number of leading dimensions.
+            If img is PIL Image mode "1", "L", "I", "F" and modes with transparency (alpha channel) are not supported.
         hue_factor (float):  How much to shift the hue channel. Should be in
             [-0.5, 0.5]. 0.5 and -0.5 give complete reversal of hue channel in
             HSV space in positive and negative direction respectively.
@@ -848,9 +848,9 @@ def adjust_gamma(img: Tensor, gamma: float, gain: float = 1) -> Tensor:
 
     Args:
         img (PIL Image or Tensor): PIL Image to be adjusted.
-        If img is torch Tensor, it is expected to be in [..., 1 or 3, H, W] format,
-        where ... means it can have an arbitrary number of leading dimensions.
-        If img is PIL Image, modes with transparency (alpha channel) are not supported.
+            If img is torch Tensor, it is expected to be in [..., 1 or 3, H, W] format,
+            where ... means it can have an arbitrary number of leading dimensions.
+            If img is PIL Image, modes with transparency (alpha channel) are not supported.
         gamma (float): Non negative real number, same as :math:`\gamma` in the equation.
             gamma larger than 1 make the shadows darker,
             while gamma smaller than 1 make dark regions lighter.
@@ -1286,8 +1286,8 @@ def adjust_sharpness(img: Tensor, sharpness_factor: float) -> Tensor:
 
     Args:
         img (PIL Image or Tensor): Image to be adjusted.
-        If img is torch Tensor, it is expected to be in [..., 1 or 3, H, W] format,
-        where ... means it can have an arbitrary number of leading dimensions.
+            If img is torch Tensor, it is expected to be in [..., 1 or 3, H, W] format,
+            where ... means it can have an arbitrary number of leading dimensions.
         sharpness_factor (float):  How much to adjust the sharpness. Can be
             any non negative number. 0 gives a blurred image, 1 gives the
             original image while 2 increases the sharpness by a factor of 2.


### PR DESCRIPTION
This PR puts back the "error  on warning " behaviour of shpinx which was temporarily deactivated in https://github.com/pytorch/vision/pull/3660, along with addition formatting fixes