### PR TITLE
Drop virtual from private member functions of Decoder class

### DIFF
--- a/torchvision/csrc/io/decoder/decoder.h
+++ b/torchvision/csrc/io/decoder/decoder.h
@@ -59,11 +59,11 @@ class Decoder : public MediaDecoder {
 
  private:
   // mark below function for a proper invocation
-  virtual bool enableLogLevel(int level) const;
-  virtual void logCallback(int level, const std::string& message);
-  virtual int readCallback(uint8_t* buf, int size);
-  virtual int64_t seekCallback(int64_t offset, int whence);
-  virtual int shutdownCallback();
+  bool enableLogLevel(int level) const;
+  void logCallback(int level, const std::string& message);
+  int readCallback(uint8_t* buf, int size);
+  int64_t seekCallback(int64_t offset, int whence);
+  int shutdownCallback();
 
   bool openStreams(std::vector<DecoderMetadata>* metadata);
   Stream* findByIndex(int streamIndex) const;


### PR DESCRIPTION
Only `SyncDecoder` class inherits `Decoder` class and I don't see any of these functions(marked virtual) being overwritten there.
enableLogLevel() and logCallback() functions being marked virtual is causing segfault when we cast [ void * to Decoder * ](https://github.com/pytorch/vision/blob/810811f81ca24b196d08778c9e7f50bc5fe3ef3d/torchvision/csrc/io/decoder/decoder.cpp#L111) and then call these virtual [functions](https://github.com/pytorch/vision/blob/810811f81ca24b196d08778c9e7f50bc5fe3ef3d/torchvision/csrc/io/decoder/decoder.cpp#L135). Objects of classes with virtual function have a VPTR data member pointing to the VTABLE. Since, we are type-casting to Decoder *  here, I think it doesn't have that information and hence throwing SIGSEGV.
For more information, check T91816044(FB internal task).