### PR TITLE
[CircleCI] s/gpu.small/gpu.nvidia.small/ (#4482)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -835,7 +835,7 @@ jobs:
     <<: *binary_common
     machine:
       image: ubuntu-1604-cuda-10.2:202012-01
-    resource_class: gpu.small
+    resource_class: gpu.nvidia.small
     environment:
       PYTHON_VERSION: << parameters.python_version >>
       PYTORCH_VERSION: << parameters.pytorch_version >>

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -835,7 +835,7 @@ jobs:
     <<: *binary_common
     machine:
       image: ubuntu-1604-cuda-10.2:202012-01
-    resource_class: gpu.small
+    resource_class: gpu.nvidia.small
     environment:
       PYTHON_VERSION: << parameters.python_version >>
       PYTORCH_VERSION: << parameters.pytorch_version >>


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* (to be filled)

Old resource class is getting deprecated