### PR TITLE
Make StochasticDepth FX-compatible

### DIFF
--- a/test/test_backbone_utils.py
+++ b/test/test_backbone_utils.py
@@ -39,7 +39,7 @@ class TestFxFeatureExtraction:
         'num_classes': 1,
         'pretrained': False
     }
-    leaf_modules = [torchvision.ops.StochasticDepth]
+    leaf_modules = []
 
     def _create_feature_extractor(self, *args, **kwargs):
         """

--- a/torchvision/ops/stochastic_depth.py
+++ b/torchvision/ops/stochastic_depth.py
@@ -1,4 +1,5 @@
 import torch
+import torch.fx
 from torch import nn, Tensor
 
 
@@ -35,6 +36,9 @@ def stochastic_depth(input: Tensor, p: float, mode: str, training: bool = True) 
     noise = torch.empty(size, dtype=input.dtype, device=input.device)
     noise = noise.bernoulli_(survival_rate).div_(survival_rate)
     return input * noise
+
+
+torch.fx.wrap('stochastic_depth')
 
 
 class StochasticDepth(nn.Module):


### PR DESCRIPTION
Follow-up from https://github.com/pytorch/vision/pull/4372

Let's just entirely wrap `stochastic_depth`, we can consider it as an elementary operator