### PR TITLE
Show link to rendered docs -- follow up

### DIFF
--- a/.github/workflows/show_link_to_built_docs.yml
+++ b/.github/workflows/show_link_to_built_docs.yml
@@ -1,4 +1,4 @@
-name: Show CI job with links to build docs
+name: Show CI job with links to built docs
 
 on:
   status

--- a/.github/workflows/show_link_to_built_docs.yml
+++ b/.github/workflows/show_link_to_built_docs.yml
@@ -1,4 +1,4 @@
-name: See built docs here!
+name: Show CI job with links to build docs
 
 on:
   status

--- a/.github/workflows/show_link_to_built_docs.yml
+++ b/.github/workflows/show_link_to_built_docs.yml
@@ -14,3 +14,4 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           artifact-path: 0/docs/index.html
           circleci-jobs: build_docs
+          job-title: See the built docs here!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,7 +127,7 @@ Then open `docs/build/html/index.html` in your favorite browser.
 
 The docs are also automatically built when you submit a PR. The job that
 builds the docs is named `build_docs`. If that job passes, a link to the
-rendered docs will be available in the `build_docs artifact` job.
+rendered docs will be available in a job called `See the built docs here!`.
 
 ### New model
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,6 +125,10 @@ make html
 
 Then open `docs/build/html/index.html` in your favorite browser.
 
+The docs are also automatically built when you submit a PR. The job that
+builds the docs is named `build_docs`. If that job passes, a link to the
+rendered docs will be available in the `build_docs artifact` job.
+
 ### New model
 
 More details on how to add a new model will be provided later. Please, do not send any PR with a new model without discussing 


### PR DESCRIPTION
This is a follow up to https://github.com/pytorch/vision/pull/3711 to update the contributing guidelines, and change the title of the job.

The title is what appears in https://github.com/pytorch/vision/actions, not (as I thought it would) how the job will be named in the job GUI of the PRs. Now that https://github.com/larsoner/circleci-artifacts-redirector-action/pull/16 is merged we can properly set the name of the job as it renders on the PR GUI.