### PR TITLE
docs: Fixed hyperlink in docstring of TrivialAugmentWide

### DIFF
--- a/torchvision/transforms/autoaugment.py
+++ b/torchvision/transforms/autoaugment.py
@@ -365,7 +365,7 @@ class RandAugment(torch.nn.Module):
 
 class TrivialAugmentWide(torch.nn.Module):
     r"""Dataset-independent data-augmentation with TrivialAugment Wide, as described in
-    `"TrivialAugment: Tuning-free Yet State-of-the-Art Data Augmentation" <https://arxiv.org/abs/2103.10158>`.
+    `"TrivialAugment: Tuning-free Yet State-of-the-Art Data Augmentation" <https://arxiv.org/abs/2103.10158>`_.
     If the image is torch Tensor, it should be of type torch.uint8, and it is expected
     to have [..., 1 or 3, H, W] shape, where ... means an arbitrary number of leading dimensions.
     If img is PIL Image, it is expected to be in mode "L" or "RGB".


### PR DESCRIPTION
Hello folks :wave: 

I was checking the documentation of the new transformations and realized there was a small rendering issue of the paper hyperlink for `torchvision.transforms.autoaugment.TrivialAugmentWide`.
So this PR simply fixes the hyperlink in its docstring.

Any feedback is welcome!