### PR TITLE
Add logging to torchvision ops

### DIFF
--- a/torchvision/ops/boxes.py
+++ b/torchvision/ops/boxes.py
@@ -6,6 +6,7 @@ from torch import Tensor
 from torchvision.extension import _assert_has_ops
 
 from ._box_convert import _box_cxcywh_to_xyxy, _box_xyxy_to_cxcywh, _box_xywh_to_xyxy, _box_xyxy_to_xywh
+from ..utils import _log_api_usage_once
 
 
 def nms(boxes: Tensor, scores: Tensor, iou_threshold: float) -> Tensor:
@@ -33,7 +34,7 @@ def nms(boxes: Tensor, scores: Tensor, iou_threshold: float) -> Tensor:
         Tensor: int64 tensor with the indices of the elements that have been kept
         by NMS, sorted in decreasing order of scores
     """
-    torch._C._log_api_usage_once("torchvision.ops.nms")
+    _log_api_usage_once("torchvision.ops.nms")
     _assert_has_ops()
     return torch.ops.torchvision.nms(boxes, scores, iou_threshold)
 
@@ -62,7 +63,7 @@ def batched_nms(
         Tensor: int64 tensor with the indices of the elements that have been kept by NMS, sorted
         in decreasing order of scores
     """
-    torch._C._log_api_usage_once("torchvision.ops.batched_nms")
+    _log_api_usage_once("torchvision.ops.batched_nms")
     # Benchmarks that drove the following thresholds are at
     # https://github.com/pytorch/vision/issues/1311#issuecomment-781329339
     # Ideally for GPU we'd use a higher threshold
@@ -122,7 +123,7 @@ def remove_small_boxes(boxes: Tensor, min_size: float) -> Tensor:
         Tensor[K]: indices of the boxes that have both sides
         larger than min_size
     """
-    torch._C._log_api_usage_once("torchvision.ops.remove_small_boxes")
+    _log_api_usage_once("torchvision.ops.remove_small_boxes")
     ws, hs = boxes[:, 2] - boxes[:, 0], boxes[:, 3] - boxes[:, 1]
     keep = (ws >= min_size) & (hs >= min_size)
     keep = torch.where(keep)[0]
@@ -141,7 +142,7 @@ def clip_boxes_to_image(boxes: Tensor, size: Tuple[int, int]) -> Tensor:
     Returns:
         Tensor[N, 4]: clipped boxes
     """
-    torch._C._log_api_usage_once("torchvision.ops.clip_boxes_to_image")
+    _log_api_usage_once("torchvision.ops.clip_boxes_to_image")
     dim = boxes.dim()
     boxes_x = boxes[..., 0::2]
     boxes_y = boxes[..., 1::2]
@@ -182,7 +183,7 @@ def box_convert(boxes: Tensor, in_fmt: str, out_fmt: str) -> Tensor:
         Tensor[N, 4]: Boxes into converted format.
     """
 
-    torch._C._log_api_usage_once("torchvision.ops.box_convert")
+    _log_api_usage_once("torchvision.ops.box_convert")
     allowed_fmts = ("xyxy", "xywh", "cxcywh")
     if in_fmt not in allowed_fmts or out_fmt not in allowed_fmts:
         raise ValueError("Unsupported Bounding Box Conversions for given in_fmt and out_fmt")
@@ -232,7 +233,7 @@ def box_area(boxes: Tensor) -> Tensor:
     Returns:
         Tensor[N]: the area for each box
     """
-    torch._C._log_api_usage_once("torchvision.ops.box_area")
+    _log_api_usage_once("torchvision.ops.box_area")
     boxes = _upcast(boxes)
     return (boxes[:, 2] - boxes[:, 0]) * (boxes[:, 3] - boxes[:, 1])
 
@@ -268,7 +269,7 @@ def box_iou(boxes1: Tensor, boxes2: Tensor) -> Tensor:
     Returns:
         Tensor[N, M]: the NxM matrix containing the pairwise IoU values for every element in boxes1 and boxes2
     """
-    torch._C._log_api_usage_once("torchvision.ops.box_iou")
+    _log_api_usage_once("torchvision.ops.box_iou")
     inter, union = _box_inter_union(boxes1, boxes2)
     iou = inter / union
     return iou
@@ -291,7 +292,7 @@ def generalized_box_iou(boxes1: Tensor, boxes2: Tensor) -> Tensor:
         for every element in boxes1 and boxes2
     """
 
-    torch._C._log_api_usage_once("torchvision.ops.generalized_box_iou")
+    _log_api_usage_once("torchvision.ops.generalized_box_iou")
     # degenerate boxes gives inf / nan results
     # so do an early check
     assert (boxes1[:, 2:] >= boxes1[:, :2]).all()
@@ -323,7 +324,7 @@ def masks_to_boxes(masks: torch.Tensor) -> torch.Tensor:
     Returns:
         Tensor[N, 4]: bounding boxes
     """
-    torch._C._log_api_usage_once("torchvision.ops.masks_to_boxes")
+    _log_api_usage_once("torchvision.ops.masks_to_boxes")
     if masks.numel() == 0:
         return torch.zeros((0, 4), device=masks.device, dtype=torch.float)
 

--- a/torchvision/ops/boxes.py
+++ b/torchvision/ops/boxes.py
@@ -5,8 +5,8 @@ import torchvision
 from torch import Tensor
 from torchvision.extension import _assert_has_ops
 
-from ._box_convert import _box_cxcywh_to_xyxy, _box_xyxy_to_cxcywh, _box_xywh_to_xyxy, _box_xyxy_to_xywh
 from ..utils import _log_api_usage_once
+from ._box_convert import _box_cxcywh_to_xyxy, _box_xyxy_to_cxcywh, _box_xywh_to_xyxy, _box_xyxy_to_xywh
 
 
 def nms(boxes: Tensor, scores: Tensor, iou_threshold: float) -> Tensor:

--- a/torchvision/ops/boxes.py
+++ b/torchvision/ops/boxes.py
@@ -33,6 +33,7 @@ def nms(boxes: Tensor, scores: Tensor, iou_threshold: float) -> Tensor:
         Tensor: int64 tensor with the indices of the elements that have been kept
         by NMS, sorted in decreasing order of scores
     """
+    torch._C._log_api_usage_once("torchvision.ops.nms")
     _assert_has_ops()
     return torch.ops.torchvision.nms(boxes, scores, iou_threshold)
 
@@ -61,6 +62,7 @@ def batched_nms(
         Tensor: int64 tensor with the indices of the elements that have been kept by NMS, sorted
         in decreasing order of scores
     """
+    torch._C._log_api_usage_once("torchvision.ops.batched_nms")
     # Benchmarks that drove the following thresholds are at
     # https://github.com/pytorch/vision/issues/1311#issuecomment-781329339
     # Ideally for GPU we'd use a higher threshold
@@ -120,6 +122,7 @@ def remove_small_boxes(boxes: Tensor, min_size: float) -> Tensor:
         Tensor[K]: indices of the boxes that have both sides
         larger than min_size
     """
+    torch._C._log_api_usage_once("torchvision.ops.remove_small_boxes")
     ws, hs = boxes[:, 2] - boxes[:, 0], boxes[:, 3] - boxes[:, 1]
     keep = (ws >= min_size) & (hs >= min_size)
     keep = torch.where(keep)[0]
@@ -138,6 +141,7 @@ def clip_boxes_to_image(boxes: Tensor, size: Tuple[int, int]) -> Tensor:
     Returns:
         Tensor[N, 4]: clipped boxes
     """
+    torch._C._log_api_usage_once("torchvision.ops.clip_boxes_to_image")
     dim = boxes.dim()
     boxes_x = boxes[..., 0::2]
     boxes_y = boxes[..., 1::2]
@@ -178,6 +182,7 @@ def box_convert(boxes: Tensor, in_fmt: str, out_fmt: str) -> Tensor:
         Tensor[N, 4]: Boxes into converted format.
     """
 
+    torch._C._log_api_usage_once("torchvision.ops.box_convert")
     allowed_fmts = ("xyxy", "xywh", "cxcywh")
     if in_fmt not in allowed_fmts or out_fmt not in allowed_fmts:
         raise ValueError("Unsupported Bounding Box Conversions for given in_fmt and out_fmt")
@@ -227,6 +232,7 @@ def box_area(boxes: Tensor) -> Tensor:
     Returns:
         Tensor[N]: the area for each box
     """
+    torch._C._log_api_usage_once("torchvision.ops.box_area")
     boxes = _upcast(boxes)
     return (boxes[:, 2] - boxes[:, 0]) * (boxes[:, 3] - boxes[:, 1])
 
@@ -262,6 +268,7 @@ def box_iou(boxes1: Tensor, boxes2: Tensor) -> Tensor:
     Returns:
         Tensor[N, M]: the NxM matrix containing the pairwise IoU values for every element in boxes1 and boxes2
     """
+    torch._C._log_api_usage_once("torchvision.ops.box_iou")
     inter, union = _box_inter_union(boxes1, boxes2)
     iou = inter / union
     return iou
@@ -284,6 +291,7 @@ def generalized_box_iou(boxes1: Tensor, boxes2: Tensor) -> Tensor:
         for every element in boxes1 and boxes2
     """
 
+    torch._C._log_api_usage_once("torchvision.ops.generalized_box_iou")
     # degenerate boxes gives inf / nan results
     # so do an early check
     assert (boxes1[:, 2:] >= boxes1[:, :2]).all()
@@ -315,6 +323,7 @@ def masks_to_boxes(masks: torch.Tensor) -> torch.Tensor:
     Returns:
         Tensor[N, 4]: bounding boxes
     """
+    torch._C._log_api_usage_once("torchvision.ops.masks_to_boxes")
     if masks.numel() == 0:
         return torch.zeros((0, 4), device=masks.device, dtype=torch.float)
 

--- a/torchvision/ops/deform_conv.py
+++ b/torchvision/ops/deform_conv.py
@@ -59,6 +59,7 @@ def deform_conv2d(
         >>>  torch.Size([4, 5, 8, 8])
     """
 
+    torch._C._log_api_usage_once("torchvision.ops.deform_conv2d")
     _assert_has_ops()
     out_channels = weight.shape[0]
 

--- a/torchvision/ops/deform_conv.py
+++ b/torchvision/ops/deform_conv.py
@@ -8,6 +8,8 @@ from torch.nn.modules.utils import _pair
 from torch.nn.parameter import Parameter
 from torchvision.extension import _assert_has_ops
 
+from ..utils import _log_api_usage_once
+
 
 def deform_conv2d(
     input: Tensor,
@@ -59,7 +61,7 @@ def deform_conv2d(
         >>>  torch.Size([4, 5, 8, 8])
     """
 
-    torch._C._log_api_usage_once("torchvision.ops.deform_conv2d")
+    _log_api_usage_once("torchvision.ops.deform_conv2d")
     _assert_has_ops()
     out_channels = weight.shape[0]
 

--- a/torchvision/ops/feature_pyramid_network.py
+++ b/torchvision/ops/feature_pyramid_network.py
@@ -4,6 +4,8 @@ from typing import Tuple, List, Dict, Optional
 import torch.nn.functional as F
 from torch import nn, Tensor
 
+from ..utils import _log_api_usage_once
+
 
 class ExtraFPNBlock(nn.Module):
     """
@@ -75,6 +77,7 @@ class FeaturePyramidNetwork(nn.Module):
         extra_blocks: Optional[ExtraFPNBlock] = None,
     ):
         super().__init__()
+        _log_api_usage_once(self)
         self.inner_blocks = nn.ModuleList()
         self.layer_blocks = nn.ModuleList()
         for in_channels in in_channels_list:

--- a/torchvision/ops/focal_loss.py
+++ b/torchvision/ops/focal_loss.py
@@ -30,6 +30,7 @@ def sigmoid_focal_loss(
     Returns:
         Loss tensor with the reduction option applied.
     """
+    torch._C._log_api_usage_once("torchvision.ops.sigmoid_focal_loss")
     p = torch.sigmoid(inputs)
     ce_loss = F.binary_cross_entropy_with_logits(inputs, targets, reduction="none")
     p_t = p * targets + (1 - p) * (1 - targets)

--- a/torchvision/ops/focal_loss.py
+++ b/torchvision/ops/focal_loss.py
@@ -1,6 +1,8 @@
 import torch
 import torch.nn.functional as F
 
+from ..utils import _log_api_usage_once
+
 
 def sigmoid_focal_loss(
     inputs: torch.Tensor,
@@ -30,7 +32,7 @@ def sigmoid_focal_loss(
     Returns:
         Loss tensor with the reduction option applied.
     """
-    torch._C._log_api_usage_once("torchvision.ops.sigmoid_focal_loss")
+    _log_api_usage_once("torchvision.ops.sigmoid_focal_loss")
     p = torch.sigmoid(inputs)
     ce_loss = F.binary_cross_entropy_with_logits(inputs, targets, reduction="none")
     p_t = p * targets + (1 - p) * (1 - targets)

--- a/torchvision/ops/misc.py
+++ b/torchvision/ops/misc.py
@@ -14,6 +14,8 @@ from typing import Callable, List, Optional
 import torch
 from torch import Tensor
 
+from ..utils import _log_api_usage_once
+
 
 class Conv2d(torch.nn.Conv2d):
     def __init__(self, *args, **kwargs):
@@ -66,6 +68,7 @@ class FrozenBatchNorm2d(torch.nn.Module):
             warnings.warn("`n` argument is deprecated and has been renamed `num_features`", DeprecationWarning)
             num_features = n
         super().__init__()
+        _log_api_usage_once(self)
         self.eps = eps
         self.register_buffer("weight", torch.ones(num_features))
         self.register_buffer("bias", torch.zeros(num_features))
@@ -138,6 +141,7 @@ class ConvNormActivation(torch.nn.Sequential):
         if activation_layer is not None:
             layers.append(activation_layer(inplace=inplace))
         super().__init__(*layers)
+        _log_api_usage_once(self)
         self.out_channels = out_channels
 
 
@@ -150,6 +154,7 @@ class SqueezeExcitation(torch.nn.Module):
         scale_activation: Callable[..., torch.nn.Module] = torch.nn.Sigmoid,
     ) -> None:
         super().__init__()
+        _log_api_usage_once(self)
         self.avgpool = torch.nn.AdaptiveAvgPool2d(1)
         self.fc1 = torch.nn.Conv2d(input_channels, squeeze_channels, 1)
         self.fc2 = torch.nn.Conv2d(squeeze_channels, input_channels, 1)

--- a/torchvision/ops/poolers.py
+++ b/torchvision/ops/poolers.py
@@ -5,8 +5,8 @@ import torchvision
 from torch import nn, Tensor
 from torchvision.ops.boxes import box_area
 
-from .roi_align import roi_align
 from ..utils import _log_api_usage_once
+from .roi_align import roi_align
 
 
 # copying result_idx_in_level to a specific index in result[]

--- a/torchvision/ops/poolers.py
+++ b/torchvision/ops/poolers.py
@@ -6,6 +6,7 @@ from torch import nn, Tensor
 from torchvision.ops.boxes import box_area
 
 from .roi_align import roi_align
+from ..utils import _log_api_usage_once
 
 
 # copying result_idx_in_level to a specific index in result[]
@@ -130,6 +131,7 @@ class MultiScaleRoIAlign(nn.Module):
         canonical_level: int = 4,
     ):
         super().__init__()
+        _log_api_usage_once(self)
         if isinstance(output_size, int):
             output_size = (output_size, output_size)
         self.featmap_names = featmap_names

--- a/torchvision/ops/ps_roi_align.py
+++ b/torchvision/ops/ps_roi_align.py
@@ -3,7 +3,7 @@ from torch import nn, Tensor
 from torch.nn.modules.utils import _pair
 from torchvision.extension import _assert_has_ops
 
-from ._utils import convert_boxes_to_roi_format, check_roi_boxes_shape
+from ._utils import convert_boxes_to_roi_format, check_roi_boxes_shape, _log_api_usage_once
 
 
 def ps_roi_align(
@@ -42,7 +42,7 @@ def ps_roi_align(
     Returns:
         Tensor[K, C / (output_size[0] * output_size[1]), output_size[0], output_size[1]]: The pooled RoIs
     """
-    torch._C._log_api_usage_once("torchvision.ops.ps_roi_align")
+    _log_api_usage_once("torchvision.ops.ps_roi_align")
     _assert_has_ops()
     check_roi_boxes_shape(boxes)
     rois = boxes

--- a/torchvision/ops/ps_roi_align.py
+++ b/torchvision/ops/ps_roi_align.py
@@ -42,6 +42,7 @@ def ps_roi_align(
     Returns:
         Tensor[K, C / (output_size[0] * output_size[1]), output_size[0], output_size[1]]: The pooled RoIs
     """
+    torch._C._log_api_usage_once("torchvision.ops.ps_roi_align")
     _assert_has_ops()
     check_roi_boxes_shape(boxes)
     rois = boxes

--- a/torchvision/ops/ps_roi_align.py
+++ b/torchvision/ops/ps_roi_align.py
@@ -3,7 +3,8 @@ from torch import nn, Tensor
 from torch.nn.modules.utils import _pair
 from torchvision.extension import _assert_has_ops
 
-from ._utils import convert_boxes_to_roi_format, check_roi_boxes_shape, _log_api_usage_once
+from ._utils import convert_boxes_to_roi_format, check_roi_boxes_shape
+from ..utils import _log_api_usage_once
 
 
 def ps_roi_align(

--- a/torchvision/ops/ps_roi_align.py
+++ b/torchvision/ops/ps_roi_align.py
@@ -3,8 +3,8 @@ from torch import nn, Tensor
 from torch.nn.modules.utils import _pair
 from torchvision.extension import _assert_has_ops
 
-from ._utils import convert_boxes_to_roi_format, check_roi_boxes_shape
 from ..utils import _log_api_usage_once
+from ._utils import convert_boxes_to_roi_format, check_roi_boxes_shape
 
 
 def ps_roi_align(

--- a/torchvision/ops/ps_roi_pool.py
+++ b/torchvision/ops/ps_roi_pool.py
@@ -3,8 +3,8 @@ from torch import nn, Tensor
 from torch.nn.modules.utils import _pair
 from torchvision.extension import _assert_has_ops
 
-from ._utils import convert_boxes_to_roi_format, check_roi_boxes_shape
 from ..utils import _log_api_usage_once
+from ._utils import convert_boxes_to_roi_format, check_roi_boxes_shape
 
 
 def ps_roi_pool(

--- a/torchvision/ops/ps_roi_pool.py
+++ b/torchvision/ops/ps_roi_pool.py
@@ -3,7 +3,8 @@ from torch import nn, Tensor
 from torch.nn.modules.utils import _pair
 from torchvision.extension import _assert_has_ops
 
-from ._utils import convert_boxes_to_roi_format, check_roi_boxes_shape, _log_api_usage_once
+from ._utils import convert_boxes_to_roi_format, check_roi_boxes_shape
+from ..utils import _log_api_usage_once
 
 
 def ps_roi_pool(

--- a/torchvision/ops/ps_roi_pool.py
+++ b/torchvision/ops/ps_roi_pool.py
@@ -36,6 +36,7 @@ def ps_roi_pool(
     Returns:
         Tensor[K, C / (output_size[0] * output_size[1]), output_size[0], output_size[1]]: The pooled RoIs.
     """
+    torch._C._log_api_usage_once("torchvision.ops.ps_roi_pool")
     _assert_has_ops()
     check_roi_boxes_shape(boxes)
     rois = boxes

--- a/torchvision/ops/ps_roi_pool.py
+++ b/torchvision/ops/ps_roi_pool.py
@@ -3,7 +3,7 @@ from torch import nn, Tensor
 from torch.nn.modules.utils import _pair
 from torchvision.extension import _assert_has_ops
 
-from ._utils import convert_boxes_to_roi_format, check_roi_boxes_shape
+from ._utils import convert_boxes_to_roi_format, check_roi_boxes_shape, _log_api_usage_once
 
 
 def ps_roi_pool(
@@ -36,7 +36,7 @@ def ps_roi_pool(
     Returns:
         Tensor[K, C / (output_size[0] * output_size[1]), output_size[0], output_size[1]]: The pooled RoIs.
     """
-    torch._C._log_api_usage_once("torchvision.ops.ps_roi_pool")
+    _log_api_usage_once("torchvision.ops.ps_roi_pool")
     _assert_has_ops()
     check_roi_boxes_shape(boxes)
     rois = boxes

--- a/torchvision/ops/roi_align.py
+++ b/torchvision/ops/roi_align.py
@@ -6,8 +6,8 @@ from torch.jit.annotations import BroadcastingList2
 from torch.nn.modules.utils import _pair
 from torchvision.extension import _assert_has_ops
 
-from ._utils import convert_boxes_to_roi_format, check_roi_boxes_shape
 from ..utils import _log_api_usage_once
+from ._utils import convert_boxes_to_roi_format, check_roi_boxes_shape
 
 
 def roi_align(

--- a/torchvision/ops/roi_align.py
+++ b/torchvision/ops/roi_align.py
@@ -6,7 +6,8 @@ from torch.jit.annotations import BroadcastingList2
 from torch.nn.modules.utils import _pair
 from torchvision.extension import _assert_has_ops
 
-from ._utils import convert_boxes_to_roi_format, check_roi_boxes_shape, _log_api_usage_once
+from ._utils import convert_boxes_to_roi_format, check_roi_boxes_shape
+from ..utils import _log_api_usage_once
 
 
 def roi_align(

--- a/torchvision/ops/roi_align.py
+++ b/torchvision/ops/roi_align.py
@@ -49,6 +49,7 @@ def roi_align(
     Returns:
         Tensor[K, C, output_size[0], output_size[1]]: The pooled RoIs.
     """
+    torch._C._log_api_usage_once("torchvision.ops.roi_align")
     _assert_has_ops()
     check_roi_boxes_shape(boxes)
     rois = boxes

--- a/torchvision/ops/roi_align.py
+++ b/torchvision/ops/roi_align.py
@@ -6,7 +6,7 @@ from torch.jit.annotations import BroadcastingList2
 from torch.nn.modules.utils import _pair
 from torchvision.extension import _assert_has_ops
 
-from ._utils import convert_boxes_to_roi_format, check_roi_boxes_shape
+from ._utils import convert_boxes_to_roi_format, check_roi_boxes_shape, _log_api_usage_once
 
 
 def roi_align(
@@ -49,7 +49,7 @@ def roi_align(
     Returns:
         Tensor[K, C, output_size[0], output_size[1]]: The pooled RoIs.
     """
-    torch._C._log_api_usage_once("torchvision.ops.roi_align")
+    _log_api_usage_once("torchvision.ops.roi_align")
     _assert_has_ops()
     check_roi_boxes_shape(boxes)
     rois = boxes

--- a/torchvision/ops/roi_pool.py
+++ b/torchvision/ops/roi_pool.py
@@ -6,7 +6,7 @@ from torch.jit.annotations import BroadcastingList2
 from torch.nn.modules.utils import _pair
 from torchvision.extension import _assert_has_ops
 
-from ._utils import convert_boxes_to_roi_format, check_roi_boxes_shape
+from ._utils import convert_boxes_to_roi_format, check_roi_boxes_shape, _log_api_usage_once
 
 
 def roi_pool(
@@ -38,7 +38,7 @@ def roi_pool(
     Returns:
         Tensor[K, C, output_size[0], output_size[1]]: The pooled RoIs.
     """
-    torch._C._log_api_usage_once("torchvision.ops.roi_pool")
+    _log_api_usage_once("torchvision.ops.roi_pool")
     _assert_has_ops()
     check_roi_boxes_shape(boxes)
     rois = boxes

--- a/torchvision/ops/roi_pool.py
+++ b/torchvision/ops/roi_pool.py
@@ -6,7 +6,8 @@ from torch.jit.annotations import BroadcastingList2
 from torch.nn.modules.utils import _pair
 from torchvision.extension import _assert_has_ops
 
-from ._utils import convert_boxes_to_roi_format, check_roi_boxes_shape, _log_api_usage_once
+from ._utils import convert_boxes_to_roi_format, check_roi_boxes_shape
+from ..utils import _log_api_usage_once
 
 
 def roi_pool(

--- a/torchvision/ops/roi_pool.py
+++ b/torchvision/ops/roi_pool.py
@@ -38,6 +38,7 @@ def roi_pool(
     Returns:
         Tensor[K, C, output_size[0], output_size[1]]: The pooled RoIs.
     """
+    torch._C._log_api_usage_once("torchvision.ops.roi_pool")
     _assert_has_ops()
     check_roi_boxes_shape(boxes)
     rois = boxes

--- a/torchvision/ops/roi_pool.py
+++ b/torchvision/ops/roi_pool.py
@@ -6,8 +6,8 @@ from torch.jit.annotations import BroadcastingList2
 from torch.nn.modules.utils import _pair
 from torchvision.extension import _assert_has_ops
 
-from ._utils import convert_boxes_to_roi_format, check_roi_boxes_shape
 from ..utils import _log_api_usage_once
+from ._utils import convert_boxes_to_roi_format, check_roi_boxes_shape
 
 
 def roi_pool(

--- a/torchvision/ops/stochastic_depth.py
+++ b/torchvision/ops/stochastic_depth.py
@@ -21,6 +21,7 @@ def stochastic_depth(input: Tensor, p: float, mode: str, training: bool = True) 
     Returns:
         Tensor[N, ...]: The randomly zeroed tensor.
     """
+    torch._C._log_api_usage_once("torchvision.ops.stochastic_depth")
     if p < 0.0 or p > 1.0:
         raise ValueError(f"drop probability has to be between 0 and 1, but got {p}")
     if mode not in ["batch", "row"]:

--- a/torchvision/ops/stochastic_depth.py
+++ b/torchvision/ops/stochastic_depth.py
@@ -2,6 +2,8 @@ import torch
 import torch.fx
 from torch import nn, Tensor
 
+from ..utils import _log_api_usage_once
+
 
 def stochastic_depth(input: Tensor, p: float, mode: str, training: bool = True) -> Tensor:
     """
@@ -21,7 +23,7 @@ def stochastic_depth(input: Tensor, p: float, mode: str, training: bool = True) 
     Returns:
         Tensor[N, ...]: The randomly zeroed tensor.
     """
-    torch._C._log_api_usage_once("torchvision.ops.stochastic_depth")
+    _log_api_usage_once("torchvision.ops.stochastic_depth")
     if p < 0.0 or p > 1.0:
         raise ValueError(f"drop probability has to be between 0 and 1, but got {p}")
     if mode not in ["batch", "row"]:

--- a/torchvision/utils.py
+++ b/torchvision/utils.py
@@ -305,7 +305,7 @@ def _generate_color_palette(num_masks: int):
     return [tuple((i * palette) % 255) for i in range(num_masks)]
 
 
-def _log_api_usage_once(obj: str) -> None:
+def _log_api_usage_once(obj: str) -> None:  # type: ignore
     if torch.jit.is_scripting() or torch.jit.is_tracing():
         return
     # NOTE: obj can be an object as well, but mocking it here to be

--- a/torchvision/utils.py
+++ b/torchvision/utils.py
@@ -1,7 +1,7 @@
 import math
 import pathlib
 import warnings
-from typing import Union, Optional, List, Tuple, BinaryIO
+from typing import Union, Optional, List, Tuple, BinaryIO, no_type_check
 
 import numpy as np
 import torch
@@ -305,7 +305,8 @@ def _generate_color_palette(num_masks: int):
     return [tuple((i * palette) % 255) for i in range(num_masks)]
 
 
-def _log_api_usage_once(obj) -> None:  # type: ignore
+@no_type_check
+def _log_api_usage_once(obj: str) -> None:  # type: ignore
     if torch.jit.is_scripting() or torch.jit.is_tracing():
         return
     # NOTE: obj can be an object as well, but mocking it here to be

--- a/torchvision/utils.py
+++ b/torchvision/utils.py
@@ -306,4 +306,9 @@ def _generate_color_palette(num_masks: int):
 
 
 def _log_api_usage_once(obj: object) -> None:
-    torch._C._log_api_usage_once(f"{obj.__module__}.{obj.__class__.__name__}")
+    if torch.jit.is_scripting():
+        return
+    if isinstance(obj, str):
+        torch._C._log_api_usage_once(obj)
+    else:
+        torch._C._log_api_usage_once(f"{obj.__module__}.{obj.__class__.__name__}")

--- a/torchvision/utils.py
+++ b/torchvision/utils.py
@@ -305,8 +305,9 @@ def _generate_color_palette(num_masks: int):
     return [tuple((i * palette) % 255) for i in range(num_masks)]
 
 
-@torch.jit.ignore
 def _log_api_usage_once(obj: str) -> None:
+    if torch.jit.is_scripting() or torch.jit.is_tracing():
+        return
     # NOTE: obj can be an object as well, but mocking it here to be
     # only a string to appease torchscript
     if isinstance(obj, str):

--- a/torchvision/utils.py
+++ b/torchvision/utils.py
@@ -305,9 +305,10 @@ def _generate_color_palette(num_masks: int):
     return [tuple((i * palette) % 255) for i in range(num_masks)]
 
 
-def _log_api_usage_once(obj: object) -> None:
-    if torch.jit.is_scripting():
-        return
+@torch.jit.ignore
+def _log_api_usage_once(obj: str) -> None:
+    # NOTE: obj can be an object as well, but mocking it here to be
+    # only a string to appease torchscript
     if isinstance(obj, str):
         torch._C._log_api_usage_once(obj)
     else:

--- a/torchvision/utils.py
+++ b/torchvision/utils.py
@@ -305,7 +305,7 @@ def _generate_color_palette(num_masks: int):
     return [tuple((i * palette) % 255) for i in range(num_masks)]
 
 
-def _log_api_usage_once(obj: str) -> None:  # type: ignore
+def _log_api_usage_once(obj) -> None:  # type: ignore
     if torch.jit.is_scripting() or torch.jit.is_tracing():
         return
     # NOTE: obj can be an object as well, but mocking it here to be


### PR DESCRIPTION
This PR adds logging to the public ops in torchvision.

~I haven't tried making it use `inspect` to automatically find the name of the function as there is no chance this is supported in torchscript.~
This function isn't supported in torchscript anyway, so let's make it a no-op in torchscript for now.

A quick benchmark shows ~900ns of overhead, which should be fine
```python
%timeit torchvision.utils._log_api_usage_once('testing')
914 ns ± 17.6 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
```