### PR TITLE
ci: Remove mentions of conda-forge

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -312,7 +312,7 @@ jobs:
             conda activate base
             conda install -yq conda-build "conda-package-handling!=1.5.0"
             # cudatoolkit >= 11 isn't available for windows in the nvidia channel
-            if [[ "${CU_VERSION}" =~ "cu11*" ]]; then
+            if [[ "${CU_VERSION}" =~ cu11.* ]]; then
               export CONDA_CHANNEL_FLAGS="-c conda-forge"
             fi
             packaging/build_conda.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -311,6 +311,10 @@ jobs:
             eval "$('/C/tools/miniconda3/Scripts/conda.exe' 'shell.bash' 'hook')"
             conda activate base
             conda install -yq conda-build "conda-package-handling!=1.5.0"
+            # cudatoolkit >= 11 isn't available for windows in the nvidia channel
+            if [[ "${CU_VERSION}" =~ "cu11*" ]]; then
+              export CONDA_CHANNEL_FLAGS="-c conda-forge"
+            fi
             packaging/build_conda.sh
             rm /C/tools/miniconda3/conda-bld/win-64/vs${VC_YEAR}*.tar.bz2
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -577,11 +577,7 @@ jobs:
             set -x
             eval "$('/C/tools/miniconda3/Scripts/conda.exe' 'shell.bash' 'hook')"
             conda env remove -n python${PYTHON_VERSION} || true
-            CONDA_CHANNEL_FLAGS=""
-            if [[ "${PYTHON_VERSION}" = 3.9 ]]; then
-              CONDA_CHANNEL_FLAGS="-c=conda-forge"
-            fi
-            conda create ${CONDA_CHANNEL_FLAGS} -yn python${PYTHON_VERSION} python=${PYTHON_VERSION}
+            conda create -yn python${PYTHON_VERSION} python=${PYTHON_VERSION}
             conda activate python${PYTHON_VERSION}
             conda install Pillow>=5.3.0
             conda install -v -y -c pytorch-nightly pytorch
@@ -606,11 +602,6 @@ jobs:
           command: |
             set -x
             eval "$('/C/tools/miniconda3/Scripts/conda.exe' 'shell.bash' 'hook')"
-            CONDA_CHANNEL_FLAGS=""
-            if [[ "${PYTHON_VERSION}" = 3.9 ]]; then
-              CONDA_CHANNEL_FLAGS="-c=conda-forge"
-            fi
-            conda create ${CONDA_CHANNEL_FLAGS} -yn python${PYTHON_VERSION} python=${PYTHON_VERSION}
             conda create -yn python${PYTHON_VERSION} python=${PYTHON_VERSION}
             conda activate python${PYTHON_VERSION}
             pip install $(ls ~/workspace/torchvision*.whl) --pre -f https://download.pytorch.org/whl/nightly/torch_nightly.html

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -312,7 +312,7 @@ jobs:
             conda activate base
             conda install -yq conda-build "conda-package-handling!=1.5.0"
             # cudatoolkit >= 11 isn't available for windows in the nvidia channel
-            if [[ "${CU_VERSION}" =~ "cu11*" ]]; then
+            if [[ "${CU_VERSION}" =~ cu11.* ]]; then
               export CONDA_CHANNEL_FLAGS="-c conda-forge"
             fi
             packaging/build_conda.sh

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -311,6 +311,10 @@ jobs:
             eval "$('/C/tools/miniconda3/Scripts/conda.exe' 'shell.bash' 'hook')"
             conda activate base
             conda install -yq conda-build "conda-package-handling!=1.5.0"
+            # cudatoolkit >= 11 isn't available for windows in the nvidia channel
+            if [[ "${CU_VERSION}" =~ "cu11*" ]]; then
+              export CONDA_CHANNEL_FLAGS="-c conda-forge"
+            fi
             packaging/build_conda.sh
             rm /C/tools/miniconda3/conda-bld/win-64/vs${VC_YEAR}*.tar.bz2
       - store_artifacts:

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -577,11 +577,7 @@ jobs:
             set -x
             eval "$('/C/tools/miniconda3/Scripts/conda.exe' 'shell.bash' 'hook')"
             conda env remove -n python${PYTHON_VERSION} || true
-            CONDA_CHANNEL_FLAGS=""
-            if [[ "${PYTHON_VERSION}" = 3.9 ]]; then
-              CONDA_CHANNEL_FLAGS="-c=conda-forge"
-            fi
-            conda create ${CONDA_CHANNEL_FLAGS} -yn python${PYTHON_VERSION} python=${PYTHON_VERSION}
+            conda create -yn python${PYTHON_VERSION} python=${PYTHON_VERSION}
             conda activate python${PYTHON_VERSION}
             conda install Pillow>=5.3.0
             conda install -v -y -c pytorch-nightly pytorch
@@ -606,11 +602,6 @@ jobs:
           command: |
             set -x
             eval "$('/C/tools/miniconda3/Scripts/conda.exe' 'shell.bash' 'hook')"
-            CONDA_CHANNEL_FLAGS=""
-            if [[ "${PYTHON_VERSION}" = 3.9 ]]; then
-              CONDA_CHANNEL_FLAGS="-c=conda-forge"
-            fi
-            conda create ${CONDA_CHANNEL_FLAGS} -yn python${PYTHON_VERSION} python=${PYTHON_VERSION}
             conda create -yn python${PYTHON_VERSION} python=${PYTHON_VERSION}
             conda activate python${PYTHON_VERSION}
             pip install $(ls ~/workspace/torchvision*.whl) --pre -f https://download.pytorch.org/whl/nightly/torch_nightly.html

--- a/.circleci/unittest/linux/scripts/environment.yml
+++ b/.circleci/unittest/linux/scripts/environment.yml
@@ -1,8 +1,6 @@
 channels:
   - pytorch
   - defaults
-  # using conda-forge for python v3.9
-  - conda-forge
 dependencies:
   - pytest
   - pytest-cov

--- a/.circleci/unittest/linux/scripts/install.sh
+++ b/.circleci/unittest/linux/scripts/install.sh
@@ -24,7 +24,7 @@ else
 fi
 
 printf "Installing PyTorch with %s\n" "${cudatoolkit}"
-conda install -y -c "pytorch-${UPLOAD_CHANNEL}" -c conda-forge "pytorch-${UPLOAD_CHANNEL}"::pytorch "${cudatoolkit}" pytest
+conda install -y -c "pytorch-${UPLOAD_CHANNEL}" "pytorch-${UPLOAD_CHANNEL}"::pytorch "${cudatoolkit}" pytest
 
 if [ $PYTHON_VERSION == "3.6" ]; then
     printf "Installing minimal PILLOW version\n"

--- a/.circleci/unittest/windows/scripts/environment.yml
+++ b/.circleci/unittest/windows/scripts/environment.yml
@@ -1,8 +1,6 @@
 channels:
   - pytorch
   - defaults
-  # use conda-forge for python v3.9+
-  - conda-forge
 dependencies:
   - pytest
   - pytest-cov

--- a/.circleci/unittest/windows/scripts/install.sh
+++ b/.circleci/unittest/windows/scripts/install.sh
@@ -26,7 +26,7 @@ else
 fi
 
 printf "Installing PyTorch with %s\n" "${cudatoolkit}"
-conda install -y -c "pytorch-${UPLOAD_CHANNEL}" -c conda-forge "pytorch-${UPLOAD_CHANNEL}"::pytorch "${cudatoolkit}" pytest
+conda install -y -c "pytorch-${UPLOAD_CHANNEL}" "pytorch-${UPLOAD_CHANNEL}"::pytorch "${cudatoolkit}" pytest
 
 if [ $PYTHON_VERSION == "3.6" ]; then
     printf "Installing minimal PILLOW version\n"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ clear and has sufficient instructions to be able to reproduce the issue.
 ### Install PyTorch Nightly 
 
 ```bash
-conda install pytorch -c pytorch-nightly -c conda-forge
+conda install pytorch -c pytorch-nightly
 # or with pip (see https://pytorch.org/get-started/locally/)
 # pip install numpy
 # pip install --pre torch -f https://download.pytorch.org/whl/nightly/cu102/torch_nightly.html

--- a/packaging/build_conda.sh
+++ b/packaging/build_conda.sh
@@ -11,4 +11,5 @@ setup_conda_pytorch_constraint
 setup_conda_cudatoolkit_constraint
 setup_visual_studio_constraint
 setup_junit_results_folder
-conda build $CONDA_CHANNEL_FLAGS -c defaults --no-anaconda-upload --python "$PYTHON_VERSION" packaging/torchvision
+# nvidia channel included for cudatoolkit >= 11
+conda build $CONDA_CHANNEL_FLAGS -c defaults -c nvidia --no-anaconda-upload --python "$PYTHON_VERSION" packaging/torchvision

--- a/packaging/build_conda.sh
+++ b/packaging/build_conda.sh
@@ -11,4 +11,4 @@ setup_conda_pytorch_constraint
 setup_conda_cudatoolkit_constraint
 setup_visual_studio_constraint
 setup_junit_results_folder
-conda build $CONDA_CHANNEL_FLAGS -c defaults -c conda-forge --no-anaconda-upload --python "$PYTHON_VERSION" packaging/torchvision
+conda build $CONDA_CHANNEL_FLAGS -c defaults --no-anaconda-upload --python "$PYTHON_VERSION" packaging/torchvision

--- a/packaging/build_conda.sh
+++ b/packaging/build_conda.sh
@@ -12,4 +12,4 @@ setup_conda_cudatoolkit_constraint
 setup_visual_studio_constraint
 setup_junit_results_folder
 # nvidia channel included for cudatoolkit >= 11
-conda build $CONDA_CHANNEL_FLAGS -c defaults -c nvidia --no-anaconda-upload --python "$PYTHON_VERSION" packaging/torchvision
+conda build -c defaults -c nvidia $CONDA_CHANNEL_FLAGS --no-anaconda-upload --python "$PYTHON_VERSION" packaging/torchvision

--- a/packaging/pkg_helpers.bash
+++ b/packaging/pkg_helpers.bash
@@ -247,7 +247,7 @@ setup_pip_pytorch_version() {
 # You MUST have populated PYTORCH_VERSION_SUFFIX before hand.
 setup_conda_pytorch_constraint() {
   if [[ -z "$PYTORCH_VERSION" ]]; then
-    export CONDA_CHANNEL_FLAGS="-c pytorch-nightly -c pytorch"
+    export CONDA_CHANNEL_FLAGS="${CONDA_CHANNEL_FLAGS} -c pytorch-nightly -c pytorch"
     export PYTORCH_VERSION="$(conda search --json 'pytorch[channel=pytorch-nightly]' | \
                               python -c "import os, sys, json, re; cuver = os.environ.get('CU_VERSION'); \
                                cuver_1 = cuver.replace('cu', 'cuda') if cuver != 'cpu' else cuver; \
@@ -262,7 +262,7 @@ setup_conda_pytorch_constraint() {
       exit 1
     fi
   else
-    export CONDA_CHANNEL_FLAGS="-c pytorch -c pytorch-${UPLOAD_CHANNEL}"
+    export CONDA_CHANNEL_FLAGS="${CONDA_CHANNEL_FLAGS} -c pytorch -c pytorch-${UPLOAD_CHANNEL}"
   fi
   if [[ "$CU_VERSION" == cpu ]]; then
     export CONDA_PYTORCH_BUILD_CONSTRAINT="- pytorch==$PYTORCH_VERSION${PYTORCH_VERSION_SUFFIX}"

--- a/packaging/pkg_helpers.bash
+++ b/packaging/pkg_helpers.bash
@@ -180,13 +180,10 @@ setup_wheel_python() {
   if [[ "$(uname)" == Darwin || "$OSTYPE" == "msys" ]]; then
     eval "$(conda shell.bash hook)"
     conda env remove -n "env$PYTHON_VERSION" || true
-    if [[ "$PYTHON_VERSION" == 3.9 ]]; then
-      export CONDA_CHANNEL_FLAGS="${CONDA_CHANNEL_FLAGS} -c=conda-forge"
-    fi
     conda create ${CONDA_CHANNEL_FLAGS} -yn "env$PYTHON_VERSION" python="$PYTHON_VERSION"
     conda activate "env$PYTHON_VERSION"
     # Install libpng from Anaconda (defaults)
-    conda install ${CONDA_CHANNEL_FLAGS} -c conda-forge libpng "jpeg<=9b" -y
+    conda install ${CONDA_CHANNEL_FLAGS} libpng "jpeg<=9b" -y
   else
     # Install native CentOS libJPEG, LAME, freetype and GnuTLS
     yum install -y libjpeg-turbo-devel lame freetype gnutls
@@ -276,9 +273,6 @@ setup_conda_pytorch_constraint() {
   fi
   if [[ "$OSTYPE" == msys && "$CU_VERSION" == cu92 ]]; then
     export CONDA_CHANNEL_FLAGS="${CONDA_CHANNEL_FLAGS} -c defaults -c numba/label/dev"
-  fi
-  if [[ "$PYTHON_VERSION" == 3.9 ]]; then
-    export CONDA_CHANNEL_FLAGS="${CONDA_CHANNEL_FLAGS} -c=conda-forge"
   fi
 }
 

--- a/packaging/torchvision/meta.yaml
+++ b/packaging/torchvision/meta.yaml
@@ -52,7 +52,6 @@ test:
   requires:
     - pytest
     - scipy
-    - av
     # NOTE: Pinned to fix issues with size_t on Windows
     - jpeg <=9b
     - ca-certificates


### PR DESCRIPTION
We run into a lot of build / runtime issues when relying on things from
conda-forge. Now that Python 3.9 is more thoroughly supported on the
default anaconda channel lets remove the hooks for conda-forge now.

This PR also removes the `av` dependency from the conda `meta.yaml` since it's currently only available within `conda-forge`.

It isn't critical to run the import smoke tests that we specify for conda and the test coverage should already be covered by the unit tests which do install `av` but choose to install it from `pypi` instead. (which cannot be done with `conda-build`, see https://github.com/conda/conda-build/issues/548)

I think not having `av` within the conda recipe should be fine considering the trade-off is having to use `conda-forge` for all of our dependencies.

Resolves https://github.com/pytorch/vision/issues/4076

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>