### PR TITLE
DOC: remove git tag from page title

### DIFF
--- a/0.10/_modules/index.html
+++ b/0.10/_modules/index.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Overview: module code &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>Overview: module code &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/_modules/torchvision.html
+++ b/0.10/_modules/torchvision.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/_modules/torchvision/datasets/caltech.html
+++ b/0.10/_modules/torchvision/datasets/caltech.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.caltech &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision.datasets.caltech &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/_modules/torchvision/datasets/celeba.html
+++ b/0.10/_modules/torchvision/datasets/celeba.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.celeba &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision.datasets.celeba &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/_modules/torchvision/datasets/cifar.html
+++ b/0.10/_modules/torchvision/datasets/cifar.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.cifar &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision.datasets.cifar &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/_modules/torchvision/datasets/cityscapes.html
+++ b/0.10/_modules/torchvision/datasets/cityscapes.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.cityscapes &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision.datasets.cityscapes &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/_modules/torchvision/datasets/coco.html
+++ b/0.10/_modules/torchvision/datasets/coco.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.coco &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision.datasets.coco &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/_modules/torchvision/datasets/fakedata.html
+++ b/0.10/_modules/torchvision/datasets/fakedata.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.fakedata &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision.datasets.fakedata &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/_modules/torchvision/datasets/flickr.html
+++ b/0.10/_modules/torchvision/datasets/flickr.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.flickr &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision.datasets.flickr &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/_modules/torchvision/datasets/folder.html
+++ b/0.10/_modules/torchvision/datasets/folder.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.folder &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision.datasets.folder &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/_modules/torchvision/datasets/hmdb51.html
+++ b/0.10/_modules/torchvision/datasets/hmdb51.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.hmdb51 &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision.datasets.hmdb51 &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/_modules/torchvision/datasets/imagenet.html
+++ b/0.10/_modules/torchvision/datasets/imagenet.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.imagenet &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision.datasets.imagenet &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/_modules/torchvision/datasets/kinetics.html
+++ b/0.10/_modules/torchvision/datasets/kinetics.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.kinetics &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision.datasets.kinetics &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/_modules/torchvision/datasets/kitti.html
+++ b/0.10/_modules/torchvision/datasets/kitti.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.kitti &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision.datasets.kitti &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/_modules/torchvision/datasets/lsun.html
+++ b/0.10/_modules/torchvision/datasets/lsun.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.lsun &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision.datasets.lsun &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/_modules/torchvision/datasets/mnist.html
+++ b/0.10/_modules/torchvision/datasets/mnist.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.mnist &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision.datasets.mnist &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/_modules/torchvision/datasets/omniglot.html
+++ b/0.10/_modules/torchvision/datasets/omniglot.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.omniglot &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision.datasets.omniglot &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/_modules/torchvision/datasets/phototour.html
+++ b/0.10/_modules/torchvision/datasets/phototour.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.phototour &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision.datasets.phototour &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/_modules/torchvision/datasets/places365.html
+++ b/0.10/_modules/torchvision/datasets/places365.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.places365 &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision.datasets.places365 &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/_modules/torchvision/datasets/sbd.html
+++ b/0.10/_modules/torchvision/datasets/sbd.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.sbd &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision.datasets.sbd &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/_modules/torchvision/datasets/sbu.html
+++ b/0.10/_modules/torchvision/datasets/sbu.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.sbu &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision.datasets.sbu &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/_modules/torchvision/datasets/semeion.html
+++ b/0.10/_modules/torchvision/datasets/semeion.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.semeion &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision.datasets.semeion &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/_modules/torchvision/datasets/stl10.html
+++ b/0.10/_modules/torchvision/datasets/stl10.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.stl10 &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision.datasets.stl10 &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/_modules/torchvision/datasets/svhn.html
+++ b/0.10/_modules/torchvision/datasets/svhn.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.svhn &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision.datasets.svhn &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/_modules/torchvision/datasets/ucf101.html
+++ b/0.10/_modules/torchvision/datasets/ucf101.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.ucf101 &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision.datasets.ucf101 &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/_modules/torchvision/datasets/usps.html
+++ b/0.10/_modules/torchvision/datasets/usps.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.usps &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision.datasets.usps &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/_modules/torchvision/datasets/voc.html
+++ b/0.10/_modules/torchvision/datasets/voc.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.voc &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision.datasets.voc &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/_modules/torchvision/datasets/widerface.html
+++ b/0.10/_modules/torchvision/datasets/widerface.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.widerface &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision.datasets.widerface &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/_modules/torchvision/io.html
+++ b/0.10/_modules/torchvision/io.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.io &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision.io &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/_modules/torchvision/io/image.html
+++ b/0.10/_modules/torchvision/io/image.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.io.image &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision.io.image &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/_modules/torchvision/io/video.html
+++ b/0.10/_modules/torchvision/io/video.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.io.video &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision.io.video &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/_modules/torchvision/models/alexnet.html
+++ b/0.10/_modules/torchvision/models/alexnet.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.models.alexnet &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision.models.alexnet &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/_modules/torchvision/models/densenet.html
+++ b/0.10/_modules/torchvision/models/densenet.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.models.densenet &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision.models.densenet &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/_modules/torchvision/models/detection/faster_rcnn.html
+++ b/0.10/_modules/torchvision/models/detection/faster_rcnn.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.models.detection.faster_rcnn &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision.models.detection.faster_rcnn &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/_modules/torchvision/models/detection/keypoint_rcnn.html
+++ b/0.10/_modules/torchvision/models/detection/keypoint_rcnn.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.models.detection.keypoint_rcnn &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision.models.detection.keypoint_rcnn &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/_modules/torchvision/models/detection/mask_rcnn.html
+++ b/0.10/_modules/torchvision/models/detection/mask_rcnn.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.models.detection.mask_rcnn &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision.models.detection.mask_rcnn &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/_modules/torchvision/models/detection/retinanet.html
+++ b/0.10/_modules/torchvision/models/detection/retinanet.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.models.detection.retinanet &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision.models.detection.retinanet &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/_modules/torchvision/models/detection/ssd.html
+++ b/0.10/_modules/torchvision/models/detection/ssd.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.models.detection.ssd &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision.models.detection.ssd &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/_modules/torchvision/models/detection/ssdlite.html
+++ b/0.10/_modules/torchvision/models/detection/ssdlite.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.models.detection.ssdlite &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision.models.detection.ssdlite &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/_modules/torchvision/models/googlenet.html
+++ b/0.10/_modules/torchvision/models/googlenet.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.models.googlenet &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision.models.googlenet &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/_modules/torchvision/models/inception.html
+++ b/0.10/_modules/torchvision/models/inception.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.models.inception &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision.models.inception &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/_modules/torchvision/models/mnasnet.html
+++ b/0.10/_modules/torchvision/models/mnasnet.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.models.mnasnet &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision.models.mnasnet &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/_modules/torchvision/models/mobilenetv2.html
+++ b/0.10/_modules/torchvision/models/mobilenetv2.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.models.mobilenetv2 &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision.models.mobilenetv2 &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/_modules/torchvision/models/mobilenetv3.html
+++ b/0.10/_modules/torchvision/models/mobilenetv3.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.models.mobilenetv3 &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision.models.mobilenetv3 &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/_modules/torchvision/models/resnet.html
+++ b/0.10/_modules/torchvision/models/resnet.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.models.resnet &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision.models.resnet &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/_modules/torchvision/models/segmentation/segmentation.html
+++ b/0.10/_modules/torchvision/models/segmentation/segmentation.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.models.segmentation.segmentation &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision.models.segmentation.segmentation &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/_modules/torchvision/models/shufflenetv2.html
+++ b/0.10/_modules/torchvision/models/shufflenetv2.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.models.shufflenetv2 &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision.models.shufflenetv2 &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/_modules/torchvision/models/squeezenet.html
+++ b/0.10/_modules/torchvision/models/squeezenet.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.models.squeezenet &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision.models.squeezenet &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/_modules/torchvision/models/vgg.html
+++ b/0.10/_modules/torchvision/models/vgg.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.models.vgg &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision.models.vgg &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/_modules/torchvision/models/video/resnet.html
+++ b/0.10/_modules/torchvision/models/video/resnet.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.models.video.resnet &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision.models.video.resnet &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/_modules/torchvision/ops/boxes.html
+++ b/0.10/_modules/torchvision/ops/boxes.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.ops.boxes &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision.ops.boxes &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/_modules/torchvision/ops/deform_conv.html
+++ b/0.10/_modules/torchvision/ops/deform_conv.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.ops.deform_conv &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision.ops.deform_conv &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/_modules/torchvision/ops/feature_pyramid_network.html
+++ b/0.10/_modules/torchvision/ops/feature_pyramid_network.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.ops.feature_pyramid_network &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision.ops.feature_pyramid_network &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/_modules/torchvision/ops/focal_loss.html
+++ b/0.10/_modules/torchvision/ops/focal_loss.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.ops.focal_loss &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision.ops.focal_loss &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/_modules/torchvision/ops/poolers.html
+++ b/0.10/_modules/torchvision/ops/poolers.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.ops.poolers &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision.ops.poolers &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/_modules/torchvision/ops/ps_roi_align.html
+++ b/0.10/_modules/torchvision/ops/ps_roi_align.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.ops.ps_roi_align &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision.ops.ps_roi_align &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/_modules/torchvision/ops/ps_roi_pool.html
+++ b/0.10/_modules/torchvision/ops/ps_roi_pool.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.ops.ps_roi_pool &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision.ops.ps_roi_pool &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/_modules/torchvision/ops/roi_align.html
+++ b/0.10/_modules/torchvision/ops/roi_align.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.ops.roi_align &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision.ops.roi_align &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/_modules/torchvision/ops/roi_pool.html
+++ b/0.10/_modules/torchvision/ops/roi_pool.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.ops.roi_pool &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision.ops.roi_pool &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/_modules/torchvision/transforms/autoaugment.html
+++ b/0.10/_modules/torchvision/transforms/autoaugment.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.transforms.autoaugment &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision.transforms.autoaugment &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/_modules/torchvision/transforms/functional.html
+++ b/0.10/_modules/torchvision/transforms/functional.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.transforms.functional &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision.transforms.functional &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/_modules/torchvision/transforms/transforms.html
+++ b/0.10/_modules/torchvision/transforms/transforms.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.transforms.transforms &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision.transforms.transforms &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/_modules/torchvision/utils.html
+++ b/0.10/_modules/torchvision/utils.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.utils &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision.utils &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/auto_examples/index.html
+++ b/0.10/auto_examples/index.html
@@ -10,7 +10,7 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Example gallery &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>Example gallery &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/auto_examples/plot_scripted_tensor_transforms.html
+++ b/0.10/auto_examples/plot_scripted_tensor_transforms.html
@@ -10,7 +10,7 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Tensor transforms and JIT &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>Tensor transforms and JIT &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/auto_examples/plot_transforms.html
+++ b/0.10/auto_examples/plot_transforms.html
@@ -10,7 +10,7 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Illustration of transforms &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>Illustration of transforms &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/auto_examples/plot_visualization_utils.html
+++ b/0.10/auto_examples/plot_visualization_utils.html
@@ -10,7 +10,7 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Visualization utilities &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>Visualization utilities &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/auto_examples/sg_execution_times.html
+++ b/0.10/auto_examples/sg_execution_times.html
@@ -10,7 +10,7 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Computation times &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>Computation times &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/datasets.html
+++ b/0.10/datasets.html
@@ -10,7 +10,7 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision.datasets &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/genindex.html
+++ b/0.10/genindex.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Index &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>Index &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/index.html
+++ b/0.10/index.html
@@ -10,7 +10,7 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/io.html
+++ b/0.10/io.html
@@ -10,7 +10,7 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.io &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision.io &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/models.html
+++ b/0.10/models.html
@@ -10,7 +10,7 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.models &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision.models &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/ops.html
+++ b/0.10/ops.html
@@ -10,7 +10,7 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.ops &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision.ops &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/py-modindex.html
+++ b/0.10/py-modindex.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Python Module Index &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>Python Module Index &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/search.html
+++ b/0.10/search.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Search &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>Search &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/transforms.html
+++ b/0.10/transforms.html
@@ -10,7 +10,7 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.transforms &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision.transforms &mdash; Torchvision 0.10.0 documentation</title>
   
 
   

--- a/0.10/utils.html
+++ b/0.10/utils.html
@@ -10,7 +10,7 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.utils &mdash; Torchvision 0.10.0a0+25b2e69 documentation</title>
+  <title>torchvision.utils &mdash; Torchvision 0.10.0 documentation</title>
   
 
   


### PR DESCRIPTION
The page titles (what you see when you hover over the page's tab in the browser) still had the git tag.

`for f in $(find . -name "*.html"); do sed -i -e"s/0\.10\.0a0+25b2e69/0.10.0/" $f; done`