### PR TITLE
NORMG injecting weights metadata into docstrings

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -283,5 +283,14 @@ def inject_minigalleries(app, what, name, obj, options, lines):
         lines.append("\n")
 
 
+def inject_weight_metadata(app, what, name, obj, options, lines):
+
+    if obj.__name__.endswith("Weights"):
+        for field in obj:
+            lines.append(str(field) + "\n")
+            lines.append(f"metadata = {field.meta}")
+
+
 def setup(app):
     app.connect("autodoc-process-docstring", inject_minigalleries)
+    app.connect("autodoc-process-docstring", inject_weight_metadata)

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -697,3 +697,10 @@ ResNet (2+1)D
 -------------
 
 .. autofunction:: torchvision.models.video.r2plus1d_18
+
+
+
+LOLOLOL
+-------
+
+.. autoclass:: torchvision.prototype.models.ResNet101Weights


### PR DESCRIPTION
@datumbox this is an example of something we could do, following our discussion, to programmatically include the weights metadata into the docstrings. Obviously the code is too hacky but this is just a POC.

renders like this:

( we would need to tweak what we want to print, the category key being super long, etc...)

![image](https://user-images.githubusercontent.com/1190450/139277037-587ff8b7-46ee-495e-8c19-6e6085f3d0c4.png)
