### PR TITLE
Mark CircleCI weight downloads with `source=ci`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -278,8 +278,9 @@ jobs:
           background: true
           command: |
             sudo apt update -qy && sudo apt install -qy parallel wget
+            mkdir -p ~/.cache/torch/hub/checkpoints
             python scripts/collect_model_urls.py torchvision/prototype/models \
-                | parallel -j0 wget --no-verbose -P ~/.cache/torch/hub/checkpoints {}
+                | parallel -j0 'wget --no-verbose -O ~/.cache/torch/hub/checkpoints/`basename {}` {}\?source=ci'
       - run:
           name: Install torchvision
           command: pip install --user --progress-bar off --no-build-isolation .

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -278,8 +278,9 @@ jobs:
           background: true
           command: |
             sudo apt update -qy && sudo apt install -qy parallel wget
+            mkdir -p ~/.cache/torch/hub/checkpoints
             python scripts/collect_model_urls.py torchvision/prototype/models \
-                | parallel -j0 wget --no-verbose -P ~/.cache/torch/hub/checkpoints {}
+                | parallel -j0 'wget --no-verbose -O ~/.cache/torch/hub/checkpoints/`basename {}` {}\?source=ci'
       - run:
           name: Install torchvision
           command: pip install --user --progress-bar off --no-build-isolation .


### PR DESCRIPTION
Mark model weight downloads from CircleCI with a URL param.

cc @seemethere @bjuncek