### PR TITLE
fix nargs specifier for category file generation

### DIFF
--- a/torchvision/prototype/datasets/generate_category_files.py
+++ b/torchvision/prototype/datasets/generate_category_files.py
@@ -38,7 +38,7 @@ def parse_args(argv=None):
 
     parser.add_argument(
         "names",
-        nargs="?",
+        nargs="*",
         type=str,
         help="Names of datasets to generate category files for. If omitted, all datasets will be used.",
     )


### PR DESCRIPTION
`?` is for a single argument and the argument will be `None` if nothing is passed. `*` will always be a list that is empty if nothing is passed. That is what I wanted to have, but I misread the documentation.

Without this, the script only works as intended if we pass nothing.

cc @pmeier @bjuncek