### PR TITLE
fix formatting CIRCLECI_TAG when building docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -941,7 +941,8 @@ jobs:
           name: Build docs
           command: |
             set -ex
-            tag=${CIRCLE_TAG:1:5}
+            # turn v1.12.0rc3 into 1.12.0
+            tag=$(echo $CIRCLE_TAG | sed -e 's/v*\([0-9.]*\).*/\1/')
             VERSION=${tag:-main}
             eval "$(./conda/bin/conda shell.bash hook)"
             conda activate ./env

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -941,7 +941,8 @@ jobs:
           name: Build docs
           command: |
             set -ex
-            tag=${CIRCLE_TAG:1:5}
+            # turn v1.12.0rc3 into 1.12.0
+            tag=$(echo $CIRCLE_TAG | sed -e 's/v*\([0-9.]*\).*/\1/')
             VERSION=${tag:-main}
             eval "$(./conda/bin/conda shell.bash hook)"
             conda activate ./env


### PR DESCRIPTION
Related to pytorch/text#1416. Minor version became two digits which broke the old code, resulting in docs being pushed to the wrong directory