### PR TITLE
Fix all flake8 issues

### DIFF
--- a/.circleci/unittest/linux/scripts/run-clang-format.py
+++ b/.circleci/unittest/linux/scripts/run-clang-format.py
@@ -32,7 +32,6 @@ A diff output is produced and a sensible exit code is returned.
 """
 
 import argparse
-import codecs
 import difflib
 import fnmatch
 import io

--- a/packaging/wheel/relocate.py
+++ b/packaging/wheel/relocate.py
@@ -19,7 +19,6 @@ from base64 import urlsafe_b64encode
 # Third party imports
 if sys.platform == "linux":
     from auditwheel.lddtree import lddtree
-from wheel.bdist_wheel import get_abi_tag
 
 
 ALLOWLIST = {

--- a/references/classification/utils.py
+++ b/references/classification/utils.py
@@ -167,7 +167,9 @@ class ExponentialMovingAverage(torch.optim.swa_utils.AveragedModel):
     """
 
     def __init__(self, model, decay, device="cpu"):
-        ema_avg = lambda avg_model_param, model_param, num_averaged: decay * avg_model_param + (1 - decay) * model_param
+        def ema_avg(avg_model_param, model_param, num_averaged):
+            return decay * avg_model_param + (1 - decay) * model_param
+
         super().__init__(model, device, ema_avg)
 
     def update_parameters(self, model):

--- a/references/detection/coco_utils.py
+++ b/references/detection/coco_utils.py
@@ -5,7 +5,6 @@ import torch
 import torch.utils.data
 import torchvision
 import transforms as T
-from PIL import Image
 from pycocotools import mask as coco_mask
 from pycocotools.coco import COCO
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,8 +8,9 @@ license_file = LICENSE
 max-line-length = 120
 
 [flake8]
+# note: we ignore all 501s (line too long) anyway as they're taken care of by black
 max-line-length = 120
-ignore = E203, E402, W503, W504, F821
+ignore = E203, E402, W503, W504, F821, E501
 per-file-ignores =
     __init__.py: F401, F403, F405
     ./hubconf.py: F401

--- a/setup.py
+++ b/setup.py
@@ -3,11 +3,9 @@ import distutils.spawn
 import glob
 import io
 import os
-import re
 import shutil
 import subprocess
 import sys
-from distutils.version import StrictVersion
 
 import torch
 from pkg_resources import parse_version, get_distribution, DistributionNotFound

--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -1,24 +1,16 @@
-import argparse
 import contextlib
 import functools
-import inspect
 import os
 import random
 import shutil
-import sys
 import tempfile
-import unittest
-from collections import OrderedDict
-from numbers import Number
 
 import numpy as np
-import pytest
 import torch
 from PIL import Image
-from torch._six import string_classes
 from torchvision import io
 
-import __main__
+import __main__  # noqa
 
 
 IN_CIRCLE_CI = os.getenv("CIRCLECI", False) == "true"

--- a/test/test_backbone_utils.py
+++ b/test/test_backbone_utils.py
@@ -1,10 +1,8 @@
 import random
-from functools import partial
 from itertools import chain
 
 import pytest
 import torch
-import torchvision
 from common_utils import set_rng_seed
 from torchvision import models
 from torchvision.models._utils import IntermediateLayerGetter

--- a/test/test_cpp_models.py
+++ b/test/test_cpp_models.py
@@ -5,7 +5,7 @@ import unittest
 import torch
 import torchvision.transforms.functional as F
 from PIL import Image
-from torchvision import models, transforms
+from torchvision import models
 
 try:
     from torchvision import _C_tests

--- a/test/test_datasets_samplers.py
+++ b/test/test_datasets_samplers.py
@@ -1,18 +1,13 @@
-import contextlib
-import os
-import sys
-
 import pytest
 import torch
 from common_utils import get_list_of_videos, assert_equal
-from torchvision import get_video_backend
 from torchvision import io
 from torchvision.datasets.samplers import (
     DistributedSampler,
     RandomClipSampler,
     UniformClipSampler,
 )
-from torchvision.datasets.video_utils import VideoClips, unfold
+from torchvision.datasets.video_utils import VideoClips
 
 
 @pytest.mark.skipif(not io.video._av_available(), reason="this test requires av")

--- a/test/test_datasets_utils.py
+++ b/test/test_datasets_utils.py
@@ -1,13 +1,8 @@
-import bz2
 import contextlib
 import gzip
-import itertools
-import lzma
 import os
 import tarfile
-import warnings
 import zipfile
-from urllib.error import URLError
 
 import pytest
 import torchvision.datasets.utils as utils

--- a/test/test_datasets_video_utils.py
+++ b/test/test_datasets_video_utils.py
@@ -1,6 +1,3 @@
-import contextlib
-import os
-
 import pytest
 import torch
 from common_utils import get_list_of_videos, assert_equal

--- a/test/test_datasets_video_utils_opt.py
+++ b/test/test_datasets_video_utils_opt.py
@@ -1,7 +1,6 @@
 import unittest
 
 import test_datasets_video_utils
-from torchvision import set_video_backend
 
 # Disabling the video backend switching temporarily
 # set_video_backend('video_reader')

--- a/test/test_functional_tensor.py
+++ b/test/test_functional_tensor.py
@@ -2,8 +2,7 @@ import colorsys
 import itertools
 import math
 import os
-from functools import partial
-from typing import Dict, List, Sequence, Tuple
+from typing import Sequence
 
 import numpy as np
 import pytest

--- a/test/test_internet.py
+++ b/test/test_internet.py
@@ -6,7 +6,6 @@ cleanly ignored in FB internal test infra.
 """
 
 import os
-import warnings
 from urllib.error import URLError
 
 import pytest

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -2,8 +2,6 @@ import contextlib
 import os
 import sys
 import tempfile
-import warnings
-from urllib.error import URLError
 
 import pytest
 import torch

--- a/test/test_io_opt.py
+++ b/test/test_io_opt.py
@@ -1,7 +1,7 @@
 import unittest
 
 import test_io
-from torchvision import set_video_backend
+from torchvision import set_video_backend  # noqa
 
 
 # Disabling the video backend switching temporarily

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -2,7 +2,6 @@ import functools
 import io
 import operator
 import os
-import sys
 import traceback
 import warnings
 from collections import OrderedDict

--- a/test/test_transforms_tensor.py
+++ b/test/test_transforms_tensor.py
@@ -1,5 +1,4 @@
 import os
-from typing import Sequence
 
 import numpy as np
 import pytest

--- a/torchvision/_internally_replaced_utils.py
+++ b/torchvision/_internally_replaced_utils.py
@@ -11,9 +11,9 @@ def _is_remote_location_available() -> bool:
 
 
 try:
-    from torch.hub import load_state_dict_from_url
+    from torch.hub import load_state_dict_from_url  # noqa
 except ImportError:
-    from torch.utils.model_zoo import load_url as load_state_dict_from_url
+    from torch.utils.model_zoo import load_url as load_state_dict_from_url  # noqa
 
 
 def _get_extension_path(lib_name):

--- a/torchvision/datasets/cifar.py
+++ b/torchvision/datasets/cifar.py
@@ -4,7 +4,6 @@ import pickle
 from typing import Any, Callable, Optional, Tuple
 
 import numpy as np
-import torch
 from PIL import Image
 
 from .utils import check_integrity, download_and_extract_archive

--- a/torchvision/datasets/widerface.py
+++ b/torchvision/datasets/widerface.py
@@ -6,7 +6,6 @@ import torch
 from PIL import Image
 
 from .utils import (
-    check_integrity,
     download_file_from_google_drive,
     download_and_extract_archive,
     extract_archive,

--- a/torchvision/io/_video_opt.py
+++ b/torchvision/io/_video_opt.py
@@ -1,5 +1,4 @@
 import math
-import os
 import warnings
 from fractions import Fraction
 from typing import List, Tuple

--- a/torchvision/models/densenet.py
+++ b/torchvision/models/densenet.py
@@ -64,12 +64,12 @@ class _DenseLayer(nn.Module):
 
         return cp.checkpoint(closure, *input)
 
-    @torch.jit._overload_method  # noqa: F811
-    def forward(self, input: List[Tensor]) -> Tensor:
+    @torch.jit._overload_method
+    def forward(self, input: List[Tensor]) -> Tensor:  # noqa: F811
         pass
 
-    @torch.jit._overload_method  # noqa: F811
-    def forward(self, input: Tensor) -> Tensor:
+    @torch.jit._overload_method
+    def forward(self, input: Tensor) -> Tensor:  # noqa: F811
         pass
 
     # torchscript does not yet support *args, so we overload method

--- a/torchvision/models/detection/rpn.py
+++ b/torchvision/models/detection/rpn.py
@@ -9,7 +9,7 @@ from torchvision.ops import boxes as box_ops
 from . import _utils as det_utils
 
 # Import AnchorGenerator to keep compatibility.
-from .anchor_utils import AnchorGenerator
+from .anchor_utils import AnchorGenerator  # noqa
 from .image_list import ImageList
 
 

--- a/torchvision/models/detection/ssdlite.py
+++ b/torchvision/models/detection/ssdlite.py
@@ -1,7 +1,7 @@
 import warnings
 from collections import OrderedDict
 from functools import partial
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional
 
 import torch
 from torch import nn, Tensor

--- a/torchvision/models/mobilenetv2.py
+++ b/torchvision/models/mobilenetv2.py
@@ -1,5 +1,4 @@
 import warnings
-from functools import partial
 from typing import Callable, Any, Optional, List
 
 import torch

--- a/torchvision/ops/_register_onnx_ops.py
+++ b/torchvision/ops/_register_onnx_ops.py
@@ -7,12 +7,7 @@ _onnx_opset_version = 11
 
 
 def _register_custom_op():
-    from torch.onnx.symbolic_helper import (
-        parse_args,
-        scalar_type_to_onnx,
-        scalar_type_to_pytorch_type,
-        cast_pytorch_to_onnx,
-    )
+    from torch.onnx.symbolic_helper import parse_args
     from torch.onnx.symbolic_opset11 import select, squeeze, unsqueeze
     from torch.onnx.symbolic_opset9 import _cast_Long
 


### PR DESCRIPTION
This fixes all outstanding flake8 issues that popped up after https://github.com/pytorch/vision/pull/4384 (https://github.com/pytorch/vision/pull/4384#issuecomment-933474723)

Most of it is just removing unused imports. I stayed conservative (i.e. keep the import with a `# noqa`) when I wasn't sure.

It also ignores the `line-too-long` errors from flake8: those are taken care of by black now anyway, but there can be minor conflicts in the case e.g. of https://github.com/pytorch/vision/blob/main/torchvision/models/detection/ssdlite.py#L21:L21, so we just keep `flake8` quite and trust `black` in those cases.