### PR TITLE
save grad_scaler if use amp for better resume

### DIFF
--- a/references/classification/train.py
+++ b/references/classification/train.py
@@ -325,6 +325,8 @@ def main(args):
         args.start_epoch = checkpoint["epoch"] + 1
         if model_ema:
             model_ema.load_state_dict(checkpoint["model_ema"])
+        if scaler:
+            scaler.load_state_dict(checkpoint["scaler"])
 
     if args.test_only:
         # We disable the cudnn benchmarking because it can noticeably affect the accuracy
@@ -356,6 +358,8 @@ def main(args):
             }
             if model_ema:
                 checkpoint["model_ema"] = model_ema.state_dict()
+            if scaler:
+                checkpoint["scaler"] = scaler.state_dict()
             utils.save_on_master(checkpoint, os.path.join(args.output_dir, f"model_{epoch}.pth"))
             utils.save_on_master(checkpoint, os.path.join(args.output_dir, "checkpoint.pth"))
 


### PR DESCRIPTION
The pr is about https://github.com/pytorch/vision/issues/4509
when use amp, it is better to save/resuem scaler state_dict https://pytorch.org/tutorials/recipes/recipes/amp_recipe.html#saving-resuming

cc @datumbox