### PR TITLE
Updates PIL version specifier to prevent issues with padding when image mode = P

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ requirements = [
     pytorch_dep,
 ]
 
-# Excluding 8.3.* because of https://github.com/pytorch/vision/issues/4146
+# Excluding 8.3.* because of https://github.com/pytorch/vision/issues/4934
 pillow_ver = " >= 5.3.0, !=8.3.*"
 pillow_req = "pillow-simd" if get_dist("pillow-simd") is not None else "pillow"
 requirements.append(pillow_req + pillow_ver)

--- a/setup.py
+++ b/setup.py
@@ -62,8 +62,8 @@ requirements = [
     pytorch_dep,
 ]
 
-# Excluding 8.3.0 because of https://github.com/pytorch/vision/issues/4146
-pillow_ver = " >= 5.3.0, !=8.3.0"
+# Excluding 8.3.* because of https://github.com/pytorch/vision/issues/4146
+pillow_ver = " >= 5.3.0, !=8.3.*"
 pillow_req = "pillow-simd" if get_dist("pillow-simd") is not None else "pillow"
 requirements.append(pillow_req + pillow_ver)
 


### PR DESCRIPTION
As discussed in #4934, this PR updates the version specifier of PIL to avoid incompatibility of the padding function for specific versions.

Closes #4934 

Any feedback is welcome!

cc @oke-aditya 