### PR TITLE
Updated annotation to be a Union of Tensor and List

### DIFF
--- a/torchvision/ops/_utils.py
+++ b/torchvision/ops/_utils.py
@@ -1,6 +1,6 @@
 import torch
 from torch import Tensor
-from typing import List
+from typing import List, Union
 
 
 def _cat(tensors: List[Tensor], dim: int = 0) -> Tensor:
@@ -24,7 +24,7 @@ def convert_boxes_to_roi_format(boxes: List[Tensor]) -> Tensor:
     return rois
 
 
-def check_roi_boxes_shape(boxes: Tensor):
+def check_roi_boxes_shape(boxes: Union[Tensor, List[Tensor]]):
     if isinstance(boxes, (list, tuple)):
         for _tensor in boxes:
             assert _tensor.size(1) == 4, \

--- a/torchvision/ops/roi_align.py
+++ b/torchvision/ops/roi_align.py
@@ -1,16 +1,17 @@
+from typing import List, Union
+
 import torch
 from torch import nn, Tensor
-
 from torch.nn.modules.utils import _pair
 from torch.jit.annotations import BroadcastingList2
-
 from torchvision.extension import _assert_has_ops
+
 from ._utils import convert_boxes_to_roi_format, check_roi_boxes_shape
 
 
 def roi_align(
     input: Tensor,
-    boxes: Tensor,
+    boxes: Union[Tensor, List[Tensor]],
     output_size: BroadcastingList2[int],
     spatial_scale: float = 1.0,
     sampling_ratio: int = -1,

--- a/torchvision/ops/roi_pool.py
+++ b/torchvision/ops/roi_pool.py
@@ -1,16 +1,17 @@
+from typing import List, Union
+
 import torch
 from torch import nn, Tensor
-
 from torch.nn.modules.utils import _pair
 from torch.jit.annotations import BroadcastingList2
-
 from torchvision.extension import _assert_has_ops
+
 from ._utils import convert_boxes_to_roi_format, check_roi_boxes_shape
 
 
 def roi_pool(
     input: Tensor,
-    boxes: Tensor,
+    boxes: Union[Tensor, List[Tensor]],
     output_size: BroadcastingList2[int],
     spatial_scale: float = 1.0,
 ) -> Tensor:


### PR DESCRIPTION
Resolves https://github.com/pytorch/vision/issues/3737

```
import torch
from torchvision.ops import roi_align, roi_pool


def _make_rois2(img_size, num_imgs, dtype, num_rois=1000): 
    rois = torch.randint(0, img_size // 2, size=(num_rois, 4)).to(dtype) 
    rois[:, 0] = torch.randint(0, num_imgs, size=(num_rois,)) 
    rois[:, 2:] += rois[:, 1:2]  
    return [rois]


pool_size = 5
img_size = 10
n_channels = 2
num_imgs = 1
dtype = torch.float

x = torch.randint(50, 100, size=(num_imgs, n_channels, img_size, img_size)).to(dtype)
rois2 = _make_rois2(img_size, num_imgs, dtype)

f1 = torch.jit.script(roi_align)
f2 = torch.jit.script(roi_pool)

print(torch.mean((f1(x, rois2, pool_size) == roi_align(x, rois2, pool_size)).to(float)))
print(torch.mean((f2(x, rois2, pool_size) == roi_pool(x, rois2, pool_size)).to(float)))
```
```
tensor(1., dtype=torch.float64)
tensor(1., dtype=torch.float64)
```