### PR TITLE
[release/0.11] .circleci: Update default pytorch_version to 1.10.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ binary_common: &binary_common
     pytorch_version:
       description: "PyTorch version to build against; by default, use a nightly"
       type: string
-      default: ""
+      default: "1.10.0"
     # Don't edit these
     python_version:
       description: "Python version to build against (e.g., 3.7)"

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -105,7 +105,7 @@ binary_common: &binary_common
     pytorch_version:
       description: "PyTorch version to build against; by default, use a nightly"
       type: string
-      default: ""
+      default: "1.10.0"
     # Don't edit these
     python_version:
       description: "Python version to build against (e.g., 3.7)"


### PR DESCRIPTION
Value should've been updated at release branch cut