### PR TITLE
Fix quantization error on Reference Scripts

### DIFF
--- a/references/classification/utils.py
+++ b/references/classification/utils.py
@@ -33,7 +33,6 @@ class SmoothedValue(object):
         Warning: does not synchronize the deque!
         """
         t = reduce_across_processes([self.count, self.total])
-        t = t.tolist()
         self.count = int(t[0])
         self.total = t[1]
 
@@ -407,4 +406,4 @@ def reduce_across_processes(val):
     t = torch.tensor(val, device="cuda")
     dist.barrier()
     dist.all_reduce(t)
-    return t
+    return t.tolist()


### PR DESCRIPTION
Running the quantization script after #4609 leads to:
```
Traceback (most recent call last):
  File "./vision/references/classification/train_quantization.py", line 257, in <module>
    main(args)
  File "./vision/references/classification/train_quantization.py", line 103, in main
    evaluate(model, criterion, data_loader_test, device=device)
  File "./vision/references/classification/train.py", line 92, in evaluate
    metric_logger.synchronize_between_processes()
  File "./vision/references/classification/utils.py", line 95, in synchronize_between_processes
    meter.synchronize_between_processes()
  File "./vision/references/classification/utils.py", line 36, in synchronize_between_processes
    t = t.tolist()
AttributeError: 'list' object has no attribute 'tolist'
```

This is because the quantization script doesn't run in distributed mode so the `reduce_across_processes()` returns a list not a tensor.