### PR TITLE
Refactored and fixed flaky resize tests

### DIFF
--- a/test/test_functional_tensor.py
+++ b/test/test_functional_tensor.py
@@ -825,10 +825,7 @@ def test_resize(device, dt, size, max_size, interpolation, tester):
     resized_tensor = F.resize(tensor, size=size, interpolation=interpolation, max_size=max_size)
     resized_pil_img = F.resize(pil_img, size=size, interpolation=interpolation, max_size=max_size)
 
-    assert_equal(
-        resized_tensor.size()[1:],
-        resized_pil_img.size[::-1],
-    )
+    assert resized_tensor.size()[1:] == resized_pil_img.size[::-1]
 
     if interpolation not in [NEAREST, ]:
         # We can not check values if mode = NEAREST, as results are different


### PR DESCRIPTION
Addresses https://github.com/pytorch/vision/pull/3906#issuecomment-847297168

Description:
- Refactored and fixed flaky resize tests

> I refactored the test using pytest and could find seed value with MAE larger 8. The case when it is failing looks like to be related to `max_size=33`. I suppose that odd values are not handled in the same way between PIL and pytorch. If I use `max_size=34` I could not find a seed value between 0 to 2000 such that MAE > 8.0.