### PR TITLE
[nms]: replace unstable sort with stable sort

### DIFF
--- a/torchvision/csrc/ops/cpu/nms_kernel.cpp
+++ b/torchvision/csrc/ops/cpu/nms_kernel.cpp
@@ -27,7 +27,8 @@ at::Tensor nms_kernel_impl(
 
   at::Tensor areas_t = (x2_t - x1_t) * (y2_t - y1_t);
 
-  auto order_t = std::get<1>(scores.sort(0, /* descending=*/true));
+  auto order_t =
+      std::get<1>(scores.sort(0, /* descending=*/true, /*stable*/ true));
 
   auto ndets = dets.size(0);
   at::Tensor suppressed_t = at::zeros({ndets}, dets.options().dtype(at::kByte));

--- a/torchvision/csrc/ops/cuda/nms_kernel.cu
+++ b/torchvision/csrc/ops/cuda/nms_kernel.cu
@@ -109,7 +109,8 @@ at::Tensor nms_kernel(
     return at::empty({0}, dets.options().dtype(at::kLong));
   }
 
-  auto order_t = std::get<1>(scores.sort(0, /* descending=*/true));
+  auto order_t =
+      std::get<1>(scores.sort(0, /* descending=*/true, /*stable=*/true));
   auto dets_sorted = dets.index_select(0, order_t).contiguous();
 
   int dets_num = dets.size(0);


### PR DESCRIPTION
Use stable sort in nms since pytorch1.9 has supported stable sort. The discussion is in https://github.com/pytorch/vision/issues/4488