### PR TITLE
Port NMS tests to use pytest

### DIFF
--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -409,6 +409,7 @@ def call_args_to_kwargs_only(call_args, *callable_or_arg_names):
 
 
 def cpu_and_gpu():
+    # TODO: make this properly handle CircleCI
     import pytest  # noqa
 
     # ignore CPU tests in RE as they're already covered by another contbuild
@@ -430,6 +431,7 @@ def cpu_and_gpu():
 
 
 def needs_cuda(test_func):
+    # TODO: make this properly handle CircleCI
     import pytest  # noqa
 
     if IN_FBCODE and not IN_RE_WORKER:
@@ -441,3 +443,14 @@ def needs_cuda(test_func):
         return test_func
     else:
         return pytest.mark.skip(reason=CUDA_NOT_AVAILABLE_MSG)(test_func)
+
+
+def doesnt_need_cuda(test_func):
+    # TODO: make this properly handle CircleCI
+    import pytest  # noqa
+
+    if IN_RE_WORKER:
+        # The assumption is that all RE workers have GPUs.
+        return pytest.mark.dont_collect(test_func)
+    else:
+        return test_func

--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -445,7 +445,7 @@ def needs_cuda(test_func):
         return pytest.mark.skip(reason=CUDA_NOT_AVAILABLE_MSG)(test_func)
 
 
-def doesnt_need_cuda(test_func):
+def cpu_only(test_func):
     # TODO: make this properly handle CircleCI
     import pytest  # noqa
 

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1,4 +1,3 @@
-from torch._C import PyTorchFileReader
 from common_utils import needs_cuda, doesnt_need_cuda
 import math
 import unittest

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1,4 +1,4 @@
-from common_utils import needs_cuda, doesnt_need_cuda
+from common_utils import needs_cuda, cpu_only
 import math
 import unittest
 import pytest
@@ -479,7 +479,7 @@ class TestNMS:
         scores = torch.rand(N)
         return boxes, scores
 
-    @doesnt_need_cuda
+    @cpu_only
     @pytest.mark.parametrize("iou", (.2, .5, .8))
     def test_nms_ref(self, iou):
         err_msg = 'NMS incompatible between CPU and reference implementation for IoU={}'
@@ -488,7 +488,7 @@ class TestNMS:
         keep = ops.nms(boxes, scores, iou)
         assert torch.allclose(keep, keep_ref), err_msg.format(iou)
 
-    @doesnt_need_cuda
+    @cpu_only
     def test_nms_input_errors(self):
         with pytest.raises(RuntimeError):
             ops.nms(torch.rand(4), torch.rand(3), 0.5)
@@ -499,7 +499,7 @@ class TestNMS:
         with pytest.raises(RuntimeError):
             ops.nms(torch.rand(3, 4), torch.rand(4), 0.5)
 
-    @doesnt_need_cuda
+    @cpu_only
     @pytest.mark.parametrize("iou", (.2, .5, .8))
     @pytest.mark.parametrize("scale, zero_point", ((1, 0), (2, 50), (3, 10)))
     def test_qnms(self, iou, scale, zero_point):
@@ -557,7 +557,7 @@ class TestNMS:
         keep16 = ops.nms(boxes.to(torch.float16), scores.to(torch.float16), iou_thres)
         assert torch.all(torch.eq(keep32, keep16))
 
-    @doesnt_need_cuda
+    @cpu_only
     def test_batched_nms_implementations(self):
         """Make sure that both implementations of batched_nms yield identical results"""
 


### PR DESCRIPTION
This PR ports the current tests for nms so that they rely on pytest.

It also introduces the `doesnt_need_cuda` decorator which is pretty much the opposite of `needs_cuda`: it allows **not** to run the CPU-only tests on CI GPU machines, since those CPU tests will be run by the CPU-only machines already. Would `no_cuda` be a better name? `cpu_only`?