### PR TITLE
Remove git diff pager

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,7 +190,7 @@ jobs:
       - run:
           name: Required lint modifications
           when: on_fail
-          command: git diff
+          command: git --no-pager diff
 
   python_type_check:
     docker:

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -190,7 +190,7 @@ jobs:
       - run:
           name: Required lint modifications
           when: on_fail
-          command: git diff
+          command: git --no-pager diff
 
   python_type_check:
     docker:


### PR DESCRIPTION
The #4791 update uses pager which means that the CI waits for input on console. See [this](https://app.circleci.com/pipelines/github/pytorch/vision/12047/workflows/920bd3f8-b84a-4595-958d-0cef5614fe5a/jobs/944359).

We shouldn't wait for input, so this PR removes the pager.

cc @seemethere