### PR TITLE
Enable building torchvision with ffmpeg regardless of version on Linux

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -355,13 +355,8 @@ def get_extensions():
         has_ffmpeg = False
     if has_ffmpeg:
         try:
-            # this splits on both dots and spaces as the output format differs across versions / platforms
-            ffmpeg_version_str = str(subprocess.check_output(["ffmpeg", "-version"]))
-            ffmpeg_version = re.split(r"ffmpeg version |\.| |-", ffmpeg_version_str)[1:3]
-            ffmpeg_version = ".".join(ffmpeg_version)
-            if StrictVersion(ffmpeg_version) >= StrictVersion('4.3'):
-                print(f'ffmpeg {ffmpeg_version} not supported yet, please use ffmpeg 4.2.')
-                has_ffmpeg = False
+            # This is to check if ffmpeg is installed properly.
+            _ = subprocess.check_output(["ffmpeg", "-version"])
         except (subprocess.CalledProcessError, IndexError, ValueError):
             print('Error fetching ffmpeg version, ignoring ffmpeg.')
             has_ffmpeg = False

--- a/setup.py
+++ b/setup.py
@@ -361,8 +361,8 @@ def get_extensions():
     if has_ffmpeg:
         try:
             # This is to check if ffmpeg is installed properly.
-            _ = subprocess.check_output(["ffmpeg", "-version"])
-        except (subprocess.CalledProcessError, IndexError, ValueError):
+            subprocess.check_output(["ffmpeg", "-version"])
+        except subprocess.CalledProcessError:
             print('Error fetching ffmpeg version, ignoring ffmpeg.')
             has_ffmpeg = False
 

--- a/test/test_video_reader.py
+++ b/test/test_video_reader.py
@@ -1234,6 +1234,7 @@ class TestVideoReader:
         with pytest.raises(RuntimeError):
             io.read_video('foo.mp4')
 
+    @PY39_SKIP
     def test_audio_present_pts(self):
         """Test if audio frames are returned with pts unit."""
         backends = ['video_reader', 'pyav']
@@ -1250,6 +1251,7 @@ class TestVideoReader:
                         full_path, start_offset, end_offset, pts_unit='pts')
                     assert all([dimension > 0 for dimension in audio.shape[:2]])
 
+    @PY39_SKIP
     def test_audio_present_sec(self):
         """Test if audio frames are returned with sec unit."""
         backends = ['video_reader', 'pyav']

--- a/test/test_video_reader.py
+++ b/test/test_video_reader.py
@@ -1226,7 +1226,6 @@ class TestVideoReader:
         with pytest.raises(RuntimeError):
             io.read_video('foo.mp4')
 
-    @PY39_SKIP
     def test_audio_present_pts(self):
         """Test if audio frames are returned with pts unit."""
         backends = ['video_reader', 'pyav']
@@ -1243,7 +1242,6 @@ class TestVideoReader:
                         full_path, start_offset, end_offset, pts_unit='pts')
                     assert all([dimension > 0 for dimension in audio.shape[:2]])
 
-    @PY39_SKIP
     def test_audio_present_sec(self):
         """Test if audio frames are returned with sec unit."""
         backends = ['video_reader', 'pyav']


### PR DESCRIPTION
torchvision now works fine with latest ffmpeg(4.3) on Linux, hence this check is not needed.