### PR TITLE
don't close file handles in protoype dataset tests

### DIFF
--- a/test/test_prototype_builtin_datasets.py
+++ b/test/test_prototype_builtin_datasets.py
@@ -10,10 +10,7 @@ from torchvision.prototype.utils._internal import sequence_to_str
 
 
 def to_bytes(file):
-    try:
-        return file.read()
-    finally:
-        file.close()
+    return file.read()
 
 
 def dataset_parametrization(*names, decoder=to_bytes):

--- a/torchvision/prototype/datasets/decoder.py
+++ b/torchvision/prototype/datasets/decoder.py
@@ -13,7 +13,4 @@ def raw(buffer: io.IOBase) -> torch.Tensor:
 
 
 def pil(buffer: io.IOBase) -> features.Image:
-    try:
-        return features.Image(pil_to_tensor(PIL.Image.open(buffer)))
-    finally:
-        buffer.close()
+    return features.Image(pil_to_tensor(PIL.Image.open(buffer)))


### PR DESCRIPTION
I thought that would be a good idea when I added it in #4863. Turns out, this only works under the assumption that every file is present in exactly one sample. Optical flow datasets like Sintel violate that assumption, which leads to [test failures](https://app.circleci.com/pipelines/github/pytorch/vision/12723/workflows/553b8f97-51fd-4534-b1ee-33f8df0af2e8/jobs/1009461) although the dataset works fine.

`torchdata` has some internal functionality to close files when a datapipe is exhausted. Better to just rely on that to avoid issues like this in the future.

cc @pmeier @bjuncek