### PR TITLE
Add bzip2 file compression support

### DIFF
--- a/torchvision/datasets/utils.py
+++ b/torchvision/datasets/utils.py
@@ -263,6 +263,7 @@ def _extract_tar(from_path: str, to_path: str, compression: Optional[str]) -> No
 
 
 _ZIP_COMPRESSION_MAP: Dict[str, int] = {
+    ".bz2": zipfile.ZIP_BZIP2,
     ".xz": zipfile.ZIP_LZMA,
 }
 

--- a/torchvision/datasets/utils.py
+++ b/torchvision/datasets/utils.py
@@ -1,3 +1,4 @@
+import bz2
 import os
 import os.path
 import hashlib
@@ -277,8 +278,16 @@ _ARCHIVE_EXTRACTORS: Dict[str, Callable[[str, str, Optional[str]], None]] = {
     ".tar": _extract_tar,
     ".zip": _extract_zip,
 }
-_COMPRESSED_FILE_OPENERS: Dict[str, Callable[..., IO]] = {".gz": gzip.open, ".xz": lzma.open}
-_FILE_TYPE_ALIASES: Dict[str, Tuple[Optional[str], Optional[str]]] = {".tgz": (".tar", ".gz")}
+_COMPRESSED_FILE_OPENERS: Dict[str, Callable[..., IO]] = {
+    ".bz2": bz2.open,
+    ".gz": gzip.open,
+    ".xz": lzma.open
+}
+_FILE_TYPE_ALIASES: Dict[str, Tuple[Optional[str], Optional[str]]] = {
+    ".tbz": (".tar", ".bz2"),
+    ".tbz2": (".tar", ".bz2"),
+    ".tgz": (".tar", ".gz")
+}
 
 
 def _verify_archive_type(archive_type: str) -> None:

--- a/torchvision/datasets/utils.py
+++ b/torchvision/datasets/utils.py
@@ -282,12 +282,12 @@ _ARCHIVE_EXTRACTORS: Dict[str, Callable[[str, str, Optional[str]], None]] = {
 _COMPRESSED_FILE_OPENERS: Dict[str, Callable[..., IO]] = {
     ".bz2": bz2.open,
     ".gz": gzip.open,
-    ".xz": lzma.open
+    ".xz": lzma.open,
 }
 _FILE_TYPE_ALIASES: Dict[str, Tuple[Optional[str], Optional[str]]] = {
     ".tbz": (".tar", ".bz2"),
     ".tbz2": (".tar", ".bz2"),
-    ".tgz": (".tar", ".gz")
+    ".tgz": (".tar", ".gz"),
 }
 
 


### PR DESCRIPTION
This PR adds support for the bzip2 decompression scheme.

Examples of datasets that use bzip2 compression:

* [Cars Overhead With Context](https://gdo152.llnl.gov/cowc/): uses both `.bz2` and `.tbz`
* [WikiSmall and WikiLarge](https://github.com/XingxingZhang/dress): uses `.tar.bz2`

Also see https://github.com/pytorch/text/issues/815 for a related issue in `torchtext`.

@pmeier @calebrob6