### PR TITLE
Remove inconsistent FB copyright headers

### DIFF
--- a/test/cpp/test_custom_operators.cpp
+++ b/test/cpp/test_custom_operators.cpp
@@ -1,5 +1,3 @@
-// Copyright 2004-present Facebook. All Rights Reserved.
-
 #include <gtest/gtest.h>
 #include <torch/script.h>
 #include <torch/torch.h>

--- a/torchvision/csrc/io/decoder/stream.cpp
+++ b/torchvision/csrc/io/decoder/stream.cpp
@@ -17,7 +17,7 @@ Stream::Stream(
 
 Stream::~Stream() {
   if (frame_) {
-    av_free(frame_); // Copyright 2004-present Facebook. All Rights Reserved.
+    av_free(frame_);
   }
   if (codecCtx_) {
     avcodec_free_context(&codecCtx_);

--- a/torchvision/models/detection/anchor_utils.py
+++ b/torchvision/models/detection/anchor_utils.py
@@ -1,4 +1,3 @@
-# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
 import torch
 from torch import nn, Tensor
 

--- a/torchvision/models/detection/generalized_rcnn.py
+++ b/torchvision/models/detection/generalized_rcnn.py
@@ -1,4 +1,3 @@
-# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
 """
 Implements the Generalized R-CNN framework
 """

--- a/torchvision/models/detection/image_list.py
+++ b/torchvision/models/detection/image_list.py
@@ -1,4 +1,3 @@
-# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
 import torch
 from torch import Tensor
 from typing import List, Tuple

--- a/torchvision/models/detection/rpn.py
+++ b/torchvision/models/detection/rpn.py
@@ -1,4 +1,3 @@
-# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
 import torch
 from torch.nn import functional as F
 from torch import nn, Tensor

--- a/torchvision/ops/poolers.py
+++ b/torchvision/ops/poolers.py
@@ -1,4 +1,3 @@
-# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
 import torch
 from torch import nn, Tensor
 


### PR DESCRIPTION
There are some randomly placed FB copyright headers in the codebase. As discussed, these can be removed. 

This PR does not remove any copyright headers that are required because we incorporate code from other company projects.