### PR TITLE
fix splitting CelebA dataset + corresponding test

### DIFF
--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -605,7 +605,7 @@ class CelebATestCase(datasets_utils.ImageDatasetTestCase):
             with self.create_dataset(split=split) as (dataset, _):
                 merged_imgs_names += dataset.filename
 
-        assert(merged_imgs_names == all_imgs_names)
+        assert merged_imgs_names == all_imgs_names
 
 
 class VOCSegmentationTestCase(datasets_utils.ImageDatasetTestCase):

--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -512,7 +512,7 @@ class CelebATestCase(datasets_utils.ImageDatasetTestCase):
         return dict(num_examples=num_images_per_split[config["split"]], attr_names=attr_names)
 
     def _create_split_txt(self, root):
-        num_images_per_split = dict(train=3, valid=2, test=1)
+        num_images_per_split = dict(train=3, valid=2, test=2)
 
         data = [
             [self._SPLIT_TO_IDX[split]] for split, num_images in num_images_per_split.items() for _ in range(num_images)

--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -595,6 +595,18 @@ class CelebATestCase(datasets_utils.ImageDatasetTestCase):
         with self.create_dataset() as (dataset, info):
             assert tuple(dataset.attr_names) == info["attr_names"]
 
+    def test_images_names_split(self):
+        splits = ["train", "valid", "test"]
+        with self.create_dataset(split='all') as (dataset, _):
+            all_imgs_names = dataset.filename
+
+        merged_imgs_names = []
+        for split in splits:
+            with self.create_dataset(split=split) as (dataset, _):
+                merged_imgs_names += dataset.filename
+
+        assert(merged_imgs_names == all_imgs_names)
+
 
 class VOCSegmentationTestCase(datasets_utils.ImageDatasetTestCase):
     DATASET_CLASS = datasets.VOCSegmentation

--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -596,9 +596,8 @@ class CelebATestCase(datasets_utils.ImageDatasetTestCase):
             assert tuple(dataset.attr_names) == info["attr_names"]
 
     def test_images_names_split(self):
-        splits = ["train", "valid", "test"]
         with self.create_dataset(split='all') as (dataset, _):
-            all_imgs_names = dataset.filename
+            all_imgs_names = set(dataset.filename)
 
         merged_imgs_names = set()
         for split in ["train", "valid", "test"]:

--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -600,10 +600,10 @@ class CelebATestCase(datasets_utils.ImageDatasetTestCase):
         with self.create_dataset(split='all') as (dataset, _):
             all_imgs_names = dataset.filename
 
-        merged_imgs_names = []
-        for split in splits:
+        merged_imgs_names = set()
+        for split in ["train", "valid", "test"]:
             with self.create_dataset(split=split) as (dataset, _):
-                merged_imgs_names += dataset.filename
+                merged_imgs_names.update(dataset.filename)
 
         assert merged_imgs_names == all_imgs_names
 

--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -512,7 +512,7 @@ class CelebATestCase(datasets_utils.ImageDatasetTestCase):
         return dict(num_examples=num_images_per_split[config["split"]], attr_names=attr_names)
 
     def _create_split_txt(self, root):
-        num_images_per_split = dict(train=3, valid=2, test=2)
+        num_images_per_split = dict(train=4, valid=3, test=2)
 
         data = [
             [self._SPLIT_TO_IDX[split]] for split, num_images in num_images_per_split.items() for _ in range(num_images)

--- a/torchvision/datasets/celeba.py
+++ b/torchvision/datasets/celeba.py
@@ -99,7 +99,12 @@ class CelebA(VisionDataset):
 
         mask = slice(None) if split_ is None else (splits.data == split_).squeeze()
 
-        self.filename = splits.index
+        if mask == slice(None):  # if split == all
+            self.filename = splits.index
+        elif len(torch.nonzero(mask)) == 1:  # check for the case of a single sample
+            self.filename = [splits.index[torch.nonzero(mask)]]
+        else:
+            self.filename = [splits.index[i] for i in torch.squeeze(torch.nonzero(mask))]
         self.identity = identity.data[mask]
         self.bbox = bbox.data[mask]
         self.landmarks_align = landmarks_align.data[mask]

--- a/torchvision/datasets/celeba.py
+++ b/torchvision/datasets/celeba.py
@@ -101,8 +101,6 @@ class CelebA(VisionDataset):
 
         if mask == slice(None):  # if split == all
             self.filename = splits.index
-        elif len(torch.nonzero(mask)) == 1:  # check for the case of a single sample
-            self.filename = [splits.index[torch.nonzero(mask)]]
         else:
             self.filename = [splits.index[i] for i in torch.squeeze(torch.nonzero(mask))]
         self.identity = identity.data[mask]

--- a/torchvision/datasets/celeba.py
+++ b/torchvision/datasets/celeba.py
@@ -99,7 +99,7 @@ class CelebA(VisionDataset):
 
         mask = slice(None) if split_ is None else (splits.data == split_).squeeze()
 
-        if mask == slice(None):  # if split == all
+        if mask == slice(None):  # if split == "all"
             self.filename = splits.index
         else:
             self.filename = [splits.index[i] for i in torch.squeeze(torch.nonzero(mask))]


### PR DESCRIPTION
While working on the CelebA dataset, I noticed that when splitting the dataset (into 'train'/'valid'/'test' or take it as a whole 'all') only the target (the attributes) were coherent with the split. The input images were always the same, the only thing changing was their number. I traced the code and noticed that the mask that was created for picking the correct samples for the split was only applied on the targets (the attributes) and not the input images. Therefore I fixed the above issue by applying the mask on the input images as well. Also, I added a corresponding test function that checks if each individual split ('train', 'valid', 'test') merged together would create the same input images as if taking the whole dataset ('all'). This test Fails without the aforementioned fix. 

cc @pmeier