### PR TITLE
Add numpy as explicit dependency to build_cmake.sh

### DIFF
--- a/packaging/build_cmake.sh
+++ b/packaging/build_cmake.sh
@@ -42,7 +42,7 @@ else
   PYTORCH_MUTEX_CONSTRAINT=''
 fi
 
-conda install -yq \pytorch=$PYTORCH_VERSION $CONDA_CUDATOOLKIT_CONSTRAINT $PYTORCH_MUTEX_CONSTRAINT $MKL_CONSTRAINT -c "pytorch-${UPLOAD_CHANNEL}"
+conda install -yq \pytorch=$PYTORCH_VERSION $CONDA_CUDATOOLKIT_CONSTRAINT $PYTORCH_MUTEX_CONSTRAINT $MKL_CONSTRAINT numpy -c "pytorch-${UPLOAD_CHANNEL}"
 TORCH_PATH=$(dirname $(python -c "import torch; print(torch.__file__)"))
 
 if [[ "$(uname)" == Darwin || "$OSTYPE" == "msys" ]]; then


### PR DESCRIPTION
Otherwise, it `setuptools.py`  will try to install latest, which is not compatible with Python runtime older than 3.8

Fixes https://github.com/pytorch/vision/issues/4985

cc @seemethere