### PR TITLE
Only sync cuda if cuda available

### DIFF
--- a/references/detection/engine.py
+++ b/references/detection/engine.py
@@ -84,7 +84,8 @@ def evaluate(model, data_loader, device):
     for images, targets in metric_logger.log_every(data_loader, 100, header):
         images = list(img.to(device) for img in images)
 
-        torch.cuda.synchronize()
+        if torch.cuda.is_available():
+            torch.cuda.synchronize()
         model_time = time.time()
         outputs = model(images)
 


### PR DESCRIPTION
This PR avoids calling `torch.cuda.synchronize()` if cuda is not available on the machine. This is to address https://github.com/pytorch/vision/issues/1204#issuecomment-647295646