### PR TITLE
Port Group A test_transforms.py to pytest

### DIFF
--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -1029,10 +1029,12 @@ def test_2_channel_ndarray_to_pil_image_error():
     img_data = torch.ByteTensor(4, 4, 2).random_(0, 255).numpy()
     transforms.ToPILImage().__repr__()
 
+    # should raise if we try a mode for 4 or 1 or 3 channel images
     with pytest.raises(ValueError, match=r"Only modes \['LA'\] are supported for 2D inputs"):
-        # should raise if we try a mode for 4 or 1 or 3 channel images
         transforms.ToPILImage(mode='RGBA')(img_data)
+    with pytest.raises(ValueError, match=r"Only modes \['LA'\] are supported for 2D inputs"):
         transforms.ToPILImage(mode='P')(img_data)
+    with pytest.raises(ValueError, match=r"Only modes \['LA'\] are supported for 2D inputs"):
         transforms.ToPILImage(mode='RGB')(img_data)
 
 
@@ -1055,10 +1057,12 @@ def test_2_channel_tensor_to_pil_image(expected_mode):
 def test_2_channel_tensor_to_pil_image_error():
     img_data = torch.Tensor(2, 4, 4).uniform_()
 
+    # should raise if we try a mode for 4 or 1 or 3 channel images
     with pytest.raises(ValueError, match=r"Only modes \['LA'\] are supported for 2D inputs"):
-        # should raise if we try a mode for 4 or 1 or 3 channel images
         transforms.ToPILImage(mode='RGBA')(img_data)
+    with pytest.raises(ValueError, match=r"Only modes \['LA'\] are supported for 2D inputs"):
         transforms.ToPILImage(mode='P')(img_data)
+    with pytest.raises(ValueError, match=r"Only modes \['LA'\] are supported for 2D inputs"):
         transforms.ToPILImage(mode='RGB')(img_data)
 
 

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -1128,10 +1128,12 @@ def test_3_channel_tensor_to_pil_image(expected_mode):
 def test_3_channel_tensor_to_pil_image_error():
     img_data = torch.Tensor(3, 4, 4).uniform_()
     error_message_3d = r"Only modes \['RGB', 'YCbCr', 'HSV'\] are supported for 3D inputs"
+    # should raise if we try a mode for 4 or 1 or 2 channel images
     with pytest.raises(ValueError, match=error_message_3d):
-        # should raise if we try a mode for 4 or 1 or 2 channel images
         transforms.ToPILImage(mode='RGBA')(img_data)
+    with pytest.raises(ValueError, match=error_message_3d):
         transforms.ToPILImage(mode='P')(img_data)
+    with pytest.raises(ValueError, match=error_message_3d):
         transforms.ToPILImage(mode='LA')(img_data)
 
     with pytest.raises(ValueError, match=r'pic should be 2/3 dimensional. Got \d+ dimensions.'):
@@ -1160,10 +1162,12 @@ def test_3_channel_ndarray_to_pil_image_error():
     transforms.ToPILImage().__repr__()
 
     error_message_3d = r"Only modes \['RGB', 'YCbCr', 'HSV'\] are supported for 3D inputs"
+    # should raise if we try a mode for 4 or 1 or 2 channel images
     with pytest.raises(ValueError, match=error_message_3d):
-        # should raise if we try a mode for 4 or 1 or 2 channel images
         transforms.ToPILImage(mode='RGBA')(img_data)
+    with pytest.raises(ValueError, match=error_message_3d):
         transforms.ToPILImage(mode='P')(img_data)
+    with pytest.raises(ValueError, match=error_message_3d):
         transforms.ToPILImage(mode='LA')(img_data)
 
 
@@ -1188,10 +1192,12 @@ def test_4_channel_tensor_to_pil_image_error():
     img_data = torch.Tensor(4, 4, 4).uniform_()
 
     error_message_4d = r"Only modes \['RGBA', 'CMYK', 'RGBX'\] are supported for 4D inputs"
+    # should raise if we try a mode for 3 or 1 or 2 channel images
     with pytest.raises(ValueError, match=error_message_4d):
-        # should raise if we try a mode for 3 or 1 or 2 channel images
         transforms.ToPILImage(mode='RGB')(img_data)
+    with pytest.raises(ValueError, match=error_message_4d):
         transforms.ToPILImage(mode='P')(img_data)
+    with pytest.raises(ValueError, match=error_message_4d):
         transforms.ToPILImage(mode='LA')(img_data)
 
 
@@ -1214,10 +1220,12 @@ def test_4_channel_ndarray_to_pil_image_error():
     img_data = torch.ByteTensor(4, 4, 4).random_(0, 255).numpy()
 
     error_message_4d = r"Only modes \['RGBA', 'CMYK', 'RGBX'\] are supported for 4D inputs"
+    # should raise if we try a mode for 3 or 1 or 2 channel images
     with pytest.raises(ValueError, match=error_message_4d):
-        # should raise if we try a mode for 3 or 1 or 2 channel images
         transforms.ToPILImage(mode='RGB')(img_data)
+    with pytest.raises(ValueError, match=error_message_4d):
         transforms.ToPILImage(mode='P')(img_data)
+    with pytest.raises(ValueError, match=error_message_4d):
         transforms.ToPILImage(mode='LA')(img_data)
 
 

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -1588,31 +1588,31 @@ def test_1_channel_float_tensor_to_pil_image():
     )
 
 
-@pytest.mark.parametrize('img_data, mode', [
+@pytest.mark.parametrize('img_data, expected_mode', [
     (torch.Tensor(4, 4, 1).uniform_().numpy(), 'F'),
     (torch.ByteTensor(4, 4, 1).random_(0, 255).numpy(), 'L'),
     (torch.ShortTensor(4, 4, 1).random_().numpy(), 'I;16'),
     (torch.IntTensor(4, 4, 1).random_().numpy(), 'I'),
 ])
-def test_1_channel_ndarray_to_pil_image(img_data, mode):
-    for transform in [transforms.ToPILImage(), transforms.ToPILImage(mode=mode)]:
+def test_1_channel_ndarray_to_pil_image(img_data, expected_mode):
+    for transform in [transforms.ToPILImage(), transforms.ToPILImage(mode=expected_mode)]:
         img = transform(img_data)
-        assert img.mode == mode
+        assert img.mode == expected_mode
         # note: we explicitly convert img's dtype because pytorch doesn't support uint16
         # and otherwise assert_close wouldn't be able to construct a tensor from the uint16 array
         torch.testing.assert_close(img_data[:, :, 0], np.asarray(img).astype(img_data.dtype))
 
 
-@pytest.mark.parametrize('mode', [None, 'LA'])
-def test_2_channel_ndarray_to_pil_image(mode):
+@pytest.mark.parametrize('expected_mode', [None, 'LA'])
+def test_2_channel_ndarray_to_pil_image(expected_mode):
     img_data = torch.ByteTensor(4, 4, 2).random_(0, 255).numpy()
 
-    if mode is None:
+    if expected_mode is None:
         img = transforms.ToPILImage()(img_data)
         assert img.mode == 'LA'  # default should assume LA
     else:
-        img = transforms.ToPILImage(mode=mode)(img_data)
-        assert img.mode == mode
+        img = transforms.ToPILImage(mode=expected_mode)(img_data)
+        assert img.mode == expected_mode
     split = img.split()
     for i in range(2):
         torch.testing.assert_close(img_data[:, :, i], np.asarray(split[i]), check_stride=False)
@@ -1629,16 +1629,16 @@ def test_2_channel_ndarray_to_pil_image_error():
         transforms.ToPILImage(mode='RGB')(img_data)
 
 
-@pytest.mark.parametrize('mode', [None, 'LA'])
-def test_2_channel_tensor_to_pil_image(mode):
+@pytest.mark.parametrize('expected_mode', [None, 'LA'])
+def test_2_channel_tensor_to_pil_image(expected_mode):
     img_data = torch.Tensor(2, 4, 4).uniform_()
     expected_output = img_data.mul(255).int().float().div(255)
-    if mode is None:
+    if expected_mode is None:
         img = transforms.ToPILImage()(img_data)
         assert img.mode == 'LA'  # default should assume LA
     else:
-        img = transforms.ToPILImage(mode=mode)(img_data)
-        assert img.mode == mode
+        img = transforms.ToPILImage(mode=expected_mode)(img_data)
+        assert img.mode == expected_mode
 
     split = img.split()
     for i in range(2):
@@ -1673,7 +1673,6 @@ def _get_2d_tensor_various_types():
     yield img_data_int, expected_output, 'I'
 
 
-
 @pytest.mark.parametrize('pass_mode', [False, True])
 @pytest.mark.parametrize('img_data, expected_output, expected_mode', _get_2d_tensor_various_types())
 def test_2d_tensor_to_pil_image(pass_mode, img_data, expected_output, expected_mode):
@@ -1699,17 +1698,17 @@ def test_2d_ndarray_to_pil_image(pass_mode, img_data, expected_mode):
     np.testing.assert_allclose(img_data, img)
 
 
-@pytest.mark.parametrize('mode', [None, 'RGB', 'HSV', 'YCbCr'])
-def test_3_channel_tensor_to_pil_image(mode):
+@pytest.mark.parametrize('expected_mode', [None, 'RGB', 'HSV', 'YCbCr'])
+def test_3_channel_tensor_to_pil_image(expected_mode):
     img_data = torch.Tensor(3, 4, 4).uniform_()
     expected_output = img_data.mul(255).int().float().div(255)
 
-    if mode is None:
+    if expected_mode is None:
         img = transforms.ToPILImage()(img_data)
         assert img.mode == 'RGB'  # default should assume RGB
     else:
-        img = transforms.ToPILImage(mode=mode)(img_data)
-        assert img.mode == mode
+        img = transforms.ToPILImage(mode=expected_mode)(img_data)
+        assert img.mode == expected_mode
     split = img.split()
     for i in range(3):
         torch.testing.assert_close(expected_output[i].numpy(), F.to_tensor(split[i]).squeeze(0).numpy())
@@ -1728,16 +1727,16 @@ def test_3_channel_tensor_to_pil_image_error():
         transforms.ToPILImage()(torch.Tensor(1, 3, 4, 4).uniform_())
 
 
-@pytest.mark.parametrize('mode', [None, 'RGB', 'HSV', 'YCbCr'])
-def test_3_channel_ndarray_to_pil_image(mode):
+@pytest.mark.parametrize('expected_mode', [None, 'RGB', 'HSV', 'YCbCr'])
+def test_3_channel_ndarray_to_pil_image(expected_mode):
     img_data = torch.ByteTensor(4, 4, 3).random_(0, 255).numpy()
 
-    if mode is None:
+    if expected_mode is None:
         img = transforms.ToPILImage()(img_data)
         assert img.mode == 'RGB'  # default should assume RGB
     else:
-        img = transforms.ToPILImage(mode=mode)(img_data)
-        assert img.mode == mode
+        img = transforms.ToPILImage(mode=expected_mode)(img_data)
+        assert img.mode == expected_mode
     split = img.split()
     for i in range(3):
         torch.testing.assert_close(img_data[:, :, i], np.asarray(split[i]), check_stride=False)
@@ -1757,17 +1756,17 @@ def test_3_channel_ndarray_to_pil_image_error():
         transforms.ToPILImage(mode='LA')(img_data)
 
 
-@pytest.mark.parametrize('mode', [None, 'RGBA', 'CMYK', 'RGBX'])
-def test_4_channel_tensor_to_pil_image(mode):
+@pytest.mark.parametrize('expected_mode', [None, 'RGBA', 'CMYK', 'RGBX'])
+def test_4_channel_tensor_to_pil_image(expected_mode):
     img_data = torch.Tensor(4, 4, 4).uniform_()
     expected_output = img_data.mul(255).int().float().div(255)
 
-    if mode is None:
+    if expected_mode is None:
         img = transforms.ToPILImage()(img_data)
         assert img.mode == 'RGBA'  # default should assume RGBA
     else:
-        img = transforms.ToPILImage(mode=mode)(img_data)
-        assert img.mode == mode
+        img = transforms.ToPILImage(mode=expected_mode)(img_data)
+        assert img.mode == expected_mode
 
     split = img.split()
     for i in range(4):
@@ -1785,16 +1784,16 @@ def test_4_channel_tensor_to_pil_image_error():
         transforms.ToPILImage(mode='LA')(img_data)
 
 
-@pytest.mark.parametrize('mode', [None, 'RGBA', 'CMYK', 'RGBX'])
-def test_4_channel_ndarray_to_pil_image(mode):
+@pytest.mark.parametrize('expected_mode', [None, 'RGBA', 'CMYK', 'RGBX'])
+def test_4_channel_ndarray_to_pil_image(expected_mode):
     img_data = torch.ByteTensor(4, 4, 4).random_(0, 255).numpy()
 
-    if mode is None:
+    if expected_mode is None:
         img = transforms.ToPILImage()(img_data)
         assert img.mode == 'RGBA'  # default should assume RGBA
     else:
-        img = transforms.ToPILImage(mode=mode)(img_data)
-        assert img.mode == mode
+        img = transforms.ToPILImage(mode=expected_mode)(img_data)
+        assert img.mode == expected_mode
     split = img.split()
     for i in range(4):
         torch.testing.assert_close(img_data[:, :, i], np.asarray(split[i]), check_stride=False)

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -1613,7 +1613,7 @@ def test_2_channel_ndarray_to_pil_image():
 
     transforms.ToPILImage().__repr__()
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"Only modes \['LA'\] are supported for 2D inputs"):
         # should raise if we try a mode for 4 or 1 or 3 channel images
         transforms.ToPILImage(mode='RGBA')(img_data)
         transforms.ToPILImage(mode='P')(img_data)
@@ -1637,7 +1637,7 @@ def test_2_channel_tensor_to_pil_image():
     for mode in [None, 'LA']:
         verify_img_data(img_data, expected_output, mode=mode)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"Only modes \['LA'\] are supported for 2D inputs"):
         # should raise if we try a mode for 4 or 1 or 3 channel images
         transforms.ToPILImage(mode='RGBA')(img_data)
         transforms.ToPILImage(mode='P')(img_data)
@@ -1698,13 +1698,14 @@ def test_3_channel_tensor_to_pil_image():
     for mode in [None, 'RGB', 'HSV', 'YCbCr']:
         verify_img_data(img_data, expected_output, mode=mode)
 
-    with pytest.raises(ValueError):
+    error_message_3d = r"Only modes \['RGB', 'YCbCr', 'HSV'\] are supported for 3D inputs"
+    with pytest.raises(ValueError, match=error_message_3d):
         # should raise if we try a mode for 4 or 1 or 2 channel images
         transforms.ToPILImage(mode='RGBA')(img_data)
         transforms.ToPILImage(mode='P')(img_data)
         transforms.ToPILImage(mode='LA')(img_data)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r'pic should be 2/3 dimensional. Got \d+ dimensions.'):
         transforms.ToPILImage()(torch.Tensor(1, 3, 4, 4).uniform_())
 
 
@@ -1727,7 +1728,8 @@ def test_3_channel_ndarray_to_pil_image():
     # Checking if ToPILImage can be printed as string
     transforms.ToPILImage().__repr__()
 
-    with pytest.raises(ValueError):
+    error_message_3d = r"Only modes \['RGB', 'YCbCr', 'HSV'\] are supported for 3D inputs"
+    with pytest.raises(ValueError, match=error_message_3d):
         # should raise if we try a mode for 4 or 1 or 2 channel images
         transforms.ToPILImage(mode='RGBA')(img_data)
         transforms.ToPILImage(mode='P')(img_data)
@@ -1752,7 +1754,8 @@ def test_4_channel_tensor_to_pil_image():
     for mode in [None, 'RGBA', 'CMYK', 'RGBX']:
         verify_img_data(img_data, expected_output, mode)
 
-    with pytest.raises(ValueError):
+    error_message_4d = r"Only modes \['RGBA', 'CMYK', 'RGBX'\] are supported for 4D inputs"
+    with pytest.raises(ValueError, match=error_message_4d):
         # should raise if we try a mode for 3 or 1 or 2 channel images
         transforms.ToPILImage(mode='RGB')(img_data)
         transforms.ToPILImage(mode='P')(img_data)
@@ -1775,7 +1778,8 @@ def test_4_channel_ndarray_to_pil_image():
     for mode in [None, 'RGBA', 'CMYK', 'RGBX']:
         verify_img_data(img_data, mode)
 
-    with pytest.raises(ValueError):
+    error_message_4d = r"Only modes \['RGBA', 'CMYK', 'RGBX'\] are supported for 4D inputs"
+    with pytest.raises(ValueError, match=error_message_4d):
         # should raise if we try a mode for 3 or 1 or 2 channel images
         transforms.ToPILImage(mode='RGB')(img_data)
         transforms.ToPILImage(mode='P')(img_data)

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -994,19 +994,20 @@ def test_1_channel_float_tensor_to_pil_image():
     )
 
 
+@pytest.mark.parametrize('pass_mode', [False, True])
 @pytest.mark.parametrize('img_data, expected_mode', [
     (torch.Tensor(4, 4, 1).uniform_().numpy(), 'F'),
     (torch.ByteTensor(4, 4, 1).random_(0, 255).numpy(), 'L'),
     (torch.ShortTensor(4, 4, 1).random_().numpy(), 'I;16'),
     (torch.IntTensor(4, 4, 1).random_().numpy(), 'I'),
 ])
-def test_1_channel_ndarray_to_pil_image(img_data, expected_mode):
-    for transform in [transforms.ToPILImage(), transforms.ToPILImage(mode=expected_mode)]:
-        img = transform(img_data)
-        assert img.mode == expected_mode
-        # note: we explicitly convert img's dtype because pytorch doesn't support uint16
-        # and otherwise assert_close wouldn't be able to construct a tensor from the uint16 array
-        torch.testing.assert_close(img_data[:, :, 0], np.asarray(img).astype(img_data.dtype))
+def test_1_channel_ndarray_to_pil_image(pass_mode, img_data, expected_mode):
+    transform = transforms.ToPILImage(mode=expected_mode) if pass_mode else transforms.ToPILImage()
+    img = transform(img_data)
+    assert img.mode == expected_mode
+    # note: we explicitly convert img's dtype because pytorch doesn't support uint16
+    # and otherwise assert_close wouldn't be able to construct a tensor from the uint16 array
+    torch.testing.assert_close(img_data[:, :, 0], np.asarray(img).astype(img_data.dtype))
 
 
 @pytest.mark.parametrize('expected_mode', [None, 'LA'])

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -973,10 +973,10 @@ def _get_1_channel_tensor_various_types():
     yield img_data_int, expected_output, 'I'
 
 
-@pytest.mark.parametrize('pass_mode', [False, True])
+@pytest.mark.parametrize('with_mode', [False, True])
 @pytest.mark.parametrize('img_data, expected_output, expected_mode', _get_1_channel_tensor_various_types())
-def test_1_channel_tensor_to_pil_image(pass_mode, img_data, expected_output, expected_mode):
-    transform = transforms.ToPILImage(mode=expected_mode) if pass_mode else transforms.ToPILImage()
+def test_1_channel_tensor_to_pil_image(with_mode, img_data, expected_output, expected_mode):
+    transform = transforms.ToPILImage(mode=expected_mode) if with_mode else transforms.ToPILImage()
     to_tensor = transforms.ToTensor()
 
     img = transform(img_data)
@@ -994,15 +994,15 @@ def test_1_channel_float_tensor_to_pil_image():
     )
 
 
-@pytest.mark.parametrize('pass_mode', [False, True])
+@pytest.mark.parametrize('with_mode', [False, True])
 @pytest.mark.parametrize('img_data, expected_mode', [
     (torch.Tensor(4, 4, 1).uniform_().numpy(), 'F'),
     (torch.ByteTensor(4, 4, 1).random_(0, 255).numpy(), 'L'),
     (torch.ShortTensor(4, 4, 1).random_().numpy(), 'I;16'),
     (torch.IntTensor(4, 4, 1).random_().numpy(), 'I'),
 ])
-def test_1_channel_ndarray_to_pil_image(pass_mode, img_data, expected_mode):
-    transform = transforms.ToPILImage(mode=expected_mode) if pass_mode else transforms.ToPILImage()
+def test_1_channel_ndarray_to_pil_image(with_mode, img_data, expected_mode):
+    transform = transforms.ToPILImage(mode=expected_mode) if with_mode else transforms.ToPILImage()
     img = transform(img_data)
     assert img.mode == expected_mode
     # note: we explicitly convert img's dtype because pytorch doesn't support uint16
@@ -1080,10 +1080,10 @@ def _get_2d_tensor_various_types():
     yield img_data_int, expected_output, 'I'
 
 
-@pytest.mark.parametrize('pass_mode', [False, True])
+@pytest.mark.parametrize('with_mode', [False, True])
 @pytest.mark.parametrize('img_data, expected_output, expected_mode', _get_2d_tensor_various_types())
-def test_2d_tensor_to_pil_image(pass_mode, img_data, expected_output, expected_mode):
-    transform = transforms.ToPILImage(mode=expected_mode) if pass_mode else transforms.ToPILImage()
+def test_2d_tensor_to_pil_image(with_mode, img_data, expected_output, expected_mode):
+    transform = transforms.ToPILImage(mode=expected_mode) if with_mode else transforms.ToPILImage()
     to_tensor = transforms.ToTensor()
 
     img = transform(img_data)
@@ -1091,15 +1091,15 @@ def test_2d_tensor_to_pil_image(pass_mode, img_data, expected_output, expected_m
     torch.testing.assert_close(expected_output, to_tensor(img).numpy()[0])
 
 
-@pytest.mark.parametrize('pass_mode', [False, True])
+@pytest.mark.parametrize('with_mode', [False, True])
 @pytest.mark.parametrize('img_data, expected_mode', [
     (torch.Tensor(4, 4).uniform_().numpy(), 'F'),
     (torch.ByteTensor(4, 4).random_(0, 255).numpy(), 'L'),
     (torch.ShortTensor(4, 4).random_().numpy(), 'I;16'),
     (torch.IntTensor(4, 4).random_().numpy(), 'I'),
 ])
-def test_2d_ndarray_to_pil_image(pass_mode, img_data, expected_mode):
-    transform = transforms.ToPILImage(mode=expected_mode) if pass_mode else transforms.ToPILImage()
+def test_2d_ndarray_to_pil_image(with_mode, img_data, expected_mode):
+    transform = transforms.ToPILImage(mode=expected_mode) if with_mode else transforms.ToPILImage()
     img = transform(img_data)
     assert img.mode == expected_mode
     np.testing.assert_allclose(img_data, img)


### PR DESCRIPTION
To port Group A in test_transforms.py to pytest as discussed in #3945 

- [x] test_1_channel_ndarray_to_pil_image
- [x] test_1_channel_tensor_to_pil_image
- [x] test_2_channel_ndarray_to_pil_image
- [x] test_2_channel_tensor_to_pil_image
- [x] test_2d_ndarray_to_pil_image
- [x] test_2d_tensor_to_pil_image
- [x] test_3_channel_ndarray_to_pil_image
- [x] test_3_channel_tensor_to_pil_image
- [x] test_4_channel_ndarray_to_pil_image
- [x] test_4_channel_tensor_to_pil_image
- [x] test_ndarray_bad_types_to_pil_image
- [x] test_tensor_bad_types_to_pil_image

cc @NicolasHug 