### PR TITLE
TensorRT compatible retinanet

### DIFF
--- a/torchvision/models/detection/anchor_utils.py
+++ b/torchvision/models/detection/anchor_utils.py
@@ -97,10 +97,10 @@ class AnchorGenerator(nn.Module):
 
             # For output anchor, compute [x_center, y_center, x_center, y_center]
             shifts_x = torch.arange(
-                0, grid_width, dtype=torch.float32, device=device
+                0, grid_width, dtype=torch.int32, device=device
             ) * stride_width
             shifts_y = torch.arange(
-                0, grid_height, dtype=torch.float32, device=device
+                0, grid_height, dtype=torch.int32, device=device
             ) * stride_height
             shift_y, shift_x = torch.meshgrid(shifts_y, shifts_x)
             shift_x = shift_x.reshape(-1)


### PR DESCRIPTION
Change torch.arange dtype from torch.float32 to torch.int32 in anchor_utils.py (issue #4395)

cc @datumbox