### PR TITLE
Reverted folder.py back to using complete path to file for make_dataset

### DIFF
--- a/torchvision/datasets/folder.py
+++ b/torchvision/datasets/folder.py
@@ -86,8 +86,8 @@ def make_dataset(
             continue
         for root, _, fnames in sorted(os.walk(target_dir, followlinks=True)):
             for fname in sorted(fnames):
-                if is_valid_file(fname):
-                    path = os.path.join(root, fname)
+                path = os.path.join(root, fname)
+                if is_valid_file(path):
                     item = path, class_index
                     instances.append(item)
 


### PR DESCRIPTION
Fixes [https://github.com/pytorch/vision/issues/4871](https://github.com/pytorch/vision/issues/4871) by reverting back the change introduced in [https://github.com/pytorch/vision/pull/3939](https://github.com/pytorch/vision/pull/3939).