### PR TITLE
Port test_ops.py to pytest

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -97,6 +97,7 @@ class RoIOpTester(ABC):
     def expected_fn(*args, **kwargs):
         pass
 
+
 class TestRoiPool(RoIOpTester):
     def fn(self, x, rois, pool_h, pool_w, spatial_scale=1, sampling_ratio=-1, **kwargs):
         return ops.RoIPool((pool_h, pool_w), spatial_scale)(x, rois)

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -266,8 +266,9 @@ class TestRoIAlign(RoIOpTester):
     @pytest.mark.parametrize('aligned', (True, False))
     @pytest.mark.parametrize('device', cpu_and_gpu())
     @pytest.mark.parametrize('contiguous', (True, False))
-    def test_forward(self, device, contiguous, aligned):
-        super().test_forward(device=device, contiguous=contiguous, aligned=aligned)
+    def test_forward(self, device, contiguous, aligned, x_dtype=None, rois_dtype=None):
+        super().test_forward(device=device, contiguous=contiguous, x_dtype=x_dtype, rois_dtype=rois_dtype,
+                             aligned=aligned)
 
     def _make_rois(self, img_size, num_imgs, dtype, num_rois=1000):
         rois = torch.randint(0, img_size // 2, size=(num_rois, 5)).to(dtype)
@@ -758,9 +759,9 @@ class TestDeformConv:
             out.mean().backward()
             if true_cpu_grads is None:
                 true_cpu_grads = init_weight.grad
-                self.assertTrue(true_cpu_grads is not None)
+                assert true_cpu_grads is not None
             else:
-                self.assertTrue(init_weight.grad is not None)
+                assert init_weight.grad is not None
                 res_grads = init_weight.grad.to("cpu")
                 torch.testing.assert_close(true_cpu_grads, res_grads)
 
@@ -769,7 +770,7 @@ class TestDeformConv:
     @pytest.mark.parametrize('dtype', (torch.float, torch.half))
     def test_autocast(self, batch_sz, dtype):
         with torch.cuda.amp.autocast():
-            self.test_forward(torch.device("cuda"), contiguous=False, batch_size=batch_sz, dtype=dtype)
+            self.test_forward(torch.device("cuda"), contiguous=False, batch_sz=batch_sz, dtype=dtype)
 
 
 @cpu_only

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -270,6 +270,15 @@ class TestRoIAlign(RoIOpTester):
         super().test_forward(device=device, contiguous=contiguous, x_dtype=x_dtype, rois_dtype=rois_dtype,
                              aligned=aligned)
 
+    @needs_cuda
+    @pytest.mark.parametrize('aligned', (True, False))
+    @pytest.mark.parametrize('x_dtype', (torch.float, torch.half))
+    @pytest.mark.parametrize('rois_dtype', (torch.float, torch.half))
+    def test_autocast(self, aligned, x_dtype, rois_dtype):
+        with torch.cuda.amp.autocast():
+            self.test_forward(torch.device("cuda"), contiguous=False, aligned=aligned, x_dtype=x_dtype,
+                              rois_dtype=rois_dtype)
+
     def _make_rois(self, img_size, num_imgs, dtype, num_rois=1000):
         rois = torch.randint(0, img_size // 2, size=(num_rois, 5)).to(dtype)
         rois[:, 0] = torch.randint(0, num_imgs, size=(num_rois,))  # set batch index

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -394,6 +394,7 @@ class TestPSRoIAlign(RoIOpTester):
         self._helper_boxes_shape(ops.ps_roi_align)
 
 
+@cpu_only
 class TestMultiScaleRoIAlign:
     def test_msroialign_repr(self):
         fmap_names = ['0']
@@ -552,7 +553,7 @@ class TestNMS:
         torch.testing.assert_close(empty, ops.batched_nms(empty, None, None, None))
 
 
-class TestDeformConv():
+class TestDeformConv:
     dtype = torch.float64
 
     def expected_fn(self, x, weight, offset, mask, bias, stride=1, padding=0, dilation=1):


### PR DESCRIPTION
This PR ports the entire `test_ops.py`file to pytest. It went pretty smoothly considering the size of the file, as the class structure already in place really helped.

The diff looks a bit big but it's mainly because I parametrized some methods, so the indentation of the (now removed) for loops isn't here anymore.

The rest is just adding a bunch of decorators and changing class names so that they're properly discovered by pytest