### PR TITLE
[FBcode->GH] [PyTorch] Fix windows build for torchvision when `MOBILE` is defined (#4571)

### DIFF
--- a/torchvision/csrc/vision.cpp
+++ b/torchvision/csrc/vision.cpp
@@ -13,13 +13,14 @@
 #endif
 
 // If we are in a Windows environment, we need to define
-// initialization functions for the _custom_ops extension
-#ifdef _WIN32
+// initialization functions for the _custom_ops extension.
+// For PyMODINIT_FUNC to work, we need to include Python.h
+#if !defined(MOBILE) && defined(_WIN32)
 PyMODINIT_FUNC PyInit__C(void) {
   // No need to do anything.
   return NULL;
 }
-#endif
+#endif // !defined(MOBILE) && defined(_WIN32)
 
 namespace vision {
 int64_t cuda_version() {


### PR DESCRIPTION
This is an old FBcode=>GH commit which was missed.

----------

Summary:
Pull Request resolved: https://github.com/pytorch/vision/pull/4571

Fixing windows build for `torchvision` when `MOBILE` is defined. In `csrc/vision.cpp`, since `PyMODINIT_FUNC` depends on `Python.h` I added the same condition for `PyMODINIT_FUNC` as the one for `import <PyTorch.h>`.

Reviewed By: malfet

Differential Revision: D31488734

fbshipit-source-id: fd52a9ab161288d9c8bf3b9e0ab9da856a4ebadb