### PR TITLE
Fix note about model serialization BC guarantees

### DIFF
--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -9,10 +9,10 @@ keypoint detection and video classification.
 
 .. note ::
     Backward compatibility is guaranteed for loading a serialized 
-    `state_dict` to the model created using old PyTorch version. 
+    ``state_dict`` to the model created using old PyTorch version. 
     On the contrary, loading entire saved models or serialized 
-    `ScriptModules` (seralized using older versions of PyTorch) 
-    will preserve the historic behaviour. Refer to the following 
+    ``ScriptModules`` (seralized using older versions of PyTorch) 
+    may not preserve the historic behaviour. Refer to the following 
     `documentation 
     <https://pytorch.org/docs/stable/notes/serialization.html#id6>`_   
 


### PR DESCRIPTION
This is a follow up to https://github.com/pytorch/vision/pull/4361, I might be missing something but according to the original https://github.com/pytorch/vision/issues/2923#issuecomment-719650811, BC is **not** guaranteed for fully serialized models:

> we guarantee compatibility with serialized state-dict, but not if the model is entirely serialized.

Also minor change from single ticks to double backticks which I believe was the intended formatting.