### PR TITLE
add `prototype` to primary labels

### DIFF
--- a/.github/process_commit.py
+++ b/.github/process_commit.py
@@ -21,6 +21,7 @@ PRIMARY_LABELS = {
     "bc-breaking",
     "deprecation",
     "other",
+    "prototype",
 }
 
 SECONDARY_LABELS = {


### PR DESCRIPTION
For `prototype` features it is usually hard to differentiate if a change is a bug fix / enhancement / new feature / ... Given that prototype PRs won't be included in releases and thus they are not relevant for the release notes, this is an easy way to appease the bot.

cc @seemethere