### PR TITLE
Port to_tensor tests in test_transforms to pytest

### DIFF
--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -505,54 +505,6 @@ class Tester(unittest.TestCase):
         # Checking if RandomOrder can be printed as string
         random_order_transform.__repr__()
 
-    def test_to_tensor(self):
-        test_channels = [1, 3, 4]
-        height, width = 4, 4
-        trans = transforms.ToTensor()
-
-        with self.assertRaises(TypeError):
-            trans(np.random.rand(1, height, width).tolist())
-
-        with self.assertRaises(ValueError):
-            trans(np.random.rand(height))
-            trans(np.random.rand(1, 1, height, width))
-
-        for channels in test_channels:
-            input_data = torch.ByteTensor(channels, height, width).random_(0, 255).float().div_(255)
-            img = transforms.ToPILImage()(input_data)
-            output = trans(img)
-            torch.testing.assert_close(output, input_data, check_stride=False)
-
-            ndarray = np.random.randint(low=0, high=255, size=(height, width, channels)).astype(np.uint8)
-            output = trans(ndarray)
-            expected_output = ndarray.transpose((2, 0, 1)) / 255.0
-            torch.testing.assert_close(output.numpy(), expected_output, check_stride=False, check_dtype=False)
-
-            ndarray = np.random.rand(height, width, channels).astype(np.float32)
-            output = trans(ndarray)
-            expected_output = ndarray.transpose((2, 0, 1))
-            torch.testing.assert_close(output.numpy(), expected_output, check_stride=False, check_dtype=False)
-
-        # separate test for mode '1' PIL images
-        input_data = torch.ByteTensor(1, height, width).bernoulli_()
-        img = transforms.ToPILImage()(input_data.mul(255)).convert('1')
-        output = trans(img)
-        torch.testing.assert_close(input_data, output, check_dtype=False, check_stride=False)
-
-    def test_to_tensor_with_other_default_dtypes(self):
-        current_def_dtype = torch.get_default_dtype()
-
-        t = transforms.ToTensor()
-        np_arr = np.random.randint(0, 255, (32, 32, 3), dtype=np.uint8)
-        img = Image.fromarray(np_arr)
-
-        for dtype in [torch.float16, torch.float, torch.double]:
-            torch.set_default_dtype(dtype)
-            res = t(img)
-            self.assertTrue(res.dtype == dtype, msg=f"{res.dtype} vs {dtype}")
-
-        torch.set_default_dtype(current_def_dtype)
-
     def test_max_value(self):
         for dtype in int_dtypes():
             self.assertEqual(F_t._max_value(dtype), torch.iinfo(dtype).max)
@@ -689,39 +641,6 @@ class Tester(unittest.TestCase):
         output = trans(accimage.Image(GRACE_HOPPER))
 
         torch.testing.assert_close(output, expected_output)
-
-    def test_pil_to_tensor(self):
-        test_channels = [1, 3, 4]
-        height, width = 4, 4
-        trans = transforms.PILToTensor()
-
-        with self.assertRaises(TypeError):
-            trans(np.random.rand(1, height, width).tolist())
-            trans(np.random.rand(1, height, width))
-
-        for channels in test_channels:
-            input_data = torch.ByteTensor(channels, height, width).random_(0, 255)
-            img = transforms.ToPILImage()(input_data)
-            output = trans(img)
-            torch.testing.assert_close(input_data, output, check_stride=False)
-
-            input_data = np.random.randint(low=0, high=255, size=(height, width, channels)).astype(np.uint8)
-            img = transforms.ToPILImage()(input_data)
-            output = trans(img)
-            expected_output = input_data.transpose((2, 0, 1))
-            torch.testing.assert_close(output.numpy(), expected_output)
-
-            input_data = torch.as_tensor(np.random.rand(channels, height, width).astype(np.float32))
-            img = transforms.ToPILImage()(input_data)  # CHW -> HWC and (* 255).byte()
-            output = trans(img)  # HWC -> CHW
-            expected_output = (input_data * 255).byte()
-            torch.testing.assert_close(output, expected_output, check_stride=False)
-
-        # separate test for mode '1' PIL images
-        input_data = torch.ByteTensor(1, height, width).bernoulli_()
-        img = transforms.ToPILImage()(input_data.mul(255)).convert('1')
-        output = trans(img).view(torch.uint8).bool().to(torch.uint8)
-        torch.testing.assert_close(input_data, output, check_stride=False)
 
     @unittest.skipIf(accimage is None, 'accimage not available')
     def test_accimage_pil_to_tensor(self):
@@ -1656,6 +1575,86 @@ class Tester(unittest.TestCase):
         # Checking if RandomErasing can be printed as string
         t.__repr__()
 
+def test_pil_to_tensor():
+    test_channels = [1, 3, 4]
+    height, width = 4, 4
+    trans = transforms.PILToTensor()
+
+    with pytest.raises(TypeError):
+        trans(np.random.rand(1, height, width).tolist())
+        trans(np.random.rand(1, height, width))
+
+    for channels in test_channels:
+        input_data = torch.ByteTensor(channels, height, width).random_(0, 255)
+        img = transforms.ToPILImage()(input_data)
+        output = trans(img)
+        torch.testing.assert_close(input_data, output, check_stride=False)
+
+        input_data = np.random.randint(low=0, high=255, size=(height, width, channels)).astype(np.uint8)
+        img = transforms.ToPILImage()(input_data)
+        output = trans(img)
+        expected_output = input_data.transpose((2, 0, 1))
+        torch.testing.assert_close(output.numpy(), expected_output)
+
+        input_data = torch.as_tensor(np.random.rand(channels, height, width).astype(np.float32))
+        img = transforms.ToPILImage()(input_data)  # CHW -> HWC and (* 255).byte()
+        output = trans(img)  # HWC -> CHW
+        expected_output = (input_data * 255).byte()
+        torch.testing.assert_close(output, expected_output, check_stride=False)
+
+    # separate test for mode '1' PIL images
+    input_data = torch.ByteTensor(1, height, width).bernoulli_()
+    img = transforms.ToPILImage()(input_data.mul(255)).convert('1')
+    output = trans(img).view(torch.uint8).bool().to(torch.uint8)
+    torch.testing.assert_close(input_data, output, check_stride=False)
+        
+def test_to_tensor():
+    test_channels = [1, 3, 4]
+    height, width = 4, 4
+    trans = transforms.ToTensor()
+
+    with pytest.raises(TypeError):
+        trans(np.random.rand(1, height, width).tolist())
+            
+    with pytest.raises(ValueError):
+        trans(np.random.rand(height))
+        trans(np.random.rand(1, 1, height, width))
+            
+    for channels in test_channels:
+        input_data = torch.ByteTensor(channels, height, width).random_(0, 255).float().div_(255)
+        img = transforms.ToPILImage()(input_data)
+        output = trans(img)
+        torch.testing.assert_close(output, input_data, check_stride=False)
+
+        ndarray = np.random.randint(low=0, high=255, size=(height, width, channels)).astype(np.uint8)
+        output = trans(ndarray)
+        expected_output = ndarray.transpose((2, 0, 1)) / 255.0
+        torch.testing.assert_close(output.numpy(), expected_output, check_stride=False, check_dtype=False)
+
+        ndarray = np.random.rand(height, width, channels).astype(np.float32)
+        output = trans(ndarray)
+        expected_output = ndarray.transpose((2, 0, 1))
+        torch.testing.assert_close(output.numpy(), expected_output, check_stride=False, check_dtype=False)
+
+    # separate test for mode '1' PIL images
+    input_data = torch.ByteTensor(1, height, width).bernoulli_()
+    img = transforms.ToPILImage()(input_data.mul(255)).convert('1')
+    output = trans(img)
+    torch.testing.assert_close(input_data, output, check_dtype=False, check_stride=False)
+    
+def test_to_tensor_with_other_default_dtypes():
+    current_def_dtype = torch.get_default_dtype()
+
+    t = transforms.ToTensor()
+    np_arr = np.random.randint(0, 255, (32, 32, 3), dtype=np.uint8)
+    img = Image.fromarray(np_arr)
+
+    for dtype in [torch.float16, torch.float, torch.double]:
+        torch.set_default_dtype(dtype)
+        res = t(img)
+        assert res.dtype == dtype, f"{res.dtype} vs {dtype}"
+
+    torch.set_default_dtype(current_def_dtype)
 
 class TestPad:
 

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -1577,13 +1577,65 @@ class Tester(unittest.TestCase):
 
 
 @pytest.mark.parametrize('channels', [1, 3, 4])
-def test_pil_to_tensor(channels):
+def test_to_tensor(channels):
     height, width = 4, 4
-    trans = transforms.PILToTensor()
+    trans = transforms.ToTensor()
+
+    input_data = torch.ByteTensor(channels, height, width).random_(0, 255).float().div_(255)
+    img = transforms.ToPILImage()(input_data)
+    output = trans(img)
+    torch.testing.assert_close(output, input_data, check_stride=False)
+
+    ndarray = np.random.randint(low=0, high=255, size=(height, width, channels)).astype(np.uint8)
+    output = trans(ndarray)
+    expected_output = ndarray.transpose((2, 0, 1)) / 255.0
+    torch.testing.assert_close(output.numpy(), expected_output, check_stride=False, check_dtype=False)
+
+    ndarray = np.random.rand(height, width, channels).astype(np.float32)
+    output = trans(ndarray)
+    expected_output = ndarray.transpose((2, 0, 1))
+    torch.testing.assert_close(output.numpy(), expected_output, check_stride=False, check_dtype=False)
+
+    # separate test for mode '1' PIL images
+    input_data = torch.ByteTensor(1, height, width).bernoulli_()
+    img = transforms.ToPILImage()(input_data.mul(255)).convert('1')
+    output = trans(img)
+    torch.testing.assert_close(input_data, output, check_dtype=False, check_stride=False)
+
+
+def test_to_tensor_errors():
+    height, width = 4, 4
+    trans = transforms.ToTensor()
 
     with pytest.raises(TypeError):
         trans(np.random.rand(1, height, width).tolist())
-        trans(np.random.rand(1, height, width))
+
+    with pytest.raises(ValueError):
+        trans(np.random.rand(height))
+
+    with pytest.raises(ValueError):
+        trans(np.random.rand(1, 1, height, width))
+
+
+@pytest.mark.parametrize('dtype', [torch.float16, torch.float, torch.double])
+def test_to_tensor_with_other_default_dtypes(dtype):
+    current_def_dtype = torch.get_default_dtype()
+
+    t = transforms.ToTensor()
+    np_arr = np.random.randint(0, 255, (32, 32, 3), dtype=np.uint8)
+    img = Image.fromarray(np_arr)
+
+    torch.set_default_dtype(dtype)
+    res = t(img)
+    assert res.dtype == dtype, f"{res.dtype} vs {dtype}"
+
+    torch.set_default_dtype(current_def_dtype)
+
+
+@pytest.mark.parametrize('channels', [1, 3, 4])
+def test_pil_to_tensor(channels):
+    height, width = 4, 4
+    trans = transforms.PILToTensor()
 
     input_data = torch.ByteTensor(channels, height, width).random_(0, 255)
     img = transforms.ToPILImage()(input_data)
@@ -1609,53 +1661,15 @@ def test_pil_to_tensor(channels):
     torch.testing.assert_close(input_data, output, check_stride=False)
 
 
-@pytest.mark.parametrize('channels', [1, 3, 4])
-def test_to_tensor(channels):
+def test_pil_to_tensor_errors():
     height, width = 4, 4
-    trans = transforms.ToTensor()
+    trans = transforms.PILToTensor()
 
     with pytest.raises(TypeError):
         trans(np.random.rand(1, height, width).tolist())
 
-    with pytest.raises(ValueError):
-        trans(np.random.rand(height))
-        trans(np.random.rand(1, 1, height, width))
-
-    input_data = torch.ByteTensor(channels, height, width).random_(0, 255).float().div_(255)
-    img = transforms.ToPILImage()(input_data)
-    output = trans(img)
-    torch.testing.assert_close(output, input_data, check_stride=False)
-
-    ndarray = np.random.randint(low=0, high=255, size=(height, width, channels)).astype(np.uint8)
-    output = trans(ndarray)
-    expected_output = ndarray.transpose((2, 0, 1)) / 255.0
-    torch.testing.assert_close(output.numpy(), expected_output, check_stride=False, check_dtype=False)
-
-    ndarray = np.random.rand(height, width, channels).astype(np.float32)
-    output = trans(ndarray)
-    expected_output = ndarray.transpose((2, 0, 1))
-    torch.testing.assert_close(output.numpy(), expected_output, check_stride=False, check_dtype=False)
-
-    # separate test for mode '1' PIL images
-    input_data = torch.ByteTensor(1, height, width).bernoulli_()
-    img = transforms.ToPILImage()(input_data.mul(255)).convert('1')
-    output = trans(img)
-    torch.testing.assert_close(input_data, output, check_dtype=False, check_stride=False)
-
-
-@pytest.mark.parametrize('dtype', [torch.float16, torch.float, torch.double])
-def test_to_tensor_with_other_default_dtypes(dtype):
-    current_def_dtype = torch.get_default_dtype()
-
-    t = transforms.ToTensor()
-    np_arr = np.random.randint(0, 255, (32, 32, 3), dtype=np.uint8)
-    img = Image.fromarray(np_arr)
-
-    torch.set_default_dtype(dtype)
-    res = t(img)
-    assert res.dtype == dtype, f"{res.dtype} vs {dtype}"
-
-    torch.set_default_dtype(current_def_dtype)
+    with pytest.raises(TypeError):
+        trans(np.random.rand(1, height, width))
 
 
 class TestPad:

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -1621,76 +1621,6 @@ class Tester(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, r"sigma should be a single number or a list/tuple with length 2"):
             transforms.GaussianBlur(3, "sigma_string")
 
-    def _test_randomness(self, fn, trans, configs):
-        random_state = random.getstate()
-        random.seed(42)
-        img = transforms.ToPILImage()(torch.rand(3, 16, 18))
-
-        for p in [0.5, 0.7]:
-            for config in configs:
-                inv_img = fn(img, **config)
-
-                num_samples = 250
-                counts = 0
-                for _ in range(num_samples):
-                    tranformation = trans(p=p, **config)
-                    tranformation.__repr__()
-                    out = tranformation(img)
-                    if out == inv_img:
-                        counts += 1
-
-                p_value = stats.binom_test(counts, num_samples, p=p)
-                random.setstate(random_state)
-                self.assertGreater(p_value, 0.0001)
-
-    @unittest.skipIf(stats is None, 'scipy.stats not available')
-    def test_random_invert(self):
-        self._test_randomness(
-            F.invert,
-            transforms.RandomInvert,
-            [{}]
-        )
-
-    @unittest.skipIf(stats is None, 'scipy.stats not available')
-    def test_random_posterize(self):
-        self._test_randomness(
-            F.posterize,
-            transforms.RandomPosterize,
-            [{"bits": 4}]
-        )
-
-    @unittest.skipIf(stats is None, 'scipy.stats not available')
-    def test_random_solarize(self):
-        self._test_randomness(
-            F.solarize,
-            transforms.RandomSolarize,
-            [{"threshold": 192}]
-        )
-
-    @unittest.skipIf(stats is None, 'scipy.stats not available')
-    def test_random_adjust_sharpness(self):
-        self._test_randomness(
-            F.adjust_sharpness,
-            transforms.RandomAdjustSharpness,
-            [{"sharpness_factor": 2.0}]
-        )
-
-    @unittest.skipIf(stats is None, 'scipy.stats not available')
-    def test_random_autocontrast(self):
-        self._test_randomness(
-            F.autocontrast,
-            transforms.RandomAutocontrast,
-            [{}]
-        )
-
-    @unittest.skipIf(stats is None, 'scipy.stats not available')
-    def test_random_equalize(self):
-        self._test_randomness(
-            F.equalize,
-            transforms.RandomEqualize,
-            [{}]
-        )
-
     def test_autoaugment(self):
         for policy in transforms.AutoAugmentPolicy:
             for fill in [None, 85, (128, 128, 128)]:
@@ -1832,6 +1762,36 @@ class TestPad:
         img = Image.new("F", (10, 10))
         padded_img = transform(img)
         assert_equal(padded_img.size, [edge_size + 2 * pad for edge_size in img.size], check_stride=False)
+
+
+@pytest.mark.skipif(stats is None, reason="scipy.stats not available")
+@pytest.mark.parametrize('fn, trans, config', [
+                        (F.invert, transforms.RandomInvert, {}),
+                        (F.posterize, transforms.RandomPosterize, {"bits": 4}),
+                        (F.solarize, transforms.RandomSolarize, {"threshold": 192}),
+                        (F.adjust_sharpness, transforms.RandomAdjustSharpness, {"sharpness_factor": 2.0}),
+                        (F.autocontrast, transforms.RandomAutocontrast, {}),
+                        (F.equalize, transforms.RandomEqualize, {})])
+@pytest.mark.parametrize('p', (.5, .7))
+def test_randomness(fn, trans, config, p):
+    random_state = random.getstate()
+    random.seed(42)
+    img = transforms.ToPILImage()(torch.rand(3, 16, 18))
+
+    inv_img = fn(img, **config)
+
+    num_samples = 250
+    counts = 0
+    for _ in range(num_samples):
+        tranformation = trans(p=p, **config)
+        tranformation.__repr__()
+        out = tranformation(img)
+        if out == inv_img:
+            counts += 1
+
+    p_value = stats.binom_test(counts, num_samples, p=p)
+    random.setstate(random_state)
+    assert p_value > 0.0001
 
 
 def test_adjust_brightness():

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -1575,6 +1575,7 @@ class Tester(unittest.TestCase):
         # Checking if RandomErasing can be printed as string
         t.__repr__()
 
+
 @pytest.mark.parametrize('channels', [1, 3, 4])
 def test_pil_to_tensor(channels):
     height, width = 4, 4
@@ -1606,7 +1607,8 @@ def test_pil_to_tensor(channels):
     img = transforms.ToPILImage()(input_data.mul(255)).convert('1')
     output = trans(img).view(torch.uint8).bool().to(torch.uint8)
     torch.testing.assert_close(input_data, output, check_stride=False)
-        
+
+
 @pytest.mark.parametrize('channels', [1, 3, 4])
 def test_to_tensor(channels):
     height, width = 4, 4
@@ -1614,11 +1616,11 @@ def test_to_tensor(channels):
 
     with pytest.raises(TypeError):
         trans(np.random.rand(1, height, width).tolist())
-            
+
     with pytest.raises(ValueError):
         trans(np.random.rand(height))
         trans(np.random.rand(1, 1, height, width))
-            
+
     input_data = torch.ByteTensor(channels, height, width).random_(0, 255).float().div_(255)
     img = transforms.ToPILImage()(input_data)
     output = trans(img)
@@ -1639,7 +1641,8 @@ def test_to_tensor(channels):
     img = transforms.ToPILImage()(input_data.mul(255)).convert('1')
     output = trans(img)
     torch.testing.assert_close(input_data, output, check_dtype=False, check_stride=False)
-    
+
+
 @pytest.mark.parametrize('dtype', [torch.float16, torch.float, torch.double])
 def test_to_tensor_with_other_default_dtypes(dtype):
     current_def_dtype = torch.get_default_dtype()
@@ -1653,6 +1656,7 @@ def test_to_tensor_with_other_default_dtypes(dtype):
     assert res.dtype == dtype, f"{res.dtype} vs {dtype}"
 
     torch.set_default_dtype(current_def_dtype)
+
 
 class TestPad:
 


### PR DESCRIPTION
Refactor Group F as mentioned in #3945 

- test_pil_to_tensor
- test_to_tensor
- test_to_tensor_with_default_dtypes