### PR TITLE
make mypy more strict for prototype datasets

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -4,6 +4,22 @@ files = torchvision
 show_error_codes = True
 pretty = True
 
+[mypy-torchvision.prototype.*]
+
+; untyped definitions and calls
+disallow_untyped_defs = True
+
+; None and Optional handling
+no_implicit_optional = True
+
+; warnings
+warn_unused_ignores = True
+warn_return_any = True
+warn_unreachable = True
+
+; miscellaneous strictness flags
+allow_redefinition = True
+
 [mypy-torchvision.io._video_opt.*]
 
 ignore_errors = True

--- a/torchvision/prototype/datasets/_folder.py
+++ b/torchvision/prototype/datasets/_folder.py
@@ -26,7 +26,7 @@ def _collate_and_decode_data(
     *,
     root: pathlib.Path,
     categories: List[str],
-    decoder,
+    decoder: Optional[Callable[[io.IOBase], torch.Tensor]],
 ) -> Dict[str, Any]:
     path, buffer = data
     data = decoder(buffer) if decoder else buffer
@@ -50,8 +50,8 @@ def from_data_folder(
     root = pathlib.Path(root).expanduser().resolve()
     categories = sorted(entry.name for entry in os.scandir(root) if entry.is_dir())
     masks: Union[List[str], str] = [f"*.{ext}" for ext in valid_extensions] if valid_extensions is not None else ""
-    dp: IterDataPipe = FileLister(str(root), recursive=recursive, masks=masks)
-    dp = Filter(dp, _is_not_top_level_file, fn_kwargs=dict(root=root))
+    dp = FileLister(str(root), recursive=recursive, masks=masks)
+    dp: IterDataPipe = Filter(dp, _is_not_top_level_file, fn_kwargs=dict(root=root))
     dp = Shuffler(dp, buffer_size=INFINITE_BUFFER_SIZE)
     dp = FileLoader(dp)
     return (

--- a/torchvision/prototype/datasets/decoder.py
+++ b/torchvision/prototype/datasets/decoder.py
@@ -1,4 +1,5 @@
 import io
+from typing import cast
 
 import PIL.Image
 import torch
@@ -9,4 +10,4 @@ __all__ = ["pil"]
 
 
 def pil(buffer: io.IOBase, mode: str = "RGB") -> torch.Tensor:
-    return pil_to_tensor(PIL.Image.open(buffer).convert(mode.upper()))
+    return cast(torch.Tensor, pil_to_tensor(PIL.Image.open(buffer).convert(mode.upper())))

--- a/torchvision/prototype/datasets/utils/_dataset.py
+++ b/torchvision/prototype/datasets/utils/_dataset.py
@@ -15,6 +15,8 @@ from typing import (
     NoReturn,
     Iterable,
     Tuple,
+    Iterator,
+    cast,
 )
 
 import torch
@@ -27,7 +29,7 @@ from torchvision.prototype.datasets.utils._internal import (
 from ._resource import OnlineResource
 
 
-def make_repr(name: str, items: Iterable[Tuple[str, Any]]):
+def make_repr(name: str, items: Iterable[Tuple[str, Any]]) -> str:
     def to_str(sep: str) -> str:
         return sep.join([f"{key}={value}" for key, value in items])
 
@@ -46,7 +48,7 @@ def make_repr(name: str, items: Iterable[Tuple[str, Any]]):
 
 
 class DatasetConfig(Mapping):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         data = dict(*args, **kwargs)
         self.__dict__["__data__"] = data
         self.__dict__["__final_hash__"] = hash(tuple(data.items()))
@@ -54,10 +56,10 @@ class DatasetConfig(Mapping):
     def __getitem__(self, name: str) -> Any:
         return self.__dict__["__data__"][name]
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[Any]:
         return iter(self.__dict__["__data__"].keys())
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self.__dict__["__data__"])
 
     def __getattr__(self, name: str) -> Any:
@@ -81,7 +83,7 @@ class DatasetConfig(Mapping):
         raise RuntimeError(f"'{type(self).__name__}' object is immutable")
 
     def __hash__(self) -> int:
-        return self.__dict__["__final_hash__"]
+        return cast(int, self.__dict__["__final_hash__"])
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, DatasetConfig):

--- a/torchvision/prototype/datasets/utils/_resource.py
+++ b/torchvision/prototype/datasets/utils/_resource.py
@@ -8,7 +8,7 @@ from torch.utils.data.datapipes.iter import FileLoader, IterableWrapper
 
 
 # FIXME
-def compute_sha256(_) -> str:
+def compute_sha256(path: pathlib.Path) -> str:
     return ""
 
 


### PR DESCRIPTION
Instead of retrofitting more strictness for `mypy` later, we can start off with strict settings.