### PR TITLE
Prepare test_transforms_tensor.py for porting to pytest

### DIFF
--- a/test/test_transforms_tensor.py
+++ b/test/test_transforms_tensor.py
@@ -60,7 +60,7 @@ def _test_functional_op(f, device, fn_kwargs=None, test_exact_match=True, **matc
 
 
 def _test_class_op(method, device, meth_kwargs=None, test_exact_match=True, **match_kwargs):
-    #TODO: change the name: it's not a method, it's a class.
+    # TODO: change the name: it's not a method, it's a class.
     meth_kwargs = meth_kwargs or {}
 
     # test for class interface

--- a/test/test_transforms_tensor.py
+++ b/test/test_transforms_tensor.py
@@ -86,7 +86,7 @@ def _test_class_op(method, device, meth_kwargs=None, test_exact_match=True, **ma
     _test_transform_vs_scripted_on_batch(f, scripted_fn, batch_tensors)
 
     with get_tmp_dir() as tmp_dir:
-        scripted_fn.save(os.path.join(tmp_dir, "t_{method.__name__}.pt"
+        scripted_fn.save(os.path.join(tmp_dir, f"t_{method.__name__}.pt"))
 
 
 def _test_op(func, method, device, fn_kwargs=None, meth_kwargs=None, test_exact_match=True, **match_kwargs):

--- a/test/test_transforms_tensor.py
+++ b/test/test_transforms_tensor.py
@@ -92,11 +92,11 @@ def _test_op(func, method, device, fn_kwargs=None, meth_kwargs=None, test_exact_
     _test_functional_op(func, device, fn_kwargs, test_exact_match=test_exact_match, **match_kwargs)
     _test_class_op(method, device, meth_kwargs, test_exact_match=test_exact_match, **match_kwargs)
 
+
 class Tester(unittest.TestCase):
 
     def setUp(self):
         self.device = "cpu"
-
 
     def test_random_horizontal_flip(self):
         _test_op(F.hflip, T.RandomHorizontalFlip, device=self.device)
@@ -131,8 +131,9 @@ class Tester(unittest.TestCase):
     def test_random_autocontrast(self):
         # We check the max abs difference because on some (very rare) pixels, the actual value may be different
         # between PIL and tensors due to floating approximations.
-        _test_op(F.autocontrast, T.RandomAutocontrast, device=self.device, test_exact_match=False,
-                 agg_method='max', tol=(1 + 1e-5), allowed_percentage_diff=.05
+        _test_op(
+            F.autocontrast, T.RandomAutocontrast, device=self.device, test_exact_match=False,
+            agg_method='max', tol=(1 + 1e-5), allowed_percentage_diff=.05
         )
 
     def test_random_equalize(self):

--- a/test/test_transforms_tensor.py
+++ b/test/test_transforms_tensor.py
@@ -60,6 +60,7 @@ def _test_functional_op(f, device, fn_kwargs=None, test_exact_match=True, **matc
 
 
 def _test_class_op(method, device, meth_kwargs=None, test_exact_match=True, **match_kwargs):
+    #TODO: change the name: it's not a method, it's a class.
     meth_kwargs = meth_kwargs or {}
 
     # test for class interface
@@ -85,7 +86,7 @@ def _test_class_op(method, device, meth_kwargs=None, test_exact_match=True, **ma
     _test_transform_vs_scripted_on_batch(f, scripted_fn, batch_tensors)
 
     with get_tmp_dir() as tmp_dir:
-        scripted_fn.save(os.path.join(tmp_dir, "t_{}.pt".format(method)))
+        scripted_fn.save(os.path.join(tmp_dir, "t_{method.__name__}.pt"
 
 
 def _test_op(func, method, device, fn_kwargs=None, meth_kwargs=None, test_exact_match=True, **match_kwargs):


### PR DESCRIPTION
This PR converts some `self._test_...` helper methods into pure function to help porting this file to pytest.

I also made these accept functions instead of strings (which used to be retrieved with `getattr(F, the_func_name)`). Apart from that the rest is just pure renaming