### PR TITLE
make test folder a package

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,4 +1,4 @@
-from common_utils import IN_CIRCLE_CI, CIRCLECI_GPU_NO_CUDA_MSG, IN_FBCODE, IN_RE_WORKER, CUDA_NOT_AVAILABLE_MSG
+from test.common_utils import IN_CIRCLE_CI, CIRCLECI_GPU_NO_CUDA_MSG, IN_FBCODE, IN_RE_WORKER, CUDA_NOT_AVAILABLE_MSG
 import torch
 import pytest
 

--- a/test/datasets_utils.py
+++ b/test/datasets_utils.py
@@ -19,7 +19,7 @@ import torch
 import torchvision.datasets
 import torchvision.io
 
-from common_utils import get_tmp_dir, disable_console_output
+from test.common_utils import get_tmp_dir, disable_console_output
 
 
 __all__ = [

--- a/test/test_backbone_utils.py
+++ b/test/test_backbone_utils.py
@@ -12,7 +12,7 @@ from torchvision.models._utils import IntermediateLayerGetter
 
 import pytest
 
-from common_utils import set_rng_seed
+from test.common_utils import set_rng_seed
 
 
 def get_available_models():

--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -14,7 +14,7 @@ import xml.etree.ElementTree as ET
 import zipfile
 
 import PIL
-import datasets_utils
+from test import datasets_utils
 import numpy as np
 import pytest
 import torch

--- a/test/test_datasets_samplers.py
+++ b/test/test_datasets_samplers.py
@@ -13,7 +13,7 @@ from torchvision.datasets.samplers import (
 from torchvision.datasets.video_utils import VideoClips, unfold
 from torchvision import get_video_backend
 
-from common_utils import get_list_of_videos, assert_equal
+from test.common_utils import get_list_of_videos, assert_equal
 
 
 @pytest.mark.skipif(not io.video._av_available(), reason="this test requires av")

--- a/test/test_datasets_video_utils.py
+++ b/test/test_datasets_video_utils.py
@@ -6,7 +6,7 @@ import pytest
 from torchvision import io
 from torchvision.datasets.video_utils import VideoClips, unfold
 
-from common_utils import get_list_of_videos, assert_equal
+from test.common_utils import get_list_of_videos, assert_equal
 
 
 class TestVideo:

--- a/test/test_datasets_video_utils_opt.py
+++ b/test/test_datasets_video_utils_opt.py
@@ -1,6 +1,6 @@
 import unittest
 from torchvision import set_video_backend
-import test_datasets_video_utils
+from test import test_datasets_video_utils
 
 # Disabling the video backend switching temporarily
 # set_video_backend('video_reader')

--- a/test/test_functional_tensor.py
+++ b/test/test_functional_tensor.py
@@ -14,7 +14,7 @@ import torchvision.transforms.functional as F
 import torchvision.transforms as T
 from torchvision.transforms import InterpolationMode
 
-from common_utils import (
+from test.common_utils import (
     cpu_and_gpu,
     needs_cuda,
     _create_data,

--- a/test/test_image.py
+++ b/test/test_image.py
@@ -9,7 +9,7 @@ import numpy as np
 import torch
 from PIL import Image, __version__ as PILLOW_VERSION
 import torchvision.transforms.functional as F
-from common_utils import needs_cuda, assert_equal
+from test.common_utils import needs_cuda, assert_equal
 
 from torchvision.io.image import (
     decode_png, decode_jpeg, encode_jpeg, write_jpeg, decode_image, read_file,

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -9,7 +9,7 @@ from torchvision import get_video_backend
 import warnings
 from urllib.error import URLError
 
-from common_utils import assert_equal
+from test.common_utils import assert_equal
 
 
 try:

--- a/test/test_io_opt.py
+++ b/test/test_io_opt.py
@@ -1,6 +1,6 @@
 import unittest
 from torchvision import set_video_backend
-import test_io
+from test import test_io
 
 
 # Disabling the video backend switching temporarily

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -1,8 +1,8 @@
 import os
 import io
 import sys
-from common_utils import map_nested_tensor_object, freeze_rng_state, set_rng_seed, cpu_and_gpu, needs_cuda
-from _utils_internal import get_relative_path
+from test.common_utils import map_nested_tensor_object, freeze_rng_state, set_rng_seed, cpu_and_gpu, needs_cuda
+from test._utils_internal import get_relative_path
 from collections import OrderedDict
 import functools
 import operator

--- a/test/test_models_detection_anchor_utils.py
+++ b/test/test_models_detection_anchor_utils.py
@@ -1,5 +1,5 @@
 import torch
-from common_utils import assert_equal
+from test.common_utils import assert_equal
 from torchvision.models.detection.anchor_utils import AnchorGenerator, DefaultBoxGenerator
 from torchvision.models.detection.image_list import ImageList
 import pytest

--- a/test/test_models_detection_negative_samples.py
+++ b/test/test_models_detection_negative_samples.py
@@ -7,7 +7,7 @@ from torchvision.models.detection.roi_heads import RoIHeads
 from torchvision.models.detection.faster_rcnn import FastRCNNPredictor, TwoMLPHead
 
 import pytest
-from common_utils import assert_equal
+from test.common_utils import assert_equal
 
 
 class TestModelsDetectionNegativeSamples:

--- a/test/test_models_detection_utils.py
+++ b/test/test_models_detection_utils.py
@@ -4,7 +4,7 @@ from torchvision.models.detection import _utils
 from torchvision.models.detection.transform import GeneralizedRCNNTransform
 import pytest
 from torchvision.models.detection import backbone_utils
-from common_utils import assert_equal
+from test.common_utils import assert_equal
 
 
 class TestModelsDetectionUtils:

--- a/test/test_onnx.py
+++ b/test/test_onnx.py
@@ -1,4 +1,4 @@
-from common_utils import set_rng_seed, assert_equal
+from test.common_utils import set_rng_seed, assert_equal
 import io
 import pytest
 import torch

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1,4 +1,4 @@
-from common_utils import needs_cuda, cpu_and_gpu, assert_equal
+from test.common_utils import needs_cuda, cpu_and_gpu, assert_equal
 import math
 from abc import ABC, abstractmethod
 import pytest

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -19,7 +19,7 @@ try:
 except ImportError:
     stats = None
 
-from common_utils import cycle_over, int_dtypes, float_dtypes, assert_equal
+from test.common_utils import cycle_over, int_dtypes, float_dtypes, assert_equal
 
 
 GRACE_HOPPER = get_file_path_2(

--- a/test/test_transforms_tensor.py
+++ b/test/test_transforms_tensor.py
@@ -9,7 +9,7 @@ import pytest
 
 from typing import Sequence
 
-from common_utils import (
+from test.common_utils import (
     get_tmp_dir,
     int_dtypes,
     float_dtypes,

--- a/test/test_transforms_video.py
+++ b/test/test_transforms_video.py
@@ -4,7 +4,7 @@ import pytest
 import random
 import numpy as np
 import warnings
-from common_utils import assert_equal
+from test.common_utils import assert_equal
 
 try:
     from scipy import stats

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -9,7 +9,7 @@ import torchvision.utils as utils
 from io import BytesIO
 import torchvision.transforms.functional as F
 from PIL import Image, __version__ as PILLOW_VERSION, ImageColor
-from common_utils import assert_equal
+from test.common_utils import assert_equal
 
 
 PILLOW_VERSION = tuple(int(x) for x in PILLOW_VERSION.split('.'))

--- a/test/test_video_reader.py
+++ b/test/test_video_reader.py
@@ -12,7 +12,7 @@ import torchvision.io as io
 from numpy.random import randint
 from torchvision import set_video_backend
 from torchvision.io import _HAS_VIDEO_OPT
-from common_utils import assert_equal
+from test.common_utils import assert_equal
 
 
 try:


### PR DESCRIPTION
This solves two issues:

1. Without this we cannot import other modules within subfolders, e.g. using anything from `test/common_utils.py` in `test/prototype/*`. With this change, we can do `from test.common_utils import foo` from anywhere in our test suite.
2. `pytest` requires unique module names in non-package folders. That means, we cannot have `test/protototype/datasets/test_utils.py` if `test/test_utils.py` already exists. See [this CI run](https://app.circleci.com/pipelines/github/pytorch/vision/10495/workflows/0305f2ed-1620-47ce-9ada-2872e9ac6f35/jobs/796347) from #4433 for an example.