### PR TITLE
Update inception.py

### DIFF
--- a/torchvision/models/inception.py
+++ b/torchvision/models/inception.py
@@ -116,6 +116,7 @@ class Inception3(nn.Module):
         self.Mixed_7c = inception_e(2048)
         self.avgpool = nn.AdaptiveAvgPool2d((1, 1))
         self.dropout = nn.Dropout()
+        self.flatten = nn.Flatten()
         self.fc = nn.Linear(2048, num_classes)
         if init_weights:
             for m in self.modules():
@@ -187,7 +188,7 @@ class Inception3(nn.Module):
         # N x 2048 x 1 x 1
         x = self.dropout(x)
         # N x 2048 x 1 x 1
-        x = torch.flatten(x, 1)
+        x = self.flatten(x)  # change from torch.flatten to nn.Flatten allows to override this stage, whitch was previously impossible
         # N x 2048
         x = self.fc(x)
         # N x 1000 (num_classes)


### PR DESCRIPTION
Insertion in line 119:
self.flatten = nn.Flatten()

Change in line 191:
x = torch.flatten(x, 1) -> x = self.flatten(x)

This change allows to override flattening before build-in dense classifier, therefore enabling non-dense custom processing heads(e.g. pseudo-embedders for features injection into transformers for image captioning).
Before, flattening was inaccessible, forcing users to play with un-flattening, which is inconvenient.