### PR TITLE
Minor additions to Resize docs

### DIFF
--- a/torchvision/transforms/functional.py
+++ b/torchvision/transforms/functional.py
@@ -346,7 +346,8 @@ def resize(img: Tensor, size: List[int], interpolation: InterpolationMode = Inte
         The output image might be different depending on its type: when downsampling, the interpolation of PIL images
         and tensors is slightly different, because PIL applies antialiasing. This may lead to significant differences
         in the performance of a network. Therefore, it is preferable to train and serve a model with the same input
-        types.
+        types. See also below the ``antialias`` parameter, which can help making the output of PIL images and tensors
+        closer.
 
     Args:
         img (PIL Image or Tensor): Image to be resized.
@@ -372,8 +373,9 @@ def resize(img: Tensor, size: List[int], interpolation: InterpolationMode = Inte
             if ``size`` is an int (or a sequence of length 1 in torchscript
             mode).
         antialias (bool, optional): antialias flag. If ``img`` is PIL Image, the flag is ignored and anti-alias
-            is always used. If ``img`` is Tensor, the flag is False by default and can be set True for
-            ``InterpolationMode.BILINEAR`` only mode.
+            is always used. If ``img`` is Tensor, the flag is False by default and can be set to True for
+            ``InterpolationMode.BILINEAR`` only mode. This can help making the output for PIL images and tensors
+            closer.
 
             .. warning::
                 There is no autodiff support for ``antialias=True`` option with input ``img`` as Tensor.

--- a/torchvision/transforms/transforms.py
+++ b/torchvision/transforms/transforms.py
@@ -233,7 +233,8 @@ class Resize(torch.nn.Module):
         The output image might be different depending on its type: when downsampling, the interpolation of PIL images
         and tensors is slightly different, because PIL applies antialiasing. This may lead to significant differences
         in the performance of a network. Therefore, it is preferable to train and serve a model with the same input
-        types.
+        types. See also below the ``antialias`` parameter, which can help making the output of PIL images and tensors
+        closer.
 
     Args:
         size (sequence or int): Desired output size. If size is a sequence like
@@ -258,8 +259,9 @@ class Resize(torch.nn.Module):
             if ``size`` is an int (or a sequence of length 1 in torchscript
             mode).
         antialias (bool, optional): antialias flag. If ``img`` is PIL Image, the flag is ignored and anti-alias
-            is always used. If ``img`` is Tensor, the flag is False by default and can be set True for
-            ``InterpolationMode.BILINEAR`` only mode.
+            is always used. If ``img`` is Tensor, the flag is False by default and can be set to True for
+            ``InterpolationMode.BILINEAR`` only mode. This can help making the output for PIL images and tensors
+            closer.
 
             .. warning::
                 There is no autodiff support for ``antialias=True`` option with input ``img`` as Tensor.


### PR DESCRIPTION
Just some minor edits to the docs which will hopefully explicitly clarify that using `antialias` will lead to closer outputs for PIL and tensors. This is motivated by https://github.com/pytorch/vision/issues/2950#issuecomment-871189566

CC @vfdev-5 