### PR TITLE
[FBcode->GH] [jit] Make operation call accept Stack& instead Stack* (#63414)

### DIFF
--- a/test/cpp/test_custom_operators.cpp
+++ b/test/cpp/test_custom_operators.cpp
@@ -18,7 +18,7 @@ TEST(test_custom_operators, nms) {
   double thresh = 0.7;
 
   torch::jit::push(stack, boxes, scores, thresh);
-  op->getOperation()(&stack);
+  op->getOperation()(stack);
   at::Tensor output_jit;
   torch::jit::pop(stack, output_jit);
 
@@ -47,7 +47,7 @@ TEST(test_custom_operators, roi_align_visible) {
   bool aligned = true;
 
   torch::jit::push(stack, input, rois, spatial_scale, pooled_height, pooled_width, sampling_ratio, aligned);
-  op->getOperation()(&stack);
+  op->getOperation()(stack);
   at::Tensor output_jit;
   torch::jit::pop(stack, output_jit);
 


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/pytorch/pytorch/pull/63414

Misuse of raw pointer in here where stack is never nullable.
ghstack-source-id: 136938318

Reviewed By: ejguan

Differential Revision: D30375410

fbshipit-source-id: 9d65b620bb76d90d886c800f54308520095d58ee

cc @pmeier