### PR TITLE
Mock redirection logic for tests

### DIFF
--- a/test/test_datasets_utils.py
+++ b/test/test_datasets_utils.py
@@ -34,8 +34,8 @@ def patch_url_redirection(mocker, redirect_url):
 
 class TestDatasetsUtils:
     def test_get_redirect_url(self, mocker):
-        url = "http://www.vision.caltech.edu/visipedia-data/CUB-200-2011/CUB_200_2011.tgz"
-        expected_redirect_url = "https://drive.google.com/file/d/1hbzc_P1FuxMkcabkgn9ZKinBwW683j45/view"
+        url = "https://url.org"
+        expected_redirect_url = "https://redirect.url.org"
 
         patch_url_redirection(mocker, expected_redirect_url)
 
@@ -43,8 +43,8 @@ class TestDatasetsUtils:
         assert actual == expected_redirect_url
 
     def test_get_redirect_url_max_hops_exceeded(self, mocker):
-        url = "http://www.vision.caltech.edu/visipedia-data/CUB-200-2011/CUB_200_2011.tgz"
-        redirect_url = "https://drive.google.com/file/d/1hbzc_P1FuxMkcabkgn9ZKinBwW683j45/view"
+        url = "https://url.org"
+        redirect_url = "https://redirect.url.org"
 
         patch_url_redirection(mocker, redirect_url)
 

--- a/test/test_datasets_utils.py
+++ b/test/test_datasets_utils.py
@@ -10,6 +10,7 @@ from torch._utils_internal import get_file_path_2
 from urllib.error import URLError
 import itertools
 import lzma
+import contextlib
 
 from common_utils import get_tmp_dir
 from torchvision.datasets.utils import _COMPRESSED_FILE_OPENERS
@@ -19,7 +20,36 @@ TEST_FILE = get_file_path_2(
     os.path.dirname(os.path.abspath(__file__)), 'assets', 'encode_jpeg', 'grace_hopper_517x606.jpg')
 
 
+def patch_url_redirection(mocker, redirect_url):
+    class Response:
+        def __init__(self, url):
+            self.url = url
+
+    @contextlib.contextmanager
+    def patched_opener(*args, **kwargs):
+        yield Response(redirect_url)
+
+    return mocker.patch("torchvision.datasets.utils.urllib.request.urlopen", new=patched_opener)
+
+
 class TestDatasetsUtils:
+    def test_get_redirect_url(self, mocker):
+        url = "http://www.vision.caltech.edu/visipedia-data/CUB-200-2011/CUB_200_2011.tgz"
+        expected_redirect_url = "https://drive.google.com/file/d/1hbzc_P1FuxMkcabkgn9ZKinBwW683j45/view"
+
+        patch_url_redirection(mocker, expected_redirect_url)
+
+        actual = utils._get_redirect_url(url)
+        assert actual == expected_redirect_url
+
+    def test_get_redirect_url_max_hops_exceeded(self, mocker):
+        url = "http://www.vision.caltech.edu/visipedia-data/CUB-200-2011/CUB_200_2011.tgz"
+        redirect_url = "https://drive.google.com/file/d/1hbzc_P1FuxMkcabkgn9ZKinBwW683j45/view"
+
+        patch_url_redirection(mocker, redirect_url)
+
+        with pytest.raises(RecursionError):
+            utils._get_redirect_url(url, max_hops=0)
 
     def test_check_md5(self):
         fpath = TEST_FILE

--- a/test/test_internet.py
+++ b/test/test_internet.py
@@ -98,12 +98,12 @@ class TestDatasetUtils:
         filename = "filename"
         md5 = "md5"
 
-        mocked = mocker.patch("torchvision.datasets.utils.download_file_from_google_drive")
+        mocked = mocker.patch('torchvision.datasets.utils.download_file_from_google_drive')
         with get_tmp_dir() as root:
             utils.download_url(url, root, filename, md5)
 
         mocked.assert_called_once_with(id, root, filename, md5)
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     pytest.main([__file__])

--- a/test/test_internet.py
+++ b/test/test_internet.py
@@ -9,43 +9,12 @@ import os
 import pytest
 import warnings
 from urllib.error import URLError
-import contextlib
 
 import torchvision.datasets.utils as utils
 from common_utils import get_tmp_dir
 
 
-def patch_url_redirection(mocker, redirect_url):
-    class Response:
-        def __init__(self, url):
-            self.url = url
-
-    @contextlib.contextmanager
-    def patched_opener(*args, **kwargs):
-        yield Response(redirect_url)
-
-    mocker.patch("torchvision.datasets.utils.urllib.request.urlopen", new=patched_opener)
-
-
 class TestDatasetUtils:
-    def test_get_redirect_url(self, mocker):
-        url = "http://www.vision.caltech.edu/visipedia-data/CUB-200-2011/CUB_200_2011.tgz"
-        expected_redirect_url = "https://drive.google.com/file/d/1hbzc_P1FuxMkcabkgn9ZKinBwW683j45/view"
-
-        patch_url_redirection(mocker, expected_redirect_url)
-
-        actual = utils._get_redirect_url(url)
-        assert actual == expected_redirect_url
-
-    def test_get_redirect_url_max_hops_exceeded(self, mocker):
-        url = "http://www.vision.caltech.edu/visipedia-data/CUB-200-2011/CUB_200_2011.tgz"
-        redirect_url = "https://drive.google.com/file/d/1hbzc_P1FuxMkcabkgn9ZKinBwW683j45/view"
-
-        patch_url_redirection(mocker, redirect_url)
-
-        with pytest.raises(RecursionError):
-            utils._get_redirect_url(url, max_hops=0)
-
     def test_download_url(self):
         with get_tmp_dir() as temp_dir:
             url = "http://github.com/pytorch/vision/archive/master.zip"

--- a/test/test_internet.py
+++ b/test/test_internet.py
@@ -9,22 +9,61 @@ import os
 import pytest
 import warnings
 from urllib.error import URLError
+from urllib.request import Request
 
 import torchvision.datasets.utils as utils
 from common_utils import get_tmp_dir
 
 
-class TestDatasetUtils:
+@pytest.fixture
+def patch_url_redirection(mocker):
+    class Response:
+        def __init__(self, url):
+            self.url = url
 
-    def test_get_redirect_url(self):
+    def factory(*urls):
+        class PatchedOpener:
+            def __init__(self, request_or_url, *args, **kwargs):
+                self._request_or_url = request_or_url
+
+            def __enter__(self):
+                url = (
+                    self._request_or_url.full_url
+                    if isinstance(self._request_or_url.full_url, Request)
+                    else self._request_or_url.full_url
+                )
+
+                if url == urls[-1]:
+                    redirect_url = url
+                else:
+                    redirect_url = urls[urls.index(url) + 1]
+
+                return Response(redirect_url)
+
+            def __exit__(self, exc_type, exc_val, exc_tb):
+                pass
+
+        mocker.patch("torchvision.datasets.utils.urllib.request.urlopen", new=PatchedOpener)
+
+    return factory
+
+
+class TestDatasetUtils:
+    def test_get_redirect_url(self, patch_url_redirection):
         url = "http://www.vision.caltech.edu/visipedia-data/CUB-200-2011/CUB_200_2011.tgz"
-        expected = "https://drive.google.com/file/d/1hbzc_P1FuxMkcabkgn9ZKinBwW683j45/view"
+        expected_redirected_url = "https://drive.google.com/file/d/1hbzc_P1FuxMkcabkgn9ZKinBwW683j45/view"
+
+        patch_url_redirection(url, expected_redirected_url)
 
         actual = utils._get_redirect_url(url)
-        assert actual == expected
+        assert actual == expected_redirected_url
 
-    def test_get_redirect_url_max_hops_exceeded(self):
+    def test_get_redirect_url_max_hops_exceeded(self, patch_url_redirection):
         url = "http://www.vision.caltech.edu/visipedia-data/CUB-200-2011/CUB_200_2011.tgz"
+        redirected_url = "https://drive.google.com/file/d/1hbzc_P1FuxMkcabkgn9ZKinBwW683j45/view"
+
+        patch_url_redirection(url, redirected_url)
+
         with pytest.raises(RecursionError):
             utils._get_redirect_url(url, max_hops=0)
 
@@ -59,12 +98,12 @@ class TestDatasetUtils:
         filename = "filename"
         md5 = "md5"
 
-        mocked = mocker.patch('torchvision.datasets.utils.download_file_from_google_drive')
+        mocked = mocker.patch("torchvision.datasets.utils.download_file_from_google_drive")
         with get_tmp_dir() as root:
             utils.download_url(url, root, filename, md5)
 
         mocked.assert_called_once_with(id, root, filename, md5)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     pytest.main([__file__])

--- a/test/test_internet.py
+++ b/test/test_internet.py
@@ -9,60 +9,39 @@ import os
 import pytest
 import warnings
 from urllib.error import URLError
-from urllib.request import Request
+import contextlib
 
 import torchvision.datasets.utils as utils
 from common_utils import get_tmp_dir
 
 
-@pytest.fixture
-def patch_url_redirection(mocker):
+def patch_url_redirection(mocker, redirect_url):
     class Response:
         def __init__(self, url):
             self.url = url
 
-    def factory(*urls):
-        class PatchedOpener:
-            def __init__(self, request_or_url, *args, **kwargs):
-                self._request_or_url = request_or_url
+    @contextlib.contextmanager
+    def patched_opener(*args, **kwargs):
+        yield Response(redirect_url)
 
-            def __enter__(self):
-                url = (
-                    self._request_or_url.full_url
-                    if isinstance(self._request_or_url.full_url, Request)
-                    else self._request_or_url.full_url
-                )
-
-                if url == urls[-1]:
-                    redirect_url = url
-                else:
-                    redirect_url = urls[urls.index(url) + 1]
-
-                return Response(redirect_url)
-
-            def __exit__(self, exc_type, exc_val, exc_tb):
-                pass
-
-        mocker.patch("torchvision.datasets.utils.urllib.request.urlopen", new=PatchedOpener)
-
-    return factory
+    mocker.patch("torchvision.datasets.utils.urllib.request.urlopen", new=patched_opener)
 
 
 class TestDatasetUtils:
-    def test_get_redirect_url(self, patch_url_redirection):
+    def test_get_redirect_url(self, mocker):
         url = "http://www.vision.caltech.edu/visipedia-data/CUB-200-2011/CUB_200_2011.tgz"
-        expected_redirected_url = "https://drive.google.com/file/d/1hbzc_P1FuxMkcabkgn9ZKinBwW683j45/view"
+        expected_redirect_url = "https://drive.google.com/file/d/1hbzc_P1FuxMkcabkgn9ZKinBwW683j45/view"
 
-        patch_url_redirection(url, expected_redirected_url)
+        patch_url_redirection(mocker, expected_redirect_url)
 
         actual = utils._get_redirect_url(url)
-        assert actual == expected_redirected_url
+        assert actual == expected_redirect_url
 
-    def test_get_redirect_url_max_hops_exceeded(self, patch_url_redirection):
+    def test_get_redirect_url_max_hops_exceeded(self, mocker):
         url = "http://www.vision.caltech.edu/visipedia-data/CUB-200-2011/CUB_200_2011.tgz"
-        redirected_url = "https://drive.google.com/file/d/1hbzc_P1FuxMkcabkgn9ZKinBwW683j45/view"
+        redirect_url = "https://drive.google.com/file/d/1hbzc_P1FuxMkcabkgn9ZKinBwW683j45/view"
 
-        patch_url_redirection(url, redirected_url)
+        patch_url_redirection(mocker, redirect_url)
 
         with pytest.raises(RecursionError):
             utils._get_redirect_url(url, max_hops=0)


### PR DESCRIPTION
Fixes recent CI failures like [this](https://app.circleci.com/pipelines/github/pytorch/vision/9503/workflows/395d34f3-1f69-4c04-bfed-fff13e77f403/jobs/702140/tests). Two of our tests depend on the Caltech servers, which are down for some days #4188. This PR removes the dependency and mocks out the redirection behavior.