### PR TITLE
Make torch version check numeric

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -147,7 +147,9 @@ def get_extensions():
     )
 
     is_rocm_pytorch = False
-    if torch.__version__ >= '1.5':
+    TORCH_MAJOR = int(torch.__version__.split('.')[0])
+    TORCH_MINOR = int(torch.__version__.split('.')[1])
+    if TORCH_MAJOR > 1 or (TORCH_MAJOR == 1 and TORCH_MINOR >= 5):
         from torch.utils.cpp_extension import ROCM_HOME
         is_rocm_pytorch = True if ((torch.version.hip is not None) and (ROCM_HOME is not None)) else False
 


### PR DESCRIPTION
String comparison messes up in cases such as `torch.__version__ = 1.10.blah`