### PR TITLE
Skip test if connection issues on fate

### DIFF
--- a/test/test_videoapi.py
+++ b/test/test_videoapi.py
@@ -2,6 +2,7 @@ import collections
 import os
 import pytest
 from pytest import approx
+import urllib
 
 import torch
 import torchvision
@@ -177,7 +178,10 @@ class TestVideoApi:
                 assert (lb <= frame["pts"]) and (ub >= frame["pts"])
 
     def test_fate_suite(self):
-        video_path = fate("sub/MovText_capability_tester.mp4", VIDEO_DIR)
+        try:
+            video_path = fate("sub/MovText_capability_tester.mp4", VIDEO_DIR)
+        except (urllib.error.URLError, ConnectionError) as error:
+            pytest.skip(f"Skipping due to connectivity issues: {error}")
         vr = VideoReader(video_path)
         metadata = vr.get_metadata()
 

--- a/test/test_videoapi.py
+++ b/test/test_videoapi.py
@@ -178,6 +178,7 @@ class TestVideoApi:
                 assert (lb <= frame["pts"]) and (ub >= frame["pts"])
 
     def test_fate_suite(self):
+        # TODO: remove the try-except statement once the connectivity issues are resolved
         try:
             video_path = fate("sub/MovText_capability_tester.mp4", VIDEO_DIR)
         except (urllib.error.URLError, ConnectionError) as error:


### PR DESCRIPTION
The Fate server of FFmpeg has been giving us headaches the last 2 weeks. Instead of disabling temporarily the test, I'm taking the approach to skip it if a connection issue occurs.