### PR TITLE
Fix pointer to contiguous data in quantized roi_align

### DIFF
--- a/torchvision/csrc/ops/quantized/cpu/qroi_align_kernel.cpp
+++ b/torchvision/csrc/ops/quantized/cpu/qroi_align_kernel.cpp
@@ -23,11 +23,16 @@ void qroi_align_forward_kernel_impl(
     bool aligned,
     const at::Tensor& t_rois,
     T* output) {
-  const T* input = t_input.contiguous().data_ptr<T>();
+  
+  // Don't delete these otherwise the .data_ptr() data might be undefined
+  auto t_input_cont = t_input.contiguous();
+  auto t_rois_cont = t_rois.contiguous();
+
+  const T* input = t_input_cont.data_ptr<T>();
   int64_t input_zp = t_input.q_zero_point();
   float input_scale = t_input.q_scale();
 
-  const T* rois = t_rois.contiguous().data_ptr<T>();
+  const T* rois = t_rois_cont.data_ptr<T>();
   int64_t rois_zp = t_rois.q_zero_point();
   float rois_scale = t_rois.q_scale();
 

--- a/torchvision/csrc/ops/quantized/cpu/qroi_align_kernel.cpp
+++ b/torchvision/csrc/ops/quantized/cpu/qroi_align_kernel.cpp
@@ -23,7 +23,6 @@ void qroi_align_forward_kernel_impl(
     bool aligned,
     const at::Tensor& t_rois,
     T* output) {
-  
   // Don't delete these otherwise the .data_ptr() data might be undefined
   auto t_input_cont = t_input.contiguous();
   auto t_rois_cont = t_rois.contiguous();


### PR DESCRIPTION
Using the result of `t_input.contiguous().data_ptr<T>();` is unsafe if t_input isn't contiguous in the first place, as the `t_input.contiguous()` tensor is undefined right after that block. Instead, we should keep the temporary tensors around.

Related internal post: https://fb.workplace.com/groups/1405155842844877/permalink/4735263356500759/

Similar past PR: https://github.com/pytorch/vision/pull/2131

CC @fmassa