### PR TITLE
Disabling the video tests that seg fault

### DIFF
--- a/test/test_io.py
+++ b/test/test_io.py
@@ -63,6 +63,10 @@ def temp_video(num_frames, height, width, fps, lossless=False, video_codec=None,
     os.unlink(f.name)
 
 
+# Rollback once #4402 is fixed
+@pytest.mark.skipif(sys.platform == "darwin", reason=(
+    'These tests segfault on MacOS; temporarily disabling.'
+))
 @pytest.mark.skipif(get_video_backend() != "pyav" and not io._HAS_VIDEO_OPT,
                     reason="video_reader backend not available")
 @pytest.mark.skipif(av is None, reason="PyAV unavailable")
@@ -77,10 +81,6 @@ class TestVideo:
             assert_equal(data, lv)
             assert info["video_fps"] == 5
 
-    # Rollback once #4402 is fixed
-    @pytest.mark.skipif(sys.platform == "darwin", reason=(
-        'This test segfaults on MacOS; temporarily disabling to enable test execution.'
-    ))
     @pytest.mark.skipif(not io._HAS_VIDEO_OPT, reason="video_reader backend is not chosen")
     def test_probe_video_from_file(self):
         with temp_video(10, 300, 300, 5) as (f_name, data):

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -77,6 +77,10 @@ class TestVideo:
             assert_equal(data, lv)
             assert info["video_fps"] == 5
 
+    # Rollback once #4402 is fixed
+    @pytest.mark.skipif(sys.platform == "darwin", reason=(
+        'This test segfaults on MacOS; temporarily disabling to enable test execution.'
+    ))
     @pytest.mark.skipif(not io._HAS_VIDEO_OPT, reason="video_reader backend is not chosen")
     def test_probe_video_from_file(self):
         with temp_video(10, 300, 300, 5) as (f_name, data):

--- a/test/test_video_reader.py
+++ b/test/test_video_reader.py
@@ -2,6 +2,7 @@ import collections
 import itertools
 import math
 import os
+import sys
 import pytest
 from pytest import approx
 from fractions import Fraction
@@ -269,6 +270,10 @@ def _get_video_tensor(video_dir, video_file):
     return full_path, video_tensor
 
 
+# Rollback once #4402 is fixed
+@pytest.mark.skipif(sys.platform == "darwin", reason=(
+    'These tests segfault on MacOS; temporarily disabling.'
+))
 @pytest.mark.skipif(av is None, reason="PyAV unavailable")
 @pytest.mark.skipif(_HAS_VIDEO_OPT is False, reason="Didn't compile with ffmpeg")
 class TestVideoReader:

--- a/test/test_videoapi.py
+++ b/test/test_videoapi.py
@@ -1,5 +1,6 @@
 import collections
 import os
+import sys
 import pytest
 from pytest import approx
 import urllib
@@ -64,6 +65,10 @@ test_videos = {
 }
 
 
+# Rollback once #4402 is fixed
+@pytest.mark.skipif(sys.platform == "darwin", reason=(
+    'These tests segfault on MacOS; temporarily disabling.'
+))
 @pytest.mark.skipif(_HAS_VIDEO_OPT is False, reason="Didn't compile with ffmpeg")
 @PY39_SKIP
 class TestVideoApi:


### PR DESCRIPTION
The specific tests cause the CI to seg fault on MacOS. Skipping it temporarily until https://github.com/pytorch/vision/issues/4402 is resolved, to enable the execution of the remaining tests.



cc @pmeier