### PR TITLE
Proper error message

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -375,7 +375,7 @@ def get_extensions():
 
             if not library_found:
                 print('{0} header files were not found, disabling ffmpeg '
-                      'support')
+                      'support'.format(library))
                 has_ffmpeg = False
 
     if has_ffmpeg:

--- a/setup.py
+++ b/setup.py
@@ -374,8 +374,7 @@ def get_extensions():
                 library_found |= len(glob.glob(full_path)) > 0
 
             if not library_found:
-                print('{0} header files were not found, disabling ffmpeg '
-                      'support'.format(library))
+                print(f'{library} header files were not found, disabling ffmpeg support')
                 has_ffmpeg = False
 
     if has_ffmpeg:


### PR DESCRIPTION
Now when there are missing ffmpeg libraries the error displayed is:
```
{0} header files were not found, disabling ffmpeg.
```
This is because the missing `.format`.

This PR fixes the warning message by appending the proper format operation.