### PR TITLE
Fix Android CI

### DIFF
--- a/android/ops/CMakeLists.txt
+++ b/android/ops/CMakeLists.txt
@@ -35,7 +35,7 @@ target_compile_options(${TARGET} PRIVATE
 
 set(BUILD_SUBDIR ${ANDROID_ABI})
 
-find_library(PYTORCH_LIBRARY pytorch_jni
+find_library(PYTORCH_LIBRARY pytorch_jni_lite
   PATHS ${PYTORCH_LINK_DIRS}
   NO_CMAKE_FIND_ROOT_PATH)
 


### PR DESCRIPTION
The `binary_libtorchvision_ops_android` job is failing due to:
```
2021-05-23T10:53:46.946+0000 [INFO] [com.android.build.gradle.internal.cxx.logging.IssueReporterLoggingEnvironment] /home/circleci/project/android/ops/CMakeLists.txt : C/C++ debug|armeabi-v7a : {"cookie":"","inReplyTo":"configure","message":"CMake Error: The following variables are used in this project, but they are set to NOTFOUND.\nPlease set them or make sure they are set and tested correctly in the CMake files:\nPYTORCH_LIBRARY\n    linked by target \"torchvision_ops\" in directory /home/circleci/project/android/ops\n","title":"Error","type":"message"}
```

Checking the contents of the library we see that `pytorch_jni` was renamed to `pytorch_jni_lite`:
```
$ ls -lh /home/circleci/project/android/ops/build/pytorch_android-1.9.0-SNAPSHOT.aar/jni/armeabi-v7a
total 28M
-rw-r--r-- 1 circleci circleci 562K May 23 10:53 libc++_shared.so
-rw-r--r-- 1 circleci circleci 122K May 23 10:53 libfbjni.so
-rw-r--r-- 1 circleci circleci  27M May 23 10:53 libpytorch_jni_lite.so
```

The PR fixes the issue by changing the expected name of the library.