### PR TITLE
Skip building torchvision with ffmpeg when python==3.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -351,10 +351,10 @@ def get_extensions():
 
     ffmpeg_exe = distutils.spawn.find_executable('ffmpeg')
     has_ffmpeg = ffmpeg_exe is not None
-    # Building torchvision with ffmpeg on MacOS or with Python 3.9 causes
-    # crash. See the following GitHub issues for more details.
-    # https://github.com/pytorch/pytorch/issues/65000
-    # https://github.com/pytorch/vision/issues/3367
+    # FIXME: Building torchvision with ffmpeg on MacOS or with Python 3.9
+    # FIXME: causes crash. See the following GitHub issues for more details.
+    # FIXME: https://github.com/pytorch/pytorch/issues/65000
+    # FIXME: https://github.com/pytorch/vision/issues/3367
     if sys.platform != 'linux' or (
             sys.version_info.major == 3 and sys.version_info.minor == 9):
         has_ffmpeg = False

--- a/setup.py
+++ b/setup.py
@@ -351,7 +351,12 @@ def get_extensions():
 
     ffmpeg_exe = distutils.spawn.find_executable('ffmpeg')
     has_ffmpeg = ffmpeg_exe is not None
-    if sys.platform != 'linux':
+    # Building torchvision with ffmpeg on MacOS or with Python 3.9 causes
+    # crash. See the following GitHub issues for more details.
+    # https://github.com/pytorch/pytorch/issues/65000
+    # https://github.com/pytorch/vision/issues/3367
+    if sys.platform != 'linux' or (
+            sys.version_info.major == 3 and sys.version_info.minor == 9):
         has_ffmpeg = False
     if has_ffmpeg:
         try:

--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -20,9 +20,7 @@ from torchvision import io
 import numpy as np
 from PIL import Image
 
-IS_PY39 = sys.version_info.major == 3 and sys.version_info.minor == 9
-PY39_SEGFAULT_SKIP_MSG = "Segmentation fault with Python 3.9, see https://github.com/pytorch/vision/issues/3367"
-PY39_SKIP = pytest.mark.skipif(IS_PY39, reason=PY39_SEGFAULT_SKIP_MSG)
+
 IN_CIRCLE_CI = os.getenv("CIRCLECI", False) == 'true'
 IN_RE_WORKER = os.environ.get("INSIDE_RE_WORKER") is not None
 IN_FBCODE = os.environ.get("IN_FBCODE_TORCHVISION") == "1"

--- a/test/test_video_reader.py
+++ b/test/test_video_reader.py
@@ -12,7 +12,7 @@ import torchvision.io as io
 from numpy.random import randint
 from torchvision import set_video_backend
 from torchvision.io import _HAS_VIDEO_OPT
-from common_utils import PY39_SKIP, assert_equal
+from common_utils import assert_equal
 
 
 try:
@@ -423,7 +423,6 @@ class TestVideoReader:
                     audio_timebase_den,
                 )
 
-    @PY39_SKIP
     def test_read_video_from_file(self):
         """
         Test the case when decoder starts with a video file to decode frames.
@@ -469,7 +468,6 @@ class TestVideoReader:
             # compare decoding results
             self.compare_decoding_result(tv_result, pyav_result, config)
 
-    @PY39_SKIP
     def test_read_video_from_file_read_single_stream_only(self):
         """
         Test the case when decoder starts with a video file to decode frames, and
@@ -770,7 +768,6 @@ class TestVideoReader:
             assert tv_result[0].size(1) == height
             assert tv_result[0].size(2) == width
 
-    @PY39_SKIP
     def test_read_video_from_file_audio_resampling(self):
         """
         Test the case when decoder starts with a video file to decode frames, and
@@ -826,7 +823,6 @@ class TestVideoReader:
                     )
                     assert aframes.size(0) == approx(int(duration * asample_rate.item()), abs=0.1 * asample_rate.item())
 
-    @PY39_SKIP
     def test_compare_read_video_from_memory_and_file(self):
         """
         Test the case when video is already in memory, and decoder reads data in memory
@@ -893,7 +889,6 @@ class TestVideoReader:
             # finally, compare results decoded from memory and file
             self.compare_decoding_result(tv_result_memory, tv_result_file)
 
-    @PY39_SKIP
     def test_read_video_from_memory(self):
         """
         Test the case when video is already in memory, and decoder reads data in memory
@@ -938,7 +933,6 @@ class TestVideoReader:
             self.check_separate_decoding_result(tv_result, config)
             self.compare_decoding_result(tv_result, pyav_result, config)
 
-    @PY39_SKIP
     def test_read_video_from_memory_get_pts_only(self):
         """
         Test the case when video is already in memory, and decoder reads data in memory.
@@ -1008,7 +1002,6 @@ class TestVideoReader:
             assert not tv_result_pts_only[5].numel()
             self.compare_decoding_result(tv_result, tv_result_pts_only)
 
-    @PY39_SKIP
     def test_read_video_in_range_from_memory(self):
         """
         Test the case when video is already in memory, and decoder reads data in memory.
@@ -1184,7 +1177,6 @@ class TestVideoReader:
             probe_result = scripted_fun(video_tensor)
             self.check_meta_result(probe_result, config)
 
-    @PY39_SKIP
     def test_read_video_from_memory_scripted(self):
         """
         Test the case when video is already in memory, and decoder reads data in memory

--- a/test/test_videoapi.py
+++ b/test/test_videoapi.py
@@ -9,7 +9,6 @@ import torchvision
 from torchvision.io import _HAS_VIDEO_OPT, VideoReader
 from torchvision.datasets.utils import download_url
 
-from common_utils import PY39_SKIP
 
 try:
     import av
@@ -65,7 +64,6 @@ test_videos = {
 
 
 @pytest.mark.skipif(_HAS_VIDEO_OPT is False, reason="Didn't compile with ffmpeg")
-@PY39_SKIP
 class TestVideoApi:
     @pytest.mark.skipif(av is None, reason="PyAV unavailable")
     def test_frame_reading(self):


### PR DESCRIPTION
Building torchvision with ffmpeg 4.3 causes seg fault with python 3.9. Initial debugging shows crash in ffmpeg's sws_scale(). Until this issue is resolved, it's better to avoid building torchvision with ffmpeg for python 3.9.

cc @pmeier