### PR TITLE
[FBcode->GH] Fix torchvision_functional_tensor test_rgb2hsv

### DIFF
--- a/test/test_functional_tensor.py
+++ b/test/test_functional_tensor.py
@@ -166,7 +166,7 @@ class Tester(TransformsTester):
             self.assertLess(max_diff, 1e-5)
 
             s_hsv_img = scripted_fn(rgb_img)
-            self.assertTrue(hsv_img.allclose(s_hsv_img))
+            self.assertTrue(hsv_img.allclose(s_hsv_img, atol=1e-7))
 
         batch_tensors = self._create_data_batch(120, 100, num_samples=4, device=self.device).float()
         self._test_fn_on_batch(batch_tensors, F_t._rgb2hsv)


### PR DESCRIPTION
Summary:
The test is constantly failing: https://www.internalfb.com/intern/test/562949982577806?ref_report_id=0

The fix just adjusts `atol` from 1e-8 to 1e-7.

The equality test was likely failing on exact zeros

Reviewed By: fmassa

Differential Revision: D27790959

