### PR TITLE
[Windows] Workaround for loading bundled DLLs

### DIFF
--- a/torchvision/_internally_replaced_utils.py
+++ b/torchvision/_internally_replaced_utils.py
@@ -22,7 +22,7 @@ except ImportError:
     from torch.utils.model_zoo import load_url as load_state_dict_from_url  # noqa: 401
 
 
-def _get_extension_path(lib_name):
+def _get_extension_path(lib_name) -> str:
 
     lib_dir = os.path.dirname(__file__)
     if os.name == "nt":

--- a/torchvision/_internally_replaced_utils.py
+++ b/torchvision/_internally_replaced_utils.py
@@ -56,21 +56,3 @@ def _get_extension_path(lib_name: str) -> str:
         raise ImportError
 
     return ext_specs.origin
-
-
-def _load_library(lib_name: str) -> None:
-    lib_path = _get_extension_path(lib_name)
-    # On Windows Python-3.8+ has `os.add_dll_directory` call,
-    # which is called from _get_extension_path to configure dll search path
-    # Condition below adds a workaround for older versions by
-    # explicitly calling `LoadLibraryExW` with the following flags:
-    #  - LOAD_LIBRARY_SEARCH_DEFAULT_DIRS (0x1000)
-    #  - LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR (0x100)
-    if os.name == "nt" and sys.version_info < (3, 8):
-
-        _kernel32 = ctypes.WinDLL("kernel32.dll", use_last_error=True)
-        if hasattr(_kernel32, "LoadLibraryExW"):
-            _image_lib_handle = _kernel32.LoadLibraryExW(lib_path, None, 0x00001100)
-        else:
-            warn("LoadLibraryExW is missing in kernel32.dll")
-    torch.ops.load_library(lib_path)

--- a/torchvision/_internally_replaced_utils.py
+++ b/torchvision/_internally_replaced_utils.py
@@ -22,7 +22,7 @@ except ImportError:
     from torch.utils.model_zoo import load_url as load_state_dict_from_url  # noqa: 401
 
 
-def _get_extension_path(lib_name: str) -> str:
+def _get_extension_path(lib_name):
 
     lib_dir = os.path.dirname(__file__)
     if os.name == "nt":

--- a/torchvision/extension.py
+++ b/torchvision/extension.py
@@ -72,7 +72,7 @@ def _check_cuda_version():
     return _version
 
 
-def _load_library(lib_name: str) -> None:
+def _load_library(lib_name):
     lib_path = _get_extension_path(lib_name)
     # On Windows Python-3.8+ has `os.add_dll_directory` call,
     # which is called from _get_extension_path to configure dll search path

--- a/torchvision/extension.py
+++ b/torchvision/extension.py
@@ -1,3 +1,8 @@
+import ctypes
+import os
+import sys
+from warnings import warn
+
 import torch
 
 from ._internally_replaced_utils import _get_extension_path
@@ -65,6 +70,24 @@ def _check_cuda_version():
                 "Please reinstall the torchvision that matches your PyTorch install."
             )
     return _version
+
+
+def _load_library(lib_name: str) -> None:
+    lib_path = _get_extension_path(lib_name)
+    # On Windows Python-3.8+ has `os.add_dll_directory` call,
+    # which is called from _get_extension_path to configure dll search path
+    # Condition below adds a workaround for older versions by
+    # explicitly calling `LoadLibraryExW` with the following flags:
+    #  - LOAD_LIBRARY_SEARCH_DEFAULT_DIRS (0x1000)
+    #  - LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR (0x100)
+    if os.name == "nt" and sys.version_info < (3, 8):
+        _kernel32 = ctypes.WinDLL("kernel32.dll", use_last_error=True)
+        if hasattr(_kernel32, "LoadLibraryExW"):
+            _kernel32.LoadLibraryExW(lib_path, None, 0x00001100)
+        else:
+            warn("LoadLibraryExW is missing in kernel32.dll")
+
+    torch.ops.load_library(lib_path)
 
 
 _check_cuda_version()

--- a/torchvision/io/_video_opt.py
+++ b/torchvision/io/_video_opt.py
@@ -5,7 +5,7 @@ from typing import List, Tuple, Dict, Optional, Union
 
 import torch
 
-from .._internally_replaced_utils import _load_library
+from ..extension import _load_library
 
 
 try:

--- a/torchvision/io/_video_opt.py
+++ b/torchvision/io/_video_opt.py
@@ -5,12 +5,11 @@ from typing import List, Tuple, Dict, Optional, Union
 
 import torch
 
-from .._internally_replaced_utils import _get_extension_path
+from .._internally_replaced_utils import _load_library
 
 
 try:
-    lib_path = _get_extension_path("video_reader")
-    torch.ops.load_library(lib_path)
+    _load_library("video_reader")
     _HAS_VIDEO_OPT = True
 except (ImportError, OSError):
     _HAS_VIDEO_OPT = False

--- a/torchvision/io/image.py
+++ b/torchvision/io/image.py
@@ -1,4 +1,8 @@
+import ctypes
+import os
+import sys
 from enum import Enum
+from warnings import warn
 
 import torch
 
@@ -13,22 +17,16 @@ try:
     # explicitly calling `LoadLibraryExW` with the following flags:
     #  - LOAD_LIBRARY_SEARCH_DEFAULT_DIRS (0x1000)
     #  - LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR (0x100)
-    import os as _os, _sys as _sys
-    if _os.name == "nt" and sys.version_info < (3, 8):
+    if os.name == "nt" and sys.version_info < (3, 8):
 
-        from ctypes.windll import kernel32 as _kernel32
+        _kernel32 = ctypes.WinDLL("kernel32.dll", use_last_error=True)
         if hasattr(_kernel32, "LoadLibraryExW"):
-            _image_lib_handle = _kernel32.LoadLibraryExW(lib_path,
-                                                         None,
-                                                         0x00001100)
+            _image_lib_handle = _kernel32.LoadLibraryExW(lib_path, None, 0x00001100)
         else:
-            import warnings
-            warnings.warn("LoadLibraryExW is missing in kernel32.dll")
+            warn("LoadLibraryExW is missing in kernel32.dll")
     torch.ops.load_library(lib_path)
 except (ImportError, OSError) as e:
-    import warnings
-    warnings.warn(f"Failed to load {global().get('lib_path','image.pyd')}: {e}")
-    pass
+    warn(f"Failed to load {globals().get('lib_path','image.pyd')}: {e}")
 
 
 class ImageReadMode(Enum):

--- a/torchvision/io/image.py
+++ b/torchvision/io/image.py
@@ -7,8 +7,27 @@ from .._internally_replaced_utils import _get_extension_path
 
 try:
     lib_path = _get_extension_path("image")
+    # On Windows Python-3.8+ has `os.add_dll_directory` call,
+    # which is called from _get_extension_path to configure dll search path
+    # Condition below adds a workaround for older versions by
+    # explicitly calling `LoadLibraryExW` with the following flags:
+    #  - LOAD_LIBRARY_SEARCH_DEFAULT_DIRS (0x1000)
+    #  - LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR (0x100)
+    import os as _os, _sys as _sys
+    if _os.name == "nt" and sys.version_info < (3, 8):
+
+        from ctypes.windll import kernel32 as _kernel32
+        if hasattr(_kernel32, "LoadLibraryExW"):
+            _image_lib_handle = _kernel32.LoadLibraryExW(lib_path,
+                                                         None,
+                                                         0x00001100)
+        else:
+            import warnings
+            warnings.warn("LoadLibraryExW is missing in kernel32.dll")
     torch.ops.load_library(lib_path)
-except (ImportError, OSError):
+except (ImportError, OSError) as e:
+    import warnings
+    warnings.warn(f"Failed to load {global().get('lib_path','image.pyd')}: {e}")
     pass
 
 

--- a/torchvision/io/image.py
+++ b/torchvision/io/image.py
@@ -1,18 +1,15 @@
-import ctypes
-import os
-import sys
 from enum import Enum
 from warnings import warn
 
 import torch
 
-from .._internally_replaced_utils import _load_library
+from ..extension import _load_library
 
 
 try:
     _load_library("image")
 except (ImportError, OSError) as e:
-    warn(f"Failed to load {globals().get('lib_path','image.pyd')}: {e}")
+    warn(f"Failed to load image Python extension: {e}")
 
 
 class ImageReadMode(Enum):

--- a/torchvision/io/image.py
+++ b/torchvision/io/image.py
@@ -6,25 +6,11 @@ from warnings import warn
 
 import torch
 
-from .._internally_replaced_utils import _get_extension_path
+from .._internally_replaced_utils import _load_library
 
 
 try:
-    lib_path = _get_extension_path("image")
-    # On Windows Python-3.8+ has `os.add_dll_directory` call,
-    # which is called from _get_extension_path to configure dll search path
-    # Condition below adds a workaround for older versions by
-    # explicitly calling `LoadLibraryExW` with the following flags:
-    #  - LOAD_LIBRARY_SEARCH_DEFAULT_DIRS (0x1000)
-    #  - LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR (0x100)
-    if os.name == "nt" and sys.version_info < (3, 8):
-
-        _kernel32 = ctypes.WinDLL("kernel32.dll", use_last_error=True)
-        if hasattr(_kernel32, "LoadLibraryExW"):
-            _image_lib_handle = _kernel32.LoadLibraryExW(lib_path, None, 0x00001100)
-        else:
-            warn("LoadLibraryExW is missing in kernel32.dll")
-    torch.ops.load_library(lib_path)
+    _load_library("image")
 except (ImportError, OSError) as e:
     warn(f"Failed to load {globals().get('lib_path','image.pyd')}: {e}")
 


### PR DESCRIPTION
Python-3.8+ adds `add_dll_directory` call, see https://docs.python.org/3/whatsnew/3.8.html#ctypes
Simulate this behaviour on older versions of Python runtime by calling
`LoadLibraryExW` with the appropriate flags

Fixes https://github.com/pytorch/vision/issues/4787
