### PR TITLE
Make crop work the same for pil and tensor

### DIFF
--- a/test/test_transforms_tensor.py
+++ b/test/test_transforms_tensor.py
@@ -188,6 +188,10 @@ class Tester(TransformsTester):
             'crop', 'RandomCrop', fn_kwargs=fn_kwargs, meth_kwargs=meth_kwargs
         )
 
+        # Test transforms.functional.crop including outside the image area
+        fn_kwargs = {"top": 7, "left": 8, "height": 4, "width": 5}
+        self._test_functional_op('crop', fn_kwargs=fn_kwargs)
+
         sizes = [5, [5, ], [6, 6]]
         padding_configs = [
             {"padding_mode": "constant", "fill": 0},

--- a/torchvision/transforms/functional_tensor.py
+++ b/torchvision/transforms/functional_tensor.py
@@ -122,7 +122,12 @@ def hflip(img: Tensor) -> Tensor:
 def crop(img: Tensor, top: int, left: int, height: int, width: int) -> Tensor:
     _assert_image_tensor(img)
 
-    return img[..., top:top + height, left:left + width]
+    w, h = _get_image_size(img)
+    right = left + width
+    bottom = top + height
+
+    padding = [max(-left, 0), max(-top, 0), max(right - w, 0), max(bottom - h, 0)]
+    return pad(img[..., top:top + height, left:left + width], padding)
 
 
 def rgb_to_grayscale(img: Tensor, num_output_channels: int = 1) -> Tensor:


### PR DESCRIPTION
In the `transforms.functional.crop`, if the cropping area is out of the image, in the case of pil, the box will be padded by zeros, whereas in the tensor, only the inside of the image will be returned.

See this [notebook](https://colab.research.google.com/drive/1r8SOPEF1Zv54WD-R2f_xLGOTHicmdH5N?usp=sharing).

In this PR `functional_tensor.crop` pad if needed.