### PR TITLE
Clarify deformable conv2d doc

### DIFF
--- a/torchvision/ops/deform_conv.py
+++ b/torchvision/ops/deform_conv.py
@@ -50,7 +50,15 @@ def deform_conv2d(
         >>> weight = torch.rand(5, 3, kh, kw)
         >>> # offset and mask should have the same spatial size as the output
         >>> # of the convolution. In this case, for an input of 10, stride of 1
-        >>> # and kernel size of 3, without padding, the output size is 8
+        >>> # and kernel size of 3, without padding, the output size is 8.
+        >>> # For the simplest case, 1 channel 3x3 kernel, at each valid (consider padding) input feature position:
+        >>> # [[p0 p1 p2],
+        >>> #  [p3 p4 p5],
+        >>> #  [p6 p7 p8]]
+        >>> # The 18 corresponding offsets will be:
+        >>> # [p0_offset_h, p0_offset_w, p1_offset_h, p1_offset_w, p2_offset_h, ..., p8_offset_w]
+        >>> # ``_h`` means pixel offset in the height direction (i.e. p0 -> p6),
+        >>> # ``_w`` means pixel offset in the width direction (i.e. p0 -> p2).
         >>> offset = torch.rand(4, 2 * kh * kw, 8, 8)
         >>> mask = torch.rand(4, kh * kw, 8, 8)
         >>> out = deform_conv2d(input, offset, weight, mask=mask)


### PR DESCRIPTION
After some careful paper reading, I added an example to explain the offset formulation in torchvision's implementation.
Although I'm pretty sure it is correct, it still would be better if you/others can check this. @NicolasHug 

Also, I'm not sure it is the best looking way to express these in the doc...