### PR TITLE
Support big endian for .flo file decoding

### DIFF
--- a/test/datasets_utils.py
+++ b/test/datasets_utils.py
@@ -929,7 +929,14 @@ def make_fake_pfm_file(h, w, file_name):
 
 def make_fake_flo_file(h, w, file_name):
     """Creates a fake flow file in .flo format."""
+    # Everything needs to be in little Endian according to
+    # https://vision.middlebury.edu/flow/code/flow-code/README.txt
     values = list(range(2 * h * w))
-    content = b"PIEH" + struct.pack("i", w) + struct.pack("i", h) + struct.pack("f" * len(values), *values)
+    content = (
+        struct.pack("<4c", *(c.encode() for c in "PIEH"))
+        + struct.pack("<i", w)
+        + struct.pack("<i", h)
+        + struct.pack("<" + "f" * len(values), *values)
+    )
     with open(file_name, "wb") as f:
         f.write(content)

--- a/torchvision/datasets/_optical_flow.py
+++ b/torchvision/datasets/_optical_flow.py
@@ -366,15 +366,16 @@ def _read_flo(file_name):
     """Read .flo file in Middlebury format"""
     # Code adapted from:
     # http://stackoverflow.com/questions/28013200/reading-middlebury-flow-files-with-python-bytes-array-numpy
-    # WARNING: this will work on little-endian architectures (eg Intel x86) only!
+    # Everything needs to be in little Endian according to
+    # https://vision.middlebury.edu/flow/code/flow-code/README.txt
     with open(file_name, "rb") as f:
-        magic = np.fromfile(f, np.float32, count=1)
-        if 202021.25 != magic:
+        magic = np.fromfile(f, "c", count=4).tobytes()
+        if magic != b"PIEH":
             raise ValueError("Magic number incorrect. Invalid .flo file")
 
-        w = int(np.fromfile(f, np.int32, count=1))
-        h = int(np.fromfile(f, np.int32, count=1))
-        data = np.fromfile(f, np.float32, count=2 * w * h)
+        w = int(np.fromfile(f, "<i4", count=1))
+        h = int(np.fromfile(f, "<i4", count=1))
+        data = np.fromfile(f, "<f4", count=2 * w * h)
         return data.reshape(2, h, w)
 
 


### PR DESCRIPTION
From https://vision.middlebury.edu/flow/code/flow-code/README.txt,
.flo files contain a magic number which is to 'PIEH' in ascii.

Our previous code was relying on the expectation that this is equivalent to `202021.25` on little endian archs. This PR updates the magic-number checks to also support  big-endian archs.

cc @pmeier