### PR TITLE
backport fixes to build/push docs on tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1011,6 +1011,11 @@ workflows:
       - binary_linux_wheel:
           conda_docker_image: pytorch/conda-builder:cpu
           cu_version: cpu
+          filters:
+            branches:
+              only: /.*/
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
           name: binary_linux_wheel_py3.7_cpu
           python_version: '3.7'
           wheel_docker_image: pytorch/manylinux-cuda102
@@ -1409,6 +1414,12 @@ workflows:
           name: binary_win_conda_py3.9_cu111
           python_version: '3.9'
       - build_docs:
+          filters:
+            branches:
+              only:
+              - /.*/
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
           name: build_docs
           python_version: '3.7'
           requires:

--- a/.circleci/regenerate.py
+++ b/.circleci/regenerate.py
@@ -45,13 +45,19 @@ def build_workflows(prefix='', filter_branch=None, upload=False, indentation=6, 
                             (python_version != python_versions[-1] or
                              (cu_version not in [cu_versions[0], cu_versions[-1]])):
                             fb = "master"
+                        if not fb and (os_type == 'linux' and
+                                       cu_version == 'cpu' and
+                                       btype == 'wheel' and
+                                       python_version == '3.7'):
+                            # the fields must match the build_docs "requires" dependency
+                            fb = "/.*/"
                         w += workflow_pair(
                             btype, os_type, python_version, cu_version,
                             unicode, prefix, upload, filter_branch=fb)
 
     if not filter_branch:
         # Build on every pull request, but upload only on nightly and tags
-        w += build_doc_job(None)
+        w += build_doc_job('/.*/')
         w += upload_doc_job('nightly')
     return indent(indentation, w)
 
@@ -83,7 +89,8 @@ def build_doc_job(filter_branch):
     }
 
     if filter_branch:
-        job["filters"] = gen_filter_branch_tree(filter_branch)
+        job["filters"] = gen_filter_branch_tree(filter_branch,
+                                                tags_list=RC_PATTERN)
     return [{"build_docs": job}]
 
 


### PR DESCRIPTION
Backport #3998, #4053, #4059 (sorry it took three tries) for the 0.10 release.

Is this the correct release branch for backports?