### PR TITLE
fix mobilenetv3 quantization state dict loading

### DIFF
--- a/torchvision/models/quantization/mobilenetv3.py
+++ b/torchvision/models/quantization/mobilenetv3.py
@@ -46,7 +46,11 @@ class QuantizableSqueezeExcitation(SqueezeExcitation):
         if hasattr(self, "qconfig") and (version is None or version < 2):
             default_state_dict = {
                 "scale_activation.activation_post_process.scale": torch.tensor([1.0]),
+                "scale_activation.activation_post_process.activation_post_process.scale": torch.tensor([1.0]),
                 "scale_activation.activation_post_process.zero_point": torch.tensor([0], dtype=torch.int32),
+                "scale_activation.activation_post_process.activation_post_process.zero_point": torch.tensor(
+                    [0], dtype=torch.int32
+                ),
                 "scale_activation.activation_post_process.fake_quant_enabled": torch.tensor([1]),
                 "scale_activation.activation_post_process.observer_enabled": torch.tensor([1]),
             }


### PR DESCRIPTION
The failure is currently not visible in CI, since we do not test with loaded weights. See [this CI run](https://app.circleci.com/pipelines/github/pytorch/vision/12903/workflows/ab47f567-64d9-4074-aca5-b7817bb27aff/jobs/1026438) from #4772 for the failure.

