### PR TITLE
DOC: fix intersphinx links

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -199,9 +199,9 @@ texinfo_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    "python": ("https://docs.python.org/", None),
+    "python": ("https://docs.python.org/3/", None),
     "torch": ("https://pytorch.org/docs/stable/", None),
-    "numpy": ("http://docs.scipy.org/doc/numpy/", None),
+    "numpy": ("https://numpy.org/doc/stable/", None),
     "PIL": ("https://pillow.readthedocs.io/en/stable/", None),
     "matplotlib": ("https://matplotlib.org/stable/", None),
 }


### PR DESCRIPTION
This is a tiny cleanup. The config file had old links. The old links have forwards to the new ones, so nothing was broken.