### PR TITLE
Raise proper error when deconding 16-bits jpegs

### DIFF
--- a/torchvision/csrc/io/image/cpu/decode_png.cpp
+++ b/torchvision/csrc/io/image/cpu/decode_png.cpp
@@ -71,6 +71,11 @@ torch::Tensor decode_png(const torch::Tensor& data, ImageReadMode mode) {
     TORCH_CHECK(retval == 1, "Could read image metadata from content.")
   }
 
+  if (bit_depth > 8) {
+    png_destroy_read_struct(&png_ptr, &info_ptr, nullptr);
+    TORCH_CHECK(false, "At most 8-bit PNG images are supported currently.")
+  }
+
   int channels = png_get_channels(png_ptr, info_ptr);
 
   if (color_type == PNG_COLOR_TYPE_GRAY && bit_depth < 8)


### PR DESCRIPTION
After some investigation, I found that #3613 failed because the image is 16 bit. However our decoding code assumes the image is 8-bit. So our allocated tensor size is too small to hold the decoded data and leads to memory overflow.

However, I can't find an easy way to decode 16-bit images without breaking the current decoding logic(we would have to change too many code places). So I simply issue an error.

Note: In order to support 16-bit png images, we should allocate the tensor with torch::kI16 and change 
```
auto datap = data.accessor<unsigned char, 1>().data();
```  
and 
```
auto ptr = tensor.accessor<uint8_t, 3>().data();
```
and the logic of read_callback. And although #4051 didn't fix this bug, I still think it's useful..