### PR TITLE
Convert classes used for Detection to nn.Modules

### DIFF
--- a/torchvision/models/detection/retinanet.py
+++ b/torchvision/models/detection/retinanet.py
@@ -153,9 +153,6 @@ class RetinaNetRegressionHead(nn.Module):
         in_channels (int): number of channels of the input feature
         num_anchors (int): number of anchors to be predicted
     """
-    __annotations__ = {
-        'box_coder': det_utils.BoxCoder,
-    }
 
     def __init__(self, in_channels, num_anchors):
         super().__init__()
@@ -309,10 +306,6 @@ class RetinaNet(nn.Module):
         >>> x = [torch.rand(3, 300, 400), torch.rand(3, 500, 400)]
         >>> predictions = model(x)
     """
-    __annotations__ = {
-        'box_coder': det_utils.BoxCoder,
-        'proposal_matcher': det_utils.Matcher,
-    }
 
     def __init__(self, backbone, num_classes,
                  # transform parameters

--- a/torchvision/models/detection/roi_heads.py
+++ b/torchvision/models/detection/roi_heads.py
@@ -483,11 +483,6 @@ def paste_masks_in_image(masks, boxes, img_shape, padding=1):
 
 
 class RoIHeads(nn.Module):
-    __annotations__ = {
-        'box_coder': det_utils.BoxCoder,
-        'proposal_matcher': det_utils.Matcher,
-        'fg_bg_sampler': det_utils.BalancedPositiveNegativeSampler,
-    }
 
     def __init__(self,
                  box_roi_pool,

--- a/torchvision/models/detection/rpn.py
+++ b/torchvision/models/detection/rpn.py
@@ -126,9 +126,6 @@ class RegionProposalNetwork(torch.nn.Module):
 
     """
     __annotations__ = {
-        'box_coder': det_utils.BoxCoder,
-        'proposal_matcher': det_utils.Matcher,
-        'fg_bg_sampler': det_utils.BalancedPositiveNegativeSampler,
         'pre_nms_top_n': Dict[str, int],
         'post_nms_top_n': Dict[str, int],
     }

--- a/torchvision/models/detection/ssd.py
+++ b/torchvision/models/detection/ssd.py
@@ -159,10 +159,6 @@ class SSD(nn.Module):
             proposals used during the training of the classification head. It is used to estimate the negative to
             positive ratio.
     """
-    __annotations__ = {
-        'box_coder': det_utils.BoxCoder,
-        'proposal_matcher': det_utils.Matcher,
-    }
 
     def __init__(self, backbone: nn.Module, anchor_generator: DefaultBoxGenerator,
                  size: Tuple[int, int], num_classes: int,


### PR DESCRIPTION
I'm converting some of the existing classes used to do computations for Detection models to nn.Modules. It's unclear why they were structured like this, could be because they were ported from DETR in the past (perhaps @fmassa can provide more info). 

This PR was originally done to investigate https://github.com/pytorch/vision/issues/4386#issuecomment-916751913. Though it does not resolves it (might be partial solution), this conversion enables us to drop the `__annotation__` declarations.

I also tried to convert the `LevelMapper` but it's modification is not straightforward as it modifies arguments post compilation and creates JIT issues. Worth checking this on a separate PR.