### PR TITLE
Cleanup Models prototype implementation

### DIFF
--- a/torchvision/prototype/models/_api.py
+++ b/torchvision/prototype/models/_api.py
@@ -63,7 +63,7 @@ class Weights(Enum):
                 return v
         raise ValueError(f"Invalid value {value} for enum {cls.__name__}.")
 
-    def state_dict(self, progress: bool) -> OrderedDict:
+    def get_state_dict(self, progress: bool) -> OrderedDict:
         return load_state_dict_from_url(self.url, progress=progress)
 
     def __repr__(self):

--- a/torchvision/prototype/models/_api.py
+++ b/torchvision/prototype/models/_api.py
@@ -50,7 +50,7 @@ class Weights(Enum):
         if obj is not None:
             if type(obj) is str:
                 obj = cls.from_str(obj)
-            elif not isinstance(obj, cls) and not isinstance(obj, WeightEntry):
+            elif not isinstance(obj, cls):
                 raise TypeError(
                     f"Invalid Weight class provided; expected {cls.__name__} but received {obj.__class__.__name__}."
                 )

--- a/torchvision/prototype/models/_api.py
+++ b/torchvision/prototype/models/_api.py
@@ -90,7 +90,7 @@ def get_weight(fn: Callable, weight_name: str) -> Weights:
     """
     sig = signature(fn)
     if "weights" not in sig.parameters:
-        raise ValueError("The method is missing the 'weights' argument.")
+        raise ValueError("The method is missing the 'weights' parameter.")
 
     ann = signature(fn).parameters["weights"].annotation
     weights_class = None

--- a/torchvision/prototype/models/alexnet.py
+++ b/torchvision/prototype/models/alexnet.py
@@ -30,7 +30,7 @@ class AlexNetWeights(Weights):
 
 def alexnet(weights: Optional[AlexNetWeights] = None, progress: bool = True, **kwargs: Any) -> AlexNet:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = AlexNetWeights.ImageNet1K_RefV1 if kwargs.pop("pretrained") else None
     weights = AlexNetWeights.verify(weights)
     if weights is not None:

--- a/torchvision/prototype/models/alexnet.py
+++ b/torchvision/prototype/models/alexnet.py
@@ -39,6 +39,6 @@ def alexnet(weights: Optional[AlexNetWeights] = None, progress: bool = True, **k
     model = AlexNet(**kwargs)
 
     if weights is not None:
-        model.load_state_dict(weights.state_dict(progress=progress))
+        model.load_state_dict(weights.get_state_dict(progress=progress))
 
     return model

--- a/torchvision/prototype/models/densenet.py
+++ b/torchvision/prototype/models/densenet.py
@@ -63,7 +63,7 @@ def _densenet(
     return model
 
 
-_common_meta = {
+_COMMON_META = {
     "size": (224, 224),
     "categories": _IMAGENET_CATEGORIES,
     "interpolation": InterpolationMode.BILINEAR,
@@ -76,7 +76,7 @@ class DenseNet121Weights(Weights):
         url="https://download.pytorch.org/models/densenet121-a639ec97.pth",
         transforms=partial(ImageNetEval, crop_size=224),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "acc@1": 74.434,
             "acc@5": 91.972,
         },
@@ -88,7 +88,7 @@ class DenseNet161Weights(Weights):
         url="https://download.pytorch.org/models/densenet161-8d451a50.pth",
         transforms=partial(ImageNetEval, crop_size=224),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "acc@1": 77.138,
             "acc@5": 93.560,
         },
@@ -100,7 +100,7 @@ class DenseNet169Weights(Weights):
         url="https://download.pytorch.org/models/densenet169-b2777c0a.pth",
         transforms=partial(ImageNetEval, crop_size=224),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "acc@1": 75.600,
             "acc@5": 92.806,
         },
@@ -112,7 +112,7 @@ class DenseNet201Weights(Weights):
         url="https://download.pytorch.org/models/densenet201-c1103571.pth",
         transforms=partial(ImageNetEval, crop_size=224),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "acc@1": 76.896,
             "acc@5": 93.370,
         },

--- a/torchvision/prototype/models/densenet.py
+++ b/torchvision/prototype/models/densenet.py
@@ -121,7 +121,7 @@ class DenseNet201Weights(Weights):
 
 def densenet121(weights: Optional[DenseNet121Weights] = None, progress: bool = True, **kwargs: Any) -> DenseNet:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = DenseNet121Weights.ImageNet1K_Community if kwargs.pop("pretrained") else None
     weights = DenseNet121Weights.verify(weights)
 
@@ -130,7 +130,7 @@ def densenet121(weights: Optional[DenseNet121Weights] = None, progress: bool = T
 
 def densenet161(weights: Optional[DenseNet161Weights] = None, progress: bool = True, **kwargs: Any) -> DenseNet:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = DenseNet161Weights.ImageNet1K_Community if kwargs.pop("pretrained") else None
     weights = DenseNet161Weights.verify(weights)
 
@@ -139,7 +139,7 @@ def densenet161(weights: Optional[DenseNet161Weights] = None, progress: bool = T
 
 def densenet169(weights: Optional[DenseNet169Weights] = None, progress: bool = True, **kwargs: Any) -> DenseNet:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = DenseNet169Weights.ImageNet1K_Community if kwargs.pop("pretrained") else None
     weights = DenseNet169Weights.verify(weights)
 
@@ -148,7 +148,7 @@ def densenet169(weights: Optional[DenseNet169Weights] = None, progress: bool = T
 
 def densenet201(weights: Optional[DenseNet201Weights] = None, progress: bool = True, **kwargs: Any) -> DenseNet:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = DenseNet201Weights.ImageNet1K_Community if kwargs.pop("pretrained") else None
     weights = DenseNet201Weights.verify(weights)
 

--- a/torchvision/prototype/models/densenet.py
+++ b/torchvision/prototype/models/densenet.py
@@ -34,7 +34,7 @@ def _load_state_dict(model: nn.Module, weights: Weights, progress: bool) -> None
         r"^(.*denselayer\d+\.(?:norm|relu|conv))\.((?:[12])\.(?:weight|bias|running_mean|running_var))$"
     )
 
-    state_dict = weights.state_dict(progress=progress)
+    state_dict = weights.get_state_dict(progress=progress)
     for key in list(state_dict.keys()):
         res = pattern.match(key)
         if res:

--- a/torchvision/prototype/models/densenet.py
+++ b/torchvision/prototype/models/densenet.py
@@ -67,7 +67,7 @@ _common_meta = {
     "size": (224, 224),
     "categories": _IMAGENET_CATEGORIES,
     "interpolation": InterpolationMode.BILINEAR,
-    "recipe": None,  # weights ported from LuaTorch
+    "recipe": None,  # TODO: add here a URL to documentation stating that the weights were ported from LuaTorch
 }
 
 

--- a/torchvision/prototype/models/detection/faster_rcnn.py
+++ b/torchvision/prototype/models/detection/faster_rcnn.py
@@ -30,7 +30,7 @@ __all__ = [
 ]
 
 
-_common_meta = {
+_COMMON_META = {
     "categories": _COCO_CATEGORIES,
     "interpolation": InterpolationMode.BILINEAR,
 }
@@ -41,7 +41,7 @@ class FasterRCNNResNet50FPNWeights(Weights):
         url="https://download.pytorch.org/models/fasterrcnn_resnet50_fpn_coco-258fb6c6.pth",
         transforms=CocoEval,
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "recipe": "https://github.com/pytorch/vision/tree/main/references/detection#faster-r-cnn-resnet-50-fpn",
             "map": 37.0,
         },
@@ -53,7 +53,7 @@ class FasterRCNNMobileNetV3LargeFPNWeights(Weights):
         url="https://download.pytorch.org/models/fasterrcnn_mobilenet_v3_large_fpn-fb6a3cc7.pth",
         transforms=CocoEval,
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "recipe": "https://github.com/pytorch/vision/tree/main/references/detection#faster-r-cnn-mobilenetv3-large-fpn",
             "map": 32.8,
         },
@@ -65,7 +65,7 @@ class FasterRCNNMobileNetV3Large320FPNWeights(Weights):
         url="https://download.pytorch.org/models/fasterrcnn_mobilenet_v3_large_320_fpn-907ea3f9.pth",
         transforms=CocoEval,
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "recipe": "https://github.com/pytorch/vision/tree/main/references/detection#faster-r-cnn-mobilenetv3-large-320-fpn",
             "map": 22.8,
         },

--- a/torchvision/prototype/models/detection/faster_rcnn.py
+++ b/torchvision/prototype/models/detection/faster_rcnn.py
@@ -102,7 +102,7 @@ def fasterrcnn_resnet50_fpn(
     model = FasterRCNN(backbone, num_classes=num_classes, **kwargs)
 
     if weights is not None:
-        model.load_state_dict(weights.state_dict(progress=progress))
+        model.load_state_dict(weights.get_state_dict(progress=progress))
         if weights == FasterRCNNResNet50FPNWeights.Coco_RefV1:
             overwrite_eps(model, 0.0)
 
@@ -142,7 +142,7 @@ def _fasterrcnn_mobilenet_v3_large_fpn(
     )
 
     if weights is not None:
-        model.load_state_dict(weights.state_dict(progress=progress))
+        model.load_state_dict(weights.get_state_dict(progress=progress))
 
     return model
 

--- a/torchvision/prototype/models/detection/faster_rcnn.py
+++ b/torchvision/prototype/models/detection/faster_rcnn.py
@@ -81,11 +81,11 @@ def fasterrcnn_resnet50_fpn(
     **kwargs: Any,
 ) -> FasterRCNN:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = FasterRCNNResNet50FPNWeights.Coco_RefV1 if kwargs.pop("pretrained") else None
     weights = FasterRCNNResNet50FPNWeights.verify(weights)
     if "pretrained_backbone" in kwargs:
-        warnings.warn("The argument pretrained_backbone is deprecated, please use weights_backbone instead.")
+        warnings.warn("The parameter pretrained_backbone is deprecated, please use weights_backbone instead.")
         weights_backbone = ResNet50Weights.ImageNet1K_RefV1 if kwargs.pop("pretrained_backbone") else None
     weights_backbone = ResNet50Weights.verify(weights_backbone)
 
@@ -156,11 +156,11 @@ def fasterrcnn_mobilenet_v3_large_fpn(
     **kwargs: Any,
 ) -> FasterRCNN:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = FasterRCNNMobileNetV3LargeFPNWeights.Coco_RefV1 if kwargs.pop("pretrained") else None
     weights = FasterRCNNMobileNetV3LargeFPNWeights.verify(weights)
     if "pretrained_backbone" in kwargs:
-        warnings.warn("The argument pretrained_backbone is deprecated, please use weights_backbone instead.")
+        warnings.warn("The parameter pretrained_backbone is deprecated, please use weights_backbone instead.")
         weights_backbone = MobileNetV3LargeWeights.ImageNet1K_RefV1 if kwargs.pop("pretrained_backbone") else None
     weights_backbone = MobileNetV3LargeWeights.verify(weights_backbone)
 
@@ -188,11 +188,11 @@ def fasterrcnn_mobilenet_v3_large_320_fpn(
     **kwargs: Any,
 ) -> FasterRCNN:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = FasterRCNNMobileNetV3Large320FPNWeights.Coco_RefV1 if kwargs.pop("pretrained") else None
     weights = FasterRCNNMobileNetV3Large320FPNWeights.verify(weights)
     if "pretrained_backbone" in kwargs:
-        warnings.warn("The argument pretrained_backbone is deprecated, please use weights_backbone instead.")
+        warnings.warn("The parameter pretrained_backbone is deprecated, please use weights_backbone instead.")
         weights_backbone = MobileNetV3LargeWeights.ImageNet1K_RefV1 if kwargs.pop("pretrained_backbone") else None
     weights_backbone = MobileNetV3LargeWeights.verify(weights_backbone)
 

--- a/torchvision/prototype/models/detection/keypoint_rcnn.py
+++ b/torchvision/prototype/models/detection/keypoint_rcnn.py
@@ -86,7 +86,7 @@ def keypointrcnn_resnet50_fpn(
     model = KeypointRCNN(backbone, num_classes, num_keypoints=num_keypoints, **kwargs)
 
     if weights is not None:
-        model.load_state_dict(weights.state_dict(progress=progress))
+        model.load_state_dict(weights.get_state_dict(progress=progress))
         if weights == KeypointRCNNResNet50FPNWeights.Coco_RefV1:
             overwrite_eps(model, 0.0)
 

--- a/torchvision/prototype/models/detection/keypoint_rcnn.py
+++ b/torchvision/prototype/models/detection/keypoint_rcnn.py
@@ -58,7 +58,7 @@ def keypointrcnn_resnet50_fpn(
     **kwargs: Any,
 ) -> KeypointRCNN:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         pretrained = kwargs.pop("pretrained")
         if type(pretrained) == str and pretrained == "legacy":
             weights = KeypointRCNNResNet50FPNWeights.Coco_RefV1_Legacy
@@ -68,7 +68,7 @@ def keypointrcnn_resnet50_fpn(
             weights = None
     weights = KeypointRCNNResNet50FPNWeights.verify(weights)
     if "pretrained_backbone" in kwargs:
-        warnings.warn("The argument pretrained_backbone is deprecated, please use weights_backbone instead.")
+        warnings.warn("The parameter pretrained_backbone is deprecated, please use weights_backbone instead.")
         weights_backbone = ResNet50Weights.ImageNet1K_RefV1 if kwargs.pop("pretrained_backbone") else None
     weights_backbone = ResNet50Weights.verify(weights_backbone)
 

--- a/torchvision/prototype/models/detection/keypoint_rcnn.py
+++ b/torchvision/prototype/models/detection/keypoint_rcnn.py
@@ -22,7 +22,7 @@ __all__ = [
 ]
 
 
-_common_meta = {"categories": _COCO_PERSON_CATEGORIES, "keypoint_names": _COCO_PERSON_KEYPOINT_NAMES}
+_COMMON_META = {"categories": _COCO_PERSON_CATEGORIES, "keypoint_names": _COCO_PERSON_KEYPOINT_NAMES}
 
 
 class KeypointRCNNResNet50FPNWeights(Weights):
@@ -30,7 +30,7 @@ class KeypointRCNNResNet50FPNWeights(Weights):
         url="https://download.pytorch.org/models/keypointrcnn_resnet50_fpn_coco-9f466800.pth",
         transforms=CocoEval,
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "recipe": "https://github.com/pytorch/vision/issues/1606",
             "box_map": 50.6,
             "kp_map": 61.1,
@@ -40,7 +40,7 @@ class KeypointRCNNResNet50FPNWeights(Weights):
         url="https://download.pytorch.org/models/keypointrcnn_resnet50_fpn_coco-fc266e95.pth",
         transforms=CocoEval,
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "recipe": "https://github.com/pytorch/vision/tree/main/references/detection#keypoint-r-cnn",
             "box_map": 54.6,
             "kp_map": 65.0,

--- a/torchvision/prototype/models/detection/mask_rcnn.py
+++ b/torchvision/prototype/models/detection/mask_rcnn.py
@@ -46,11 +46,11 @@ def maskrcnn_resnet50_fpn(
     **kwargs: Any,
 ) -> MaskRCNN:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = MaskRCNNResNet50FPNWeights.Coco_RefV1 if kwargs.pop("pretrained") else None
     weights = MaskRCNNResNet50FPNWeights.verify(weights)
     if "pretrained_backbone" in kwargs:
-        warnings.warn("The argument pretrained_backbone is deprecated, please use weights_backbone instead.")
+        warnings.warn("The parameter pretrained_backbone is deprecated, please use weights_backbone instead.")
         weights_backbone = ResNet50Weights.ImageNet1K_RefV1 if kwargs.pop("pretrained_backbone") else None
     weights_backbone = ResNet50Weights.verify(weights_backbone)
 

--- a/torchvision/prototype/models/detection/mask_rcnn.py
+++ b/torchvision/prototype/models/detection/mask_rcnn.py
@@ -67,7 +67,7 @@ def maskrcnn_resnet50_fpn(
     model = MaskRCNN(backbone, num_classes=num_classes, **kwargs)
 
     if weights is not None:
-        model.load_state_dict(weights.state_dict(progress=progress))
+        model.load_state_dict(weights.get_state_dict(progress=progress))
         if weights == MaskRCNNResNet50FPNWeights.Coco_RefV1:
             overwrite_eps(model, 0.0)
 

--- a/torchvision/prototype/models/detection/retinanet.py
+++ b/torchvision/prototype/models/detection/retinanet.py
@@ -70,7 +70,7 @@ def retinanet_resnet50_fpn(
     model = RetinaNet(backbone, num_classes, **kwargs)
 
     if weights is not None:
-        model.load_state_dict(weights.state_dict(progress=progress))
+        model.load_state_dict(weights.get_state_dict(progress=progress))
         if weights == RetinaNetResNet50FPNWeights.Coco_RefV1:
             overwrite_eps(model, 0.0)
 

--- a/torchvision/prototype/models/detection/retinanet.py
+++ b/torchvision/prototype/models/detection/retinanet.py
@@ -46,11 +46,11 @@ def retinanet_resnet50_fpn(
     **kwargs: Any,
 ) -> RetinaNet:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = RetinaNetResNet50FPNWeights.Coco_RefV1 if kwargs.pop("pretrained") else None
     weights = RetinaNetResNet50FPNWeights.verify(weights)
     if "pretrained_backbone" in kwargs:
-        warnings.warn("The argument pretrained_backbone is deprecated, please use weights_backbone instead.")
+        warnings.warn("The parameter pretrained_backbone is deprecated, please use weights_backbone instead.")
         weights_backbone = ResNet50Weights.ImageNet1K_RefV1 if kwargs.pop("pretrained_backbone") else None
     weights_backbone = ResNet50Weights.verify(weights_backbone)
 

--- a/torchvision/prototype/models/detection/ssd.py
+++ b/torchvision/prototype/models/detection/ssd.py
@@ -81,6 +81,6 @@ def ssd300_vgg16(
     model = SSD(backbone, anchor_generator, (300, 300), num_classes, **kwargs)
 
     if weights is not None:
-        model.load_state_dict(weights.state_dict(progress=progress))
+        model.load_state_dict(weights.get_state_dict(progress=progress))
 
     return model

--- a/torchvision/prototype/models/detection/ssd.py
+++ b/torchvision/prototype/models/detection/ssd.py
@@ -44,16 +44,16 @@ def ssd300_vgg16(
     **kwargs: Any,
 ) -> SSD:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = SSD300VGG16Weights.Coco_RefV1 if kwargs.pop("pretrained") else None
     weights = SSD300VGG16Weights.verify(weights)
     if "pretrained_backbone" in kwargs:
-        warnings.warn("The argument pretrained_backbone is deprecated, please use weights_backbone instead.")
+        warnings.warn("The parameter pretrained_backbone is deprecated, please use weights_backbone instead.")
         weights_backbone = VGG16Weights.ImageNet1K_Features if kwargs.pop("pretrained_backbone") else None
     weights_backbone = VGG16Weights.verify(weights_backbone)
 
     if "size" in kwargs:
-        warnings.warn("The size of the model is already fixed; ignoring the argument.")
+        warnings.warn("The size of the model is already fixed; ignoring the parameter.")
 
     if weights is not None:
         weights_backbone = None

--- a/torchvision/prototype/models/detection/ssdlite.py
+++ b/torchvision/prototype/models/detection/ssdlite.py
@@ -114,6 +114,6 @@ def ssdlite320_mobilenet_v3_large(
     )
 
     if weights is not None:
-        model.load_state_dict(weights.state_dict(progress=progress))
+        model.load_state_dict(weights.get_state_dict(progress=progress))
 
     return model

--- a/torchvision/prototype/models/detection/ssdlite.py
+++ b/torchvision/prototype/models/detection/ssdlite.py
@@ -50,16 +50,16 @@ def ssdlite320_mobilenet_v3_large(
     **kwargs: Any,
 ) -> SSD:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = SSDlite320MobileNetV3LargeFPNWeights.Coco_RefV1 if kwargs.pop("pretrained") else None
     weights = SSDlite320MobileNetV3LargeFPNWeights.verify(weights)
     if "pretrained_backbone" in kwargs:
-        warnings.warn("The argument pretrained_backbone is deprecated, please use weights_backbone instead.")
+        warnings.warn("The parameter pretrained_backbone is deprecated, please use weights_backbone instead.")
         weights_backbone = MobileNetV3LargeWeights.ImageNet1K_RefV1 if kwargs.pop("pretrained_backbone") else None
     weights_backbone = MobileNetV3LargeWeights.verify(weights_backbone)
 
     if "size" in kwargs:
-        warnings.warn("The size of the model is already fixed; ignoring the argument.")
+        warnings.warn("The size of the model is already fixed; ignoring the parameter.")
 
     if weights is not None:
         weights_backbone = None

--- a/torchvision/prototype/models/efficientnet.py
+++ b/torchvision/prototype/models/efficientnet.py
@@ -177,7 +177,7 @@ def efficientnet_b0(
     weights: Optional[EfficientNetB0Weights] = None, progress: bool = True, **kwargs: Any
 ) -> EfficientNet:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = EfficientNetB0Weights.ImageNet1K_TimmV1 if kwargs.pop("pretrained") else None
     weights = EfficientNetB0Weights.verify(weights)
     return _efficientnet(width_mult=1.0, depth_mult=1.0, dropout=0.2, weights=weights, progress=progress, **kwargs)
@@ -187,7 +187,7 @@ def efficientnet_b1(
     weights: Optional[EfficientNetB1Weights] = None, progress: bool = True, **kwargs: Any
 ) -> EfficientNet:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = EfficientNetB1Weights.ImageNet1K_TimmV1 if kwargs.pop("pretrained") else None
     weights = EfficientNetB1Weights.verify(weights)
     return _efficientnet(width_mult=1.0, depth_mult=1.1, dropout=0.2, weights=weights, progress=progress, **kwargs)
@@ -197,7 +197,7 @@ def efficientnet_b2(
     weights: Optional[EfficientNetB2Weights] = None, progress: bool = True, **kwargs: Any
 ) -> EfficientNet:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = EfficientNetB2Weights.ImageNet1K_TimmV1 if kwargs.pop("pretrained") else None
     weights = EfficientNetB2Weights.verify(weights)
     return _efficientnet(width_mult=1.1, depth_mult=1.2, dropout=0.3, weights=weights, progress=progress, **kwargs)
@@ -207,7 +207,7 @@ def efficientnet_b3(
     weights: Optional[EfficientNetB3Weights] = None, progress: bool = True, **kwargs: Any
 ) -> EfficientNet:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = EfficientNetB3Weights.ImageNet1K_TimmV1 if kwargs.pop("pretrained") else None
     weights = EfficientNetB3Weights.verify(weights)
     return _efficientnet(width_mult=1.2, depth_mult=1.4, dropout=0.3, weights=weights, progress=progress, **kwargs)
@@ -217,7 +217,7 @@ def efficientnet_b4(
     weights: Optional[EfficientNetB4Weights] = None, progress: bool = True, **kwargs: Any
 ) -> EfficientNet:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = EfficientNetB4Weights.ImageNet1K_TimmV1 if kwargs.pop("pretrained") else None
     weights = EfficientNetB4Weights.verify(weights)
     return _efficientnet(width_mult=1.4, depth_mult=1.8, dropout=0.4, weights=weights, progress=progress, **kwargs)
@@ -227,7 +227,7 @@ def efficientnet_b5(
     weights: Optional[EfficientNetB5Weights] = None, progress: bool = True, **kwargs: Any
 ) -> EfficientNet:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = EfficientNetB5Weights.ImageNet1K_TFV1 if kwargs.pop("pretrained") else None
     weights = EfficientNetB5Weights.verify(weights)
     return _efficientnet(
@@ -245,7 +245,7 @@ def efficientnet_b6(
     weights: Optional[EfficientNetB6Weights] = None, progress: bool = True, **kwargs: Any
 ) -> EfficientNet:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = EfficientNetB6Weights.ImageNet1K_TFV1 if kwargs.pop("pretrained") else None
     weights = EfficientNetB6Weights.verify(weights)
     return _efficientnet(
@@ -263,7 +263,7 @@ def efficientnet_b7(
     weights: Optional[EfficientNetB7Weights] = None, progress: bool = True, **kwargs: Any
 ) -> EfficientNet:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = EfficientNetB7Weights.ImageNet1K_TFV1 if kwargs.pop("pretrained") else None
     weights = EfficientNetB7Weights.verify(weights)
     return _efficientnet(

--- a/torchvision/prototype/models/efficientnet.py
+++ b/torchvision/prototype/models/efficientnet.py
@@ -57,7 +57,7 @@ def _efficientnet(
     model = EfficientNet(inverted_residual_setting, dropout, **kwargs)
 
     if weights is not None:
-        model.load_state_dict(weights.state_dict(progress=progress))
+        model.load_state_dict(weights.get_state_dict(progress=progress))
 
     return model
 

--- a/torchvision/prototype/models/efficientnet.py
+++ b/torchvision/prototype/models/efficientnet.py
@@ -62,7 +62,7 @@ def _efficientnet(
     return model
 
 
-_common_meta = {
+_COMMON_META = {
     "categories": _IMAGENET_CATEGORIES,
     "interpolation": InterpolationMode.BICUBIC,
     "recipe": "https://github.com/pytorch/vision/tree/main/references/classification#efficientnet",
@@ -74,7 +74,7 @@ class EfficientNetB0Weights(Weights):
         url="https://download.pytorch.org/models/efficientnet_b0_rwightman-3dd342df.pth",
         transforms=partial(ImageNetEval, crop_size=224, resize_size=256, interpolation=InterpolationMode.BICUBIC),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "size": (224, 224),
             "acc@1": 77.692,
             "acc@5": 93.532,
@@ -87,7 +87,7 @@ class EfficientNetB1Weights(Weights):
         url="https://download.pytorch.org/models/efficientnet_b1_rwightman-533bc792.pth",
         transforms=partial(ImageNetEval, crop_size=240, resize_size=256, interpolation=InterpolationMode.BICUBIC),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "size": (240, 240),
             "acc@1": 78.642,
             "acc@5": 94.186,
@@ -100,7 +100,7 @@ class EfficientNetB2Weights(Weights):
         url="https://download.pytorch.org/models/efficientnet_b2_rwightman-bcdf34b7.pth",
         transforms=partial(ImageNetEval, crop_size=288, resize_size=288, interpolation=InterpolationMode.BICUBIC),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "size": (288, 288),
             "acc@1": 80.608,
             "acc@5": 95.310,
@@ -113,7 +113,7 @@ class EfficientNetB3Weights(Weights):
         url="https://download.pytorch.org/models/efficientnet_b3_rwightman-cf984f9c.pth",
         transforms=partial(ImageNetEval, crop_size=300, resize_size=320, interpolation=InterpolationMode.BICUBIC),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "size": (300, 300),
             "acc@1": 82.008,
             "acc@5": 96.054,
@@ -126,7 +126,7 @@ class EfficientNetB4Weights(Weights):
         url="https://download.pytorch.org/models/efficientnet_b4_rwightman-7eb33cd5.pth",
         transforms=partial(ImageNetEval, crop_size=380, resize_size=384, interpolation=InterpolationMode.BICUBIC),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "size": (380, 380),
             "acc@1": 83.384,
             "acc@5": 96.594,
@@ -139,7 +139,7 @@ class EfficientNetB5Weights(Weights):
         url="https://download.pytorch.org/models/efficientnet_b5_lukemelas-b6417697.pth",
         transforms=partial(ImageNetEval, crop_size=456, resize_size=456, interpolation=InterpolationMode.BICUBIC),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "size": (456, 456),
             "acc@1": 83.444,
             "acc@5": 96.628,
@@ -152,7 +152,7 @@ class EfficientNetB6Weights(Weights):
         url="https://download.pytorch.org/models/efficientnet_b6_lukemelas-c76e70fd.pth",
         transforms=partial(ImageNetEval, crop_size=528, resize_size=528, interpolation=InterpolationMode.BICUBIC),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "size": (528, 528),
             "acc@1": 84.008,
             "acc@5": 96.916,
@@ -165,7 +165,7 @@ class EfficientNetB7Weights(Weights):
         url="https://download.pytorch.org/models/efficientnet_b7_lukemelas-dcc49843.pth",
         transforms=partial(ImageNetEval, crop_size=600, resize_size=600, interpolation=InterpolationMode.BICUBIC),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "size": (600, 600),
             "acc@1": 84.122,
             "acc@5": 96.908,

--- a/torchvision/prototype/models/googlenet.py
+++ b/torchvision/prototype/models/googlenet.py
@@ -38,10 +38,6 @@ def googlenet(weights: Optional[GoogLeNetWeights] = None, progress: bool = True,
     if weights is not None:
         if "transform_input" not in kwargs:
             kwargs["transform_input"] = True
-        if original_aux_logits:
-            warnings.warn(
-                "auxiliary heads in the pretrained googlenet model are NOT pretrained, so make sure to train them"
-            )
         kwargs["aux_logits"] = True
         kwargs["init_weights"] = False
         kwargs["num_classes"] = len(weights.meta["categories"])
@@ -54,5 +50,9 @@ def googlenet(weights: Optional[GoogLeNetWeights] = None, progress: bool = True,
             model.aux_logits = False
             model.aux1 = None  # type: ignore[assignment]
             model.aux2 = None  # type: ignore[assignment]
+        else:
+            warnings.warn(
+                "auxiliary heads in the pretrained googlenet model are NOT pretrained, so make sure to train them"
+            )
 
     return model

--- a/torchvision/prototype/models/googlenet.py
+++ b/torchvision/prototype/models/googlenet.py
@@ -49,7 +49,7 @@ def googlenet(weights: Optional[GoogLeNetWeights] = None, progress: bool = True,
     model = GoogLeNet(**kwargs)
 
     if weights is not None:
-        model.load_state_dict(weights.state_dict(progress=progress))
+        model.load_state_dict(weights.get_state_dict(progress=progress))
         if not original_aux_logits:
             model.aux_logits = False
             model.aux1 = None  # type: ignore[assignment]

--- a/torchvision/prototype/models/googlenet.py
+++ b/torchvision/prototype/models/googlenet.py
@@ -30,7 +30,7 @@ class GoogLeNetWeights(Weights):
 
 def googlenet(weights: Optional[GoogLeNetWeights] = None, progress: bool = True, **kwargs: Any) -> GoogLeNet:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = GoogLeNetWeights.ImageNet1K_TFV1 if kwargs.pop("pretrained") else None
     weights = GoogLeNetWeights.verify(weights)
 

--- a/torchvision/prototype/models/inception.py
+++ b/torchvision/prototype/models/inception.py
@@ -30,7 +30,7 @@ class InceptionV3Weights(Weights):
 
 def inception_v3(weights: Optional[InceptionV3Weights] = None, progress: bool = True, **kwargs: Any) -> Inception3:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = InceptionV3Weights.ImageNet1K_TFV1 if kwargs.pop("pretrained") else None
     weights = InceptionV3Weights.verify(weights)
 

--- a/torchvision/prototype/models/inception.py
+++ b/torchvision/prototype/models/inception.py
@@ -45,7 +45,7 @@ def inception_v3(weights: Optional[InceptionV3Weights] = None, progress: bool = 
     model = Inception3(**kwargs)
 
     if weights is not None:
-        model.load_state_dict(weights.state_dict(progress=progress))
+        model.load_state_dict(weights.get_state_dict(progress=progress))
         if not original_aux_logits:
             model.aux_logits = False
             model.AuxLogits = None

--- a/torchvision/prototype/models/mnasnet.py
+++ b/torchvision/prototype/models/mnasnet.py
@@ -72,7 +72,7 @@ def _mnasnet(alpha: float, weights: Optional[Weights], progress: bool, **kwargs:
     model = MNASNet(alpha, **kwargs)
 
     if weights:
-        model.load_state_dict(weights.state_dict(progress=progress))
+        model.load_state_dict(weights.get_state_dict(progress=progress))
 
     return model
 

--- a/torchvision/prototype/models/mnasnet.py
+++ b/torchvision/prototype/models/mnasnet.py
@@ -23,7 +23,7 @@ __all__ = [
 ]
 
 
-_common_meta = {
+_COMMON_META = {
     "size": (224, 224),
     "categories": _IMAGENET_CATEGORIES,
     "interpolation": InterpolationMode.BILINEAR,
@@ -36,7 +36,7 @@ class MNASNet0_5Weights(Weights):
         url="https://download.pytorch.org/models/mnasnet0.5_top1_67.823-3ffadce67e.pth",
         transforms=partial(ImageNetEval, crop_size=224),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "acc@1": 67.734,
             "acc@5": 87.490,
         },
@@ -53,7 +53,7 @@ class MNASNet1_0Weights(Weights):
         url="https://download.pytorch.org/models/mnasnet1.0_top1_73.512-f206786ef8.pth",
         transforms=partial(ImageNetEval, crop_size=224),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "acc@1": 73.456,
             "acc@5": 91.510,
         },

--- a/torchvision/prototype/models/mnasnet.py
+++ b/torchvision/prototype/models/mnasnet.py
@@ -79,7 +79,7 @@ def _mnasnet(alpha: float, weights: Optional[Weights], progress: bool, **kwargs:
 
 def mnasnet0_5(weights: Optional[MNASNet0_5Weights] = None, progress: bool = True, **kwargs: Any) -> MNASNet:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = MNASNet0_5Weights.ImageNet1K_Community if kwargs.pop("pretrained") else None
 
     weights = MNASNet0_5Weights.verify(weights)
@@ -89,7 +89,7 @@ def mnasnet0_5(weights: Optional[MNASNet0_5Weights] = None, progress: bool = Tru
 
 def mnasnet0_75(weights: Optional[MNASNet0_75Weights] = None, progress: bool = True, **kwargs: Any) -> MNASNet:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         if kwargs.pop("pretrained"):
             raise ValueError("No checkpoint is available for model type mnasnet0_75")
 
@@ -100,7 +100,7 @@ def mnasnet0_75(weights: Optional[MNASNet0_75Weights] = None, progress: bool = T
 
 def mnasnet1_0(weights: Optional[MNASNet1_0Weights] = None, progress: bool = True, **kwargs: Any) -> MNASNet:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = MNASNet1_0Weights.ImageNet1K_Community if kwargs.pop("pretrained") else None
     weights = MNASNet1_0Weights.verify(weights)
 
@@ -109,7 +109,7 @@ def mnasnet1_0(weights: Optional[MNASNet1_0Weights] = None, progress: bool = Tru
 
 def mnasnet1_3(weights: Optional[MNASNet1_3Weights] = None, progress: bool = True, **kwargs: Any) -> MNASNet:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         if kwargs.pop("pretrained"):
             raise ValueError("No checkpoint is available for model type mnasnet1_3")
 

--- a/torchvision/prototype/models/mobilenetv2.py
+++ b/torchvision/prototype/models/mobilenetv2.py
@@ -40,6 +40,6 @@ def mobilenet_v2(weights: Optional[MobileNetV2Weights] = None, progress: bool = 
     model = MobileNetV2(**kwargs)
 
     if weights is not None:
-        model.load_state_dict(weights.state_dict(progress=progress))
+        model.load_state_dict(weights.get_state_dict(progress=progress))
 
     return model

--- a/torchvision/prototype/models/mobilenetv2.py
+++ b/torchvision/prototype/models/mobilenetv2.py
@@ -30,7 +30,7 @@ class MobileNetV2Weights(Weights):
 
 def mobilenet_v2(weights: Optional[MobileNetV2Weights] = None, progress: bool = True, **kwargs: Any) -> MobileNetV2:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = MobileNetV2Weights.ImageNet1K_RefV1 if kwargs.pop("pretrained") else None
     weights = MobileNetV2Weights.verify(weights)
 

--- a/torchvision/prototype/models/mobilenetv3.py
+++ b/torchvision/prototype/models/mobilenetv3.py
@@ -32,7 +32,7 @@ def _mobilenet_v3(
     model = MobileNetV3(inverted_residual_setting, last_channel, **kwargs)
 
     if weights is not None:
-        model.load_state_dict(weights.state_dict(progress=progress))
+        model.load_state_dict(weights.get_state_dict(progress=progress))
 
     return model
 

--- a/torchvision/prototype/models/mobilenetv3.py
+++ b/torchvision/prototype/models/mobilenetv3.py
@@ -37,7 +37,7 @@ def _mobilenet_v3(
     return model
 
 
-_common_meta = {
+_COMMON_META = {
     "size": (224, 224),
     "categories": _IMAGENET_CATEGORIES,
     "interpolation": InterpolationMode.BILINEAR,
@@ -50,7 +50,7 @@ class MobileNetV3LargeWeights(Weights):
         url="https://download.pytorch.org/models/mobilenet_v3_large-8738ca79.pth",
         transforms=partial(ImageNetEval, crop_size=224),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "acc@1": 74.042,
             "acc@5": 91.340,
         },
@@ -62,7 +62,7 @@ class MobileNetV3SmallWeights(Weights):
         url="https://download.pytorch.org/models/mobilenet_v3_small-047dcff4.pth",
         transforms=partial(ImageNetEval, crop_size=224),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "acc@1": 67.668,
             "acc@5": 87.402,
         },

--- a/torchvision/prototype/models/mobilenetv3.py
+++ b/torchvision/prototype/models/mobilenetv3.py
@@ -73,7 +73,7 @@ def mobilenet_v3_large(
     weights: Optional[MobileNetV3LargeWeights] = None, progress: bool = True, **kwargs: Any
 ) -> MobileNetV3:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = MobileNetV3LargeWeights.ImageNet1K_RefV1 if kwargs.pop("pretrained") else None
     weights = MobileNetV3LargeWeights.verify(weights)
 
@@ -85,7 +85,7 @@ def mobilenet_v3_small(
     weights: Optional[MobileNetV3SmallWeights] = None, progress: bool = True, **kwargs: Any
 ) -> MobileNetV3:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = MobileNetV3SmallWeights.ImageNet1K_RefV1 if kwargs.pop("pretrained") else None
     weights = MobileNetV3SmallWeights.verify(weights)
 

--- a/torchvision/prototype/models/quantization/googlenet.py
+++ b/torchvision/prototype/models/quantization/googlenet.py
@@ -47,7 +47,7 @@ def googlenet(
     **kwargs: Any,
 ) -> QuantizableGoogLeNet:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         if kwargs.pop("pretrained"):
             weights = QuantizedGoogLeNetWeights.ImageNet1K_FBGEMM_TFV1 if quantize else GoogLeNetWeights.ImageNet1K_TFV1
         else:

--- a/torchvision/prototype/models/quantization/googlenet.py
+++ b/torchvision/prototype/models/quantization/googlenet.py
@@ -62,10 +62,6 @@ def googlenet(
     if weights is not None:
         if "transform_input" not in kwargs:
             kwargs["transform_input"] = True
-        if original_aux_logits:
-            warnings.warn(
-                "auxiliary heads in the pretrained googlenet model are NOT pretrained, so make sure to train them"
-            )
         kwargs["aux_logits"] = True
         kwargs["init_weights"] = False
         kwargs["num_classes"] = len(weights.meta["categories"])
@@ -84,5 +80,9 @@ def googlenet(
             model.aux_logits = False
             model.aux1 = None  # type: ignore[assignment]
             model.aux2 = None  # type: ignore[assignment]
+        else:
+            warnings.warn(
+                "auxiliary heads in the pretrained googlenet model are NOT pretrained, so make sure to train them"
+            )
 
     return model

--- a/torchvision/prototype/models/quantization/googlenet.py
+++ b/torchvision/prototype/models/quantization/googlenet.py
@@ -79,7 +79,7 @@ def googlenet(
         quantize_model(model, backend)
 
     if weights is not None:
-        model.load_state_dict(weights.state_dict(progress=progress))
+        model.load_state_dict(weights.get_state_dict(progress=progress))
         if not original_aux_logits:
             model.aux_logits = False
             model.aux1 = None  # type: ignore[assignment]

--- a/torchvision/prototype/models/quantization/inception.py
+++ b/torchvision/prototype/models/quantization/inception.py
@@ -47,7 +47,7 @@ def inception_v3(
     **kwargs: Any,
 ) -> QuantizableInception3:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         if kwargs.pop("pretrained"):
             weights = (
                 QuantizedInceptionV3Weights.ImageNet1K_FBGEMM_TFV1 if quantize else InceptionV3Weights.ImageNet1K_TFV1

--- a/torchvision/prototype/models/quantization/inception.py
+++ b/torchvision/prototype/models/quantization/inception.py
@@ -79,7 +79,7 @@ def inception_v3(
         if quantize and not original_aux_logits:
             model.aux_logits = False
             model.AuxLogits = None
-        model.load_state_dict(weights.state_dict(progress=progress))
+        model.load_state_dict(weights.get_state_dict(progress=progress))
         if not quantize and not original_aux_logits:
             model.aux_logits = False
             model.AuxLogits = None

--- a/torchvision/prototype/models/quantization/mobilenetv2.py
+++ b/torchvision/prototype/models/quantization/mobilenetv2.py
@@ -75,6 +75,6 @@ def mobilenet_v2(
         quantize_model(model, backend)
 
     if weights is not None:
-        model.load_state_dict(weights.state_dict(progress=progress))
+        model.load_state_dict(weights.get_state_dict(progress=progress))
 
     return model

--- a/torchvision/prototype/models/quantization/mobilenetv2.py
+++ b/torchvision/prototype/models/quantization/mobilenetv2.py
@@ -48,7 +48,7 @@ def mobilenet_v2(
     **kwargs: Any,
 ) -> QuantizableMobileNetV2:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         if kwargs.pop("pretrained"):
             weights = (
                 QuantizedMobileNetV2Weights.ImageNet1K_QNNPACK_RefV1

--- a/torchvision/prototype/models/quantization/mobilenetv3.py
+++ b/torchvision/prototype/models/quantization/mobilenetv3.py
@@ -81,7 +81,7 @@ def mobilenet_v3_large(
     **kwargs: Any,
 ) -> QuantizableMobileNetV3:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         if kwargs.pop("pretrained"):
             weights = (
                 QuantizedMobileNetV3LargeWeights.ImageNet1K_QNNPACK_RefV1

--- a/torchvision/prototype/models/quantization/mobilenetv3.py
+++ b/torchvision/prototype/models/quantization/mobilenetv3.py
@@ -47,7 +47,7 @@ def _mobilenet_v3_model(
         torch.quantization.prepare_qat(model, inplace=True)
 
     if weights is not None:
-        model.load_state_dict(weights.state_dict(progress=progress))
+        model.load_state_dict(weights.get_state_dict(progress=progress))
 
     if quantize:
         torch.quantization.convert(model, inplace=True)

--- a/torchvision/prototype/models/quantization/resnet.py
+++ b/torchvision/prototype/models/quantization/resnet.py
@@ -48,7 +48,7 @@ def _resnet(
         quantize_model(model, backend)
 
     if weights is not None:
-        model.load_state_dict(weights.state_dict(progress=progress))
+        model.load_state_dict(weights.get_state_dict(progress=progress))
 
     return model
 

--- a/torchvision/prototype/models/quantization/resnet.py
+++ b/torchvision/prototype/models/quantization/resnet.py
@@ -53,7 +53,7 @@ def _resnet(
     return model
 
 
-_common_meta = {
+_COMMON_META = {
     "size": (224, 224),
     "categories": _IMAGENET_CATEGORIES,
     "interpolation": InterpolationMode.BILINEAR,
@@ -68,7 +68,7 @@ class QuantizedResNet18Weights(Weights):
         url="https://download.pytorch.org/models/quantized/resnet18_fbgemm_16fa66dd.pth",
         transforms=partial(ImageNetEval, crop_size=224),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "unquantized": ResNet18Weights.ImageNet1K_RefV1,
             "acc@1": 69.494,
             "acc@5": 88.882,
@@ -81,7 +81,7 @@ class QuantizedResNet50Weights(Weights):
         url="https://download.pytorch.org/models/quantized/resnet50_fbgemm_bf931d71.pth",
         transforms=partial(ImageNetEval, crop_size=224),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "unquantized": ResNet50Weights.ImageNet1K_RefV1,
             "acc@1": 75.920,
             "acc@5": 92.814,
@@ -94,7 +94,7 @@ class QuantizedResNeXt101_32x8dWeights(Weights):
         url="https://download.pytorch.org/models/quantized/resnext101_32x8_fbgemm_09835ccf.pth",
         transforms=partial(ImageNetEval, crop_size=224),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "unquantized": ResNeXt101_32x8dWeights.ImageNet1K_RefV1,
             "acc@1": 78.986,
             "acc@5": 94.480,

--- a/torchvision/prototype/models/quantization/resnet.py
+++ b/torchvision/prototype/models/quantization/resnet.py
@@ -109,7 +109,7 @@ def resnet18(
     **kwargs: Any,
 ) -> QuantizableResNet:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         if kwargs.pop("pretrained"):
             weights = QuantizedResNet18Weights.ImageNet1K_FBGEMM_RefV1 if quantize else ResNet18Weights.ImageNet1K_RefV1
         else:
@@ -130,7 +130,7 @@ def resnet50(
     **kwargs: Any,
 ) -> QuantizableResNet:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         if kwargs.pop("pretrained"):
             weights = QuantizedResNet50Weights.ImageNet1K_FBGEMM_RefV1 if quantize else ResNet50Weights.ImageNet1K_RefV1
         else:
@@ -151,7 +151,7 @@ def resnext101_32x8d(
     **kwargs: Any,
 ) -> QuantizableResNet:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         if kwargs.pop("pretrained"):
             weights = (
                 QuantizedResNeXt101_32x8dWeights.ImageNet1K_FBGEMM_RefV1

--- a/torchvision/prototype/models/quantization/shufflenetv2.py
+++ b/torchvision/prototype/models/quantization/shufflenetv2.py
@@ -92,7 +92,7 @@ def shufflenet_v2_x0_5(
     **kwargs: Any,
 ) -> QuantizableShuffleNetV2:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         if kwargs.pop("pretrained"):
             weights = (
                 QuantizedShuffleNetV2_x0_5Weights.ImageNet1K_FBGEMM_Community
@@ -117,7 +117,7 @@ def shufflenet_v2_x1_0(
     **kwargs: Any,
 ) -> QuantizableShuffleNetV2:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         if kwargs.pop("pretrained"):
             weights = (
                 QuantizedShuffleNetV2_x1_0Weights.ImageNet1K_FBGEMM_Community

--- a/torchvision/prototype/models/quantization/shufflenetv2.py
+++ b/torchvision/prototype/models/quantization/shufflenetv2.py
@@ -49,7 +49,7 @@ def _shufflenetv2(
     return model
 
 
-_common_meta = {
+_COMMON_META = {
     "size": (224, 224),
     "categories": _IMAGENET_CATEGORIES,
     "interpolation": InterpolationMode.BILINEAR,
@@ -64,7 +64,7 @@ class QuantizedShuffleNetV2_x0_5Weights(Weights):
         url="https://download.pytorch.org/models/quantized/shufflenetv2_x0.5_fbgemm-00845098.pth",
         transforms=partial(ImageNetEval, crop_size=224),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "unquantized": ShuffleNetV2_x0_5Weights.ImageNet1K_Community,
             "acc@1": 57.972,
             "acc@5": 79.780,
@@ -77,7 +77,7 @@ class QuantizedShuffleNetV2_x1_0Weights(Weights):
         url="https://download.pytorch.org/models/quantized/shufflenetv2_x1_fbgemm-db332c57.pth",
         transforms=partial(ImageNetEval, crop_size=224),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "unquantized": ShuffleNetV2_x1_0Weights.ImageNet1K_Community,
             "acc@1": 68.360,
             "acc@5": 87.582,

--- a/torchvision/prototype/models/quantization/shufflenetv2.py
+++ b/torchvision/prototype/models/quantization/shufflenetv2.py
@@ -44,7 +44,7 @@ def _shufflenetv2(
         quantize_model(model, backend)
 
     if weights is not None:
-        model.load_state_dict(weights.state_dict(progress=progress))
+        model.load_state_dict(weights.get_state_dict(progress=progress))
 
     return model
 

--- a/torchvision/prototype/models/regnet.py
+++ b/torchvision/prototype/models/regnet.py
@@ -248,7 +248,7 @@ class RegNet_x_32gfWeights(Weights):
 
 def regnet_y_400mf(weights: Optional[RegNet_y_400mfWeights] = None, progress: bool = True, **kwargs: Any) -> RegNet:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = RegNet_y_400mfWeights.ImageNet1K_RefV1 if kwargs.pop("pretrained") else None
     weights = RegNet_y_400mfWeights.verify(weights)
 
@@ -258,7 +258,7 @@ def regnet_y_400mf(weights: Optional[RegNet_y_400mfWeights] = None, progress: bo
 
 def regnet_y_800mf(weights: Optional[RegNet_y_800mfWeights] = None, progress: bool = True, **kwargs: Any) -> RegNet:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = RegNet_y_800mfWeights.ImageNet1K_RefV1 if kwargs.pop("pretrained") else None
     weights = RegNet_y_800mfWeights.verify(weights)
 
@@ -268,7 +268,7 @@ def regnet_y_800mf(weights: Optional[RegNet_y_800mfWeights] = None, progress: bo
 
 def regnet_y_1_6gf(weights: Optional[RegNet_y_1_6gfWeights] = None, progress: bool = True, **kwargs: Any) -> RegNet:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = RegNet_y_1_6gfWeights.ImageNet1K_RefV1 if kwargs.pop("pretrained") else None
     weights = RegNet_y_1_6gfWeights.verify(weights)
 
@@ -280,7 +280,7 @@ def regnet_y_1_6gf(weights: Optional[RegNet_y_1_6gfWeights] = None, progress: bo
 
 def regnet_y_3_2gf(weights: Optional[RegNet_y_3_2gfWeights] = None, progress: bool = True, **kwargs: Any) -> RegNet:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = RegNet_y_3_2gfWeights.ImageNet1K_RefV1 if kwargs.pop("pretrained") else None
     weights = RegNet_y_3_2gfWeights.verify(weights)
     params = BlockParams.from_init_params(
@@ -291,7 +291,7 @@ def regnet_y_3_2gf(weights: Optional[RegNet_y_3_2gfWeights] = None, progress: bo
 
 def regnet_y_8gf(weights: Optional[RegNet_y_8gfWeights] = None, progress: bool = True, **kwargs: Any) -> RegNet:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = RegNet_y_8gfWeights.ImageNet1K_RefV1 if kwargs.pop("pretrained") else None
     weights = RegNet_y_8gfWeights.verify(weights)
     params = BlockParams.from_init_params(
@@ -302,7 +302,7 @@ def regnet_y_8gf(weights: Optional[RegNet_y_8gfWeights] = None, progress: bool =
 
 def regnet_y_16gf(weights: Optional[RegNet_y_16gfWeights] = None, progress: bool = True, **kwargs: Any) -> RegNet:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = RegNet_y_16gfWeights.ImageNet1K_RefV1 if kwargs.pop("pretrained") else None
     weights = RegNet_y_16gfWeights.verify(weights)
     params = BlockParams.from_init_params(
@@ -313,7 +313,7 @@ def regnet_y_16gf(weights: Optional[RegNet_y_16gfWeights] = None, progress: bool
 
 def regnet_y_32gf(weights: Optional[RegNet_y_32gfWeights] = None, progress: bool = True, **kwargs: Any) -> RegNet:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = RegNet_y_32gfWeights.ImageNet1K_RefV1 if kwargs.pop("pretrained") else None
     weights = RegNet_y_32gfWeights.verify(weights)
     params = BlockParams.from_init_params(
@@ -324,7 +324,7 @@ def regnet_y_32gf(weights: Optional[RegNet_y_32gfWeights] = None, progress: bool
 
 def regnet_x_400mf(weights: Optional[RegNet_x_400mfWeights] = None, progress: bool = True, **kwargs: Any) -> RegNet:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = RegNet_x_400mfWeights.ImageNet1K_RefV1 if kwargs.pop("pretrained") else None
     weights = RegNet_x_400mfWeights.verify(weights)
     params = BlockParams.from_init_params(depth=22, w_0=24, w_a=24.48, w_m=2.54, group_width=16, **kwargs)
@@ -334,7 +334,7 @@ def regnet_x_400mf(weights: Optional[RegNet_x_400mfWeights] = None, progress: bo
 
 def regnet_x_800mf(weights: Optional[RegNet_x_800mfWeights] = None, progress: bool = True, **kwargs: Any) -> RegNet:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = RegNet_x_800mfWeights.ImageNet1K_RefV1 if kwargs.pop("pretrained") else None
     weights = RegNet_x_800mfWeights.verify(weights)
     params = BlockParams.from_init_params(depth=16, w_0=56, w_a=35.73, w_m=2.28, group_width=16, **kwargs)
@@ -344,7 +344,7 @@ def regnet_x_800mf(weights: Optional[RegNet_x_800mfWeights] = None, progress: bo
 
 def regnet_x_1_6gf(weights: Optional[RegNet_x_1_6gfWeights] = None, progress: bool = True, **kwargs: Any) -> RegNet:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = RegNet_x_1_6gfWeights.ImageNet1K_RefV1 if kwargs.pop("pretrained") else None
     weights = RegNet_x_1_6gfWeights.verify(weights)
     params = BlockParams.from_init_params(depth=18, w_0=80, w_a=34.01, w_m=2.25, group_width=24, **kwargs)
@@ -354,7 +354,7 @@ def regnet_x_1_6gf(weights: Optional[RegNet_x_1_6gfWeights] = None, progress: bo
 
 def regnet_x_3_2gf(weights: Optional[RegNet_x_3_2gfWeights] = None, progress: bool = True, **kwargs: Any) -> RegNet:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = RegNet_x_3_2gfWeights.ImageNet1K_RefV1 if kwargs.pop("pretrained") else None
     weights = RegNet_x_3_2gfWeights.verify(weights)
     params = BlockParams.from_init_params(depth=25, w_0=88, w_a=26.31, w_m=2.25, group_width=48, **kwargs)
@@ -364,7 +364,7 @@ def regnet_x_3_2gf(weights: Optional[RegNet_x_3_2gfWeights] = None, progress: bo
 
 def regnet_x_8gf(weights: Optional[RegNet_x_8gfWeights] = None, progress: bool = True, **kwargs: Any) -> RegNet:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = RegNet_x_8gfWeights.ImageNet1K_RefV1 if kwargs.pop("pretrained") else None
     weights = RegNet_x_8gfWeights.verify(weights)
     params = BlockParams.from_init_params(depth=23, w_0=80, w_a=49.56, w_m=2.88, group_width=120, **kwargs)
@@ -374,7 +374,7 @@ def regnet_x_8gf(weights: Optional[RegNet_x_8gfWeights] = None, progress: bool =
 
 def regnet_x_16gf(weights: Optional[RegNet_x_16gfWeights] = None, progress: bool = True, **kwargs: Any) -> RegNet:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = RegNet_x_16gfWeights.ImageNet1K_RefV1 if kwargs.pop("pretrained") else None
     weights = RegNet_x_16gfWeights.verify(weights)
     params = BlockParams.from_init_params(depth=22, w_0=216, w_a=55.59, w_m=2.1, group_width=128, **kwargs)
@@ -384,7 +384,7 @@ def regnet_x_16gf(weights: Optional[RegNet_x_16gfWeights] = None, progress: bool
 
 def regnet_x_32gf(weights: Optional[RegNet_x_32gfWeights] = None, progress: bool = True, **kwargs: Any) -> RegNet:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = RegNet_x_32gfWeights.ImageNet1K_RefV1 if kwargs.pop("pretrained") else None
     weights = RegNet_x_32gfWeights.verify(weights)
     params = BlockParams.from_init_params(depth=23, w_0=320, w_a=69.86, w_m=2.0, group_width=168, **kwargs)

--- a/torchvision/prototype/models/regnet.py
+++ b/torchvision/prototype/models/regnet.py
@@ -59,7 +59,7 @@ def _regnet(
     model = RegNet(block_params, norm_layer=norm_layer, **kwargs)
 
     if weights is not None:
-        model.load_state_dict(weights.state_dict(progress=progress))
+        model.load_state_dict(weights.get_state_dict(progress=progress))
 
     return model
 

--- a/torchvision/prototype/models/regnet.py
+++ b/torchvision/prototype/models/regnet.py
@@ -43,7 +43,7 @@ __all__ = [
     "regnet_x_32gf",
 ]
 
-_common_meta = {"size": (224, 224), "categories": _IMAGENET_CATEGORIES, "interpolation": InterpolationMode.BILINEAR}
+_COMMON_META = {"size": (224, 224), "categories": _IMAGENET_CATEGORIES, "interpolation": InterpolationMode.BILINEAR}
 
 
 def _regnet(
@@ -69,7 +69,7 @@ class RegNet_y_400mfWeights(Weights):
         url="https://download.pytorch.org/models/regnet_y_400mf-c65dace8.pth",
         transforms=partial(ImageNetEval, crop_size=224),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "recipe": "https://github.com/pytorch/vision/tree/main/references/classification#small-models",
             "acc@1": 74.046,
             "acc@5": 91.716,
@@ -82,7 +82,7 @@ class RegNet_y_800mfWeights(Weights):
         url="https://download.pytorch.org/models/regnet_y_800mf-1b27b58c.pth",
         transforms=partial(ImageNetEval, crop_size=224),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "recipe": "https://github.com/pytorch/vision/tree/main/references/classification#small-models",
             "acc@1": 76.420,
             "acc@5": 93.136,
@@ -95,7 +95,7 @@ class RegNet_y_1_6gfWeights(Weights):
         url="https://download.pytorch.org/models/regnet_y_1_6gf-b11a554e.pth",
         transforms=partial(ImageNetEval, crop_size=224),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "recipe": "https://github.com/pytorch/vision/tree/main/references/classification#small-models",
             "acc@1": 77.950,
             "acc@5": 93.966,
@@ -108,7 +108,7 @@ class RegNet_y_3_2gfWeights(Weights):
         url="https://download.pytorch.org/models/regnet_y_3_2gf-b5a9779c.pth",
         transforms=partial(ImageNetEval, crop_size=224),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "recipe": "https://github.com/pytorch/vision/tree/main/references/classification#medium-models",
             "acc@1": 78.948,
             "acc@5": 94.576,
@@ -121,7 +121,7 @@ class RegNet_y_8gfWeights(Weights):
         url="https://download.pytorch.org/models/regnet_y_8gf-d0d0e4a8.pth",
         transforms=partial(ImageNetEval, crop_size=224),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "recipe": "https://github.com/pytorch/vision/tree/main/references/classification#medium-models",
             "acc@1": 80.032,
             "acc@5": 95.048,
@@ -134,7 +134,7 @@ class RegNet_y_16gfWeights(Weights):
         url="https://download.pytorch.org/models/regnet_y_16gf-9e6ed7dd.pth",
         transforms=partial(ImageNetEval, crop_size=224),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "recipe": "https://github.com/pytorch/vision/tree/main/references/classification#large-models",
             "acc@1": 80.424,
             "acc@5": 95.240,
@@ -147,7 +147,7 @@ class RegNet_y_32gfWeights(Weights):
         url="https://download.pytorch.org/models/regnet_y_32gf-4dee3f7a.pth",
         transforms=partial(ImageNetEval, crop_size=224),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "recipe": "https://github.com/pytorch/vision/tree/main/references/classification#large-models",
             "acc@1": 80.878,
             "acc@5": 95.340,
@@ -160,7 +160,7 @@ class RegNet_x_400mfWeights(Weights):
         url="https://download.pytorch.org/models/regnet_x_400mf-adf1edd5.pth",
         transforms=partial(ImageNetEval, crop_size=224),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "recipe": "https://github.com/pytorch/vision/tree/main/references/classification#small-models",
             "acc@1": 72.834,
             "acc@5": 90.950,
@@ -173,7 +173,7 @@ class RegNet_x_800mfWeights(Weights):
         url="https://download.pytorch.org/models/regnet_x_800mf-ad17e45c.pth",
         transforms=partial(ImageNetEval, crop_size=224),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "recipe": "https://github.com/pytorch/vision/tree/main/references/classification#small-models",
             "acc@1": 75.212,
             "acc@5": 92.348,
@@ -186,7 +186,7 @@ class RegNet_x_1_6gfWeights(Weights):
         url="https://download.pytorch.org/models/regnet_x_1_6gf-e3633e7f.pth",
         transforms=partial(ImageNetEval, crop_size=224),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "recipe": "https://github.com/pytorch/vision/tree/main/references/classification#small-models",
             "acc@1": 77.040,
             "acc@5": 93.440,
@@ -199,7 +199,7 @@ class RegNet_x_3_2gfWeights(Weights):
         url="https://download.pytorch.org/models/regnet_x_3_2gf-f342aeae.pth",
         transforms=partial(ImageNetEval, crop_size=224),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "recipe": "https://github.com/pytorch/vision/tree/main/references/classification#medium-models",
             "acc@1": 78.364,
             "acc@5": 93.992,
@@ -212,7 +212,7 @@ class RegNet_x_8gfWeights(Weights):
         url="https://download.pytorch.org/models/regnet_x_8gf-03ceed89.pth",
         transforms=partial(ImageNetEval, crop_size=224),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "recipe": "https://github.com/pytorch/vision/tree/main/references/classification#medium-models",
             "acc@1": 79.344,
             "acc@5": 94.686,
@@ -225,7 +225,7 @@ class RegNet_x_16gfWeights(Weights):
         url="https://download.pytorch.org/models/regnet_x_16gf-2007eb11.pth",
         transforms=partial(ImageNetEval, crop_size=224),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "recipe": "https://github.com/pytorch/vision/tree/main/references/classification#medium-models",
             "acc@1": 80.058,
             "acc@5": 94.944,
@@ -238,7 +238,7 @@ class RegNet_x_32gfWeights(Weights):
         url="https://download.pytorch.org/models/regnet_x_32gf-9d47f8d0.pth",
         transforms=partial(ImageNetEval, crop_size=224),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "recipe": "https://github.com/pytorch/vision/tree/main/references/classification#large-models",
             "acc@1": 80.622,
             "acc@5": 95.248,

--- a/torchvision/prototype/models/resnet.py
+++ b/torchvision/prototype/models/resnet.py
@@ -233,7 +233,7 @@ class WideResNet101_2Weights(Weights):
 
 def resnet18(weights: Optional[ResNet18Weights] = None, progress: bool = True, **kwargs: Any) -> ResNet:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = ResNet18Weights.ImageNet1K_RefV1 if kwargs.pop("pretrained") else None
 
     weights = ResNet18Weights.verify(weights)
@@ -243,7 +243,7 @@ def resnet18(weights: Optional[ResNet18Weights] = None, progress: bool = True, *
 
 def resnet34(weights: Optional[ResNet34Weights] = None, progress: bool = True, **kwargs: Any) -> ResNet:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = ResNet34Weights.ImageNet1K_RefV1 if kwargs.pop("pretrained") else None
 
     weights = ResNet34Weights.verify(weights)
@@ -253,7 +253,7 @@ def resnet34(weights: Optional[ResNet34Weights] = None, progress: bool = True, *
 
 def resnet50(weights: Optional[ResNet50Weights] = None, progress: bool = True, **kwargs: Any) -> ResNet:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = ResNet50Weights.ImageNet1K_RefV1 if kwargs.pop("pretrained") else None
     weights = ResNet50Weights.verify(weights)
 
@@ -262,7 +262,7 @@ def resnet50(weights: Optional[ResNet50Weights] = None, progress: bool = True, *
 
 def resnet101(weights: Optional[ResNet101Weights] = None, progress: bool = True, **kwargs: Any) -> ResNet:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = ResNet101Weights.ImageNet1K_RefV1 if kwargs.pop("pretrained") else None
 
     weights = ResNet101Weights.verify(weights)
@@ -272,7 +272,7 @@ def resnet101(weights: Optional[ResNet101Weights] = None, progress: bool = True,
 
 def resnet152(weights: Optional[ResNet152Weights] = None, progress: bool = True, **kwargs: Any) -> ResNet:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = ResNet152Weights.ImageNet1K_RefV1 if kwargs.pop("pretrained") else None
 
     weights = ResNet152Weights.verify(weights)
@@ -282,7 +282,7 @@ def resnet152(weights: Optional[ResNet152Weights] = None, progress: bool = True,
 
 def resnext50_32x4d(weights: Optional[ResNeXt50_32x4dWeights] = None, progress: bool = True, **kwargs: Any) -> ResNet:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = ResNeXt50_32x4dWeights.ImageNet1K_RefV1 if kwargs.pop("pretrained") else None
 
     weights = ResNeXt50_32x4dWeights.verify(weights)
@@ -293,7 +293,7 @@ def resnext50_32x4d(weights: Optional[ResNeXt50_32x4dWeights] = None, progress: 
 
 def resnext101_32x8d(weights: Optional[ResNeXt101_32x8dWeights] = None, progress: bool = True, **kwargs: Any) -> ResNet:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = ResNeXt101_32x8dWeights.ImageNet1K_RefV1 if kwargs.pop("pretrained") else None
 
     weights = ResNeXt101_32x8dWeights.verify(weights)
@@ -304,7 +304,7 @@ def resnext101_32x8d(weights: Optional[ResNeXt101_32x8dWeights] = None, progress
 
 def wide_resnet50_2(weights: Optional[WideResNet50_2Weights] = None, progress: bool = True, **kwargs: Any) -> ResNet:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = WideResNet50_2Weights.ImageNet1K_Community if kwargs.pop("pretrained") else None
 
     weights = WideResNet50_2Weights.verify(weights)
@@ -314,7 +314,7 @@ def wide_resnet50_2(weights: Optional[WideResNet50_2Weights] = None, progress: b
 
 def wide_resnet101_2(weights: Optional[WideResNet101_2Weights] = None, progress: bool = True, **kwargs: Any) -> ResNet:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = WideResNet101_2Weights.ImageNet1K_Community if kwargs.pop("pretrained") else None
 
     weights = WideResNet101_2Weights.verify(weights)

--- a/torchvision/prototype/models/resnet.py
+++ b/torchvision/prototype/models/resnet.py
@@ -46,7 +46,7 @@ def _resnet(
     model = ResNet(block, layers, **kwargs)
 
     if weights is not None:
-        model.load_state_dict(weights.state_dict(progress=progress))
+        model.load_state_dict(weights.get_state_dict(progress=progress))
 
     return model
 

--- a/torchvision/prototype/models/resnet.py
+++ b/torchvision/prototype/models/resnet.py
@@ -51,7 +51,7 @@ def _resnet(
     return model
 
 
-_common_meta = {"size": (224, 224), "categories": _IMAGENET_CATEGORIES, "interpolation": InterpolationMode.BILINEAR}
+_COMMON_META = {"size": (224, 224), "categories": _IMAGENET_CATEGORIES, "interpolation": InterpolationMode.BILINEAR}
 
 
 class ResNet18Weights(Weights):
@@ -59,7 +59,7 @@ class ResNet18Weights(Weights):
         url="https://download.pytorch.org/models/resnet18-f37072fd.pth",
         transforms=partial(ImageNetEval, crop_size=224),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "recipe": "https://github.com/pytorch/vision/tree/main/references/classification#resnet",
             "acc@1": 69.758,
             "acc@5": 89.078,
@@ -72,7 +72,7 @@ class ResNet34Weights(Weights):
         url="https://download.pytorch.org/models/resnet34-b627a593.pth",
         transforms=partial(ImageNetEval, crop_size=224),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "recipe": "https://github.com/pytorch/vision/tree/main/references/classification#resnet",
             "acc@1": 73.314,
             "acc@5": 91.420,
@@ -85,7 +85,7 @@ class ResNet50Weights(Weights):
         url="https://download.pytorch.org/models/resnet50-0676ba61.pth",
         transforms=partial(ImageNetEval, crop_size=224),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "recipe": "https://github.com/pytorch/vision/tree/main/references/classification#resnet",
             "acc@1": 76.130,
             "acc@5": 92.862,
@@ -95,7 +95,7 @@ class ResNet50Weights(Weights):
         url="https://download.pytorch.org/models/resnet50-f46c3f97.pth",
         transforms=partial(ImageNetEval, crop_size=224, resize_size=232),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "recipe": "https://github.com/pytorch/vision/issues/3995",
             "acc@1": 80.674,
             "acc@5": 95.166,
@@ -108,7 +108,7 @@ class ResNet101Weights(Weights):
         url="https://download.pytorch.org/models/resnet101-63fe2227.pth",
         transforms=partial(ImageNetEval, crop_size=224),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "recipe": "https://github.com/pytorch/vision/tree/main/references/classification#resnet",
             "acc@1": 77.374,
             "acc@5": 93.546,
@@ -118,7 +118,7 @@ class ResNet101Weights(Weights):
         url="https://download.pytorch.org/models/resnet101-b641f3a9.pth",
         transforms=partial(ImageNetEval, crop_size=224, resize_size=232),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "recipe": "https://github.com/pytorch/vision/issues/3995",
             "acc@1": 81.728,
             "acc@5": 95.670,
@@ -131,7 +131,7 @@ class ResNet152Weights(Weights):
         url="https://download.pytorch.org/models/resnet152-394f9c45.pth",
         transforms=partial(ImageNetEval, crop_size=224),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "recipe": "https://github.com/pytorch/vision/tree/main/references/classification#resnet",
             "acc@1": 78.312,
             "acc@5": 94.046,
@@ -141,7 +141,7 @@ class ResNet152Weights(Weights):
         url="https://download.pytorch.org/models/resnet152-089c0848.pth",
         transforms=partial(ImageNetEval, crop_size=224, resize_size=232),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "recipe": "https://github.com/pytorch/vision/issues/3995",
             "acc@1": 82.042,
             "acc@5": 95.926,
@@ -154,7 +154,7 @@ class ResNeXt50_32x4dWeights(Weights):
         url="https://download.pytorch.org/models/resnext50_32x4d-7cdf4587.pth",
         transforms=partial(ImageNetEval, crop_size=224),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "recipe": "https://github.com/pytorch/vision/tree/main/references/classification#resnext",
             "acc@1": 77.618,
             "acc@5": 93.698,
@@ -164,7 +164,7 @@ class ResNeXt50_32x4dWeights(Weights):
         url="https://download.pytorch.org/models/resnext50_32x4d-b260af35.pth",
         transforms=partial(ImageNetEval, crop_size=224, resize_size=232),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "recipe": "https://github.com/pytorch/vision/issues/3995",
             "acc@1": 81.116,
             "acc@5": 95.478,
@@ -177,7 +177,7 @@ class ResNeXt101_32x8dWeights(Weights):
         url="https://download.pytorch.org/models/resnext101_32x8d-8ba56ff5.pth",
         transforms=partial(ImageNetEval, crop_size=224),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "recipe": "https://github.com/pytorch/vision/tree/main/references/classification#resnext",
             "acc@1": 79.312,
             "acc@5": 94.526,
@@ -190,7 +190,7 @@ class WideResNet50_2Weights(Weights):
         url="https://download.pytorch.org/models/wide_resnet50_2-95faca4d.pth",
         transforms=partial(ImageNetEval, crop_size=224),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "recipe": "https://github.com/pytorch/vision/pull/912#issue-445437439",
             "acc@1": 78.468,
             "acc@5": 94.086,
@@ -200,7 +200,7 @@ class WideResNet50_2Weights(Weights):
         url="https://download.pytorch.org/models/wide_resnet50_2-9ba9bcbe.pth",
         transforms=partial(ImageNetEval, crop_size=224, resize_size=232),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "recipe": "https://github.com/pytorch/vision/issues/3995",
             "acc@1": 81.602,
             "acc@5": 95.758,
@@ -213,7 +213,7 @@ class WideResNet101_2Weights(Weights):
         url="https://download.pytorch.org/models/wide_resnet101_2-32ee1156.pth",
         transforms=partial(ImageNetEval, crop_size=224),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "recipe": "https://github.com/pytorch/vision/pull/912#issue-445437439",
             "acc@1": 78.848,
             "acc@5": 94.284,
@@ -223,7 +223,7 @@ class WideResNet101_2Weights(Weights):
         url="https://download.pytorch.org/models/wide_resnet101_2-b8680a8c.pth",
         transforms=partial(ImageNetEval, crop_size=224, resize_size=232),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "recipe": "https://github.com/pytorch/vision/issues/3995",
             "acc@1": 82.492,
             "acc@5": 96.110,

--- a/torchvision/prototype/models/segmentation/deeplabv3.py
+++ b/torchvision/prototype/models/segmentation/deeplabv3.py
@@ -96,7 +96,7 @@ def deeplabv3_resnet50(
     model = _deeplabv3_resnet(backbone, num_classes, aux_loss)
 
     if weights is not None:
-        model.load_state_dict(weights.state_dict(progress=progress))
+        model.load_state_dict(weights.get_state_dict(progress=progress))
 
     return model
 
@@ -128,7 +128,7 @@ def deeplabv3_resnet101(
     model = _deeplabv3_resnet(backbone, num_classes, aux_loss)
 
     if weights is not None:
-        model.load_state_dict(weights.state_dict(progress=progress))
+        model.load_state_dict(weights.get_state_dict(progress=progress))
 
     return model
 
@@ -160,6 +160,6 @@ def deeplabv3_mobilenet_v3_large(
     model = _deeplabv3_mobilenetv3(backbone, num_classes, aux_loss)
 
     if weights is not None:
-        model.load_state_dict(weights.state_dict(progress=progress))
+        model.load_state_dict(weights.get_state_dict(progress=progress))
 
     return model

--- a/torchvision/prototype/models/segmentation/deeplabv3.py
+++ b/torchvision/prototype/models/segmentation/deeplabv3.py
@@ -78,12 +78,12 @@ def deeplabv3_resnet50(
     **kwargs: Any,
 ) -> DeepLabV3:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = DeepLabV3ResNet50Weights.CocoWithVocLabels_RefV1 if kwargs.pop("pretrained") else None
 
     weights = DeepLabV3ResNet50Weights.verify(weights)
     if "pretrained_backbone" in kwargs:
-        warnings.warn("The argument pretrained_backbone is deprecated, please use weights_backbone instead.")
+        warnings.warn("The parameter pretrained_backbone is deprecated, please use weights_backbone instead.")
         weights_backbone = ResNet50Weights.ImageNet1K_RefV1 if kwargs.pop("pretrained_backbone") else None
     weights_backbone = ResNet50Weights.verify(weights_backbone)
 
@@ -110,12 +110,12 @@ def deeplabv3_resnet101(
     **kwargs: Any,
 ) -> DeepLabV3:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = DeepLabV3ResNet101Weights.CocoWithVocLabels_RefV1 if kwargs.pop("pretrained") else None
 
     weights = DeepLabV3ResNet101Weights.verify(weights)
     if "pretrained_backbone" in kwargs:
-        warnings.warn("The argument pretrained_backbone is deprecated, please use weights_backbone instead.")
+        warnings.warn("The parameter pretrained_backbone is deprecated, please use weights_backbone instead.")
         weights_backbone = ResNet101Weights.ImageNet1K_RefV1 if kwargs.pop("pretrained_backbone") else None
     weights_backbone = ResNet101Weights.verify(weights_backbone)
 
@@ -142,12 +142,12 @@ def deeplabv3_mobilenet_v3_large(
     **kwargs: Any,
 ) -> DeepLabV3:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = DeepLabV3MobileNetV3LargeWeights.CocoWithVocLabels_RefV1 if kwargs.pop("pretrained") else None
 
     weights = DeepLabV3MobileNetV3LargeWeights.verify(weights)
     if "pretrained_backbone" in kwargs:
-        warnings.warn("The argument pretrained_backbone is deprecated, please use weights_backbone instead.")
+        warnings.warn("The parameter pretrained_backbone is deprecated, please use weights_backbone instead.")
         weights_backbone = MobileNetV3LargeWeights.ImageNet1K_RefV1 if kwargs.pop("pretrained_backbone") else None
     weights_backbone = MobileNetV3LargeWeights.verify(weights_backbone)
 

--- a/torchvision/prototype/models/segmentation/deeplabv3.py
+++ b/torchvision/prototype/models/segmentation/deeplabv3.py
@@ -24,7 +24,7 @@ __all__ = [
 ]
 
 
-_common_meta = {
+_COMMON_META = {
     "categories": _VOC_CATEGORIES,
     "interpolation": InterpolationMode.BILINEAR,
 }
@@ -35,7 +35,7 @@ class DeepLabV3ResNet50Weights(Weights):
         url="https://download.pytorch.org/models/deeplabv3_resnet50_coco-cd0a2569.pth",
         transforms=partial(VocEval, resize_size=520),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "recipe": "https://github.com/pytorch/vision/tree/main/references/segmentation#deeplabv3_resnet50",
             "mIoU": 66.4,
             "acc": 92.4,
@@ -48,7 +48,7 @@ class DeepLabV3ResNet101Weights(Weights):
         url="https://download.pytorch.org/models/deeplabv3_resnet101_coco-586e9e4e.pth",
         transforms=partial(VocEval, resize_size=520),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "recipe": "https://github.com/pytorch/vision/tree/main/references/segmentation#fcn_resnet101",
             "mIoU": 67.4,
             "acc": 92.4,
@@ -61,7 +61,7 @@ class DeepLabV3MobileNetV3LargeWeights(Weights):
         url="https://download.pytorch.org/models/deeplabv3_mobilenet_v3_large-fc3c493d.pth",
         transforms=partial(VocEval, resize_size=520),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "recipe": "https://github.com/pytorch/vision/tree/main/references/segmentation#deeplabv3_mobilenet_v3_large",
             "mIoU": 60.3,
             "acc": 91.2,

--- a/torchvision/prototype/models/segmentation/fcn.py
+++ b/torchvision/prototype/models/segmentation/fcn.py
@@ -14,7 +14,7 @@ from ..resnet import ResNet50Weights, ResNet101Weights, resnet50, resnet101
 __all__ = ["FCN", "FCNResNet50Weights", "FCNResNet101Weights", "fcn_resnet50", "fcn_resnet101"]
 
 
-_common_meta = {
+_COMMON_META = {
     "categories": _VOC_CATEGORIES,
     "interpolation": InterpolationMode.BILINEAR,
 }
@@ -25,7 +25,7 @@ class FCNResNet50Weights(Weights):
         url="https://download.pytorch.org/models/fcn_resnet50_coco-1167a1af.pth",
         transforms=partial(VocEval, resize_size=520),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "recipe": "https://github.com/pytorch/vision/tree/main/references/segmentation#fcn_resnet50",
             "mIoU": 60.5,
             "acc": 91.4,
@@ -38,7 +38,7 @@ class FCNResNet101Weights(Weights):
         url="https://download.pytorch.org/models/fcn_resnet101_coco-7ecb50ca.pth",
         transforms=partial(VocEval, resize_size=520),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "recipe": "https://github.com/pytorch/vision/tree/main/references/segmentation#deeplabv3_resnet101",
             "mIoU": 63.7,
             "acc": 91.9,

--- a/torchvision/prototype/models/segmentation/fcn.py
+++ b/torchvision/prototype/models/segmentation/fcn.py
@@ -55,11 +55,11 @@ def fcn_resnet50(
     **kwargs: Any,
 ) -> FCN:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = FCNResNet50Weights.CocoWithVocLabels_RefV1 if kwargs.pop("pretrained") else None
     weights = FCNResNet50Weights.verify(weights)
     if "pretrained_backbone" in kwargs:
-        warnings.warn("The argument pretrained_backbone is deprecated, please use weights_backbone instead.")
+        warnings.warn("The parameter pretrained_backbone is deprecated, please use weights_backbone instead.")
         weights_backbone = ResNet50Weights.ImageNet1K_RefV1 if kwargs.pop("pretrained_backbone") else None
     weights_backbone = ResNet50Weights.verify(weights_backbone)
 
@@ -86,11 +86,11 @@ def fcn_resnet101(
     **kwargs: Any,
 ) -> FCN:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = FCNResNet101Weights.CocoWithVocLabels_RefV1 if kwargs.pop("pretrained") else None
     weights = FCNResNet101Weights.verify(weights)
     if "pretrained_backbone" in kwargs:
-        warnings.warn("The argument pretrained_backbone is deprecated, please use weights_backbone instead.")
+        warnings.warn("The parameter pretrained_backbone is deprecated, please use weights_backbone instead.")
         weights_backbone = ResNet101Weights.ImageNet1K_RefV1 if kwargs.pop("pretrained_backbone") else None
     weights_backbone = ResNet101Weights.verify(weights_backbone)
 

--- a/torchvision/prototype/models/segmentation/fcn.py
+++ b/torchvision/prototype/models/segmentation/fcn.py
@@ -72,7 +72,7 @@ def fcn_resnet50(
     model = _fcn_resnet(backbone, num_classes, aux_loss)
 
     if weights is not None:
-        model.load_state_dict(weights.state_dict(progress=progress))
+        model.load_state_dict(weights.get_state_dict(progress=progress))
 
     return model
 
@@ -103,6 +103,6 @@ def fcn_resnet101(
     model = _fcn_resnet(backbone, num_classes, aux_loss)
 
     if weights is not None:
-        model.load_state_dict(weights.state_dict(progress=progress))
+        model.load_state_dict(weights.get_state_dict(progress=progress))
 
     return model

--- a/torchvision/prototype/models/segmentation/lraspp.py
+++ b/torchvision/prototype/models/segmentation/lraspp.py
@@ -55,6 +55,6 @@ def lraspp_mobilenet_v3_large(
     model = _lraspp_mobilenetv3(backbone, num_classes)
 
     if weights is not None:
-        model.load_state_dict(weights.state_dict(progress=progress))
+        model.load_state_dict(weights.get_state_dict(progress=progress))
 
     return model

--- a/torchvision/prototype/models/segmentation/lraspp.py
+++ b/torchvision/prototype/models/segmentation/lraspp.py
@@ -39,11 +39,11 @@ def lraspp_mobilenet_v3_large(
         raise NotImplementedError("This model does not use auxiliary loss")
 
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = LRASPPMobileNetV3LargeWeights.CocoWithVocLabels_RefV1 if kwargs.pop("pretrained") else None
     weights = LRASPPMobileNetV3LargeWeights.verify(weights)
     if "pretrained_backbone" in kwargs:
-        warnings.warn("The argument pretrained_backbone is deprecated, please use weights_backbone instead.")
+        warnings.warn("The parameter pretrained_backbone is deprecated, please use weights_backbone instead.")
         weights_backbone = MobileNetV3LargeWeights.ImageNet1K_RefV1 if kwargs.pop("pretrained_backbone") else None
     weights_backbone = MobileNetV3LargeWeights.verify(weights_backbone)
 

--- a/torchvision/prototype/models/shufflenetv2.py
+++ b/torchvision/prototype/models/shufflenetv2.py
@@ -84,7 +84,7 @@ def shufflenet_v2_x0_5(
     weights: Optional[ShuffleNetV2_x0_5Weights] = None, progress: bool = True, **kwargs: Any
 ) -> ShuffleNetV2:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = ShuffleNetV2_x0_5Weights.ImageNet1K_Community if kwargs.pop("pretrained") else None
     weights = ShuffleNetV2_x0_5Weights.verify(weights)
 
@@ -95,7 +95,7 @@ def shufflenet_v2_x1_0(
     weights: Optional[ShuffleNetV2_x1_0Weights] = None, progress: bool = True, **kwargs: Any
 ) -> ShuffleNetV2:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = ShuffleNetV2_x1_0Weights.ImageNet1K_Community if kwargs.pop("pretrained") else None
     weights = ShuffleNetV2_x1_0Weights.verify(weights)
 
@@ -106,7 +106,7 @@ def shufflenet_v2_x1_5(
     weights: Optional[ShuffleNetV2_x1_5Weights] = None, progress: bool = True, **kwargs: Any
 ) -> ShuffleNetV2:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         if kwargs.pop("pretrained"):
             raise ValueError("No checkpoint is available for model type shufflenet_v2_x1_5")
     weights = ShuffleNetV2_x1_5Weights.verify(weights)
@@ -118,7 +118,7 @@ def shufflenet_v2_x2_0(
     weights: Optional[ShuffleNetV2_x2_0Weights] = None, progress: bool = True, **kwargs: Any
 ) -> ShuffleNetV2:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         if kwargs.pop("pretrained"):
             raise ValueError("No checkpoint is available for model type shufflenet_v2_x2_0")
     weights = ShuffleNetV2_x2_0Weights.verify(weights)

--- a/torchvision/prototype/models/shufflenetv2.py
+++ b/torchvision/prototype/models/shufflenetv2.py
@@ -40,7 +40,7 @@ def _shufflenetv2(
     return model
 
 
-_common_meta = {
+_COMMON_META = {
     "size": (224, 224),
     "categories": _IMAGENET_CATEGORIES,
     "interpolation": InterpolationMode.BILINEAR,
@@ -53,7 +53,7 @@ class ShuffleNetV2_x0_5Weights(Weights):
         url="https://download.pytorch.org/models/shufflenetv2_x0.5-f707e7126e.pth",
         transforms=partial(ImageNetEval, crop_size=224),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "acc@1": 69.362,
             "acc@5": 88.316,
         },
@@ -65,7 +65,7 @@ class ShuffleNetV2_x1_0Weights(Weights):
         url="https://download.pytorch.org/models/shufflenetv2_x1-5666bf0f80.pth",
         transforms=partial(ImageNetEval, crop_size=224),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "acc@1": 60.552,
             "acc@5": 81.746,
         },

--- a/torchvision/prototype/models/shufflenetv2.py
+++ b/torchvision/prototype/models/shufflenetv2.py
@@ -35,7 +35,7 @@ def _shufflenetv2(
     model = ShuffleNetV2(*args, **kwargs)
 
     if weights is not None:
-        model.load_state_dict(weights.state_dict(progress=progress))
+        model.load_state_dict(weights.get_state_dict(progress=progress))
 
     return model
 

--- a/torchvision/prototype/models/squeezenet.py
+++ b/torchvision/prototype/models/squeezenet.py
@@ -47,7 +47,7 @@ class SqueezeNet1_1Weights(Weights):
 
 def squeezenet1_0(weights: Optional[SqueezeNet1_0Weights] = None, progress: bool = True, **kwargs: Any) -> SqueezeNet:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = SqueezeNet1_0Weights.ImageNet1K_Community if kwargs.pop("pretrained") else None
     weights = SqueezeNet1_0Weights.verify(weights)
     if weights is not None:
@@ -63,7 +63,7 @@ def squeezenet1_0(weights: Optional[SqueezeNet1_0Weights] = None, progress: bool
 
 def squeezenet1_1(weights: Optional[SqueezeNet1_1Weights] = None, progress: bool = True, **kwargs: Any) -> SqueezeNet:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = SqueezeNet1_1Weights.ImageNet1K_Community if kwargs.pop("pretrained") else None
     weights = SqueezeNet1_1Weights.verify(weights)
     if weights is not None:

--- a/torchvision/prototype/models/squeezenet.py
+++ b/torchvision/prototype/models/squeezenet.py
@@ -13,7 +13,7 @@ from ._meta import _IMAGENET_CATEGORIES
 __all__ = ["SqueezeNet", "SqueezeNet1_0Weights", "SqueezeNet1_1Weights", "squeezenet1_0", "squeezenet1_1"]
 
 
-_common_meta = {
+_COMMON_META = {
     "size": (224, 224),
     "categories": _IMAGENET_CATEGORIES,
     "interpolation": InterpolationMode.BILINEAR,
@@ -26,7 +26,7 @@ class SqueezeNet1_0Weights(Weights):
         url="https://download.pytorch.org/models/squeezenet1_0-b66bff10.pth",
         transforms=partial(ImageNetEval, crop_size=224),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "acc@1": 58.092,
             "acc@5": 80.420,
         },
@@ -38,7 +38,7 @@ class SqueezeNet1_1Weights(Weights):
         url="https://download.pytorch.org/models/squeezenet1_1-b8a52dc0.pth",
         transforms=partial(ImageNetEval, crop_size=224),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "acc@1": 58.178,
             "acc@5": 80.624,
         },

--- a/torchvision/prototype/models/squeezenet.py
+++ b/torchvision/prototype/models/squeezenet.py
@@ -56,7 +56,7 @@ def squeezenet1_0(weights: Optional[SqueezeNet1_0Weights] = None, progress: bool
     model = SqueezeNet("1_0", **kwargs)
 
     if weights is not None:
-        model.load_state_dict(weights.state_dict(progress=progress))
+        model.load_state_dict(weights.get_state_dict(progress=progress))
 
     return model
 
@@ -72,6 +72,6 @@ def squeezenet1_1(weights: Optional[SqueezeNet1_1Weights] = None, progress: bool
     model = SqueezeNet("1_1", **kwargs)
 
     if weights is not None:
-        model.load_state_dict(weights.state_dict(progress=progress))
+        model.load_state_dict(weights.get_state_dict(progress=progress))
 
     return model

--- a/torchvision/prototype/models/vgg.py
+++ b/torchvision/prototype/models/vgg.py
@@ -36,7 +36,7 @@ def _vgg(cfg: str, batch_norm: bool, weights: Optional[Weights], progress: bool,
         kwargs["num_classes"] = len(weights.meta["categories"])
     model = VGG(make_layers(cfgs[cfg], batch_norm=batch_norm), **kwargs)
     if weights is not None:
-        model.load_state_dict(weights.state_dict(progress=progress))
+        model.load_state_dict(weights.get_state_dict(progress=progress))
     return model
 
 

--- a/torchvision/prototype/models/vgg.py
+++ b/torchvision/prototype/models/vgg.py
@@ -163,7 +163,7 @@ class VGG19BNWeights(Weights):
 
 def vgg11(weights: Optional[VGG11Weights] = None, progress: bool = True, **kwargs: Any) -> VGG:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = VGG11Weights.ImageNet1K_RefV1 if kwargs.pop("pretrained") else None
     weights = VGG11Weights.verify(weights)
 
@@ -172,7 +172,7 @@ def vgg11(weights: Optional[VGG11Weights] = None, progress: bool = True, **kwarg
 
 def vgg11_bn(weights: Optional[VGG11BNWeights] = None, progress: bool = True, **kwargs: Any) -> VGG:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = VGG11BNWeights.ImageNet1K_RefV1 if kwargs.pop("pretrained") else None
     weights = VGG11BNWeights.verify(weights)
 
@@ -181,7 +181,7 @@ def vgg11_bn(weights: Optional[VGG11BNWeights] = None, progress: bool = True, **
 
 def vgg13(weights: Optional[VGG13Weights] = None, progress: bool = True, **kwargs: Any) -> VGG:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = VGG13Weights.ImageNet1K_RefV1 if kwargs.pop("pretrained") else None
     weights = VGG13Weights.verify(weights)
 
@@ -190,7 +190,7 @@ def vgg13(weights: Optional[VGG13Weights] = None, progress: bool = True, **kwarg
 
 def vgg13_bn(weights: Optional[VGG13BNWeights] = None, progress: bool = True, **kwargs: Any) -> VGG:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = VGG13BNWeights.ImageNet1K_RefV1 if kwargs.pop("pretrained") else None
     weights = VGG13BNWeights.verify(weights)
 
@@ -199,7 +199,7 @@ def vgg13_bn(weights: Optional[VGG13BNWeights] = None, progress: bool = True, **
 
 def vgg16(weights: Optional[VGG16Weights] = None, progress: bool = True, **kwargs: Any) -> VGG:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = VGG16Weights.ImageNet1K_RefV1 if kwargs.pop("pretrained") else None
     weights = VGG16Weights.verify(weights)
 
@@ -208,7 +208,7 @@ def vgg16(weights: Optional[VGG16Weights] = None, progress: bool = True, **kwarg
 
 def vgg16_bn(weights: Optional[VGG16BNWeights] = None, progress: bool = True, **kwargs: Any) -> VGG:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = VGG16BNWeights.ImageNet1K_RefV1 if kwargs.pop("pretrained") else None
     weights = VGG16BNWeights.verify(weights)
 
@@ -217,7 +217,7 @@ def vgg16_bn(weights: Optional[VGG16BNWeights] = None, progress: bool = True, **
 
 def vgg19(weights: Optional[VGG19Weights] = None, progress: bool = True, **kwargs: Any) -> VGG:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = VGG19Weights.ImageNet1K_RefV1 if kwargs.pop("pretrained") else None
     weights = VGG19Weights.verify(weights)
 
@@ -226,7 +226,7 @@ def vgg19(weights: Optional[VGG19Weights] = None, progress: bool = True, **kwarg
 
 def vgg19_bn(weights: Optional[VGG19BNWeights] = None, progress: bool = True, **kwargs: Any) -> VGG:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = VGG19BNWeights.ImageNet1K_RefV1 if kwargs.pop("pretrained") else None
     weights = VGG19BNWeights.verify(weights)
 

--- a/torchvision/prototype/models/vgg.py
+++ b/torchvision/prototype/models/vgg.py
@@ -40,7 +40,7 @@ def _vgg(cfg: str, batch_norm: bool, weights: Optional[Weights], progress: bool,
     return model
 
 
-_common_meta = {
+_COMMON_META = {
     "size": (224, 224),
     "categories": _IMAGENET_CATEGORIES,
     "interpolation": InterpolationMode.BILINEAR,
@@ -53,7 +53,7 @@ class VGG11Weights(Weights):
         url="https://download.pytorch.org/models/vgg11-8a719046.pth",
         transforms=partial(ImageNetEval, crop_size=224),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "acc@1": 69.020,
             "acc@5": 88.628,
         },
@@ -65,7 +65,7 @@ class VGG11BNWeights(Weights):
         url="https://download.pytorch.org/models/vgg11_bn-6002323d.pth",
         transforms=partial(ImageNetEval, crop_size=224),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "acc@1": 70.370,
             "acc@5": 89.810,
         },
@@ -77,7 +77,7 @@ class VGG13Weights(Weights):
         url="https://download.pytorch.org/models/vgg13-19584684.pth",
         transforms=partial(ImageNetEval, crop_size=224),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "acc@1": 69.928,
             "acc@5": 89.246,
         },
@@ -89,7 +89,7 @@ class VGG13BNWeights(Weights):
         url="https://download.pytorch.org/models/vgg13_bn-abd245e5.pth",
         transforms=partial(ImageNetEval, crop_size=224),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "acc@1": 71.586,
             "acc@5": 90.374,
         },
@@ -101,7 +101,7 @@ class VGG16Weights(Weights):
         url="https://download.pytorch.org/models/vgg16-397923af.pth",
         transforms=partial(ImageNetEval, crop_size=224),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "acc@1": 71.592,
             "acc@5": 90.382,
         },
@@ -130,7 +130,7 @@ class VGG16BNWeights(Weights):
         url="https://download.pytorch.org/models/vgg16_bn-6c64b313.pth",
         transforms=partial(ImageNetEval, crop_size=224),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "acc@1": 73.360,
             "acc@5": 91.516,
         },
@@ -142,7 +142,7 @@ class VGG19Weights(Weights):
         url="https://download.pytorch.org/models/vgg19-dcbb9e9d.pth",
         transforms=partial(ImageNetEval, crop_size=224),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "acc@1": 72.376,
             "acc@5": 90.876,
         },
@@ -154,7 +154,7 @@ class VGG19BNWeights(Weights):
         url="https://download.pytorch.org/models/vgg19_bn-c79401a0.pth",
         transforms=partial(ImageNetEval, crop_size=224),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "acc@1": 74.218,
             "acc@5": 91.842,
         },

--- a/torchvision/prototype/models/video/resnet.py
+++ b/torchvision/prototype/models/video/resnet.py
@@ -46,7 +46,7 @@ def _video_resnet(
     model = VideoResNet(block, conv_makers, layers, stem, **kwargs)
 
     if weights is not None:
-        model.load_state_dict(weights.state_dict(progress=progress))
+        model.load_state_dict(weights.get_state_dict(progress=progress))
 
     return model
 

--- a/torchvision/prototype/models/video/resnet.py
+++ b/torchvision/prototype/models/video/resnet.py
@@ -51,7 +51,7 @@ def _video_resnet(
     return model
 
 
-_common_meta = {
+_COMMON_META = {
     "size": (112, 112),
     "categories": _KINETICS400_CATEGORIES,
     "interpolation": InterpolationMode.BILINEAR,
@@ -64,7 +64,7 @@ class R3D_18Weights(Weights):
         url="https://download.pytorch.org/models/r3d_18-b3b3357e.pth",
         transforms=partial(Kinect400Eval, resize_size=(128, 171), crop_size=(112, 112)),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "acc@1": 52.75,
             "acc@5": 75.45,
         },
@@ -76,7 +76,7 @@ class MC3_18Weights(Weights):
         url="https://download.pytorch.org/models/mc3_18-a90a0ba3.pth",
         transforms=partial(Kinect400Eval, resize_size=(128, 171), crop_size=(112, 112)),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "acc@1": 53.90,
             "acc@5": 76.29,
         },
@@ -88,7 +88,7 @@ class R2Plus1D_18Weights(Weights):
         url="https://download.pytorch.org/models/r2plus1d_18-91a641e6.pth",
         transforms=partial(Kinect400Eval, resize_size=(128, 171), crop_size=(112, 112)),
         meta={
-            **_common_meta,
+            **_COMMON_META,
             "acc@1": 57.50,
             "acc@5": 78.81,
         },

--- a/torchvision/prototype/models/video/resnet.py
+++ b/torchvision/prototype/models/video/resnet.py
@@ -97,7 +97,7 @@ class R2Plus1D_18Weights(Weights):
 
 def r3d_18(weights: Optional[R3D_18Weights] = None, progress: bool = True, **kwargs: Any) -> VideoResNet:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = R3D_18Weights.Kinetics400_RefV1 if kwargs.pop("pretrained") else None
     weights = R3D_18Weights.verify(weights)
 
@@ -114,7 +114,7 @@ def r3d_18(weights: Optional[R3D_18Weights] = None, progress: bool = True, **kwa
 
 def mc3_18(weights: Optional[MC3_18Weights] = None, progress: bool = True, **kwargs: Any) -> VideoResNet:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = MC3_18Weights.Kinetics400_RefV1 if kwargs.pop("pretrained") else None
     weights = MC3_18Weights.verify(weights)
 
@@ -131,7 +131,7 @@ def mc3_18(weights: Optional[MC3_18Weights] = None, progress: bool = True, **kwa
 
 def r2plus1d_18(weights: Optional[R2Plus1D_18Weights] = None, progress: bool = True, **kwargs: Any) -> VideoResNet:
     if "pretrained" in kwargs:
-        warnings.warn("The argument pretrained is deprecated, please use weights instead.")
+        warnings.warn("The parameter pretrained is deprecated, please use weights instead.")
         weights = R2Plus1D_18Weights.Kinetics400_RefV1 if kwargs.pop("pretrained") else None
     weights = R2Plus1D_18Weights.verify(weights)
 


### PR DESCRIPTION
Fixes partially #4652

Addresses some of the comments at #4937. Each commit in this PR addresses a single of the comments below, so it can be seen as a stacked diff:

- [x] Disable WeightEntry to pass-through `Weights.verify()` - https://github.com/pytorch/vision/pull/4937#discussion_r749509355
- [x] Rename `Weights.state_dict()` to `Weights.get_state_dict()` - https://github.com/pytorch/vision/pull/4937#discussion_r749516648
- [x] Add TODO for missing doc - https://github.com/pytorch/vision/pull/4937#discussion_r749527596
- [x] Moving warning messages for googlenet - https://github.com/pytorch/vision/pull/4937#discussion_r749557596
- [x] Upper-case global `_COMMON_META` var - https://github.com/pytorch/vision/pull/4937#discussion_r749560677
- [x] Replace argument with parameter in all warnings - https://github.com/pytorch/vision/pull/4937#discussion_r749575515

cc @datumbox @bjuncek