### PR TITLE
Only tag merger if PR isn't properly labeled

### DIFF
--- a/.github/process_commit.py
+++ b/.github/process_commit.py
@@ -63,7 +63,7 @@ if __name__ == "__main__":
     commit_hash = sys.argv[1]
     pr_number = get_pr_number(commit_hash)
     if not pr_number:
-        exit
+        sys.exit(0)
 
     merger, labels = get_pr_merger_and_labels(pr_number)
     is_properly_labeled = bool(REQUIRED_LABELS.intersection(labels))

--- a/.github/process_commit.py
+++ b/.github/process_commit.py
@@ -1,7 +1,10 @@
 """
-This script finds all responsible users for labeling a PR by a commit SHA. It is used by the workflow in
+This script finds the merger responsible for labeling a PR by a commit SHA. It is used by the workflow in
 '.github/workflows/pr-labels.yml'. If there exists no PR associated with the commit or the PR is properly labeled,
 this script is a no-op.
+
+Note: we ping the merger only, not the reviewers, as the reviewers can sometimes be external to torchvision
+with no labeling responsibility, so we don't want to bother them.
 """
 
 import sys

--- a/.github/process_commit.py
+++ b/.github/process_commit.py
@@ -38,19 +38,6 @@ REQUIRED_LABELS = {
 }
 
 
-def find_responsible_users(commit_hash: str) -> Set[str]:
-    pr_number = get_pr_number(commit_hash)
-    if not pr_number:
-        return set()
-
-    merger, labels = get_pr_merger_and_labels(pr_number)
-    is_properly_labeled = bool(REQUIRED_LABELS.intersection(labels))
-    if is_properly_labeled:
-        return set()
-
-    return {merger, *get_pr_reviewers(pr_number)}
-
-
 def query_torchvision(cmd: str, *, accept) -> Any:
     response = requests.get(f"https://api.github.com/repos/pytorch/vision/{cmd}", headers=dict(Accept=accept))
     return response.json()
@@ -72,13 +59,14 @@ def get_pr_merger_and_labels(pr_number: int) -> Tuple[str, Set[str]]:
     return merger, labels
 
 
-def get_pr_reviewers(pr_number: int) -> Set[str]:
-    # See https://docs.github.com/en/rest/reference/pulls#list-reviews-for-a-pull-request
-    data = query_torchvision(f"pulls/{pr_number}/reviews", accept="application/vnd.github.v3+json")
-    return {review["user"]["login"] for review in data if review["state"] == "APPROVED"}
-
-
 if __name__ == "__main__":
     commit_hash = sys.argv[1]
-    users = find_responsible_users(commit_hash)
-    print(", ".join(sorted([f"@{user}" for user in users])))
+    pr_number = get_pr_number(commit_hash)
+    if not pr_number:
+        exit
+
+    merger, labels = get_pr_merger_and_labels(pr_number)
+    is_properly_labeled = bool(REQUIRED_LABELS.intersection(labels))
+
+    if not is_properly_labeled:
+        print(f"@{merger}")

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Process commit and find merger for labeling
+      - name: Process commit and find merger responsible for labeling
         id: commit
         run: echo "::set-output name=merger::$(python .github/process_commit.py ${{ github.sha }})"
 

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -19,17 +19,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Process commit and find users responsible for labeling
+      - name: Process commit and find merger for labeling
         id: commit
-        run: echo "::set-output name=responsible_users::$(python .github/process_commit.py ${{ github.sha }})"
+        run: echo "::set-output name=merger::$(python .github/process_commit.py ${{ github.sha }})"
 
-      - name: Ping users responsible for labeling if necessary
-        if: ${{ steps.commit.outputs.responsible_users != '' }}
+      - name: Ping merger responsible for labeling if necessary
+        if: ${{ steps.commit.outputs.merger != '' }}
         uses: mshick/add-pr-comment@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           message: |
-            Hey ${{ steps.commit.outputs.responsible_users }}!
+            Hey ${{ steps.commit.outputs.merger }}!
 
-            You approved or merged this PR, but no labels were added.
+            You merged this PR, but no labels were added.


### PR DESCRIPTION
I think we should only ping the one who merged the PR. Sometimes, people review and approve but it doesn't mean they should be concerned with tagging the PR, and they shouldn't be pinged either as we need to be respectful of people's notifications. For example I asked for a stamp for https://github.com/pytorch/vision/pull/4080  and Moto kindly approved the PR, but there's no reason he should be pinged.


CC @pmeier 