### PR TITLE
Set seed on `test_nms_ref` to reduce flakiness

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -479,7 +479,9 @@ class TestNMS:
         return boxes, scores
 
     @pytest.mark.parametrize("iou", (0.2, 0.5, 0.8))
-    def test_nms_ref(self, iou):
+    @pytest.mark.parametrize("seed", range(10))
+    def test_nms_ref(self, iou, seed):
+        torch.random.manual_seed(seed)
         err_msg = "NMS incompatible between CPU and reference implementation for IoU={}"
         boxes, scores = self._create_tensors_with_iou(1000, iou)
         keep_ref = self._reference_nms(boxes, scores, iou)


### PR DESCRIPTION
The `test_nms_ref` seems to be [flaky](https://app.circleci.com/pipelines/github/pytorch/vision/12449/workflows/ef9169de-d537-4b02-b3d2-1ae9808c6410/jobs/983040/tests). This is related to the unstable sort used by NMS. To resolve this we could fix the seeds. A better solution currently investigated at #4767 is to make the sort stale within NMS.

cc @pmeier