### PR TITLE
Port test_datasets_utils to pytest

### DIFF
--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -240,23 +240,6 @@ def disable_console_output():
         yield
 
 
-def call_args_to_kwargs_only(call_args, *callable_or_arg_names):
-    callable_or_arg_name = callable_or_arg_names[0]
-    if callable(callable_or_arg_name):
-        argspec = inspect.getfullargspec(callable_or_arg_name)
-        arg_names = argspec.args
-        if isinstance(callable_or_arg_name, type):
-            # remove self
-            arg_names.pop(0)
-    else:
-        arg_names = callable_or_arg_names
-
-    args, kwargs = call_args
-    kwargs_only = kwargs.copy()
-    kwargs_only.update(dict(zip(arg_names, args)))
-    return kwargs_only
-
-
 def cpu_and_gpu():
     import pytest  # noqa
     return ('cpu', pytest.param('cuda', marks=pytest.mark.needs_cuda))

--- a/test/test_datasets_utils.py
+++ b/test/test_datasets_utils.py
@@ -127,7 +127,6 @@ class TestDatasetsUtils:
         utils.extract_archive(file, remove_finished=remove_finished)
 
         mocked.assert_called_once()
-        print(mocked.call_args)
 
         assert (call_args_to_kwargs_only(mocked.call_args, original_decompress) ==
                 dict(from_path=file, to_path=filename, remove_finished=remove_finished))

--- a/test/test_datasets_utils.py
+++ b/test/test_datasets_utils.py
@@ -117,13 +117,13 @@ class TestDatasetsUtils:
 
             assert not os.path.exists(compressed)
 
-    @pytest.mark.parametrize('ext', [".gz", ".xz"])
+    @pytest.mark.parametrize('extension', [".gz", ".xz"])
     @pytest.mark.parametrize('remove_finished', [True, False])
-    def test_extract_archive_defer_to_decompress(self, ext, remove_finished, mocker):
+    def test_extract_archive_defer_to_decompress(self, extension, remove_finished, mocker):
         filename = "foo"
         original_decompress = utils._decompress
         mocked = mocker.patch("torchvision.datasets.utils._decompress")
-        file = f"{filename}{ext}"
+        file = f"{filename}{extension}"
         utils.extract_archive(file, remove_finished=remove_finished)
 
         mocked.assert_called_once()
@@ -152,13 +152,13 @@ class TestDatasetsUtils:
             with open(file, "r") as fh:
                 assert fh.read() == content
 
-    @pytest.mark.parametrize('ext, mode', [
+    @pytest.mark.parametrize('extension, mode', [
         ('.tar', 'w'), ('.tar.gz', 'w:gz'), ('.tgz', 'w:gz'), ('.tar.xz', 'w:xz')])
-    def test_extract_tar(self, ext, mode):
-        def create_archive(root, ext, mode, content="this is the content"):
+    def test_extract_tar(self, extension, mode):
+        def create_archive(root, extension, mode, content="this is the content"):
             src = os.path.join(root, "src.txt")
             dst = os.path.join(root, "dst.txt")
-            archive = os.path.join(root, f"archive{ext}")
+            archive = os.path.join(root, f"archive{extension}")
 
             with open(src, "w") as fh:
                 fh.write(content)
@@ -169,7 +169,7 @@ class TestDatasetsUtils:
             return archive, dst, content
 
         with get_tmp_dir() as temp_dir:
-            archive, file, content = create_archive(temp_dir, ext, mode)
+            archive, file, content = create_archive(temp_dir, extension, mode)
 
             utils.extract_archive(archive, temp_dir)
 

--- a/test/test_datasets_utils.py
+++ b/test/test_datasets_utils.py
@@ -11,7 +11,7 @@ from urllib.error import URLError
 import itertools
 import lzma
 
-from common_utils import get_tmp_dir, call_args_to_kwargs_only
+from common_utils import get_tmp_dir
 from torchvision.datasets.utils import _COMPRESSED_FILE_OPENERS
 
 
@@ -121,15 +121,12 @@ class TestDatasetsUtils:
     @pytest.mark.parametrize('remove_finished', [True, False])
     def test_extract_archive_defer_to_decompress(self, extension, remove_finished, mocker):
         filename = "foo"
-        original_decompress = utils._decompress
-        mocked = mocker.patch("torchvision.datasets.utils._decompress")
         file = f"{filename}{extension}"
+
+        mocked = mocker.patch("torchvision.datasets.utils._decompress")
         utils.extract_archive(file, remove_finished=remove_finished)
 
-        mocked.assert_called_once()
-
-        assert (call_args_to_kwargs_only(mocked.call_args, original_decompress) ==
-                dict(from_path=file, to_path=filename, remove_finished=remove_finished))
+        mocked.assert_called_once_with(file, filename, remove_finished=remove_finished)
 
     def test_extract_zip(self):
         def create_archive(root, content="this is the content"):


### PR DESCRIPTION
Fixes #4063

@NicolasHug apologies for the delay. Please note the following main changes (might be helpful in reviewing the PR):

- `test_detect_file_type` is parametrized over `file, expected` 
- `test_detect_file_type_incompatible` now represents and clubs the following three different tests:
  - `test_detect_file_type_no_ext`
  - `test_detect_file_type_unknown_compression`
  - `test_detect_file_type_unknown_partial_ext`
- `test_decompress` is parametrized over `extension` and makes use of `_COMPRESSED_FILE_OPENERS` `dict` defined in `torchvision.datasets.utils`. This also clubs following tests into one:
  - `test_decompress_bz2`
  - `test_decompress_gzip`
  - `test_decompress_lzma`
- `test_extract_archive_defer_to_decompress` is parametrized over `extension` and `remove_finished` and makes use of `pytest-mock`. Note the original copy required to avoid mocked `utils._decompress` function in the final assert. 
- `test_extract_tar` is parametrized over `extension, mode` combining `test_extract_tar` and `test_extract_tar_xz` into one.
