### PR TITLE
Add illustrations for CenterCrop and FiveCrop in gallery example

### DIFF
--- a/gallery/plot_transforms.py
+++ b/gallery/plot_transforms.py
@@ -17,7 +17,7 @@ import torchvision.transforms as T
 orig_img = Image.open(Path('assets') / 'astronaut.jpg')
 
 
-def plot(img, title="", with_orig=True, **kwargs):
+def plot(img, title: str = "", with_orig: bool = True, **kwargs):
     def _plot(img, title, **kwargs):
         plt.figure().suptitle(title, fontsize=25)
         plt.imshow(np.asarray(img), **kwargs)
@@ -50,8 +50,8 @@ plot(resized_img, "Resized image")
 # CenterCrop
 # ----------
 # The :class:`~torchvision.transforms.CenterCrop` transform
-# (see also :func:`~torchvision.transforms.functional.centercrop`)
-# Crops the image to center
+# (see also :func:`~torchvision.transforms.functional.center_crop`)
+# Crops the given image at the center.
 center_cropped_img = T.CenterCrop(size=(100, 100))(orig_img)
 plot(center_cropped_img, "Center Cropped Image")
 
@@ -60,10 +60,14 @@ plot(center_cropped_img, "Center Cropped Image")
 # FiveCrop
 # --------
 # The :class:`~torchvision.transforms.FiveCrop` transform
-# (see also :func:`~torchvision.transforms.functional.centercrop`)
-# Crop the given image into four corners and the centre crop.
-five_cropped_img = T.FiveCrop(size=(100, 100))(orig_img)
-plot(five_cropped_img, "Five Cropped Image")
+# (see also :func:`~torchvision.transforms.functional.five_crop`)
+# Crop the given image into four corners and the central crop.
+(img1, img2, img3, img4, img5) = T.FiveCrop(size=(100, 100))(orig_img)
+plot(img1, "Top Left Corner Image")
+plot(img2, "Top Right Corner Image", with_orig=False)
+plot(img3, "Bottom Left Corner Image", with_orig=False)
+plot(img4, "Bottom Right Corner Image", with_orig=False)
+plot(img5, "Center Image", with_orig=False)
 
 ####################################
 # ColorJitter

--- a/gallery/plot_transforms.py
+++ b/gallery/plot_transforms.py
@@ -47,6 +47,25 @@ resized_img = T.Resize(size=30)(orig_img)
 plot(resized_img, "Resized image")
 
 ####################################
+# CenterCrop
+# ----------
+# The :class:`~torchvision.transforms.CenterCrop` transform
+# (see also :func:`~torchvision.transforms.functional.centercrop`)
+# Crops the image to center
+center_cropped_img = T.CenterCrop(size=(100, 100))(orig_img)
+plot(center_cropped_img, "Center Cropped Image")
+
+
+####################################
+# FiveCrop
+# --------
+# The :class:`~torchvision.transforms.FiveCrop` transform
+# (see also :func:`~torchvision.transforms.functional.centercrop`)
+# Crop the given image into four corners and the centre crop.
+five_cropped_img = T.FiveCrop(size=(100, 100))(orig_img)
+plot(five_cropped_img, "Five Cropped Image")
+
+####################################
 # ColorJitter
 # -----------
 # The :class:`~torchvision.transforms.ColorJitter` transform

--- a/gallery/plot_transforms.py
+++ b/gallery/plot_transforms.py
@@ -51,7 +51,7 @@ plot(resized_img, "Resized image")
 # ----------
 # The :class:`~torchvision.transforms.CenterCrop` transform
 # (see also :func:`~torchvision.transforms.functional.center_crop`)
-# Crops the given image at the center.
+# crops the given image at the center.
 center_cropped_img = T.CenterCrop(size=(100, 100))(orig_img)
 plot(center_cropped_img, "Center Cropped Image")
 
@@ -61,7 +61,7 @@ plot(center_cropped_img, "Center Cropped Image")
 # --------
 # The :class:`~torchvision.transforms.FiveCrop` transform
 # (see also :func:`~torchvision.transforms.functional.five_crop`)
-# Crop the given image into four corners and the central crop.
+# crops the given image into four corners and the central crop.
 (img1, img2, img3, img4, img5) = T.FiveCrop(size=(100, 100))(orig_img)
 plot(img1, "Top Left Corner Image")
 plot(img2, "Top Right Corner Image", with_orig=False)
@@ -119,8 +119,8 @@ plot(affined_img, "Affine transformed image")
 # The :class:`~torchvision.transforms.RandomCrop` transform
 # (see also :func:`~torchvision.transforms.functional.crop`)
 # crops an image at a random location.
-crop = T.RandomCrop(size=(128, 128))(orig_img)
-plot(crop, "Random crop")
+crop_img = T.RandomCrop(size=(128, 128))(orig_img)
+plot(crop_img, "Random crop")
 
 ####################################
 # RandomResizedCrop
@@ -129,8 +129,8 @@ plot(crop, "Random crop")
 # (see also :func:`~torchvision.transforms.functional.resized_crop`)
 # crops an image at a random location, and then resizes the crop to a given
 # size.
-resized_crop = T.RandomResizedCrop(size=(32, 32))(orig_img)
-plot(resized_crop, "Random resized crop")
+resized_crop_img = T.RandomResizedCrop(size=(32, 32))(orig_img)
+plot(resized_crop_img, "Random resized crop")
 
 ####################################
 # RandomHorizontalFlip
@@ -142,8 +142,8 @@ plot(resized_crop, "Random resized crop")
 # .. note::
 #   Since the transform is applied randomly, the two images below may actually be
 #   the same.
-random_hflip = T.RandomHorizontalFlip(p=0.5)(orig_img)
-plot(random_hflip, "Random horizontal flip")
+random_hflip_img = T.RandomHorizontalFlip(p=0.5)(orig_img)
+plot(random_hflip_img, "Random horizontal flip")
 
 ####################################
 # RandomVerticalFlip
@@ -155,8 +155,8 @@ plot(random_hflip, "Random horizontal flip")
 # .. note::
 #   Since the transform is applied randomly, the two images below may actually be
 #   the same.
-random_vflip = T.RandomVerticalFlip(p=0.5)(orig_img)
-plot(random_vflip, "Random vertical flip")
+random_vflip_img = T.RandomVerticalFlip(p=0.5)(orig_img)
+plot(random_vflip_img, "Random vertical flip")
 
 ####################################
 # RandomApply
@@ -167,8 +167,8 @@ plot(random_vflip, "Random vertical flip")
 # .. note::
 #   Since the transform is applied randomly, the two images below may actually be
 #   the same.
-random_apply = T.RandomApply(transforms=[T.RandomCrop(size=(64, 64))], p=0.5)(orig_img)
-plot(random_apply, "Random Apply transform")
+random_apply_img = T.RandomApply(transforms=[T.RandomCrop(size=(64, 64))], p=0.5)(orig_img)
+plot(random_apply_img, "Random Apply transform")
 
 ####################################
 # GaussianBlur

--- a/gallery/plot_transforms.py
+++ b/gallery/plot_transforms.py
@@ -24,7 +24,7 @@ def plot(img, title: str = "", with_orig: bool = True, **kwargs):
         plt.axis('off')
 
     if with_orig:
-        _plot(orig_img, "Original image")
+        _plot(orig_img, "Original Image")
     _plot(img, title, **kwargs)
 
 
@@ -35,7 +35,7 @@ def plot(img, title: str = "", with_orig: bool = True, **kwargs):
 # (see also :func:`~torchvision.transforms.functional.pad`)
 # fills image borders with some pixel values.
 padded_img = T.Pad(padding=30)(orig_img)
-plot(padded_img, "Padded image")
+plot(padded_img, "Padded Image")
 
 ####################################
 # Resize
@@ -44,7 +44,7 @@ plot(padded_img, "Padded image")
 # (see also :func:`~torchvision.transforms.functional.resize`)
 # resizes an image.
 resized_img = T.Resize(size=30)(orig_img)
-plot(resized_img, "Resized image")
+plot(resized_img, "Resized Image")
 
 ####################################
 # CenterCrop
@@ -75,7 +75,7 @@ plot(img5, "Center Image", with_orig=False)
 # The :class:`~torchvision.transforms.ColorJitter` transform
 # randomly changes the brightness, saturation, and other properties of an image.
 jitted_img = T.ColorJitter(brightness=.5, hue=.3)(orig_img)
-plot(jitted_img, "Jitted image")
+plot(jitted_img, "Jitted Image")
 
 ####################################
 # Grayscale
@@ -84,7 +84,7 @@ plot(jitted_img, "Jitted image")
 # (see also :func:`~torchvision.transforms.functional.to_grayscale`)
 # converts an image to grayscale
 gray_img = T.Grayscale()(orig_img)
-plot(gray_img, "Grayscale image", cmap='gray')
+plot(gray_img, "Grayscale Image", cmap='gray')
 
 ####################################
 # RandomPerspective
@@ -93,7 +93,7 @@ plot(gray_img, "Grayscale image", cmap='gray')
 # (see also :func:`~torchvision.transforms.functional.perspective`)
 # performs random perspective transform on an image.
 perspectived_img = T.RandomPerspective(distortion_scale=0.6, p=1.0)(orig_img)
-plot(perspectived_img, "Perspective transformed image")
+plot(perspectived_img, "Perspective transformed Image")
 
 ####################################
 # RandomRotation
@@ -102,7 +102,7 @@ plot(perspectived_img, "Perspective transformed image")
 # (see also :func:`~torchvision.transforms.functional.rotate`)
 # rotates an image with random angle.
 rotated_img = T.RandomRotation(degrees=(30, 70))(orig_img)
-plot(rotated_img, "Rotated image")
+plot(rotated_img, "Rotated Image")
 
 ####################################
 # RandomAffine
@@ -111,7 +111,7 @@ plot(rotated_img, "Rotated image")
 # (see also :func:`~torchvision.transforms.functional.affine`)
 # performs random affine transform on an image.
 affined_img = T.RandomAffine(degrees=(30, 70), translate=(0.1, 0.3), scale=(0.5, 0.75))(orig_img)
-plot(affined_img, "Affine transformed image")
+plot(affined_img, "Affine transformed Image")
 
 ####################################
 # RandomCrop
@@ -120,7 +120,7 @@ plot(affined_img, "Affine transformed image")
 # (see also :func:`~torchvision.transforms.functional.crop`)
 # crops an image at a random location.
 crop_img = T.RandomCrop(size=(128, 128))(orig_img)
-plot(crop_img, "Random crop")
+plot(crop_img, "Random cropped Image")
 
 ####################################
 # RandomResizedCrop
@@ -130,7 +130,7 @@ plot(crop_img, "Random crop")
 # crops an image at a random location, and then resizes the crop to a given
 # size.
 resized_crop_img = T.RandomResizedCrop(size=(32, 32))(orig_img)
-plot(resized_crop_img, "Random resized crop")
+plot(resized_crop_img, "Random resized cropped Image")
 
 ####################################
 # RandomHorizontalFlip
@@ -143,7 +143,7 @@ plot(resized_crop_img, "Random resized crop")
 #   Since the transform is applied randomly, the two images below may actually be
 #   the same.
 random_hflip_img = T.RandomHorizontalFlip(p=0.5)(orig_img)
-plot(random_hflip_img, "Random horizontal flip")
+plot(random_hflip_img, "Random horizontal flipped Image")
 
 ####################################
 # RandomVerticalFlip
@@ -156,7 +156,7 @@ plot(random_hflip_img, "Random horizontal flip")
 #   Since the transform is applied randomly, the two images below may actually be
 #   the same.
 random_vflip_img = T.RandomVerticalFlip(p=0.5)(orig_img)
-plot(random_vflip_img, "Random vertical flip")
+plot(random_vflip_img, "Random vertical flipped Image")
 
 ####################################
 # RandomApply
@@ -168,7 +168,7 @@ plot(random_vflip_img, "Random vertical flip")
 #   Since the transform is applied randomly, the two images below may actually be
 #   the same.
 random_apply_img = T.RandomApply(transforms=[T.RandomCrop(size=(64, 64))], p=0.5)(orig_img)
-plot(random_apply_img, "Random Apply transform")
+plot(random_apply_img, "Random Apply transformed Image")
 
 ####################################
 # GaussianBlur
@@ -177,4 +177,4 @@ plot(random_apply_img, "Random Apply transform")
 # (see also :func:`~torchvision.transforms.functional.gaussian_blur`)
 # performs gaussianblur transform on an image.
 gaus_blur_img = T.GaussianBlur(kernel_size=(5, 9), sigma=(0.4, 3.0))(orig_img)
-plot(gaus_blur_img, "Gaussian Blur of image")
+plot(gaus_blur_img, "Gaussian Blurred Image")


### PR DESCRIPTION
Helps #3688

Rendered [Transform docs](https://530931-73328905-gh.circle-artifacts.com/0/docs/transforms.html#torchvision.transforms.CenterCrop)

Rendered [Gallery docs](https://530931-73328905-gh.circle-artifacts.com/0/docs/auto_examples/plot_transforms.html#centercrop)

Hope it is fine.

cc @NicolasHug 

