### PR TITLE
fix MacOS cmake workflow

### DIFF
--- a/packaging/build_cmake.sh
+++ b/packaging/build_cmake.sh
@@ -28,7 +28,15 @@ fi
 setup_visual_studio_constraint
 setup_junit_results_folder
 
-conda install -yq pytorch=$PYTORCH_VERSION $CONDA_CUDATOOLKIT_CONSTRAINT $CONDA_CPUONLY_FEATURE "mkl==2021.2.0" -c "pytorch-${UPLOAD_CHANNEL}"
+if [[ "$(uname)" == Darwin ]]; then
+  # TODO: this can be removed as soon as mkl's CMake support works with clang
+  #  see https://github.com/pytorch/vision/pull/4203 for details
+  MKL_CONSTRAINT=2021.2.0
+else
+  MKL_CONSTRAINT=
+fi
+
+conda install -yq \pytorch=$PYTORCH_VERSION $CONDA_CUDATOOLKIT_CONSTRAINT $CONDA_CPUONLY_FEATURE $MKL_CONSTRAINT -c "pytorch-${UPLOAD_CHANNEL}"
 TORCH_PATH=$(dirname $(python -c "import torch; print(torch.__file__)"))
 
 if [[ "$(uname)" == Darwin || "$OSTYPE" == "msys" ]]; then

--- a/packaging/build_cmake.sh
+++ b/packaging/build_cmake.sh
@@ -31,9 +31,9 @@ setup_junit_results_folder
 if [[ "$(uname)" == Darwin ]]; then
   # TODO: this can be removed as soon as mkl's CMake support works with clang
   #  see https://github.com/pytorch/vision/pull/4203 for details
-  MKL_CONSTRAINT=2021.2.0
+  MKL_CONSTRAINT='mkl==2021.2.0'
 else
-  MKL_CONSTRAINT=
+  MKL_CONSTRAINT=''
 fi
 
 conda install -yq \pytorch=$PYTORCH_VERSION $CONDA_CUDATOOLKIT_CONSTRAINT $CONDA_CPUONLY_FEATURE $MKL_CONSTRAINT -c "pytorch-${UPLOAD_CHANNEL}"

--- a/packaging/build_cmake.sh
+++ b/packaging/build_cmake.sh
@@ -28,7 +28,7 @@ fi
 setup_visual_studio_constraint
 setup_junit_results_folder
 
-conda install -yq pytorch=$PYTORCH_VERSION $CONDA_CUDATOOLKIT_CONSTRAINT $CONDA_CPUONLY_FEATURE  -c "pytorch-${UPLOAD_CHANNEL}"
+conda install -yq pytorch=$PYTORCH_VERSION $CONDA_CUDATOOLKIT_CONSTRAINT $CONDA_CPUONLY_FEATURE "mkl==2021.2.0" "intel-openmp==2021.2.0" -c "pytorch-${UPLOAD_CHANNEL}"
 TORCH_PATH=$(dirname $(python -c "import torch; print(torch.__file__)"))
 
 if [[ "$(uname)" == Darwin || "$OSTYPE" == "msys" ]]; then

--- a/packaging/build_cmake.sh
+++ b/packaging/build_cmake.sh
@@ -28,7 +28,7 @@ fi
 setup_visual_studio_constraint
 setup_junit_results_folder
 
-conda install -yq pytorch=$PYTORCH_VERSION $CONDA_CUDATOOLKIT_CONSTRAINT $CONDA_CPUONLY_FEATURE "mkl==2021.2.0" "intel-openmp==2021.2.0" -c "pytorch-${UPLOAD_CHANNEL}"
+conda install -yq pytorch=$PYTORCH_VERSION $CONDA_CUDATOOLKIT_CONSTRAINT $CONDA_CPUONLY_FEATURE "mkl==2021.2.0" -c "pytorch-${UPLOAD_CHANNEL}"
 TORCH_PATH=$(dirname $(python -c "import torch; print(torch.__file__)"))
 
 if [[ "$(uname)" == Darwin || "$OSTYPE" == "msys" ]]; then


### PR DESCRIPTION
I did some digging and it seems that `mkl==2021.3.0` and in particular their [newly added support for CMake](https://software.intel.com/content/www/us/en/develop/articles/oneapi-math-kernel-library-release-notes.html) is the problem. If you look at the executed `clang` command

```
/Applications/Xcode-12.0.1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++  -isysroot /Applications/Xcode-12.0.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -dynamiclib -Wl,-headerpad_max_install_names -o libtorchvision.dylib -install_name @rpath/libtorchvision.dylib CMakeFiles/torchvision.dir/torchvision/csrc/io/image/cpu/common_jpeg.cpp.o CMakeFiles/torchvision.dir/torchvision/csrc/io/image/cpu/decode_image.cpp.o CMakeFiles/torchvision.dir/torchvision/csrc/io/image/cpu/decode_jpeg.cpp.o CMakeFiles/torchvision.dir/torchvision/csrc/io/image/cpu/decode_png.cpp.o CMakeFiles/torchvision.dir/torchvision/csrc/io/image/cpu/encode_jpeg.cpp.o CMakeFiles/torchvision.dir/torchvision/csrc/io/image/cpu/encode_png.cpp.o CMakeFiles/torchvision.dir/torchvision/csrc/io/image/cpu/read_write_file.cpp.o CMakeFiles/torchvision.dir/torchvision/csrc/io/image/cuda/decode_jpeg_cuda.cpp.o CMakeFiles/torchvision.dir/torchvision/csrc/io/image/image.cpp.o CMakeFiles/torchvision.dir/torchvision/csrc/models/alexnet.cpp.o CMakeFiles/torchvision.dir/torchvision/csrc/models/densenet.cpp.o CMakeFiles/torchvision.dir/torchvision/csrc/models/googlenet.cpp.o CMakeFiles/torchvision.dir/torchvision/csrc/models/inception.cpp.o CMakeFiles/torchvision.dir/torchvision/csrc/models/mnasnet.cpp.o CMakeFiles/torchvision.dir/torchvision/csrc/models/mobilenet.cpp.o CMakeFiles/torchvision.dir/torchvision/csrc/models/resnet.cpp.o CMakeFiles/torchvision.dir/torchvision/csrc/models/shufflenetv2.cpp.o CMakeFiles/torchvision.dir/torchvision/csrc/models/squeezenet.cpp.o CMakeFiles/torchvision.dir/torchvision/csrc/models/vgg.cpp.o CMakeFiles/torchvision.dir/torchvision/csrc/ops/autograd/deform_conv2d_kernel.cpp.o CMakeFiles/torchvision.dir/torchvision/csrc/ops/autograd/ps_roi_align_kernel.cpp.o CMakeFiles/torchvision.dir/torchvision/csrc/ops/autograd/ps_roi_pool_kernel.cpp.o CMakeFiles/torchvision.dir/torchvision/csrc/ops/autograd/roi_align_kernel.cpp.o CMakeFiles/torchvision.dir/torchvision/csrc/ops/autograd/roi_pool_kernel.cpp.o CMakeFiles/torchvision.dir/torchvision/csrc/ops/cpu/deform_conv2d_kernel.cpp.o CMakeFiles/torchvision.dir/torchvision/csrc/ops/cpu/interpolate_aa_kernels.cpp.o CMakeFiles/torchvision.dir/torchvision/csrc/ops/cpu/nms_kernel.cpp.o CMakeFiles/torchvision.dir/torchvision/csrc/ops/cpu/ps_roi_align_kernel.cpp.o CMakeFiles/torchvision.dir/torchvision/csrc/ops/cpu/ps_roi_pool_kernel.cpp.o CMakeFiles/torchvision.dir/torchvision/csrc/ops/cpu/roi_align_kernel.cpp.o CMakeFiles/torchvision.dir/torchvision/csrc/ops/cpu/roi_pool_kernel.cpp.o CMakeFiles/torchvision.dir/torchvision/csrc/ops/deform_conv2d.cpp.o CMakeFiles/torchvision.dir/torchvision/csrc/ops/interpolate_aa.cpp.o CMakeFiles/torchvision.dir/torchvision/csrc/ops/nms.cpp.o CMakeFiles/torchvision.dir/torchvision/csrc/ops/ps_roi_align.cpp.o CMakeFiles/torchvision.dir/torchvision/csrc/ops/ps_roi_pool.cpp.o CMakeFiles/torchvision.dir/torchvision/csrc/ops/roi_align.cpp.o CMakeFiles/torchvision.dir/torchvision/csrc/ops/roi_pool.cpp.o CMakeFiles/torchvision.dir/torchvision/csrc/vision.cpp.o  -Wl,-rpath,/Users/distiller/miniconda3/lib/python3.9/site-packages/torch/lib -Wl,-rpath,/Users/distiller/miniconda3/lib /Users/distiller/miniconda3/lib/python3.9/site-packages/torch/lib/libc10.dylib /Users/distiller/miniconda3/lib/libpng.dylib /Users/distiller/miniconda3/lib/libjpeg.dylib /Users/distiller/miniconda3/lib/libpython3.9.dylib /Users/distiller/miniconda3/lib/python3.9/site-packages/torch/lib/libtorch.dylib /Users/distiller/miniconda3/lib/python3.9/site-packages/torch/lib/libtorch_cpu.dylib /Users/distiller/miniconda3/lib/python3.9/site-packages/torch/lib/libc10.dylib -lmkl_intel_ilp64 -lmkl_core -lmkl_intel_thread
```

it seems that `mkl` appends the libraries with the `-l` flag whereas everything else is listed with the full path. The `-l` flag looks a lot like `gcc` and I'm guessing this is why we are only seeing this on MacOS and not Linux or Windows.

Since there is very little we can do, this PR simply pins `mkl` to the previous version `2021.2.0` to avoid this.