### PR TITLE
Explicitly exclude PIL 8.3.0 from compatible dependencies

### DIFF
--- a/.circleci/unittest/linux/scripts/environment.yml
+++ b/.circleci/unittest/linux/scripts/environment.yml
@@ -12,6 +12,6 @@ dependencies:
   - ca-certificates
   - pip:
     - future
-    - pillow >=5.3.0
+    - pillow >=5.3.0, !=8.3.0
     - scipy
     - av

--- a/.circleci/unittest/windows/scripts/environment.yml
+++ b/.circleci/unittest/windows/scripts/environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - ca-certificates
   - pip:
     - future
-    - pillow >=5.3.0
+    - pillow >=5.3.0, !=8.3.0
     - scipy
     - av
     - dataclasses

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,8 @@ requirements = [
     pytorch_dep,
 ]
 
-pillow_ver = ' >= 5.3.0'
+# Excluding 8.3.0 because of https://github.com/pytorch/vision/issues/4146
+pillow_ver = ' >= 5.3.0, !=8.3.0'
 pillow_req = 'pillow-simd' if get_dist('pillow-simd') is not None else 'pillow'
 requirements.append(pillow_req + pillow_ver)
 


### PR DESCRIPTION
Closes https://github.com/pytorch/vision/issues/4146

CC @pmeier 