### PR TITLE
use toplevel directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,8 @@
 *.vscode
 
 # Additional Ignore to exclude torchvision code and docs.
-docs/
-torchvision/
+/docs/
+/torchvision/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/


### PR DESCRIPTION
Fixes the cause for #4814

The internal torchvision directory was being ignored, and not committed to the branch.