### PR TITLE
added serialization note to models docs

### DIFF
--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -7,6 +7,15 @@ different tasks, including: image classification, pixelwise semantic
 segmentation, object detection, instance segmentation, person
 keypoint detection and video classification.
 
+.. note ::
+    Backward compatibility is guaranteed for loading a serialized 
+    `state_dict` to the model created using old PyTorch version. 
+    On the contrary, loading entire saved models or serialized 
+    `ScriptModules` (seralized using older versions of PyTorch) 
+    will preserve the historic behaviour. Refer to the following 
+    `documentation 
+    <https://pytorch.org/docs/stable/notes/serialization.html#id6>`_   
+
 
 Classification
 ==============


### PR DESCRIPTION
Fixes #2939

A note about backward compatibility with respect to model serialization was added to the `torchvision.models` documentation. 

Since the note is not specific to classification/segmentation tasks, hence it was added in the beginning. 