### PR TITLE
Show PILToTensor in docs

### DIFF
--- a/docs/source/transforms.rst
+++ b/docs/source/transforms.rst
@@ -206,6 +206,9 @@ Conversion Transforms
 .. autoclass:: ToTensor
     :members:
 
+.. autoclass:: PILToImage
+    :members:
+
 
 Generic Transforms
 ------------------


### PR DESCRIPTION
Looks like this was missing