### PR TITLE
Change the dtype to torch.float64 to restore previous accuracy

### DIFF
--- a/torchvision/models/detection/transform.py
+++ b/torchvision/models/detection/transform.py
@@ -37,8 +37,8 @@ def _resize_image_and_masks(image: Tensor, self_min_size: float, self_max_size: 
     if fixed_size is not None:
         size = [fixed_size[1], fixed_size[0]]
     else:
-        min_size = torch.min(im_shape).to(dtype=torch.float32)
-        max_size = torch.max(im_shape).to(dtype=torch.float32)
+        min_size = torch.min(im_shape).to(dtype=torch.float64)
+        max_size = torch.max(im_shape).to(dtype=torch.float64)
         scale = torch.min(self_min_size / min_size, self_max_size / max_size)
 
         if torchvision._is_tracing():


### PR DESCRIPTION
Hi @datumbox This is a follow-up PR of #3654.

Sorry for long time no updating this stream, actually I found a bug in my proposal in https://github.com/pytorch/vision/pull/3654#issuecomment-841296468.

> Note that if the `im_shape` is set to torch.float64 in ONNX, the numerically error between PyTorch and the exported ONNX model will be greater.

I wrote a script to test the performance between Pytorch and ONNXRuntime as below, it shows that only when both are set to the same dtype, the results of PyTorch and ONNXRuntime are the same. But the `torch.nn.functional.interpolate` in

https://github.com/pytorch/vision/blob/59c6731897c2b8c48431136515ee80d235c9c2d1/torchvision/models/detection/transform.py#L50-L51

will bring some numerical errors between PyTorch and ONNXRuntime, no matter how we set this data type. And its error seems to be random.

```python
import torch
import torchvision
from torch import nn, Tensor

@torch.jit.unused
def _get_shape_onnx(image: Tensor) -> Tensor:
    from torch.onnx import operators
    return operators.shape_as_tensor(image)[-2:]

@torch.jit.unused
def _fake_cast_onnx(v: Tensor) -> float:
    # ONNX requires a tensor but here we fake its type for JIT.
    return v

class TestFloatPytorchVsONNX(nn.Module):
    def __init__(self, max_size):
        super().__init__()
        self.max_size = max_size

    def forward(self, image: Tensor) -> float:
        if torchvision._is_tracing():
            im_shape = _get_shape_onnx(image)
        else:
            im_shape = torch.tensor(image.shape[-2:])

        max_size = torch.max(im_shape).to(dtype=torch.float64)
        scale = self.max_size / max_size

        if torchvision._is_tracing():
            scale_factor = _fake_cast_onnx(scale)
        else:
            scale_factor = scale.item()

        return scale_factor

test_float_pytorch_vs_onnx = TestFloatPytorchVsONNX(416)
image = torch.rand(3, 1080, 810)
scale_factor = test_float_pytorch_vs_onnx(image)

print(scale_factor)
```

