### PR TITLE
Fix TORCH_HOME environment variable in docs

### DIFF
--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -127,7 +127,7 @@ These can be constructed by passing ``pretrained=True``:
     regnet_x_32gf = models.regnet_x_32gf(pretrained=True)
 
 Instancing a pre-trained model will download its weights to a cache directory.
-This directory can be set using the `TORCH_MODEL_ZOO` environment variable. See
+This directory can be set using the `TORCH_HOME` environment variable. See
 :func:`torch.utils.model_zoo.load_url` for details.
 
 Some models use modules which have different training and evaluation

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -128,7 +128,7 @@ These can be constructed by passing ``pretrained=True``:
 
 Instancing a pre-trained model will download its weights to a cache directory.
 This directory can be set using the `TORCH_HOME` environment variable. See
-:func:`torch.utils.model_zoo.load_url` for details.
+:func:`torch.hub.load_state_dict_from_url` for details.
 
 Some models use modules which have different training and evaluation
 behavior, such as batch normalization. To switch between these modes, use


### PR DESCRIPTION
Replaced `TORCH_MODEL_ZOO`, which is deprecated, with `TORCH_HOME` in docs.

`TORCH_MODEL_ZOO` is not used so `TORCH_HOME` is the only environment variable to set the cache directory.