### PR TITLE
NOMRG [ao_migration] torchvision: torch.quantization -> torch.ao.quantization

### DIFF
--- a/references/classification/utils.py
+++ b/references/classification/utils.py
@@ -5,10 +5,12 @@ import hashlib
 import time
 import torch
 import torch.distributed as dist
+from typing import Tuple
 
 import errno
 import os
 
+TORCH_VERSION: Tuple[int, ...] = tuple(int(x) for x in torch.__version__.split(".")[:2])
 
 class SmoothedValue(object):
     """Track a series of values and provide access to smoothed values over a
@@ -352,8 +354,8 @@ def store_model_weights(model, checkpoint_path, checkpoint_key='model', strict=T
         # Quantized Classification
         model = M.quantization.mobilenet_v3_large(pretrained=False, quantize=False)
         model.fuse_model()
-        model.qconfig = torch.quantization.get_default_qat_qconfig('qnnpack')
-        _ = torch.quantization.prepare_qat(model, inplace=True)
+        model.qconfig = torch.ao.quantization.get_default_qat_qconfig('qnnpack')
+        _ = torch.ao.quantization.prepare_qat(model, inplace=True)
         print(store_model_weights(model, './qat.pth'))
 
         # Object Detection

--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -7,6 +7,7 @@ import pytest
 import argparse
 import sys
 import torch
+from typing import Tuple
 import __main__
 import random
 import inspect
@@ -26,6 +27,7 @@ IN_RE_WORKER = os.environ.get("INSIDE_RE_WORKER") is not None
 IN_FBCODE = os.environ.get("IN_FBCODE_TORCHVISION") == "1"
 CUDA_NOT_AVAILABLE_MSG = 'CUDA device not available'
 CIRCLECI_GPU_NO_CUDA_MSG = "We're in a CircleCI GPU machine, and this test doesn't need cuda."
+TORCH_VERSION: Tuple[int, ...] = tuple(int(x) for x in torch.__version__.split(".")[:2])
 
 
 @contextlib.contextmanager

--- a/torchvision/models/quantization/mobilenetv2.py
+++ b/torchvision/models/quantization/mobilenetv2.py
@@ -7,9 +7,13 @@ from typing import Any
 
 from torchvision.models.mobilenetv2 import InvertedResidual, MobileNetV2, model_urls
 from torch.quantization import QuantStub, DeQuantStub, fuse_modules
-from .utils import _replace_relu, quantize_model
+from .utils import _replace_relu, quantize_model, TORCH_VERSION
 from ...ops.misc import ConvNormActivation
 
+if TORCH_VERSION >= (1, 10):
+    from torch.ao.quantization import QuantStub, DeQuantStub, fuse_modules
+else:
+    from torch.quantization import QuantStub, DeQuantStub, fuse_modules
 
 __all__ = ['QuantizableMobileNetV2', 'mobilenet_v2']
 


### PR DESCRIPTION
Summary:
This changes the imports in the `caffe2/torch/ao/nn` to include the new import locations.

```
codemod -d pytorch/vision --extensions py 'torch.quantization' 'torch.ao.quantization'
```

Differential Revision: D31302368

