### PR TITLE
Fix read timestamps from packets

### DIFF
--- a/torchvision/io/video.py
+++ b/torchvision/io/video.py
@@ -326,7 +326,11 @@ def read_video(
 
 
 def _can_read_timestamps_from_packets(container: "av.container.Container") -> bool:
-    extradata = container.streams[0].codec_context.extradata
+    codec_context = container.streams[0].codec_context
+    if codec_context is None:
+        return False
+    
+    extradata = codec_context.extradata
     if extradata is None:
         return False
     if b"Lavc" in extradata:


### PR DESCRIPTION
It happens to me that a video stream has a null `codec_context`.