### PR TITLE
Fixed typing annotations of torchvision/ops

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -24,10 +24,6 @@ ignore_errors = True
 
 ignore_errors = True
 
-[mypy-torchvision.ops.*]
-
-ignore_errors = True
-
 [mypy-torchvision.transforms.*]
 
 ignore_errors = True

--- a/torchvision/ops/misc.py
+++ b/torchvision/ops/misc.py
@@ -61,9 +61,13 @@ class FrozenBatchNorm2d(torch.nn.Module):
             num_features = n
         super(FrozenBatchNorm2d, self).__init__()
         self.eps = eps
+        self.weight: Tensor
         self.register_buffer("weight", torch.ones(num_features))
+        self.bias: Tensor
         self.register_buffer("bias", torch.zeros(num_features))
+        self.running_mean: Tensor
         self.register_buffer("running_mean", torch.zeros(num_features))
+        self.running_var: Tensor
         self.register_buffer("running_var", torch.ones(num_features))
 
     def _load_from_state_dict(

--- a/torchvision/ops/poolers.py
+++ b/torchvision/ops/poolers.py
@@ -5,7 +5,7 @@ import torchvision
 from .roi_align import roi_align
 from torchvision.ops.boxes import box_area
 
-from typing import Optional, List, Dict, Tuple, Union, Sequence
+from typing import Optional, List, Dict, Tuple, Union
 
 
 # copying result_idx_in_level to a specific index in result[]
@@ -134,7 +134,7 @@ class MultiScaleRoIAlign(nn.Module):
         self.featmap_names = featmap_names
         self.sampling_ratio = sampling_ratio
         self.output_size = (output_size, output_size) if isinstance(output_size, int) else tuple(output_size)
-        self.scales: Optional[Sequence[float]] = None
+        self.scales: Optional[List[float]] = None
         self.map_levels = None
         self.canonical_scale = canonical_scale
         self.canonical_level = canonical_level
@@ -152,7 +152,7 @@ class MultiScaleRoIAlign(nn.Module):
         rois = torch.cat([ids, concat_boxes], dim=1)
         return rois
 
-    def infer_scale(self, feature: Tensor, original_size: Sequence[int]) -> float:
+    def infer_scale(self, feature: Tensor, original_size: Tuple[int, int]) -> float:
         # assumption: the scale is of the form 2 ** (-k), with k integer
         size = feature.shape[-2:]
         possible_scales: List[float] = []

--- a/torchvision/ops/poolers.py
+++ b/torchvision/ops/poolers.py
@@ -2,10 +2,10 @@ import torch
 from torch import nn, Tensor
 
 import torchvision
-from torchvision.ops import roi_align
+from .roi_align import roi_align
 from torchvision.ops.boxes import box_area
 
-from typing import Optional, List, Dict, Tuple, Union
+from typing import Optional, List, Dict, Tuple, Union, Sequence
 
 
 # copying result_idx_in_level to a specific index in result[]
@@ -131,12 +131,10 @@ class MultiScaleRoIAlign(nn.Module):
         canonical_level: int = 4,
     ):
         super(MultiScaleRoIAlign, self).__init__()
-        if isinstance(output_size, int):
-            output_size = (output_size, output_size)
         self.featmap_names = featmap_names
         self.sampling_ratio = sampling_ratio
-        self.output_size = tuple(output_size)
-        self.scales = None
+        self.output_size = (output_size, output_size) if isinstance(output_size, int) else tuple(output_size)
+        self.scales: Optional[Sequence[float]] = None
         self.map_levels = None
         self.canonical_scale = canonical_scale
         self.canonical_level = canonical_level
@@ -154,7 +152,7 @@ class MultiScaleRoIAlign(nn.Module):
         rois = torch.cat([ids, concat_boxes], dim=1)
         return rois
 
-    def infer_scale(self, feature: Tensor, original_size: List[int]) -> float:
+    def infer_scale(self, feature: Tensor, original_size: Sequence[int]) -> float:
         # assumption: the scale is of the form 2 ** (-k), with k integer
         size = feature.shape[-2:]
         possible_scales: List[float] = []

--- a/torchvision/ops/ps_roi_align.py
+++ b/torchvision/ops/ps_roi_align.py
@@ -44,12 +44,12 @@ def ps_roi_align(
     _assert_has_ops()
     check_roi_boxes_shape(boxes)
     rois = boxes
-    output_size = _pair(output_size)
+    _output_size = _pair(output_size)
     if not isinstance(rois, torch.Tensor):
         rois = convert_boxes_to_roi_format(rois)
     output, _ = torch.ops.torchvision.ps_roi_align(input, rois, spatial_scale,
-                                                   output_size[0],
-                                                   output_size[1],
+                                                   _output_size[0],
+                                                   _output_size[1],
                                                    sampling_ratio)
     return output
 

--- a/torchvision/ops/ps_roi_pool.py
+++ b/torchvision/ops/ps_roi_pool.py
@@ -38,12 +38,12 @@ def ps_roi_pool(
     _assert_has_ops()
     check_roi_boxes_shape(boxes)
     rois = boxes
-    output_size = _pair(output_size)
+    _output_size = _pair(output_size)
     if not isinstance(rois, torch.Tensor):
         rois = convert_boxes_to_roi_format(rois)
     output, _ = torch.ops.torchvision.ps_roi_pool(input, rois, spatial_scale,
-                                                  output_size[0],
-                                                  output_size[1])
+                                                  _output_size[0],
+                                                  _output_size[1])
     return output
 
 


### PR DESCRIPTION
Following up on #2025, this PR fixes typing annotations in transforms/ops, and edits the `mypy.ini` to stop ignoring errors from this module.

Any feedback is welcome!