### PR TITLE
Update models weights for inception_v3, vgg11, and vgg13

### DIFF
--- a/torchvision/models/inception.py
+++ b/torchvision/models/inception.py
@@ -12,7 +12,7 @@ __all__ = ['Inception3', 'inception_v3', 'InceptionOutputs', '_InceptionOutputs'
 
 model_urls = {
     # Inception v3 ported from TensorFlow
-    'inception_v3_google': 'https://download.pytorch.org/models/inception_v3_google-1a9a5a14.pth',
+    'inception_v3_google': 'https://download.pytorch.org/models/inception_v3_google-0cc3c7bd.pth',
 }
 
 InceptionOutputs = namedtuple('InceptionOutputs', ['logits', 'aux_logits'])

--- a/torchvision/models/vgg.py
+++ b/torchvision/models/vgg.py
@@ -11,8 +11,8 @@ __all__ = [
 
 
 model_urls = {
-    'vgg11': 'https://download.pytorch.org/models/vgg11-bbd30ac9.pth',
-    'vgg13': 'https://download.pytorch.org/models/vgg13-c768596a.pth',
+    'vgg11': 'https://download.pytorch.org/models/vgg11-8a719046.pth',
+    'vgg13': 'https://download.pytorch.org/models/vgg13-19584684.pth',
     'vgg16': 'https://download.pytorch.org/models/vgg16-397923af.pth',
     'vgg19': 'https://download.pytorch.org/models/vgg19-dcbb9e9d.pth',
     'vgg11_bn': 'https://download.pytorch.org/models/vgg11_bn-6002323d.pth',


### PR DESCRIPTION
This PR udpates the URls for the above models. The weights have been uploaded to the S3 bucket and the internal facebook DB.

Closes https://github.com/pytorch/vision/issues/3767
Closes https://github.com/pytorch/vision/issues/2473

The following snippet now passes:

```py
for model_name in ('inception_v3', 'vgg11', 'vgg13'):
    getattr(models, model_name)(pretrained=True)


root = '/data/home/nicolashug/.cache/torch/hub/checkpoints/'
for filename in ('inception_v3_google-0cc3c7bd.pth', 'vgg11-8a719046.pth', 'vgg13-19584684.pth'):
    for device in ('cpu', 'cuda', 'cuda:0', 'cuda:1'):
        torch.load(root + filename, map_location=device)
```

The new weights have been generated and tested like so:

<details>

```py
import torch
import torchvision
import torchvision.transforms as t
from torchvision import models
import torchvision.ops as ops

def get_available_classification_models():
    return [k for k, v in models.__dict__.items() if callable(v) and k[0].lower() == k[0] and k[0] != "_"]

all_classification_models = get_available_classification_models()
print(all_classification_models)


for model_name in all_classification_models:
    if model_name in ('mnasnet0_75', 'mnasnet1_3', 'shufflenet_v2_x1_5', 'shufflenet_v2_x2_0'):
        continue
    getattr(models, model_name)(pretrained=True)




from glob import glob
import io
from pickle import UnpicklingError

all_files = glob('/data/home/nicolashug/.cache/torch/hub/checkpoints/*.pth')
baddies = []
goodies = []

for filename in all_files:
    try:
        state_dict = torch.load(filename, map_location='cuda')
    except RuntimeError:
        baddies.append(filename)
    else:
        goodies.append(filename)

print("these files are OK:")
print(goodies)
print("these ones failed:")
print(baddies)


import hashlib
import os
import uuid

output_dir = '/data/home/nicolashug/new_models'
tmp_path = os.path.join(output_dir, 'blah')

for filename in baddies:
    model_name = '-'.join(filename.split('/')[-1].split('-')[:-1])
    model = torch.load(filename)
    torch.save(model, tmp_path)

    sha256_hash = hashlib.sha256()
    with open(tmp_path, "rb") as f:
        # Read and update hash string value in blocks of 4K
        for byte_block in iter(lambda: f.read(4096), b""):
            sha256_hash.update(byte_block)
        hh = sha256_hash.hexdigest()


    output_path = os.path.join(output_dir, model_name + "-" + str(hh[:8]) + ".pth")
    os.replace(tmp_path, output_path)


# Make sure they can be loaded now
for filename in glob(output_dir + '/*'):
    state_dict = torch.load(filename, map_location='cuda')
    
print("The newly updated weights don't fail anymore")
print(f"They are located in {output_dir}")

# Also make sure the new dicts are the same as the old ones
for d1, d2 in zip(sorted(glob(output_dir + '/*')), sorted(baddies)):
    d1 = torch.load(d1)
    d2 = torch.load(d2)
    assert d1.keys() == d2.keys()
    for v1, v2 in zip(d1.values(), d2.values()):
        torch.testing.assert_allclose(v1, v2)

print("newly updated weights seem to be the same as the previous ones.")
print("all good")
```

</details>