### PR TITLE
Finish porting test_functional_tensor.py to pytest

### DIFF
--- a/test/test_functional_tensor.py
+++ b/test/test_functional_tensor.py
@@ -31,7 +31,7 @@ NEAREST, BILINEAR, BICUBIC = InterpolationMode.NEAREST, InterpolationMode.BILINE
 
 
 @needs_cuda
-def test_scale_channel(self):
+def test_scale_channel():
     """Make sure that _scale_channel gives the same results on CPU and GPU as
     histc or bincount are used depending on the device.
     """


### PR DESCRIPTION
There was only one test left: `test_scale_channel`.

I also removed a test that was already ported (there was some merging issue in another PR that put it back, and I missed it in the review)

After that the entire file is fully pytest-compliant!