### PR TITLE
remove unnecessary call .clone() in box_convert func

### DIFF
--- a/torchvision/ops/boxes.py
+++ b/torchvision/ops/boxes.py
@@ -181,7 +181,7 @@ def box_convert(boxes: Tensor, in_fmt: str, out_fmt: str) -> Tensor:
         raise ValueError("Unsupported Bounding Box Conversions for given in_fmt and out_fmt")
 
     if in_fmt == out_fmt:
-        return boxes.clone()
+        return boxes
 
     if in_fmt != 'xyxy' and out_fmt != 'xyxy':
         # convert to xyxy and change in_fmt xyxy


### PR DESCRIPTION
remove unnecessary call .clone() in box_convert func

fix #4091 