### PR TITLE
Do not install lame when building torchvision

### DIFF
--- a/packaging/build_wheel.sh
+++ b/packaging/build_wheel.sh
@@ -8,6 +8,7 @@ export BUILD_TYPE=wheel
 setup_env 0.11.0
 setup_wheel_python
 pip_install numpy pyyaml future ninja
+pip_install --upgrade setuptools
 setup_pip_pytorch_version
 python setup.py clean
 

--- a/packaging/pkg_helpers.bash
+++ b/packaging/pkg_helpers.bash
@@ -185,8 +185,8 @@ setup_wheel_python() {
     # Install libpng from Anaconda (defaults)
     conda install ${CONDA_CHANNEL_FLAGS} libpng "jpeg<=9b" -y
   else
-    # Install native CentOS libJPEG, LAME, freetype and GnuTLS
-    yum install -y libjpeg-turbo-devel lame freetype gnutls
+    # Install native CentOS libJPEG, freetype and GnuTLS
+    yum install -y libjpeg-turbo-devel freetype gnutls
     case "$PYTHON_VERSION" in
       2.7)
         if [[ -n "$UNICODE_ABI" ]]; then


### PR DESCRIPTION
It is needed only for ffmpeg integration, which is disabled anyway.

Also update setuptools to workaround:
```
AttributeError: 'Version' object has no attribute 'major'
```
Introduced by https://github.com/pytorch/pytorch/pull/59665 and attempted to be mitigated by https://github.com/pytorch/pytorch/pull/61053