### PR TITLE
[pytest port] test{crop_five, crop_ten, resize, resized_crop} in test_transforms_tensor

### DIFF
--- a/test/test_transforms_tensor.py
+++ b/test/test_transforms_tensor.py
@@ -671,11 +671,6 @@ def test_resize(dt, size, max_size, interpolation, device):
     if max_size is not None and isinstance(size, Sequence) and len(size) != 1:
         pass  # Not supported
     else:
-        if isinstance(size, int):
-            script_size = [size, ]
-        else:
-            script_size = size
-
         transform = T.Resize(size=script_size, interpolation=interpolation, max_size=max_size)
         s_transform = torch.jit.script(transform)
         _test_transform_vs_scripted(transform, s_transform, tensor)

--- a/test/test_transforms_tensor.py
+++ b/test/test_transforms_tensor.py
@@ -674,7 +674,7 @@ def test_resize_scripted(dt, size, max_size, interpolation, device):
         # This is a trivial cast to float of uint8 data to test all cases
         tensor = tensor.to(dt)
     if max_size is not None and isinstance(size, Sequence) and len(size) != 1:
-        pass  # Not supported
+        pytest.xfail()
     else:
         if isinstance(size, int):
             script_size = [size, ]

--- a/test/test_transforms_tensor.py
+++ b/test/test_transforms_tensor.py
@@ -599,11 +599,7 @@ def test_x_crop(func, method, out_length, fn_kwargs, device):
     assert len(transformed_t_list) == len(transformed_t_list_script)
     assert len(transformed_t_list_script) == out_length
     for transformed_tensor, transformed_tensor_script in zip(transformed_t_list, transformed_t_list_script):
-        assert_equal(
-            transformed_tensor,
-            transformed_tensor_script,
-            msg="{} vs {}".format(transformed_tensor, transformed_tensor_script),
-        )
+        assert_equal(transformed_tensor, transformed_tensor_script)
 
     # test for class interface
     fn = getattr(T, method)(**meth_kwargs)
@@ -621,11 +617,7 @@ def test_x_crop(func, method, out_length, fn_kwargs, device):
         torch.manual_seed(12)
         transformed_img_list = fn(img_tensor)
         for transformed_img, transformed_batch in zip(transformed_img_list, transformed_batch_list):
-            assert_equal(
-                transformed_img,
-                transformed_batch[i, ...],
-                msg="{} vs {}".format(transformed_img, transformed_batch[i, ...]),
-            )
+            assert_equal(transformed_img, transformed_batch[i, ...])
 
     with get_tmp_dir() as tmp_dir:
         scripted_fn.save(os.path.join(tmp_dir, "t_op_list_{}.pt".format(method)))

--- a/test/test_transforms_tensor.py
+++ b/test/test_transforms_tensor.py
@@ -646,7 +646,6 @@ def test_x_crop_save(method):
         scripted_fn.save(os.path.join(tmp_dir, "t_op_list_{}.pt".format(method)))
 
 
-
 @cpu_only
 @pytest.mark.parametrize('size', [32, 34, 35, 36, 38])
 def test_resize_int(size):

--- a/test/test_transforms_tensor.py
+++ b/test/test_transforms_tensor.py
@@ -646,23 +646,27 @@ def test_x_crop_save(method):
         scripted_fn.save(os.path.join(tmp_dir, "t_op_list_{}.pt".format(method)))
 
 
-@pytest.mark.parametrize('device', cpu_and_gpu())
-@pytest.mark.parametrize('dt', [None, torch.float32, torch.float64])
-@pytest.mark.parametrize('size', [32, 34, [32, ], [32, 32], (32, 32), [34, 35]])
-@pytest.mark.parametrize('max_size', [None, 35, 1000])
-@pytest.mark.parametrize('interpolation', [BILINEAR, BICUBIC, NEAREST])
-def test_resize(dt, size, max_size, interpolation, device):
 
+@cpu_only
+@pytest.mark.parametrize('size', [32, 34, 35, 36, 38])
+def test_resize_int(size):
     # TODO: Minimal check for bug-fix, improve this later
     x = torch.rand(3, 32, 46)
-    t = T.Resize(size=38)
+    t = T.Resize(size=size)
     y = t(x)
     # If size is an int, smaller edge of the image will be matched to this number.
     # i.e, if height > width, then image will be rescaled to (size * height / width, size).
     assert isinstance(y, torch.Tensor)
-    assert y.shape[1] == 38
-    assert y.shape[2] == int(38 * 46 / 32)
+    assert y.shape[1] == size
+    assert y.shape[2] == int(size * 46 / 32)
 
+
+@pytest.mark.parametrize('device', cpu_and_gpu())
+@pytest.mark.parametrize('dt', [None, torch.float32, torch.float64])
+@pytest.mark.parametrize('size', [[32, ], [32, 32], (32, 32), [34, 35]])
+@pytest.mark.parametrize('max_size', [None, 35, 1000])
+@pytest.mark.parametrize('interpolation', [BILINEAR, BICUBIC, NEAREST])
+def test_resize_scripted(dt, size, max_size, interpolation, device):
     tensor, _ = _create_data(height=34, width=36, device=device)
     batch_tensors = torch.randint(0, 256, size=(4, 3, 44, 56), dtype=torch.uint8, device=device)
 

--- a/test/test_transforms_tensor.py
+++ b/test/test_transforms_tensor.py
@@ -676,11 +676,6 @@ def test_resize_scripted(dt, size, max_size, interpolation, device):
     if max_size is not None and isinstance(size, Sequence) and len(size) != 1:
         pytest.xfail()
     else:
-        if isinstance(size, int):
-            script_size = [size, ]
-        else:
-            script_size = size
-
         transform = T.Resize(size=script_size, interpolation=interpolation, max_size=max_size)
         s_transform = torch.jit.script(transform)
         _test_transform_vs_scripted(transform, s_transform, tensor)

--- a/test/test_transforms_tensor.py
+++ b/test/test_transforms_tensor.py
@@ -435,6 +435,7 @@ class Tester(unittest.TestCase):
                 s_transform.save(os.path.join(tmp_dir, "t_autoaugment.pt"))
 
 
+@pytest.mark.parametrize('device', cpu_and_gpu())
 class TestColorJitter:
 
     @pytest.mark.parametrize('brightness', [0.1, 0.5, 1.0, 1.34, (0.3, 0.7), [0.4, 0.5]])
@@ -671,6 +672,11 @@ def test_resize(dt, size, max_size, interpolation, device):
     if max_size is not None and isinstance(size, Sequence) and len(size) != 1:
         pass  # Not supported
     else:
+        if isinstance(size, int):
+            script_size = [size, ]
+        else:
+            script_size = size
+
         transform = T.Resize(size=script_size, interpolation=interpolation, max_size=max_size)
         s_transform = torch.jit.script(transform)
         _test_transform_vs_scripted(transform, s_transform, tensor)


### PR DESCRIPTION
This PR ports group C from #3987. All the tests below run on `cpu_and_gpu` and have been parametrized accordingly.

- [x] test_x_crop : This merges `_test_op_list_output`, `test_five_crop`, `test_ten_crop` by parametrizing over `func`, `method`, `out_length` and `fn_kwargs`.
- [x] test_resize
- [x] test_resized_crop

Ps. @NicolasHug I kept this PR separate from #4008 to make the reviews manageable. Please don't worry about merge conflicts. I'll fix those as soon as the other PR is merged.