### PR TITLE
[references/classification] Adding gradient clipping

### DIFF
--- a/references/classification/train.py
+++ b/references/classification/train.py
@@ -42,6 +42,10 @@ def train_one_epoch(model, criterion, optimizer, data_loader, device, epoch, arg
         else:
             loss = criterion(output, target)
             loss.backward()
+        
+        if args.clip_grad_norm is not None:
+            nn.utils.clip_grad_norm_(utils.master_params(optimizer), args.clip_grad_norm)
+
         optimizer.step()
 
         if model_ema and i % args.model_ema_steps == 0:
@@ -471,6 +475,9 @@ def get_args_parser(add_help=True):
     )
     parser.add_argument(
         "--train-crop-size", default=224, type=int, help="the random crop size used for training (default: 224)"
+    )
+    parser.add_argument(
+        "--clip-grad-norm", default=None, type=float, help="the maximum gradient norm (default None)"
     )
 
     # Prototype models only

--- a/references/classification/train.py
+++ b/references/classification/train.py
@@ -42,7 +42,7 @@ def train_one_epoch(model, criterion, optimizer, data_loader, device, epoch, arg
         else:
             loss = criterion(output, target)
             loss.backward()
-        
+
         if args.clip_grad_norm is not None:
             nn.utils.clip_grad_norm_(utils.master_params(optimizer), args.clip_grad_norm)
 
@@ -476,9 +476,7 @@ def get_args_parser(add_help=True):
     parser.add_argument(
         "--train-crop-size", default=224, type=int, help="the random crop size used for training (default: 224)"
     )
-    parser.add_argument(
-        "--clip-grad-norm", default=None, type=float, help="the maximum gradient norm (default None)"
-    )
+    parser.add_argument("--clip-grad-norm", default=None, type=float, help="the maximum gradient norm (default None)")
 
     # Prototype models only
     parser.add_argument("--weights", default=None, type=str, help="the weights enum name to load")

--- a/references/classification/train.py
+++ b/references/classification/train.py
@@ -44,7 +44,7 @@ def train_one_epoch(model, criterion, optimizer, data_loader, device, epoch, arg
             loss.backward()
 
         if args.clip_grad_norm is not None:
-            nn.utils.clip_grad_norm_(utils.master_params(optimizer), args.clip_grad_norm)
+            nn.utils.clip_grad_norm_(utils.get_optimizer_params(optimizer), args.clip_grad_norm)
 
         optimizer.step()
 

--- a/references/classification/utils.py
+++ b/references/classification/utils.py
@@ -411,20 +411,9 @@ def reduce_across_processes(val):
     return t
 
 
-try:
-    import apex
-
-    apex_available = True
-except ImportError:
-    apex_available = False
-
-
 def master_params(optimizer):
     """Generator to iterate over all parameters in the optimizer param_groups."""
 
-    if apex_available:
-        yield from apex.amp.master_params(optimizer)
-    else:
-        for group in optimizer.param_groups:
-            for p in group["params"]:
-                yield p
+    for group in optimizer.param_groups:
+        for p in group["params"]:
+            yield p

--- a/references/classification/utils.py
+++ b/references/classification/utils.py
@@ -411,7 +411,7 @@ def reduce_across_processes(val):
     return t
 
 
-def master_params(optimizer):
+def get_optimizer_params(optimizer):
     """Generator to iterate over all parameters in the optimizer param_groups."""
 
     for group in optimizer.param_groups:

--- a/references/classification/utils.py
+++ b/references/classification/utils.py
@@ -409,3 +409,21 @@ def reduce_across_processes(val):
     dist.barrier()
     dist.all_reduce(t)
     return t
+
+
+try:
+    import apex
+
+    apex_available = True
+except ImportError:
+    apex_available = False
+
+def master_params(optimizer):
+    """Generator to iterate over all parameters in the optimizer param_groups."""
+    
+    if apex_available:
+        yield from apex.amp.master_params(optimizer)
+    else:
+        for group in optimizer.param_groups:
+            for p in group["params"]:
+                yield p

--- a/references/classification/utils.py
+++ b/references/classification/utils.py
@@ -418,9 +418,10 @@ try:
 except ImportError:
     apex_available = False
 
+
 def master_params(optimizer):
     """Generator to iterate over all parameters in the optimizer param_groups."""
-    
+
     if apex_available:
         yield from apex.amp.master_params(optimizer)
     else:


### PR DESCRIPTION
Gradient Clipping can be useful in training - it is a technique to prevent exploding gradients in very deep networks.
Pytorch has a related API [`torch.nn.utils.clip_grad_norm_`](https://pytorch.org/docs/stable/generated/torch.nn.utils.clip_grad_norm_.html) which can be utilized here.

By applying gradient clipping to training, we significantly improved the training accuracy of our modes. For example:

| | Job ID | Model    	| Epochs 	| Nodes 	| Batch Size Per GPU 	| Global Batch Size 	| Acc@1  	| Acc@5  	|
|---------| --------- |----------	|--------	|-------	|-----------------		|--------------------	|--------	|--------	|
|before gradient clipping| 2420 | vit_b_16 	| 300    	| 2     	| 256             	| 4096                         	|68.148 	| 87.648 	|
|after gradient clipping| 2512 | vit_b_16 	| 300    	| 2     	| 256              	| 4096                       	| 71.876 	| 89.784 	|

cc @kazhang @datumbox 