### PR TITLE
Update wide_resnet101 accuracy values and path to improved model

### DIFF
--- a/torchvision/prototype/models/resnet.py
+++ b/torchvision/prototype/models/resnet.py
@@ -234,7 +234,7 @@ class WideResNet101_2Weights(Weights):
         transforms=partial(ImageNetEval, crop_size=224, resize_size=232),
         meta={
             **_COMMON_META,
-            "recipe": "https://github.com/pytorch/vision/issues/3995#new-recipe-with-fixres",
+            "recipe": "https://github.com/pytorch/vision/issues/3995#new-recipe",
             "acc@1": 82.510,
             "acc@5": 96.020,
         },

--- a/torchvision/prototype/models/resnet.py
+++ b/torchvision/prototype/models/resnet.py
@@ -230,13 +230,13 @@ class WideResNet101_2Weights(Weights):
         },
     )
     ImageNet1K_RefV2 = WeightEntry(
-        url="https://download.pytorch.org/models/wide_resnet101_2-b8680a8c.pth",
+        url="https://download.pytorch.org/models/wide_resnet101_2-d733dc28.pth",
         transforms=partial(ImageNetEval, crop_size=224, resize_size=232),
         meta={
             **_COMMON_META,
             "recipe": "https://github.com/pytorch/vision/issues/3995#new-recipe-with-fixres",
-            "acc@1": 82.492,
-            "acc@5": 96.110,
+            "acc@1": 82.510,
+            "acc@5": 96.020,
         },
     )
 


### PR DESCRIPTION
Fixes partially #3995

```
gpurun torchrun --nproc_per_node=1 train.py --test-only --weights ImageNet1K_RefV2 --model wide_resnet101_2 -b 1
Test:  Acc@1 82.510 Acc@5 96.020
```

Recipe used:
```
python -u run_with_submitit.py --ngpus 8 --nodes 1 --model wide_resnet101_2 --batch-size 128 --lr 0.5 --lr-scheduler cosineannealinglr --lr-warmup-epochs 5 --lr-warmup-method linear --auto-augment ta_wide --epochs 600 --random-erase 0.1 --weight-decay 0.00002 --norm-weight-decay 0.0 --label-smoothing 0.1 --mixup-alpha 0.2 --cutmix-alpha 1.0 --model-ema --val-resize-size 232 --data-path=/datasets01_ontap/imagenet_full_size/061417/
```

cc @datumbox @bjuncek