### PR TITLE
Group all internally replaced utils into a single file

### DIFF
--- a/torchvision/_internally_replaced_utils.py
+++ b/torchvision/_internally_replaced_utils.py
@@ -2,6 +2,20 @@ import os
 import importlib.machinery
 
 
+def _download_file_from_remote_location(fpath: str, url: str) -> None:
+    pass
+
+
+def _is_remote_location_available() -> bool:
+    return False
+
+
+try:
+    from torch.hub import load_state_dict_from_url
+except ImportError:
+    from torch.utils.model_zoo import load_url as load_state_dict_from_url
+
+
 def _get_extension_path(lib_name):
 
     lib_dir = os.path.dirname(__file__)

--- a/torchvision/datasets/_utils.py
+++ b/torchvision/datasets/_utils.py
@@ -1,6 +1,0 @@
-def _download_file_from_remote_location(fpath: str, url: str) -> None:
-    pass
-
-
-def _is_remote_location_available() -> bool:
-    return False

--- a/torchvision/datasets/utils.py
+++ b/torchvision/datasets/utils.py
@@ -17,7 +17,7 @@ import pathlib
 import torch
 from torch.utils.model_zoo import tqdm
 
-from ._utils import (
+from .._internally_replaced_utils import (
     _download_file_from_remote_location,
     _is_remote_location_available,
 )

--- a/torchvision/extension.py
+++ b/torchvision/extension.py
@@ -1,6 +1,6 @@
 import torch
 
-from ._register_extension import _get_extension_path
+from ._internally_replaced_utils import _get_extension_path
 
 
 _HAS_OPS = False

--- a/torchvision/io/_video_opt.py
+++ b/torchvision/io/_video_opt.py
@@ -8,7 +8,7 @@ from typing import List, Tuple
 import numpy as np
 import torch
 
-from .._register_extension import _get_extension_path
+from .._internally_replaced_utils import _get_extension_path
 
 
 try:

--- a/torchvision/io/image.py
+++ b/torchvision/io/image.py
@@ -1,7 +1,7 @@
 import torch
 from enum import Enum
 
-from .._register_extension import _get_extension_path
+from .._internally_replaced_utils import _get_extension_path
 
 
 try:

--- a/torchvision/models/alexnet.py
+++ b/torchvision/models/alexnet.py
@@ -1,6 +1,6 @@
 import torch
 import torch.nn as nn
-from .utils import load_state_dict_from_url
+from .._internally_replaced_utils import load_state_dict_from_url
 from typing import Any
 
 

--- a/torchvision/models/densenet.py
+++ b/torchvision/models/densenet.py
@@ -4,7 +4,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 import torch.utils.checkpoint as cp
 from collections import OrderedDict
-from .utils import load_state_dict_from_url
+from .._internally_replaced_utils import load_state_dict_from_url
 from torch import Tensor
 from typing import Any, List, Tuple
 

--- a/torchvision/models/detection/faster_rcnn.py
+++ b/torchvision/models/detection/faster_rcnn.py
@@ -4,7 +4,7 @@ import torch.nn.functional as F
 from torchvision.ops import MultiScaleRoIAlign
 
 from ._utils import overwrite_eps
-from ..utils import load_state_dict_from_url
+from ..._internally_replaced_utils import load_state_dict_from_url
 
 from .anchor_utils import AnchorGenerator
 from .generalized_rcnn import GeneralizedRCNN

--- a/torchvision/models/detection/keypoint_rcnn.py
+++ b/torchvision/models/detection/keypoint_rcnn.py
@@ -4,7 +4,7 @@ from torch import nn
 from torchvision.ops import MultiScaleRoIAlign
 
 from ._utils import overwrite_eps
-from ..utils import load_state_dict_from_url
+from ..._internally_replaced_utils import load_state_dict_from_url
 
 from .faster_rcnn import FasterRCNN
 from .backbone_utils import resnet_fpn_backbone, _validate_trainable_layers

--- a/torchvision/models/detection/mask_rcnn.py
+++ b/torchvision/models/detection/mask_rcnn.py
@@ -5,7 +5,7 @@ from torch import nn
 from torchvision.ops import MultiScaleRoIAlign
 
 from ._utils import overwrite_eps
-from ..utils import load_state_dict_from_url
+from ..._internally_replaced_utils import load_state_dict_from_url
 
 from .faster_rcnn import FasterRCNN
 from .backbone_utils import resnet_fpn_backbone, _validate_trainable_layers

--- a/torchvision/models/detection/retinanet.py
+++ b/torchvision/models/detection/retinanet.py
@@ -7,7 +7,7 @@ from torch import nn, Tensor
 from typing import Dict, List, Tuple, Optional
 
 from ._utils import overwrite_eps
-from ..utils import load_state_dict_from_url
+from ..._internally_replaced_utils import load_state_dict_from_url
 
 from . import _utils as det_utils
 from .anchor_utils import AnchorGenerator

--- a/torchvision/models/detection/ssd.py
+++ b/torchvision/models/detection/ssd.py
@@ -11,7 +11,7 @@ from .anchor_utils import DefaultBoxGenerator
 from .backbone_utils import _validate_trainable_layers
 from .transform import GeneralizedRCNNTransform
 from .. import vgg
-from ..utils import load_state_dict_from_url
+from ..._internally_replaced_utils import load_state_dict_from_url
 from ...ops import boxes as box_ops
 
 __all__ = ['SSD', 'ssd300_vgg16']

--- a/torchvision/models/detection/ssdlite.py
+++ b/torchvision/models/detection/ssdlite.py
@@ -12,7 +12,7 @@ from .anchor_utils import DefaultBoxGenerator
 from .backbone_utils import _validate_trainable_layers
 from .. import mobilenet
 from ..mobilenetv3 import ConvBNActivation
-from ..utils import load_state_dict_from_url
+from ..._internally_replaced_utils import load_state_dict_from_url
 
 
 __all__ = ['ssdlite320_mobilenet_v3_large']

--- a/torchvision/models/googlenet.py
+++ b/torchvision/models/googlenet.py
@@ -4,7 +4,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from torch import Tensor
-from .utils import load_state_dict_from_url
+from .._internally_replaced_utils import load_state_dict_from_url
 from typing import Optional, Tuple, List, Callable, Any
 
 __all__ = ['GoogLeNet', 'googlenet', "GoogLeNetOutputs", "_GoogLeNetOutputs"]

--- a/torchvision/models/inception.py
+++ b/torchvision/models/inception.py
@@ -3,7 +3,7 @@ import warnings
 import torch
 from torch import nn, Tensor
 import torch.nn.functional as F
-from .utils import load_state_dict_from_url
+from .._internally_replaced_utils import load_state_dict_from_url
 from typing import Callable, Any, Optional, Tuple, List
 
 

--- a/torchvision/models/mnasnet.py
+++ b/torchvision/models/mnasnet.py
@@ -3,7 +3,7 @@ import warnings
 import torch
 from torch import Tensor
 import torch.nn as nn
-from .utils import load_state_dict_from_url
+from .._internally_replaced_utils import load_state_dict_from_url
 from typing import Any, Dict, List
 
 __all__ = ['MNASNet', 'mnasnet0_5', 'mnasnet0_75', 'mnasnet1_0', 'mnasnet1_3']

--- a/torchvision/models/mobilenetv2.py
+++ b/torchvision/models/mobilenetv2.py
@@ -1,7 +1,7 @@
 import torch
 from torch import nn
 from torch import Tensor
-from .utils import load_state_dict_from_url
+from .._internally_replaced_utils import load_state_dict_from_url
 from typing import Callable, Any, Optional, List
 
 

--- a/torchvision/models/mobilenetv3.py
+++ b/torchvision/models/mobilenetv3.py
@@ -5,7 +5,7 @@ from torch import nn, Tensor
 from torch.nn import functional as F
 from typing import Any, Callable, Dict, List, Optional, Sequence
 
-from torchvision.models.utils import load_state_dict_from_url
+from .._internally_replaced_utils import load_state_dict_from_url
 from torchvision.models.mobilenetv2 import _make_divisible, ConvBNActivation
 
 

--- a/torchvision/models/quantization/googlenet.py
+++ b/torchvision/models/quantization/googlenet.py
@@ -3,7 +3,7 @@ import torch
 import torch.nn as nn
 from torch.nn import functional as F
 
-from torchvision.models.utils import load_state_dict_from_url
+from ..._internally_replaced_utils import load_state_dict_from_url
 from torchvision.models.googlenet import (
     GoogLeNetOutputs, BasicConv2d, Inception, InceptionAux, GoogLeNet, model_urls)
 

--- a/torchvision/models/quantization/inception.py
+++ b/torchvision/models/quantization/inception.py
@@ -5,7 +5,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torchvision.models import inception as inception_module
 from torchvision.models.inception import InceptionOutputs
-from torchvision.models.utils import load_state_dict_from_url
+from ..._internally_replaced_utils import load_state_dict_from_url
 from .utils import _replace_relu, quantize_model
 
 

--- a/torchvision/models/quantization/mobilenetv2.py
+++ b/torchvision/models/quantization/mobilenetv2.py
@@ -1,5 +1,5 @@
 from torch import nn
-from torchvision.models.utils import load_state_dict_from_url
+from ..._internally_replaced_utils import load_state_dict_from_url
 from torchvision.models.mobilenetv2 import InvertedResidual, ConvBNReLU, MobileNetV2, model_urls
 from torch.quantization import QuantStub, DeQuantStub, fuse_modules
 from .utils import _replace_relu, quantize_model

--- a/torchvision/models/quantization/mobilenetv3.py
+++ b/torchvision/models/quantization/mobilenetv3.py
@@ -1,6 +1,6 @@
 import torch
 from torch import nn, Tensor
-from torchvision.models.utils import load_state_dict_from_url
+from ..._internally_replaced_utils import load_state_dict_from_url
 from torchvision.models.mobilenetv3 import InvertedResidual, InvertedResidualConfig, ConvBNActivation, MobileNetV3,\
     SqueezeExcitation, model_urls, _mobilenet_v3_conf
 from torch.quantization import QuantStub, DeQuantStub, fuse_modules

--- a/torchvision/models/quantization/resnet.py
+++ b/torchvision/models/quantization/resnet.py
@@ -1,7 +1,7 @@
 import torch
 from torchvision.models.resnet import Bottleneck, BasicBlock, ResNet, model_urls
 import torch.nn as nn
-from torchvision.models.utils import load_state_dict_from_url
+from ..._internally_replaced_utils import load_state_dict_from_url
 from torch.quantization import fuse_modules
 from .utils import _replace_relu, quantize_model
 

--- a/torchvision/models/quantization/shufflenetv2.py
+++ b/torchvision/models/quantization/shufflenetv2.py
@@ -1,6 +1,6 @@
 import torch
 import torch.nn as nn
-from torchvision.models.utils import load_state_dict_from_url
+from ..._internally_replaced_utils import load_state_dict_from_url
 import torchvision.models.shufflenetv2
 import sys
 from .utils import _replace_relu, quantize_model

--- a/torchvision/models/resnet.py
+++ b/torchvision/models/resnet.py
@@ -1,7 +1,7 @@
 import torch
 from torch import Tensor
 import torch.nn as nn
-from .utils import load_state_dict_from_url
+from .._internally_replaced_utils import load_state_dict_from_url
 from typing import Type, Any, Callable, Union, List, Optional
 
 

--- a/torchvision/models/segmentation/segmentation.py
+++ b/torchvision/models/segmentation/segmentation.py
@@ -1,5 +1,5 @@
 from .._utils import IntermediateLayerGetter
-from ..utils import load_state_dict_from_url
+from ..._internally_replaced_utils import load_state_dict_from_url
 from .. import mobilenetv3
 from .. import resnet
 from .deeplabv3 import DeepLabHead, DeepLabV3

--- a/torchvision/models/shufflenetv2.py
+++ b/torchvision/models/shufflenetv2.py
@@ -1,7 +1,7 @@
 import torch
 from torch import Tensor
 import torch.nn as nn
-from .utils import load_state_dict_from_url
+from .._internally_replaced_utils import load_state_dict_from_url
 from typing import Callable, Any, List
 
 

--- a/torchvision/models/squeezenet.py
+++ b/torchvision/models/squeezenet.py
@@ -1,7 +1,7 @@
 import torch
 import torch.nn as nn
 import torch.nn.init as init
-from .utils import load_state_dict_from_url
+from .._internally_replaced_utils import load_state_dict_from_url
 from typing import Any
 
 __all__ = ['SqueezeNet', 'squeezenet1_0', 'squeezenet1_1']

--- a/torchvision/models/utils.py
+++ b/torchvision/models/utils.py
@@ -1,7 +1,0 @@
-# Don't remove this file and don't change the imports of load_state_dict_from_url
-# from other files. We need this so that we can swap load_state_dict_from_url with
-# a custom internal version in fbcode.
-try:
-    from torch.hub import load_state_dict_from_url
-except ImportError:
-    from torch.utils.model_zoo import load_url as load_state_dict_from_url

--- a/torchvision/models/vgg.py
+++ b/torchvision/models/vgg.py
@@ -1,6 +1,6 @@
 import torch
 import torch.nn as nn
-from .utils import load_state_dict_from_url
+from .._internally_replaced_utils import load_state_dict_from_url
 from typing import Union, List, Dict, Any, cast
 
 

--- a/torchvision/models/video/resnet.py
+++ b/torchvision/models/video/resnet.py
@@ -1,6 +1,6 @@
 import torch.nn as nn
 
-from ..utils import load_state_dict_from_url
+from ..._internally_replaced_utils import load_state_dict_from_url
 
 
 __all__ = ['r3d_18', 'mc3_18', 'r2plus1d_18']


### PR DESCRIPTION
Summary: This diff groups all internally-replaced utils into a single file. This way, we only have to replace one file and keep the TARGETS file a bit cleaner

Differential Revision: D29199311

