### PR TITLE
Fix clang_format CI failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,6 +225,8 @@ jobs:
       - checkout
       - run:
           command: |
+            sudo apt-get update -y
+            sudo apt install -y libtinfo5
             curl https://oss-clang-format.s3.us-east-2.amazonaws.com/linux64/clang-format-linux64 -o clang-format
             chmod +x clang-format
             sudo mv clang-format /opt/clang-format

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -225,6 +225,8 @@ jobs:
       - checkout
       - run:
           command: |
+            sudo apt-get update -y
+            sudo apt install -y libtinfo5
             curl https://oss-clang-format.s3.us-east-2.amazonaws.com/linux64/clang-format-linux64 -o clang-format
             chmod +x clang-format
             sudo mv clang-format /opt/clang-format


### PR DESCRIPTION
Fixes recent CI [failures](https://app.circleci.com/pipelines/github/pytorch/vision/12538/workflows/ba382961-a261-40b4-938a-c20558aaecda/jobs/991776) on the clang_format job caused by a missing lib.

cc @seemethere