### PR TITLE
Remove fakeroot dependency of Places365 in download tests

### DIFF
--- a/test/test_datasets_download.py
+++ b/test/test_datasets_download.py
@@ -23,7 +23,6 @@ from torchvision.datasets.utils import (
 )
 
 from common_utils import get_tmp_dir
-from fakedata_generation import places365_root
 
 
 def limit_requests_per_time(min_secs_between_requests=2.0):
@@ -221,14 +220,16 @@ def root():
 
 
 def places365():
-    with log_download_attempts(patch=False) as urls_and_md5s:
-        for split, small in itertools.product(("train-standard", "train-challenge", "val"), (False, True)):
-            with places365_root(split=split, small=small) as places365:
-                root, data = places365
-
-                datasets.Places365(root, split=split, small=small, download=True)
-
-    return make_download_configs(urls_and_md5s, name="Places365")
+    return itertools.chain(
+        *[
+            collect_download_configs(
+                lambda: datasets.Places365(ROOT, split=split, small=small, download=True),
+                name=f"Places365, {split}, {'small' if small else 'large'}",
+                file="places365",
+            )
+            for split, small in itertools.product(("train-standard", "train-challenge", "val"), (False, True))
+        ]
+    )
 
 
 def caltech101():


### PR DESCRIPTION
Supersedes #3719. #3705 ported the tests for `Places365` to the new architecture. The download tests however depended on parts of the old architecture and thus failed. This was not observed in the PR itself since the download tests are usually only ran on a schedule. 

This removes the dependency. Thus, #3705 can be reinstated after it was reverted in #3718.