### PR TITLE
Keep consistency in Classes ConvBNActivation

### DIFF
--- a/torchvision/models/mobilenetv2.py
+++ b/torchvision/models/mobilenetv2.py
@@ -46,7 +46,7 @@ class ConvBNActivation(nn.Sequential):
             norm_layer = nn.BatchNorm2d
         if activation_layer is None:
             activation_layer = nn.ReLU6
-        super(ConvBNReLU, self).__init__(
+        super(ConvBNActivation, self).__init__(
             nn.Conv2d(in_planes, out_planes, kernel_size, stride, padding, dilation=dilation, groups=groups,
                       bias=False),
             norm_layer(out_planes),

--- a/torchvision/models/mobilenetv2.py
+++ b/torchvision/models/mobilenetv2.py
@@ -46,7 +46,7 @@ class ConvBNActivation(nn.Sequential):
             norm_layer = nn.BatchNorm2d
         if activation_layer is None:
             activation_layer = nn.ReLU6
-        super(ConvBNActivation, self).__init__(
+        super().__init__(
             nn.Conv2d(in_planes, out_planes, kernel_size, stride, padding, dilation=dilation, groups=groups,
                       bias=False),
             norm_layer(out_planes),


### PR DESCRIPTION
It seems that the class `ConvBNReLU ` has been renamed to `ConvBNActivation`, but it still retains in the `super(ConvBNReLU, self).__init__()` method, it will make users a little confused, so I changed it to `ConvBNActivation` in this PR.

https://github.com/pytorch/vision/blob/54d88f79b44747e462dee7523fa17d24116bd783/torchvision/models/mobilenetv2.py#L32-L55