### PR TITLE
fix: The given NumPy array is not writeable

### DIFF
--- a/torchvision/datasets/mnist.py
+++ b/torchvision/datasets/mnist.py
@@ -485,7 +485,7 @@ def read_sn3_pascalvincent_tensor(path: str, strict: bool = True) -> torch.Tenso
     """
     # read
     with open(path, "rb") as f:
-        data = f.read()
+        data = bytearray(f.read())
     # parse
     magic = get_int(data[0:4])
     nd = magic % 256


### PR DESCRIPTION
Fix the warning of "The given NumPy array is not writeable, and PyTorch does not support non-writeable tensors", while running the code of [Tutorials > Quickstart](https://pytorch.org/tutorials/beginner/basics/quickstart_tutorial.html)

It was because the `bytes` in python is readonly, and the function `read` return a `bytes`.   

The warning details:
```
/usr/local/lib/python3.9/dist-packages/torchvision/datasets/mnist.py:498: UserWarning: The given NumPy array is not writeable, and PyTorch does not support non-writeable tensors. This means you can write to the underlying (supposedly non-writeable) NumPy array using the tensor. You may want to copy the array to protect its data or make it writeable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at  /pytorch/torch/csrc/utils/tensor_numpy.cpp:180.)
  return torch.from_numpy(parsed.astype(m[2], copy=False)).view(*s)
```

The function invoking sequence is `FashionMNIST` -> `MNIST` -> `__init__` -> `_load_data` -> `read_image_file` -> `read_sn3_pascalvincent_tensor`

the code in `read_sn3_pascalvincent_tensor`:  

```python
def read_sn3_pascalvincent_tensor(path: str, strict: bool = True) -> torch.Tensor:
    """Read a SN3 file in "Pascal Vincent" format (Lush file 'libidx/idx-io.lsh').
       Argument may be a filename, compressed filename, or file object.
    """
    # read
    with open(path, "rb") as f:
        data = f.read()
    # parse
    magic = get_int(data[0:4])
    nd = magic % 256
    ty = magic // 256
    assert 1 <= nd <= 3
    assert 8 <= ty <= 14
    m = SN3_PASCALVINCENT_TYPEMAP[ty]
    s = [get_int(data[4 * (i + 1): 4 * (i + 2)]) for i in range(nd)]
    parsed = np.frombuffer(data, dtype=m[1], offset=(4 * (nd + 1)))
    assert parsed.shape[0] == np.prod(s) or not strict
    return torch.from_numpy(parsed.astype(m[2], copy=False)).view(*s)
```
