### PR TITLE
Parametrize test_perspective

### DIFF
--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -419,3 +419,27 @@ def call_args_to_kwargs_only(call_args, *callable_or_arg_names):
     kwargs_only = kwargs.copy()
     kwargs_only.update(dict(zip(arg_names, args)))
     return kwargs_only
+
+
+def cpu_and_gpu():
+    import pytest  # noqa
+    # ignore CPU tests in RE as they're already covered by another contbuild
+    IN_RE_WORKER =  os.environ.get("INSIDE_RE_WORKER") is not None
+    IN_FBCODE = os.environ.get("IN_FBCODE_TORCHVISION") == "1"
+    CUDA_NOT_AVAILABLE_MSG = 'CUDA device not available'
+
+    devices = [] if IN_RE_WORKER else ['cpu']
+
+    if torch.cuda.is_available():
+        cuda_marks = ()
+    elif IN_FBCODE:
+        # Dont collect cuda tests on fbcode if the machine doesnt have a GPU
+        # This avoids skipping the tests. More robust would be to detect if
+        # we're in sancastle instead of fbcode?
+        cuda_marks = pytest.mark.dont_collect()
+    else:
+        cuda_marks = pytest.mark.skip(reason=CUDA_NOT_AVAILABLE_MSG)
+
+    devices.append(pytest.param('cuda', marks=cuda_marks))
+
+    return devices

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,14 @@
+def pytest_configure(config):
+    # register an additional marker (see pytest_collection_modifyitems)
+    config.addinivalue_line(
+        "markers", "dont_collect: marks a test that should not be collected (avoids skipping it)"
+    )
+
+
+def pytest_collection_modifyitems(items):
+    # This hook is called by pytest after it has collected the tests (google its name!)
+    # We can ignore some tests as we see fit here. In particular we ignore the tests that
+    # we have marked with the custom 'dont_collect' mark. This avoids skipping the tests,
+    # since the internal fb infra doesn't like skipping tests.
+    to_keep = [item for item in items if item.get_closest_marker('dont_collect') is None]
+    items[:] = to_keep


### PR DESCRIPTION
Summary:
This PR parametrizes the `perspective`-related tests, and avoids having deeply nested for-loops which will help debugging. "What" gets tested is left unchanged.

The newly-introduced `cpu_and_gpu()` generator along with the `dont_collect` mark is a logic that allows to not run CPU tests on GPU machines (and vice versa).

Differential Revision: D27908299

