### PR TITLE
Document minimum required shapes for classification model builder.

### DIFF
--- a/torchvision/models/alexnet.py
+++ b/torchvision/models/alexnet.py
@@ -53,6 +53,7 @@ class AlexNet(nn.Module):
 def alexnet(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> AlexNet:
     r"""AlexNet model architecture from the
     `"One weird trick..." <https://arxiv.org/abs/1404.5997>`_ paper.
+    The required minimum input size of the model is 63x63.
 
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet

--- a/torchvision/models/densenet.py
+++ b/torchvision/models/densenet.py
@@ -257,6 +257,7 @@ def _densenet(
 def densenet121(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> DenseNet:
     r"""Densenet-121 model from
     `"Densely Connected Convolutional Networks" <https://arxiv.org/pdf/1608.06993.pdf>`_.
+    The required minimum input size of the model is 29x29.
 
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
@@ -271,6 +272,7 @@ def densenet121(pretrained: bool = False, progress: bool = True, **kwargs: Any) 
 def densenet161(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> DenseNet:
     r"""Densenet-161 model from
     `"Densely Connected Convolutional Networks" <https://arxiv.org/pdf/1608.06993.pdf>`_.
+    The required minimum input size of the model is 29x29.
 
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
@@ -285,6 +287,7 @@ def densenet161(pretrained: bool = False, progress: bool = True, **kwargs: Any) 
 def densenet169(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> DenseNet:
     r"""Densenet-169 model from
     `"Densely Connected Convolutional Networks" <https://arxiv.org/pdf/1608.06993.pdf>`_.
+    The required minimum input size of the model is 29x29.
 
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
@@ -299,6 +302,7 @@ def densenet169(pretrained: bool = False, progress: bool = True, **kwargs: Any) 
 def densenet201(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> DenseNet:
     r"""Densenet-201 model from
     `"Densely Connected Convolutional Networks" <https://arxiv.org/pdf/1608.06993.pdf>`_.
+    The required minimum input size of the model is 29x29.
 
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet

--- a/torchvision/models/googlenet.py
+++ b/torchvision/models/googlenet.py
@@ -26,6 +26,7 @@ _GoogLeNetOutputs = GoogLeNetOutputs
 def googlenet(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> "GoogLeNet":
     r"""GoogLeNet (Inception v1) model architecture from
     `"Going Deeper with Convolutions" <http://arxiv.org/abs/1409.4842>`_.
+    The required minimum input size of the model is 15x15.
 
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet

--- a/torchvision/models/inception.py
+++ b/torchvision/models/inception.py
@@ -26,6 +26,7 @@ _InceptionOutputs = InceptionOutputs
 def inception_v3(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> "Inception3":
     r"""Inception v3 model architecture from
     `"Rethinking the Inception Architecture for Computer Vision" <http://arxiv.org/abs/1512.00567>`_.
+    The required minimum input size of the model is 75x75.
 
     .. note::
         **Important**: In contrast to the other models the inception_v3 expects tensors with a size of

--- a/torchvision/models/squeezenet.py
+++ b/torchvision/models/squeezenet.py
@@ -126,6 +126,7 @@ def squeezenet1_0(pretrained: bool = False, progress: bool = True, **kwargs: Any
     r"""SqueezeNet model architecture from the `"SqueezeNet: AlexNet-level
     accuracy with 50x fewer parameters and <0.5MB model size"
     <https://arxiv.org/abs/1602.07360>`_ paper.
+    The required minimum input size of the model is 21x21.
 
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
@@ -139,6 +140,7 @@ def squeezenet1_1(pretrained: bool = False, progress: bool = True, **kwargs: Any
     <https://github.com/DeepScale/SqueezeNet/tree/master/SqueezeNet_v1.1>`_.
     SqueezeNet 1.1 has 2.4x less computation and slightly fewer parameters
     than SqueezeNet 1.0, without sacrificing accuracy.
+    The required minimum input size of the model is 17x17.
 
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet

--- a/torchvision/models/vgg.py
+++ b/torchvision/models/vgg.py
@@ -105,6 +105,7 @@ def _vgg(arch: str, cfg: str, batch_norm: bool, pretrained: bool, progress: bool
 def vgg11(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> VGG:
     r"""VGG 11-layer model (configuration "A") from
     `"Very Deep Convolutional Networks For Large-Scale Image Recognition" <https://arxiv.org/pdf/1409.1556.pdf>`_.
+    The required minimum input size of the model is 32x32.
 
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
@@ -116,6 +117,7 @@ def vgg11(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> VGG
 def vgg11_bn(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> VGG:
     r"""VGG 11-layer model (configuration "A") with batch normalization
     `"Very Deep Convolutional Networks For Large-Scale Image Recognition" <https://arxiv.org/pdf/1409.1556.pdf>`_.
+    The required minimum input size of the model is 32x32.
 
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
@@ -127,6 +129,7 @@ def vgg11_bn(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> 
 def vgg13(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> VGG:
     r"""VGG 13-layer model (configuration "B")
     `"Very Deep Convolutional Networks For Large-Scale Image Recognition" <https://arxiv.org/pdf/1409.1556.pdf>`_.
+    The required minimum input size of the model is 32x32.
 
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
@@ -138,6 +141,7 @@ def vgg13(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> VGG
 def vgg13_bn(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> VGG:
     r"""VGG 13-layer model (configuration "B") with batch normalization
     `"Very Deep Convolutional Networks For Large-Scale Image Recognition" <https://arxiv.org/pdf/1409.1556.pdf>`_.
+    The required minimum input size of the model is 32x32.
 
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
@@ -149,6 +153,7 @@ def vgg13_bn(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> 
 def vgg16(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> VGG:
     r"""VGG 16-layer model (configuration "D")
     `"Very Deep Convolutional Networks For Large-Scale Image Recognition" <https://arxiv.org/pdf/1409.1556.pdf>`_.
+    The required minimum input size of the model is 32x32.
 
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
@@ -160,6 +165,7 @@ def vgg16(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> VGG
 def vgg16_bn(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> VGG:
     r"""VGG 16-layer model (configuration "D") with batch normalization
     `"Very Deep Convolutional Networks For Large-Scale Image Recognition" <https://arxiv.org/pdf/1409.1556.pdf>`_.
+    The required minimum input size of the model is 32x32.
 
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
@@ -171,6 +177,7 @@ def vgg16_bn(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> 
 def vgg19(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> VGG:
     r"""VGG 19-layer model (configuration "E")
     `"Very Deep Convolutional Networks For Large-Scale Image Recognition" <https://arxiv.org/pdf/1409.1556.pdf>`_.
+    The required minimum input size of the model is 32x32.
 
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
@@ -182,6 +189,7 @@ def vgg19(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> VGG
 def vgg19_bn(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> VGG:
     r"""VGG 19-layer model (configuration 'E') with batch normalization
     `"Very Deep Convolutional Networks For Large-Scale Image Recognition" <https://arxiv.org/pdf/1409.1556.pdf>`_.
+    The required minimum input size of the model is 32x32.
 
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet


### PR DESCRIPTION
Document minimum required shapes for classification model builder whose minimum size is greater than one.

See discussion: https://github.com/pytorch/vision/issues/3921
See experiment: https://colab.research.google.com/drive/1T3_M55A75-b2FHaOWs8wYrmlM8gd3lgp?usp=sharing