### PR TITLE
Remove leftover exception

### DIFF
--- a/test/test_models.py
+++ b/test/test_models.py
@@ -195,7 +195,6 @@ class ModelTester(TestCase):
                 # only the best way to assert results but also handles the cases
                 # where we need to create a new expected result.
                 self.assertExpected(output, name, prec=prec)
-                raise AssertionError
             except AssertionError:
                 # Unfortunately detection models are flaky due to the unstable sort
                 # in NMS. If matching across all outputs fails, use the same approach


### PR DESCRIPTION
There is an `AssertionError` exception left accidentally by #3697, which causes all the model scripts to be partially validated and then skipped. Probably was added there during development. This PR removes it.