### PR TITLE
Faster dataset indexing

### DIFF
--- a/torchvision/datasets/folder.py
+++ b/torchvision/datasets/folder.py
@@ -86,8 +86,8 @@ def make_dataset(
             continue
         for root, _, fnames in sorted(os.walk(target_dir, followlinks=True)):
             for fname in sorted(fnames):
-                path = os.path.join(root, fname)
-                if is_valid_file(path):
+                if is_valid_file(fname):
+                    path = os.path.join(root, fname)
                     item = path, class_index
                     instances.append(item)
 


### PR DESCRIPTION
Fixes #3902 

The small fix proposed in the issue. 

- We first check if the filename is valid (only using the filename, not the full path)
- We only join the path if we have a valid filename