### PR TITLE
Fix write and encode jpeg tests

### DIFF
--- a/test/test_image.py
+++ b/test/test_image.py
@@ -105,7 +105,6 @@ class ImageTester(unittest.TestCase):
             with self.assertRaises(RuntimeError):
                 decode_jpeg(data)
 
-
     def test_decode_png(self):
         conversion = [(None, ImageReadMode.UNCHANGED), ("L", ImageReadMode.GRAY), ("LA", ImageReadMode.GRAY_ALPHA),
                       ("RGB", ImageReadMode.RGB), ("RGBA", ImageReadMode.RGB_ALPHA)]
@@ -279,7 +278,7 @@ def test_encode_jpeg_errors():
         encode_jpeg(torch.empty((3, 100, 100), dtype=torch.uint8), quality=-1)
 
     with pytest.raises(ValueError, match="Image quality should be a positive number "
-                        "between 1 and 100"):
+                                         "between 1 and 100"):
         encode_jpeg(torch.empty((3, 100, 100), dtype=torch.uint8), quality=101)
 
     with pytest.raises(RuntimeError, match="The number of channels should be 1 or 3, got: 5"):

--- a/test/test_image.py
+++ b/test/test_image.py
@@ -382,6 +382,7 @@ def test_encode_jpeg(img_path):
 
 
 @cpu_only
+@_collect_if(cond=not IS_WINDOWS)
 @pytest.mark.parametrize('img_path', [
     pytest.param(jpeg_path, id=_get_safe_image_name(jpeg_path))
     for jpeg_path in get_images(ENCODE_JPEG, ".jpg")


### PR DESCRIPTION
... well... mostly.

This PR Fixes the test logic which is currently wrong as it assumes that the "decode" phase is the same for torchvision and for PIL, which does not hold.
I also ported the tests to use `pytest`

Unfortunately the correct tests don't pass on Windows (probably a difference in the underlying libjpeg?), so we can keep them around for now. When this is merged, I will open an issue to keep track of the progress about fixing the windows tests.

This PR should fix the long-standing issues in fbcode (see https://www.internalfb.com/diff/D28605919), but I'm submitting it here instead of in fbcode because of the windows-skipping thing, which will be easier to verify with CircleCI.

CC @datumbox @pmeier @fmassa  as previously discussed