### PR TITLE
Fix clang formatting in deform_conv2d_kernel.cu

### DIFF
--- a/torchvision/csrc/ops/cuda/deform_conv2d_kernel.cu
+++ b/torchvision/csrc/ops/cuda/deform_conv2d_kernel.cu
@@ -85,7 +85,7 @@ inline unsigned int GET_THREADS() {
 #ifdef __HIP_PLATFORM_HCC__
   return 256;
 #endif
-    return 512;
+  return 512;
 }
 
 inline unsigned int GET_BLOCKS(


### PR DESCRIPTION
Minor formatting fix as a follow up to https://github.com/pytorch/vision/pull/3942

CC @datumbox 