### PR TITLE
Add new weights for ResNeXt50-32x4d

### DIFF
--- a/torchvision/prototype/models/resnet.py
+++ b/torchvision/prototype/models/resnet.py
@@ -160,6 +160,16 @@ class ResNeXt50_32x4dWeights(Weights):
             "acc@5": 93.698,
         },
     )
+    ImageNet1K_RefV2 = WeightEntry(
+        url="https://download.pytorch.org/models/resnext50_32x4d-b260af35.pth",
+        transforms=partial(ImageNetEval, crop_size=224, resize_size=232),
+        meta={
+            **_common_meta,
+            "recipe": "https://github.com/pytorch/vision/issues/3995",
+            "acc@1": 81.116,
+            "acc@5": 95.478,
+        },
+    )
 
 
 class ResNeXt101_32x8dWeights(Weights):


### PR DESCRIPTION
Fixes partially #3995

```
torchrun --nproc_per_node=1 train.py --test-only --weights ImageNet1K_RefV2 --model resnext50_32x4d -b 1
Acc@1 81.116 Acc@5 95.478
```