### PR TITLE
Catch ValueError due to recent change to torch.testing.assert_close

### DIFF
--- a/test/test_models.py
+++ b/test/test_models.py
@@ -108,7 +108,7 @@ def _check_jit_scriptable(nn_module, args, unwrapper=None, skip=False):
         tol = 3e-4
         try:
             torch.testing.assert_close(results, results_from_imported, atol=tol, rtol=tol)
-        except torch.testing._asserts.UsageError:
+        except ValueError:
             # custom check for the models that return named tuples:
             # we compare field by field while ignoring None as assert_close can't handle None
             for a, b in zip(results, results_from_imported):


### PR DESCRIPTION
With https://github.com/pytorch/pytorch/pull/61031 now merged, we should catch `ValueError`s.

This should fix most of the currently failing tests.

CC @pmeier :) !