### PR TITLE
Discrete cosine transform (DCT) -- WIP

### DIFF
--- a/torchvision/ops/__init__.py
+++ b/torchvision/ops/__init__.py
@@ -1,14 +1,15 @@
 from .boxes import nms, batched_nms, remove_small_boxes, clip_boxes_to_image, box_area, box_iou, generalized_box_iou, \
     masks_to_boxes
 from .boxes import box_convert
+from .dct import dct
 from .deform_conv import deform_conv2d, DeformConv2d
-from .roi_align import roi_align, RoIAlign
-from .roi_pool import roi_pool, RoIPool
-from .ps_roi_align import ps_roi_align, PSRoIAlign
-from .ps_roi_pool import ps_roi_pool, PSRoIPool
-from .poolers import MultiScaleRoIAlign
 from .feature_pyramid_network import FeaturePyramidNetwork
 from .focal_loss import sigmoid_focal_loss
+from .poolers import MultiScaleRoIAlign
+from .ps_roi_align import ps_roi_align, PSRoIAlign
+from .ps_roi_pool import ps_roi_pool, PSRoIPool
+from .roi_align import roi_align, RoIAlign
+from .roi_pool import roi_pool, RoIPool
 from .stochastic_depth import stochastic_depth, StochasticDepth
 
 from ._register_onnx_ops import _register_custom_op
@@ -22,5 +23,5 @@ __all__ = [
     'box_area', 'box_iou', 'generalized_box_iou', 'roi_align', 'RoIAlign', 'roi_pool',
     'RoIPool', 'ps_roi_align', 'PSRoIAlign', 'ps_roi_pool',
     'PSRoIPool', 'MultiScaleRoIAlign', 'FeaturePyramidNetwork',
-    'sigmoid_focal_loss', 'stochastic_depth', 'StochasticDepth'
+    'sigmoid_focal_loss', 'stochastic_depth', 'StochasticDepth', 'dct'
 ]

--- a/torchvision/ops/dct.py
+++ b/torchvision/ops/dct.py
@@ -90,7 +90,7 @@ def _dct_type_4(x: torch.Tensor, axis: int = -1, norm: typing.Optional[str] = No
     y = dct(x, type=2, n=2 * x.shape[-1], axis=axis, norm=None)[..., 1::2]
 
     if norm == "ortho":
-        raise NotImplementedError
+        y *= math.sqrt(0.5) * torch.rsqrt(torch.tensor(x.shape[-1], dtype=x.dtype))
 
     return y
 

--- a/torchvision/ops/dct.py
+++ b/torchvision/ops/dct.py
@@ -52,7 +52,18 @@ def _dct_type_1(x: torch.Tensor) -> torch.Tensor:
 
 
 def _dct_type_2(x: torch.Tensor, norm: typing.Optional[str] = None) -> torch.Tensor:
-    raise NotImplementedError
+    y = torch.fft.rfft(x, 2 * x.shape[-1])[..., :x.shape[-1]] * 2.0
+
+    imag = -torch.tensor(range(x.shape[-1]), dtype=x.dtype) * math.pi * 0.5 / float(x.shape[-1])
+
+    y *= torch.exp(torch.complex(torch.tensor(0.0, dtype=x.dtype), imag))
+
+    y = torch.real(y)
+
+    if norm == "ortho":
+        raise NotImplementedError
+
+    return y
 
 
 def _dct_type_3(x: torch.Tensor, norm: typing.Optional[str] = None) -> torch.Tensor:

--- a/torchvision/ops/dct.py
+++ b/torchvision/ops/dct.py
@@ -87,7 +87,12 @@ def _dct_type_3(x: torch.Tensor, norm: typing.Optional[str] = None) -> torch.Ten
 
 
 def _dct_type_4(x: torch.Tensor, axis: int = -1, norm: typing.Optional[str] = None) -> torch.Tensor:
-    raise NotImplementedError
+    y = dct(x, type=2, n=2 * x.shape[-1], axis=axis, norm=None)[..., 1::2]
+
+    if norm == "ortho":
+        raise NotImplementedError
+
+    return y
 
 
 def _pad(x: torch.Tensor, n: int) -> torch.Tensor:

--- a/torchvision/ops/dct.py
+++ b/torchvision/ops/dct.py
@@ -1,3 +1,4 @@
+import math
 import typing
 
 import torch
@@ -55,7 +56,23 @@ def _dct_type_2(x: torch.Tensor, norm: typing.Optional[str] = None) -> torch.Ten
 
 
 def _dct_type_3(x: torch.Tensor, norm: typing.Optional[str] = None) -> torch.Tensor:
-    raise NotImplementedError
+    dimension = x.shape[-1]
+
+    if norm == "ortho":
+        raise NotImplementedError
+    else:
+        x *= float(dimension)
+
+    zero = torch.tensor(0.0, dtype=x.dtype)
+
+    dimensions = torch.tensor(range(dimension), dtype=x.dtype)
+
+    a = torch.exp(torch.complex(zero, dimensions * math.pi * 0.5 / float(dimension)))
+    b = torch.complex(x, zero)
+
+    y = torch.fft.irfft(2.0 * a * b, 2 * dimension)
+
+    return y[..., :dimension]
 
 
 def _dct_type_4(x: torch.Tensor, axis: int = -1, norm: typing.Optional[str] = None) -> torch.Tensor:

--- a/torchvision/ops/dct.py
+++ b/torchvision/ops/dct.py
@@ -1,6 +1,7 @@
 import typing
 
 import torch
+import torch.fft
 
 
 def dct(
@@ -46,7 +47,7 @@ def dct(
 
 
 def _dct_type_1(x: torch.Tensor) -> torch.Tensor:
-    raise NotImplementedError
+    return torch.real(torch.fft.rfft(torch.cat([x, torch.flip(x, [-1])[..., 1:-1:1]], -1)))
 
 
 def _dct_type_2(x: torch.Tensor, norm: typing.Optional[str] = None) -> torch.Tensor:

--- a/torchvision/ops/dct.py
+++ b/torchvision/ops/dct.py
@@ -1,0 +1,65 @@
+import typing
+
+import torch
+
+
+def dct(
+        x: torch.Tensor,
+        type: int = 2,
+        n: int = None,
+        axis: int = -1,
+        norm: typing.Optional[str] = None
+) -> torch.Tensor:
+    if type not in (1, 2, 3, 4):
+        raise ValueError
+
+    if type == 1:
+        if norm == "ortho":
+            raise ValueError
+
+        if x.shape[-1] is not None and x.shape[-1] < 2:
+            raise ValueError
+
+    if n is not None and n < 1:
+        raise ValueError
+
+    if axis != -1:
+        raise NotImplementedError
+
+    if norm not in (None, "ortho"):
+        raise ValueError
+
+    if n is not None:
+        x = _pad(x, n)
+
+    if type == 1:
+        return _dct_type_1(x)
+
+    if type == 2:
+        return _dct_type_2(x, norm)
+
+    if type == 3:
+        return _dct_type_3(x, norm)
+
+    if type == 4:
+        return _dct_type_4(x, axis, norm)
+
+
+def _dct_type_1(x: torch.Tensor) -> torch.Tensor:
+    raise NotImplementedError
+
+
+def _dct_type_2(x: torch.Tensor, norm: typing.Optional[str] = None) -> torch.Tensor:
+    raise NotImplementedError
+
+
+def _dct_type_3(x: torch.Tensor, norm: typing.Optional[str] = None) -> torch.Tensor:
+    raise NotImplementedError
+
+
+def _dct_type_4(x: torch.Tensor, axis: int = -1, norm: typing.Optional[str] = None) -> torch.Tensor:
+    raise NotImplementedError
+
+
+def _pad(x: torch.Tensor, n: int) -> torch.Tensor:
+    raise NotImplementedError


### PR DESCRIPTION
A work in progress. 

* Uses the SciPy interface (this is also the interface used by TensorFlow and JAX)
    *  Interface will also be familiar to MATLAB and OpenCV users
* PyTorch/audio provides an audio-specific op (i.e. Mel-frequency) [torchaudio.functional.create_dct](https://pytorch.org/audio/stable/functional.html?highlight=create_dct#torchaudio.functional.create_dct)
* Since PyTorch does not support negative strides, TYPE-1 is slow (it uses `flip`)
* A NumPy-like `pad` function would make implementing `"ortho"` options far easier! 😵‍💫 