### PR TITLE
Add RAR file extraction support

### DIFF
--- a/.circleci/unittest/linux/scripts/environment.yml
+++ b/.circleci/unittest/linux/scripts/environment.yml
@@ -10,9 +10,9 @@ dependencies:
   # NOTE: Pinned to fix issues with size_t on Windows
   - jpeg <=9b
   - ca-certificates
-  - rarfile
   - pip:
     - future
     - pillow >=5.3.0
     - scipy
     - av
+    - rarfile

--- a/.circleci/unittest/linux/scripts/environment.yml
+++ b/.circleci/unittest/linux/scripts/environment.yml
@@ -10,6 +10,7 @@ dependencies:
   # NOTE: Pinned to fix issues with size_t on Windows
   - jpeg <=9b
   - ca-certificates
+  - rarfile
   - pip:
     - future
     - pillow >=5.3.0

--- a/.circleci/unittest/windows/scripts/environment.yml
+++ b/.circleci/unittest/windows/scripts/environment.yml
@@ -10,10 +10,10 @@ dependencies:
   # NOTE: Pinned to fix issues with size_t on Windows
   - jpeg <=9b
   - ca-certificates
-  - rarfile
   - pip:
     - future
     - pillow >=5.3.0
     - scipy
     - av
     - dataclasses
+    - rarfile

--- a/.circleci/unittest/windows/scripts/environment.yml
+++ b/.circleci/unittest/windows/scripts/environment.yml
@@ -10,6 +10,7 @@ dependencies:
   # NOTE: Pinned to fix issues with size_t on Windows
   - jpeg <=9b
   - ca-certificates
+  - rarfile
   - pip:
     - future
     - pillow >=5.3.0

--- a/.github/workflows/tests-schedule.yml
+++ b/.github/workflows/tests-schedule.yml
@@ -33,7 +33,9 @@ jobs:
         run: pip install -e .
 
       - name: Install all optional dataset requirements
-        run: pip install scipy pandas pycocotools lmdb requests
+        run: |
+            sudo apt-get install unrar
+            pip install rarfile scipy pandas pycocotools lmdb requests
 
       - name: Install tests requirements
         run: pip install pytest

--- a/.github/workflows/tests-schedule.yml
+++ b/.github/workflows/tests-schedule.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Install all optional dataset requirements
         run: |
-            sudo apt-get install unrar
+            sudo apt-get install rar unrar
             pip install rarfile scipy pandas pycocotools lmdb requests
 
       - name: Install tests requirements

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,22 +4,22 @@ We want to make contributing to this project as easy and transparent as possible
 
 ## TL;DR
 
-We appreciate all contributions. If you are interested in contributing to Torchvision, there are many ways to help out. 
+We appreciate all contributions. If you are interested in contributing to Torchvision, there are many ways to help out.
 Your contributions may fall into the following categories:
 
-- It helps the project if you could 
+- It helps the project if you could
     - Report issues you're facing
-    - Give a :+1: on issues that others reported and that are relevant to you 
+    - Give a :+1: on issues that others reported and that are relevant to you
 
 - Answering queries on the issue tracker, investigating bugs are very valuable contributions to the project.
 
-- You would like to improve the documentation. This is no less important than improving the library itself! 
+- You would like to improve the documentation. This is no less important than improving the library itself!
 If you find a typo in the documentation, do not hesitate to submit a GitHub pull request.
 
 - If you would like to fix a bug
     - please pick one from the [list of open issues labelled as "help wanted"](https://github.com/pytorch/vision/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22)
     - comment on the issue that you want to work on this issue
-    - send a PR with your fix, see below. 
+    - send a PR with your fix, see below.
 
 - If you plan to contribute new features, utility functions or extensions, please first open an issue and discuss the feature with us.
 
@@ -30,7 +30,7 @@ clear and has sufficient instructions to be able to reproduce the issue.
 
 ## Development installation
 
-### Install PyTorch Nightly 
+### Install PyTorch Nightly
 
 ```bash
 conda install pytorch -c pytorch-nightly
@@ -49,7 +49,7 @@ python setup.py develop
 # MACOSX_DEPLOYMENT_TARGET=10.9 CC=clang CXX=clang++ python setup.py develop
 # for C++ debugging, please use DEBUG=1
 # DEBUG=1 python setup.py develop
-pip install flake8 typing mypy pytest pytest-mock scipy
+pip install flake8 typing mypy pytest pytest-mock scipy rarfile
 ```
 You may also have to install `libpng-dev` and `libjpeg-turbo8-dev` libraries:
 ```bash
@@ -66,12 +66,12 @@ If you plan to modify the code or documentation, please follow the steps below:
 4. Ensure the test suite passes.
 5. Make sure your code passes `flake8` formatting check.
 
-For more details about pull requests, 
-please read [GitHub's guides](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request). 
+For more details about pull requests,
+please read [GitHub's guides](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request).
 
 If you would like to contribute a new model, please see [here](#New-model).
 
-If you would like to contribute a new dataset, please see [here](#New-dataset). 
+If you would like to contribute a new dataset, please see [here](#New-dataset).
 
 ### Code formatting and typing
 
@@ -87,8 +87,8 @@ mypy --config-file mypy.ini
 
 ### Unit tests
 
-If you have modified the code by adding a new feature or a bug-fix, please add unit tests for that. To run a specific 
-test: 
+If you have modified the code by adding a new feature or a bug-fix, please add unit tests for that. To run a specific
+test:
 ```bash
 pytest test/<test-module.py> -vvv -k <test_myfunc>
 # e.g. pytest test/test_transforms.py -vvv -k test_center_crop
@@ -97,7 +97,7 @@ pytest test/<test-module.py> -vvv -k <test_myfunc>
 If you would like to run all tests:
 ```bash
 pytest test -vvv
-``` 
+```
 
 Tests that require internet access should be in
 `test/test_internet.py`.
@@ -149,20 +149,20 @@ with "transforms" in their name.
 
 ### New model
 
-More details on how to add a new model will be provided later. Please, do not send any PR with a new model without discussing 
+More details on how to add a new model will be provided later. Please, do not send any PR with a new model without discussing
 it in an issue as, most likely, it will not be accepted.
- 
+
 ### New dataset
 
-More details on how to add a new dataset will be provided later. Please, do not send any PR with a new dataset without discussing 
+More details on how to add a new dataset will be provided later. Please, do not send any PR with a new dataset without discussing
 it in an issue as, most likely, it will not be accepted.
 
 ### Pull Request
 
-If all previous checks (flake8, mypy, unit tests) are passing, please send a PR. Submitted PR will pass other tests on 
+If all previous checks (flake8, mypy, unit tests) are passing, please send a PR. Submitted PR will pass other tests on
 different operation systems, python versions and hardwares.
 
-For more details about pull requests workflow, 
+For more details about pull requests workflow,
 please read [GitHub's guides](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request).
 
 ## License

--- a/packaging/torchvision/meta.yaml
+++ b/packaging/torchvision/meta.yaml
@@ -55,6 +55,7 @@ test:
     # NOTE: Pinned to fix issues with size_t on Windows
     - jpeg <=9b
     - ca-certificates
+    - rarfile
 
 
 about:

--- a/packaging/torchvision/meta.yaml
+++ b/packaging/torchvision/meta.yaml
@@ -55,7 +55,6 @@ test:
     # NOTE: Pinned to fix issues with size_t on Windows
     - jpeg <=9b
     - ca-certificates
-    - rarfile
 
 
 about:

--- a/packaging/wheel/osx_wheel.sh
+++ b/packaging/wheel/osx_wheel.sh
@@ -39,7 +39,7 @@ do
     echo "Building against ${TORCHAUDIO_PYTORCH_DEPENDENCY_VERSION}"
 
     # install torchvision dependencies
-    pip install ninja scipy pytest
+    pip install ninja scipy pytest rarfile
 
     python setup.py clean
     python setup.py bdist_wheel

--- a/test/test_datasets_utils.py
+++ b/test/test_datasets_utils.py
@@ -15,10 +15,6 @@ import pytest
 
 from common_utils import get_tmp_dir, call_args_to_kwargs_only
 
-try:
-    import rarfile
-except ImportError:
-    rarfile = None
 
 TEST_FILE = get_file_path_2(
     os.path.dirname(os.path.abspath(__file__)), 'assets', 'encode_jpeg', 'grace_hopper_517x606.jpg')
@@ -183,8 +179,9 @@ class Tester(unittest.TestCase):
                     dict(from_path=file, to_path=filename, remove_finished=remove_finished),
                 )
 
-    @pytest.skipif(rarfile is None, reason='rarfile is not available')
     def test_extract_rar(self):
+        rarfile = pytest.importorskip("rarfile")
+
         def create_archive(root, content="this is the content"):
             file = os.path.join(root, "dst.txt")
             archive = os.path.join(root, "archive.rar")

--- a/test/test_datasets_utils.py
+++ b/test/test_datasets_utils.py
@@ -186,8 +186,7 @@ class Tester(unittest.TestCase):
             file = os.path.join(root, "dst.txt")
             archive = os.path.join(root, "archive.rar")
 
-            with rarfile.RarFile(archive, "w") as zf:
-                zf.writestr(os.path.basename(file), content)
+            os.system(f"rar a {archive} {file}")
 
             return archive, file, content
 

--- a/test/test_datasets_utils.py
+++ b/test/test_datasets_utils.py
@@ -12,6 +12,7 @@ from urllib.error import URLError
 import itertools
 import lzma
 import pytest
+import subprocess
 
 from common_utils import get_tmp_dir, call_args_to_kwargs_only
 
@@ -186,7 +187,7 @@ class Tester(unittest.TestCase):
             file = os.path.join(root, "dst.txt")
             archive = os.path.join(root, "archive.rar")
 
-            os.system(f"rar a {archive} {file}")
+            subprocess.run(["rar", "a", archive, file], check=True)
 
             return archive, file, content
 

--- a/torchvision/datasets/utils.py
+++ b/torchvision/datasets/utils.py
@@ -258,7 +258,7 @@ def _save_response_content(
 
 
 def _extract_rar(from_path: str, to_path: str, compression: Optional[str]) -> None:
-    import rarfile
+    import rarfile  # type: ignore[import]
     with rarfile.RarFile(from_path, "r") as rar:
         rar.extractall(to_path)
 

--- a/torchvision/datasets/utils.py
+++ b/torchvision/datasets/utils.py
@@ -257,6 +257,12 @@ def _save_response_content(
         pbar.close()
 
 
+def _extract_rar(from_path: str, to_path: str, compression: Optional[str]) -> None:
+    import rarfile
+    with rarfile.RarFile(from_path, "r") as rar:
+        rar.extractall(to_path)
+
+
 def _extract_tar(from_path: str, to_path: str, compression: Optional[str]) -> None:
     with tarfile.open(from_path, f"r:{compression[1:]}" if compression else "r") as tar:
         tar.extractall(to_path)
@@ -276,6 +282,7 @@ def _extract_zip(from_path: str, to_path: str, compression: Optional[str]) -> No
 
 
 _ARCHIVE_EXTRACTORS: Dict[str, Callable[[str, str, Optional[str]], None]] = {
+    ".rar": _extract_rar,
     ".tar": _extract_tar,
     ".zip": _extract_zip,
 }


### PR DESCRIPTION
This PR adds support for the RAR archive file format.

Examples of datasets that use RAR archival:

* [NWPU VHR-10](https://github.com/chaozhong2010/VHR-10_dataset_coco)

Note that this adds an extra dependency on `rarfile`, which few people will have installed. I believe I've used lazy imports and guards everywhere I can, but let me know if I missed a spot.

Note that `rarfile` is just a wrapper around a system executable like `unrar`, `unar`, or `bsdrar`, so it won't work unless these packages are also installed. Unfortunately, `pip` and `conda` won't install `unrar` for you: https://github.com/conda-forge/rarfile-feedstock/issues/4

@pmeier @calebrob6