### PR TITLE
always run build_docs in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1432,7 +1432,7 @@ workflows:
           filters:
             branches:
               only:
-              - nightly
+              - '*'
             tags:
               only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
           name: build_docs

--- a/.circleci/regenerate.py
+++ b/.circleci/regenerate.py
@@ -57,7 +57,7 @@ def build_workflows(prefix='', filter_branch=None, upload=False, indentation=6, 
 
     if not filter_branch:
         # Build on every pull request, but upload only on nightly and tags
-        w += build_doc_job('nightly')
+        w += build_doc_job('*')
         w += upload_doc_job('nightly')
     return indent(indentation, w)
 


### PR DESCRIPTION
Continuation of #3998. In that PR, `build_docs` was mistakenly restricted to nightly and tags, see [this comment](https://github.com/pytorch/vision/pull/3998#pullrequestreview-682772013)

@fmassa