### PR TITLE
Avoid cmyk images in nvjpeg tests

### DIFF
--- a/test/test_image.py
+++ b/test/test_image.py
@@ -326,7 +326,8 @@ def test_decode_jpeg_cuda(mode, img_path, scripted):
 @pytest.mark.parametrize('cuda_device', ('cuda', 'cuda:0', torch.device('cuda')))
 def test_decode_jpeg_cuda_device_param(cuda_device):
     """Make sure we can pass a string or a torch.device as device param"""
-    data = read_file(next(get_images(IMAGE_ROOT, ".jpg")))
+    path = next(path for path in get_images(IMAGE_ROOT, ".jpg") if 'cmyk' not in path)
+    data = read_file(path)
     decode_jpeg(data, device=cuda_device)
 
 


### PR DESCRIPTION
We don't support cmyk images in tests, so we should avoid testing those images.

I think this is the cause of some [internal sporadic failures](https://www.internalfb.com/intern/test/281475021797146/runs?filters=%7B%22key%22%3A%22AND%22%2C%22children%22%3A[%7B%22key%22%3A%22CONTAINS_ANY_MEMBERS_OF%22%2C%22field%22%3A%22purposes%22%2C%22value%22%3A[%22CONTINUOUS%22%2C%22POSTCOMMIT%22%2C%22STRESS_RUN%22%2C%22STRESS_RUN_NEW_TEST%22]%7D%2C%7B%22key%22%3A%22is%22%2C%22field%22%3A%22branch%22%2C%22value%22%3A%22CONTINUOUS%22%7D%2C%7B%22key%22%3A%22since%22%2C%22field%22%3A%22since_relative%22%2C%22value%22%3A%22ONE_DAY%22%7D%2C%7B%22key%22%3A%22by%22%2C%22field%22%3A%22sort_by%22%2C%22value%22%3A%22COMMIT%22%7D]%7D&graphFilters=%7B%22purposeGraph%22%3A[]%2C%22statusGraph%22%3A[]%2C%22collectionMenu%22%3A[]%2C%22revisionMenu%22%3A[]%2C%22purposeMenu%22%3A[]%2C%22runTagMenu%22%3A[]%2C%22statusMenu%22%3A[]%7D&offset=1), as the output from `glob.glob` is machine-specific, sometimes the first entry would be a cmyk image