### PR TITLE
Port random affine, rotate, perspective and to_grayscale to pytest

### DIFF
--- a/test/test_transforms_tensor.py
+++ b/test/test_transforms_tensor.py
@@ -11,7 +11,6 @@ import pytest
 from typing import Sequence
 
 from common_utils import (
-    cpu_and_gpu,
     get_tmp_dir,
     int_dtypes,
     float_dtypes,
@@ -19,7 +18,7 @@ from common_utils import (
     _create_data_batch,
     _assert_equal_tensor_to_pil,
     _assert_approx_equal_tensor_to_pil,
-    cpu_and_gpu
+    cpu_and_gpu,
 )
 from _assert_utils import assert_equal
 

--- a/test/test_transforms_tensor.py
+++ b/test/test_transforms_tensor.py
@@ -749,7 +749,11 @@ def test_random_perspective_save():
 
 
 @pytest.mark.parametrize('device', cpu_and_gpu())
-@pytest.mark.parametrize('Klass, meth_kwargs', [(T.Grayscale, {"num_output_channels": 1}), (T.Grayscale, {"num_output_channels": 3}), (T.RandomGrayscale, {})])
+@pytest.mark.parametrize('Klass, meth_kwargs', [
+    (T.Grayscale, {"num_output_channels": 1}),
+    (T.Grayscale, {"num_output_channels": 3}),
+    (T.RandomGrayscale, {})
+])
 def test_to_grayscale(device, Klass, meth_kwargs):
 
     tol = 1.0 + 1e-10


### PR DESCRIPTION
Refactor Group D as mentioned in #3987 
- group D
  - test_random_affine -- split this into different parametrized functions (one for shear, one for scale, etc.)
  - test_random_rotate -- parametrize over all loop variables
  - test_random_perspective -- parametrize over all loop variables
  - test_to_grayscale -- parametrize over meth_kwargs
