### PR TITLE
Fix broken link in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ torchvision
     :target: https://pepy.tech/project/torchvision
 
 .. image:: https://img.shields.io/badge/dynamic/json.svg?label=docs&url=https%3A%2F%2Fpypi.org%2Fpypi%2Ftorchvision%2Fjson&query=%24.info.version&colorB=brightgreen&prefix=v
-    :target: https://pytorch.org/docs/stable/torchvision/index.html
+    :target: https://pytorch.org/vision/stable/index.html
 
 
 The torchvision package consists of popular datasets, model architectures, and common image transformations for computer vision.


### PR DESCRIPTION
Hi, it seems that the docs has beed migrated to https://pytorch.org/vision/stable/index.html, so I fixed it.

And this is a follow-up PR of #3691, I changed the link in the doc badge.