### PR TITLE
Add new weights for wide_resnet50_2 model

### DIFF
--- a/torchvision/prototype/models/resnet.py
+++ b/torchvision/prototype/models/resnet.py
@@ -196,6 +196,16 @@ class WideResNet50_2Weights(Weights):
             "acc@5": 94.086,
         },
     )
+    ImageNet1K_RefV2 = WeightEntry(
+        url="https://download.pytorch.org/models/wide_resnet50_2-8be09fd8.pth",
+        transforms=partial(ImageNetEval, crop_size=224, resize_size=232),
+        meta={
+            **_common_meta,
+            "recipe": "https://github.com/pytorch/vision/issues/3995",
+            "acc@1": 81.604,
+            "acc@5": 95.756,
+        },
+    )
 
 
 class WideResNet101_2Weights(Weights):

--- a/torchvision/prototype/models/resnet.py
+++ b/torchvision/prototype/models/resnet.py
@@ -197,13 +197,13 @@ class WideResNet50_2Weights(Weights):
         },
     )
     ImageNet1K_RefV2 = WeightEntry(
-        url="https://download.pytorch.org/models/wide_resnet50_2-8be09fd8.pth",
+        url="https://download.pytorch.org/models/wide_resnet50_2-9ba9bcbe.pth",
         transforms=partial(ImageNetEval, crop_size=224, resize_size=232),
         meta={
             **_common_meta,
             "recipe": "https://github.com/pytorch/vision/issues/3995",
-            "acc@1": 81.514,
-            "acc@5": 95.686,
+            "acc@1": 81.602,
+            "acc@5": 95.758,
         },
     )
 

--- a/torchvision/prototype/models/resnet.py
+++ b/torchvision/prototype/models/resnet.py
@@ -202,8 +202,8 @@ class WideResNet50_2Weights(Weights):
         meta={
             **_common_meta,
             "recipe": "https://github.com/pytorch/vision/issues/3995",
-            "acc@1": 81.604,
-            "acc@5": 95.756,
+            "acc@1": 81.514,
+            "acc@5": 95.686,
         },
     )
 


### PR DESCRIPTION
Fixes partially #3995

```
torchrun --nproc_per_node=1 train.py --test-only --weights ImageNet1K_RefV2 --model wide_resnet50_2 -b 1
Test:  Acc@1 81.602 Acc@5 95.758
```

cc @datumbox @bjuncek