### PR TITLE
fixup '*' -> '/.*/' for CI filter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1028,7 +1028,7 @@ workflows:
           cu_version: cpu
           filters:
             branches:
-              only: '*'
+              only: /.*/
             tags:
               only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
           name: binary_linux_wheel_py3.7_cpu
@@ -1432,7 +1432,7 @@ workflows:
           filters:
             branches:
               only:
-              - '*'
+              - /.*/
             tags:
               only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
           name: build_docs

--- a/.circleci/regenerate.py
+++ b/.circleci/regenerate.py
@@ -50,14 +50,14 @@ def build_workflows(prefix='', filter_branch=None, upload=False, indentation=6, 
                                        btype == 'wheel' and
                                        python_version == '3.7'):
                             # the fields must match the build_docs "requires" dependency
-                            fb = "*"
+                            fb = "/.*/"
                         w += workflow_pair(
                             btype, os_type, python_version, cu_version,
                             unicode, prefix, upload, filter_branch=fb)
 
     if not filter_branch:
         # Build on every pull request, but upload only on nightly and tags
-        w += build_doc_job('*')
+        w += build_doc_job('/.*/')
         w += upload_doc_job('nightly')
     return indent(indentation, w)
 


### PR DESCRIPTION
Looking at pytorch/pytorch, the syntax for the catch-all filter seems off. And indeed, it seems the doc build is [not triggering](https://app.circleci.com/pipelines/github/pytorch/vision/9041/workflows/ae873de6-487d-4885-aebd-b4b8eb2eda2b)