### PR TITLE
Fix installation instructions in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,11 +44,11 @@ conda install pytorch -c pytorch-nightly -c conda-forge
 ```bash
 git clone https://github.com/pytorch/vision.git
 cd vision
-python setup.py install
+python setup.py develop
 # or, for OSX
-# MACOSX_DEPLOYMENT_TARGET=10.9 CC=clang CXX=clang++ python setup.py install
+# MACOSX_DEPLOYMENT_TARGET=10.9 CC=clang CXX=clang++ python setup.py develop
 # for C++ debugging, please use DEBUG=1
-# DEBUG=1 python setup.py install
+# DEBUG=1 python setup.py develop
 pip install flake8 typing mypy pytest scipy
 ```
 You may also have to install `libpng-dev` and `libjpeg-turbo8-dev` libraries:


### PR DESCRIPTION
when contributing, we need inplace edits:
install -> develop
