### PR TITLE
remove vanilla tensors from prototype datasets samples

### DIFF
--- a/torchvision/prototype/features/_feature.py
+++ b/torchvision/prototype/features/_feature.py
@@ -12,7 +12,7 @@ DEFAULT = object()
 
 
 class Feature(torch.Tensor):
-    _META_ATTRS: Set[str]
+    _META_ATTRS: Set[str] = set()
     _meta_data: Dict[str, Any]
 
     def __init_subclass__(cls):

--- a/torchvision/prototype/transforms/_transform.py
+++ b/torchvision/prototype/transforms/_transform.py
@@ -360,7 +360,13 @@ class Transform(nn.Module):
         else:
             feature_type = type(sample)
             if not self.supports(feature_type):
-                if not issubclass(feature_type, features.Feature) or feature_type in self.NO_OP_FEATURE_TYPES:
+                if (
+                    not issubclass(feature_type, features.Feature)
+                    # issubclass is not a strict check, but also allows the type checked against. Thus, we need to
+                    # check it separately
+                    or feature_type is features.Feature
+                    or feature_type in self.NO_OP_FEATURE_TYPES
+                ):
                     return sample
 
                 raise TypeError(


### PR DESCRIPTION
As discussed offline with @fmassa and @NicolasHug, for now we opt to always return a plain `Feature` instead of a vanilla `torch.Tensor`. This let's us keep BC with the transforms that interpret vanilla tensors as images. This just fixes the return types for COCO. I'll send a more comprehensive follow-up PR.

cc @pmeier @bjuncek