### PR TITLE
fix import order for torchvision.prototype.datasets

### DIFF
--- a/torchvision/prototype/datasets/__init__.py
+++ b/torchvision/prototype/datasets/__init__.py
@@ -7,10 +7,9 @@ except (ModuleNotFoundError, TypeError) as error:
         "Note that you cannot install it with `pip install torchdata`, since this is another package."
     ) from error
 
-
 from . import decoder, utils
+from ._home import home
 
 # Load this last, since some parts depend on the above being loaded first
-from ._api import register, _list as list, info, load
+from ._api import register, _list as list, info, load  # usort: skip
 from ._folder import from_data_folder, from_image_folder
-from ._home import home


### PR DESCRIPTION
This was broken by #4384, but not detected since we don't have tests for the prototype functionality yet.