### PR TITLE
Making protected params of MobileNetV3 public

### DIFF
--- a/torchvision/models/detection/ssdlite.py
+++ b/torchvision/models/detection/ssdlite.py
@@ -95,11 +95,9 @@ class SSDLiteRegressionHead(SSDScoringHead):
 
 
 class SSDLiteFeatureExtractorMobileNet(nn.Module):
-    def __init__(self, backbone: nn.Module, c4_pos: int, norm_layer: Callable[..., nn.Module], **kwargs: Any):
+    def __init__(self, backbone: nn.Module, c4_pos: int, norm_layer: Callable[..., nn.Module], width_mult: float = 1.0,
+                 min_depth: int = 16, **kwargs: Any):
         super().__init__()
-        # non-public config parameters
-        min_depth = kwargs.pop('_min_depth', 16)
-        width_mult = kwargs.pop('_width_mult', 1.0)
 
         assert not backbone[c4_pos].use_res_connect
         self.features = nn.Sequential(
@@ -197,7 +195,7 @@ def ssdlite320_mobilenet_v3_large(pretrained: bool = False, progress: bool = Tru
         norm_layer = partial(nn.BatchNorm2d, eps=0.001, momentum=0.03)
 
     backbone = _mobilenet_extractor("mobilenet_v3_large", progress, pretrained_backbone, trainable_backbone_layers,
-                                    norm_layer, _reduced_tail=reduce_tail, _width_mult=1.0)
+                                    norm_layer, reduced_tail=reduce_tail)
 
     size = (320, 320)
     anchor_generator = DefaultBoxGenerator([[2, 3] for _ in range(6)], min_ratio=0.2, max_ratio=0.95)

--- a/torchvision/models/detection/ssdlite.py
+++ b/torchvision/models/detection/ssdlite.py
@@ -195,7 +195,7 @@ def ssdlite320_mobilenet_v3_large(pretrained: bool = False, progress: bool = Tru
         norm_layer = partial(nn.BatchNorm2d, eps=0.001, momentum=0.03)
 
     backbone = _mobilenet_extractor("mobilenet_v3_large", progress, pretrained_backbone, trainable_backbone_layers,
-                                    norm_layer, reduced_tail=reduce_tail)
+                                    norm_layer, reduced_tail=reduce_tail, **kwargs)
 
     size = (320, 320)
     anchor_generator = DefaultBoxGenerator([[2, 3] for _ in range(6)], min_ratio=0.2, max_ratio=0.95)

--- a/torchvision/models/mobilenetv3.py
+++ b/torchvision/models/mobilenetv3.py
@@ -184,11 +184,9 @@ class MobileNetV3(nn.Module):
         return self._forward_impl(x)
 
 
-def _mobilenet_v3_conf(arch: str, params: Dict[str, Any]):
-    # non-public config parameters
-    reduce_divider = 2 if params.pop('_reduced_tail', False) else 1
-    dilation = 2 if params.pop('_dilated', False) else 1
-    width_mult = params.pop('_width_mult', 1.0)
+def _mobilenet_v3_conf(arch: str, width_mult: float = 1.0, reduced_tail: bool = False, dilated: bool = False):
+    reduce_divider = 2 if reduced_tail else 1
+    dilation = 2 if dilated else 1
 
     bneck_conf = partial(InvertedResidualConfig, width_mult=width_mult)
     adjust_channels = partial(InvertedResidualConfig.adjust_channels, width_mult=width_mult)
@@ -260,7 +258,7 @@ def mobilenet_v3_large(pretrained: bool = False, progress: bool = True, **kwargs
         progress (bool): If True, displays a progress bar of the download to stderr
     """
     arch = "mobilenet_v3_large"
-    inverted_residual_setting, last_channel = _mobilenet_v3_conf(arch, kwargs)
+    inverted_residual_setting, last_channel = _mobilenet_v3_conf(arch, **kwargs)
     return _mobilenet_v3_model(arch, inverted_residual_setting, last_channel, pretrained, progress, **kwargs)
 
 
@@ -274,5 +272,5 @@ def mobilenet_v3_small(pretrained: bool = False, progress: bool = True, **kwargs
         progress (bool): If True, displays a progress bar of the download to stderr
     """
     arch = "mobilenet_v3_small"
-    inverted_residual_setting, last_channel = _mobilenet_v3_conf(arch, kwargs)
+    inverted_residual_setting, last_channel = _mobilenet_v3_conf(arch, **kwargs)
     return _mobilenet_v3_model(arch, inverted_residual_setting, last_channel, pretrained, progress, **kwargs)

--- a/torchvision/models/mobilenetv3.py
+++ b/torchvision/models/mobilenetv3.py
@@ -106,7 +106,8 @@ class MobileNetV3(nn.Module):
             last_channel: int,
             num_classes: int = 1000,
             block: Optional[Callable[..., nn.Module]] = None,
-            norm_layer: Optional[Callable[..., nn.Module]] = None
+            norm_layer: Optional[Callable[..., nn.Module]] = None,
+            **kwargs: Any
     ) -> None:
         """
         MobileNet V3 main class

--- a/torchvision/models/mobilenetv3.py
+++ b/torchvision/models/mobilenetv3.py
@@ -184,7 +184,8 @@ class MobileNetV3(nn.Module):
         return self._forward_impl(x)
 
 
-def _mobilenet_v3_conf(arch: str, width_mult: float = 1.0, reduced_tail: bool = False, dilated: bool = False):
+def _mobilenet_v3_conf(arch: str, width_mult: float = 1.0, reduced_tail: bool = False, dilated: bool = False,
+                       **kwargs: Any):
     reduce_divider = 2 if reduced_tail else 1
     dilation = 2 if dilated else 1
 

--- a/torchvision/models/quantization/mobilenetv3.py
+++ b/torchvision/models/quantization/mobilenetv3.py
@@ -127,5 +127,5 @@ def mobilenet_v3_large(pretrained=False, progress=True, quantize=False, **kwargs
      quantize (bool): If True, returns a quantized model, else returns a float model
     """
     arch = "mobilenet_v3_large"
-    inverted_residual_setting, last_channel = _mobilenet_v3_conf(arch, kwargs)
+    inverted_residual_setting, last_channel = _mobilenet_v3_conf(arch, **kwargs)
     return _mobilenet_v3_model(arch, inverted_residual_setting, last_channel, pretrained, progress, quantize, **kwargs)

--- a/torchvision/models/segmentation/segmentation.py
+++ b/torchvision/models/segmentation/segmentation.py
@@ -32,7 +32,7 @@ def _segm_model(name, backbone_name, num_classes, aux, pretrained_backbone=True)
         aux_layer = 'layer3'
         aux_inplanes = 1024
     elif 'mobilenet_v3' in backbone_name:
-        backbone = mobilenetv3.__dict__[backbone_name](pretrained=pretrained_backbone, _dilated=True).features
+        backbone = mobilenetv3.__dict__[backbone_name](pretrained=pretrained_backbone, dilated=True).features
 
         # Gather the indices of blocks which are strided. These are the locations of C1, ..., Cn-1 blocks.
         # The first and last blocks are always included because they are the C0 (conv1) and Cn.
@@ -87,7 +87,7 @@ def _load_weights(model, arch_type, backbone, progress):
 
 
 def _segm_lraspp_mobilenetv3(backbone_name, num_classes, pretrained_backbone=True):
-    backbone = mobilenetv3.__dict__[backbone_name](pretrained=pretrained_backbone, _dilated=True).features
+    backbone = mobilenetv3.__dict__[backbone_name](pretrained=pretrained_backbone, dilated=True).features
 
     # Gather the indices of blocks which are strided. These are the locations of C1, ..., Cn-1 blocks.
     # The first and last blocks are always included because they are the C0 (conv1) and Cn.


### PR DESCRIPTION
This PR makes the previously protected constructor parameters of MobileNetV3 public. 

Back when the model was added (see https://github.com/pytorch/vision/pull/3276#discussion_r565291443), it was unclear whether any models would use those parameters. Now with segmentation and detection models in place using them, we should properly expose them to the users in case they want to create their own backbones.

Along with unit-tests, I confirmed that all current MobileNetV3 models remain unaffected by running:
```
cd ./references/detection
python -m torch.distributed.launch --nproc_per_node=2 --use_env train.py --model ssdlite320_mobilenet_v3_large --test-only --pretrained
python -m torch.distributed.launch --nproc_per_node=2 --use_env train.py --model fasterrcnn_mobilenet_v3_large_fpn --test-only --pretrained
python -m torch.distributed.launch --nproc_per_node=2 --use_env train.py --model fasterrcnn_mobilenet_v3_large_320_fpn --test-only --pretrained

cd ./references/segmentation
python -m torch.distributed.launch --nproc_per_node=2 --use_env train.py --model lraspp_mobilenet_v3_large --test-only --pretrained
python -m torch.distributed.launch --nproc_per_node=2 --use_env train.py --model deeplabv3_mobilenet_v3_large --test-only --pretrained

cd ./references/classification
python -m torch.distributed.launch --nproc_per_node=2 --use_env train.py --model mobilenet_v3_large --test-only --pretrained
python -m torch.distributed.launch --nproc_per_node=2 --use_env train.py --model mobilenet_v3_small --test-only --pretrained
python -u train_quantization.py --device='cpu' --model='mobilenet_v3_large' --test-only 
```