### PR TITLE
[android] Add mavenCentral repository for release publishing

### DIFF
--- a/android/ops/build.gradle
+++ b/android/ops/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'maven'
 
 repositories {
   jcenter()
+  mavenCentral()
   maven {
     url "https://oss.sonatype.org/content/repositories/snapshots"
   }

--- a/android/test_app/app/build.gradle
+++ b/android/test_app/app/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'com.android.application'
 
 repositories {
     jcenter()
+    mavenCentral()
     maven {
         url "https://oss.sonatype.org/content/repositories/snapshots"
     }


### PR DESCRIPTION
We need mavenCentral() repository for release publishing as we depend on release pytorch_android artifact which is published to mavenCentral.