### PR TITLE
Remove unnecessary dispatcher/registration code

### DIFF
--- a/torchvision/csrc/ops/autograd/ps_roi_pool_kernel.cpp
+++ b/torchvision/csrc/ops/autograd/ps_roi_pool_kernel.cpp
@@ -62,45 +62,6 @@ class PSROIPoolFunction : public torch::autograd::Function<PSROIPoolFunction> {
   }
 };
 
-// TODO: There should be an easier way to do this
-class PSROIPoolBackwardFunction
-    : public torch::autograd::Function<PSROIPoolBackwardFunction> {
- public:
-  static torch::autograd::variable_list forward(
-      torch::autograd::AutogradContext* ctx,
-      const torch::autograd::Variable& grad,
-      const torch::autograd::Variable& rois,
-      const torch::autograd::Variable& channel_mapping,
-      double spatial_scale,
-      int64_t pooled_height,
-      int64_t pooled_width,
-      int64_t batch_size,
-      int64_t channels,
-      int64_t height,
-      int64_t width) {
-    at::AutoDispatchBelowADInplaceOrView g;
-    auto grad_in = detail::_ps_roi_pool_backward(
-        grad,
-        rois,
-        channel_mapping,
-        spatial_scale,
-        pooled_height,
-        pooled_width,
-        batch_size,
-        channels,
-        height,
-        width);
-
-    return {grad_in};
-  }
-
-  static torch::autograd::variable_list backward(
-      torch::autograd::AutogradContext* ctx,
-      const torch::autograd::variable_list& grad_output) {
-    TORCH_CHECK(0, "double backwards on ps_roi_pool not supported");
-  }
-};
-
 std::tuple<at::Tensor, at::Tensor> ps_roi_pool_autograd(
     const at::Tensor& input,
     const at::Tensor& rois,
@@ -113,39 +74,12 @@ std::tuple<at::Tensor, at::Tensor> ps_roi_pool_autograd(
   return std::make_tuple(result[0], result[1]);
 }
 
-at::Tensor ps_roi_pool_backward_autograd(
-    const at::Tensor& grad,
-    const at::Tensor& rois,
-    const at::Tensor& channel_mapping,
-    double spatial_scale,
-    int64_t pooled_height,
-    int64_t pooled_width,
-    int64_t batch_size,
-    int64_t channels,
-    int64_t height,
-    int64_t width) {
-  return PSROIPoolBackwardFunction::apply(
-      grad,
-      rois,
-      channel_mapping,
-      spatial_scale,
-      pooled_height,
-      pooled_width,
-      batch_size,
-      channels,
-      height,
-      width)[0];
-}
-
 } // namespace
 
 TORCH_LIBRARY_IMPL(torchvision, Autograd, m) {
   m.impl(
       TORCH_SELECTIVE_NAME("torchvision::ps_roi_pool"),
       TORCH_FN(ps_roi_pool_autograd));
-  m.impl(
-      TORCH_SELECTIVE_NAME("torchvision::_ps_roi_pool_backward"),
-      TORCH_FN(ps_roi_pool_backward_autograd));
 }
 
 } // namespace ops

--- a/torchvision/csrc/ops/autograd/roi_align_kernel.cpp
+++ b/torchvision/csrc/ops/autograd/roi_align_kernel.cpp
@@ -68,45 +68,45 @@ class ROIAlignFunction : public torch::autograd::Function<ROIAlignFunction> {
   }
 };
 
-// TODO: There should be an easier way to do this
-class ROIAlignBackwardFunction
-    : public torch::autograd::Function<ROIAlignBackwardFunction> {
- public:
-  static torch::autograd::variable_list forward(
-      torch::autograd::AutogradContext* ctx,
-      const torch::autograd::Variable& grad,
-      const torch::autograd::Variable& rois,
-      double spatial_scale,
-      int64_t pooled_height,
-      int64_t pooled_width,
-      int64_t batch_size,
-      int64_t channels,
-      int64_t height,
-      int64_t width,
-      int64_t sampling_ratio,
-      bool aligned) {
-    at::AutoDispatchBelowADInplaceOrView g;
-    auto result = detail::_roi_align_backward(
-        grad,
-        rois,
-        spatial_scale,
-        pooled_height,
-        pooled_width,
-        batch_size,
-        channels,
-        height,
-        width,
-        sampling_ratio,
-        aligned);
-    return {result};
-  }
+// // TODO: There should be an easier way to do this
+// class ROIAlignBackwardFunction
+//     : public torch::autograd::Function<ROIAlignBackwardFunction> {
+//  public:
+//   static torch::autograd::variable_list forward(
+//       torch::autograd::AutogradContext* ctx,
+//       const torch::autograd::Variable& grad,
+//       const torch::autograd::Variable& rois,
+//       double spatial_scale,
+//       int64_t pooled_height,
+//       int64_t pooled_width,
+//       int64_t batch_size,
+//       int64_t channels,
+//       int64_t height,
+//       int64_t width,
+//       int64_t sampling_ratio,
+//       bool aligned) {
+//     at::AutoDispatchBelowADInplaceOrView g;
+//     auto result = detail::_roi_align_backward(
+//         grad,
+//         rois,
+//         spatial_scale,
+//         pooled_height,
+//         pooled_width,
+//         batch_size,
+//         channels,
+//         height,
+//         width,
+//         sampling_ratio,
+//         aligned);
+//     return {result};
+//   }
 
-  static torch::autograd::variable_list backward(
-      torch::autograd::AutogradContext* ctx,
-      const torch::autograd::variable_list& grad_output) {
-    TORCH_CHECK(0, "double backwards on roi_align not supported");
-  }
-};
+//   static torch::autograd::variable_list backward(
+//       torch::autograd::AutogradContext* ctx,
+//       const torch::autograd::variable_list& grad_output) {
+//     TORCH_CHECK(0, "double backwards on roi_align not supported");
+//   }
+// };
 
 at::Tensor roi_align_autograd(
     const at::Tensor& input,
@@ -126,31 +126,31 @@ at::Tensor roi_align_autograd(
       aligned)[0];
 }
 
-at::Tensor roi_align_backward_autograd(
-    const at::Tensor& grad,
-    const at::Tensor& rois,
-    double spatial_scale,
-    int64_t pooled_height,
-    int64_t pooled_width,
-    int64_t batch_size,
-    int64_t channels,
-    int64_t height,
-    int64_t width,
-    int64_t sampling_ratio,
-    bool aligned) {
-  return ROIAlignBackwardFunction::apply(
-      grad,
-      rois,
-      spatial_scale,
-      pooled_height,
-      pooled_width,
-      batch_size,
-      channels,
-      height,
-      width,
-      sampling_ratio,
-      aligned)[0];
-}
+// at::Tensor roi_align_backward_autograd(
+//     const at::Tensor& grad,
+//     const at::Tensor& rois,
+//     double spatial_scale,
+//     int64_t pooled_height,
+//     int64_t pooled_width,
+//     int64_t batch_size,
+//     int64_t channels,
+//     int64_t height,
+//     int64_t width,
+//     int64_t sampling_ratio,
+//     bool aligned) {
+//   return ROIAlignBackwardFunction::apply(
+//       grad,
+//       rois,
+//       spatial_scale,
+//       pooled_height,
+//       pooled_width,
+//       batch_size,
+//       channels,
+//       height,
+//       width,
+//       sampling_ratio,
+//       aligned)[0];
+// }
 
 } // namespace
 
@@ -158,9 +158,9 @@ TORCH_LIBRARY_IMPL(torchvision, Autograd, m) {
   m.impl(
       TORCH_SELECTIVE_NAME("torchvision::roi_align"),
       TORCH_FN(roi_align_autograd));
-  m.impl(
-      TORCH_SELECTIVE_NAME("torchvision::_roi_align_backward"),
-      TORCH_FN(roi_align_backward_autograd));
+  // m.impl(
+  //     TORCH_SELECTIVE_NAME("torchvision::_roi_align_backward"),
+  //     TORCH_FN(roi_align_backward_autograd));
 }
 
 } // namespace ops

--- a/torchvision/csrc/ops/autograd/roi_align_kernel.cpp
+++ b/torchvision/csrc/ops/autograd/roi_align_kernel.cpp
@@ -68,46 +68,6 @@ class ROIAlignFunction : public torch::autograd::Function<ROIAlignFunction> {
   }
 };
 
-// // TODO: There should be an easier way to do this
-// class ROIAlignBackwardFunction
-//     : public torch::autograd::Function<ROIAlignBackwardFunction> {
-//  public:
-//   static torch::autograd::variable_list forward(
-//       torch::autograd::AutogradContext* ctx,
-//       const torch::autograd::Variable& grad,
-//       const torch::autograd::Variable& rois,
-//       double spatial_scale,
-//       int64_t pooled_height,
-//       int64_t pooled_width,
-//       int64_t batch_size,
-//       int64_t channels,
-//       int64_t height,
-//       int64_t width,
-//       int64_t sampling_ratio,
-//       bool aligned) {
-//     at::AutoDispatchBelowADInplaceOrView g;
-//     auto result = detail::_roi_align_backward(
-//         grad,
-//         rois,
-//         spatial_scale,
-//         pooled_height,
-//         pooled_width,
-//         batch_size,
-//         channels,
-//         height,
-//         width,
-//         sampling_ratio,
-//         aligned);
-//     return {result};
-//   }
-
-//   static torch::autograd::variable_list backward(
-//       torch::autograd::AutogradContext* ctx,
-//       const torch::autograd::variable_list& grad_output) {
-//     TORCH_CHECK(0, "double backwards on roi_align not supported");
-//   }
-// };
-
 at::Tensor roi_align_autograd(
     const at::Tensor& input,
     const at::Tensor& rois,
@@ -126,41 +86,12 @@ at::Tensor roi_align_autograd(
       aligned)[0];
 }
 
-// at::Tensor roi_align_backward_autograd(
-//     const at::Tensor& grad,
-//     const at::Tensor& rois,
-//     double spatial_scale,
-//     int64_t pooled_height,
-//     int64_t pooled_width,
-//     int64_t batch_size,
-//     int64_t channels,
-//     int64_t height,
-//     int64_t width,
-//     int64_t sampling_ratio,
-//     bool aligned) {
-//   return ROIAlignBackwardFunction::apply(
-//       grad,
-//       rois,
-//       spatial_scale,
-//       pooled_height,
-//       pooled_width,
-//       batch_size,
-//       channels,
-//       height,
-//       width,
-//       sampling_ratio,
-//       aligned)[0];
-// }
-
 } // namespace
 
 TORCH_LIBRARY_IMPL(torchvision, Autograd, m) {
   m.impl(
       TORCH_SELECTIVE_NAME("torchvision::roi_align"),
       TORCH_FN(roi_align_autograd));
-  // m.impl(
-  //     TORCH_SELECTIVE_NAME("torchvision::_roi_align_backward"),
-  //     TORCH_FN(roi_align_backward_autograd));
 }
 
 } // namespace ops

--- a/torchvision/csrc/ops/autograd/roi_pool_kernel.cpp
+++ b/torchvision/csrc/ops/autograd/roi_pool_kernel.cpp
@@ -62,45 +62,6 @@ class ROIPoolFunction : public torch::autograd::Function<ROIPoolFunction> {
   }
 };
 
-// TODO: There should be an easier way to do this
-class ROIPoolBackwardFunction
-    : public torch::autograd::Function<ROIPoolBackwardFunction> {
- public:
-  static torch::autograd::variable_list forward(
-      torch::autograd::AutogradContext* ctx,
-      const torch::autograd::Variable& grad,
-      const torch::autograd::Variable& rois,
-      const torch::autograd::Variable& argmax,
-      double spatial_scale,
-      int64_t pooled_height,
-      int64_t pooled_width,
-      int64_t batch_size,
-      int64_t channels,
-      int64_t height,
-      int64_t width) {
-    at::AutoDispatchBelowADInplaceOrView g;
-    auto grad_in = detail::_roi_pool_backward(
-        grad,
-        rois,
-        argmax,
-        spatial_scale,
-        pooled_height,
-        pooled_width,
-        batch_size,
-        channels,
-        height,
-        width);
-
-    return {grad_in};
-  }
-
-  static torch::autograd::variable_list backward(
-      torch::autograd::AutogradContext* ctx,
-      const torch::autograd::variable_list& grad_output) {
-    TORCH_CHECK(0, "double backwards on roi_pool not supported");
-  }
-};
-
 std::tuple<at::Tensor, at::Tensor> roi_pool_autograd(
     const at::Tensor& input,
     const at::Tensor& rois,
@@ -113,39 +74,12 @@ std::tuple<at::Tensor, at::Tensor> roi_pool_autograd(
   return std::make_tuple(result[0], result[1]);
 }
 
-at::Tensor roi_pool_backward_autograd(
-    const at::Tensor& grad,
-    const at::Tensor& rois,
-    const at::Tensor& argmax,
-    double spatial_scale,
-    int64_t pooled_height,
-    int64_t pooled_width,
-    int64_t batch_size,
-    int64_t channels,
-    int64_t height,
-    int64_t width) {
-  return ROIPoolBackwardFunction::apply(
-      grad,
-      rois,
-      argmax,
-      spatial_scale,
-      pooled_height,
-      pooled_width,
-      batch_size,
-      channels,
-      height,
-      width)[0];
-}
-
 } // namespace
 
 TORCH_LIBRARY_IMPL(torchvision, Autograd, m) {
   m.impl(
       TORCH_SELECTIVE_NAME("torchvision::roi_pool"),
       TORCH_FN(roi_pool_autograd));
-  m.impl(
-      TORCH_SELECTIVE_NAME("torchvision::_roi_pool_backward"),
-      TORCH_FN(roi_pool_backward_autograd));
 }
 
 } // namespace ops


### PR DESCRIPTION
I don't really understand the initial goal for these registrations, so I might be missing something. But it looks like we can remove them.

