### PR TITLE
Add CUDA-11.5 builds to torchvision

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1109,6 +1109,12 @@ workflows:
           python_version: '3.6'
           wheel_docker_image: pytorch/manylinux-cuda113
       - binary_linux_wheel:
+          conda_docker_image: pytorch/conda-builder:cuda115
+          cu_version: cu115
+          name: binary_linux_wheel_py3.6_cu115
+          python_version: '3.6'
+          wheel_docker_image: pytorch/manylinux-cuda115
+      - binary_linux_wheel:
           cu_version: rocm4.2
           name: binary_linux_wheel_py3.6_rocm4.2
           python_version: '3.6'
@@ -1148,6 +1154,12 @@ workflows:
           python_version: '3.7'
           wheel_docker_image: pytorch/manylinux-cuda113
       - binary_linux_wheel:
+          conda_docker_image: pytorch/conda-builder:cuda115
+          cu_version: cu115
+          name: binary_linux_wheel_py3.7_cu115
+          python_version: '3.7'
+          wheel_docker_image: pytorch/manylinux-cuda115
+      - binary_linux_wheel:
           cu_version: rocm4.2
           name: binary_linux_wheel_py3.7_rocm4.2
           python_version: '3.7'
@@ -1182,6 +1194,12 @@ workflows:
           python_version: '3.8'
           wheel_docker_image: pytorch/manylinux-cuda113
       - binary_linux_wheel:
+          conda_docker_image: pytorch/conda-builder:cuda115
+          cu_version: cu115
+          name: binary_linux_wheel_py3.8_cu115
+          python_version: '3.8'
+          wheel_docker_image: pytorch/manylinux-cuda115
+      - binary_linux_wheel:
           cu_version: rocm4.2
           name: binary_linux_wheel_py3.8_rocm4.2
           python_version: '3.8'
@@ -1215,6 +1233,12 @@ workflows:
           name: binary_linux_wheel_py3.9_cu113
           python_version: '3.9'
           wheel_docker_image: pytorch/manylinux-cuda113
+      - binary_linux_wheel:
+          conda_docker_image: pytorch/conda-builder:cuda115
+          cu_version: cu115
+          name: binary_linux_wheel_py3.9_cu115
+          python_version: '3.9'
+          wheel_docker_image: pytorch/manylinux-cuda115
       - binary_linux_wheel:
           cu_version: rocm4.2
           name: binary_linux_wheel_py3.9_rocm4.2
@@ -1277,6 +1301,15 @@ workflows:
           name: binary_win_wheel_py3.6_cu113
           python_version: '3.6'
       - binary_win_wheel:
+          cu_version: cu115
+          filters:
+            branches:
+              only: main
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: binary_win_wheel_py3.6_cu115
+          python_version: '3.6'
+      - binary_win_wheel:
           cu_version: cpu
           filters:
             branches:
@@ -1302,6 +1335,15 @@ workflows:
             tags:
               only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
           name: binary_win_wheel_py3.7_cu113
+          python_version: '3.7'
+      - binary_win_wheel:
+          cu_version: cu115
+          filters:
+            branches:
+              only: main
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: binary_win_wheel_py3.7_cu115
           python_version: '3.7'
       - binary_win_wheel:
           cu_version: cpu
@@ -1331,6 +1373,15 @@ workflows:
           name: binary_win_wheel_py3.8_cu113
           python_version: '3.8'
       - binary_win_wheel:
+          cu_version: cu115
+          filters:
+            branches:
+              only: main
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: binary_win_wheel_py3.8_cu115
+          python_version: '3.8'
+      - binary_win_wheel:
           cu_version: cpu
           name: binary_win_wheel_py3.9_cpu
           python_version: '3.9'
@@ -1345,7 +1396,16 @@ workflows:
           python_version: '3.9'
       - binary_win_wheel:
           cu_version: cu113
+          filters:
+            branches:
+              only: main
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
           name: binary_win_wheel_py3.9_cu113
+          python_version: '3.9'
+      - binary_win_wheel:
+          cu_version: cu115
+          name: binary_win_wheel_py3.9_cu115
           python_version: '3.9'
       - binary_linux_conda:
           conda_docker_image: pytorch/conda-builder:cpu
@@ -1372,6 +1432,12 @@ workflows:
           python_version: '3.6'
           wheel_docker_image: pytorch/manylinux-cuda113
       - binary_linux_conda:
+          conda_docker_image: pytorch/conda-builder:cuda115
+          cu_version: cu115
+          name: binary_linux_conda_py3.6_cu115
+          python_version: '3.6'
+          wheel_docker_image: pytorch/manylinux-cuda115
+      - binary_linux_conda:
           conda_docker_image: pytorch/conda-builder:cpu
           cu_version: cpu
           name: binary_linux_conda_py3.7_cpu
@@ -1395,6 +1461,12 @@ workflows:
           name: binary_linux_conda_py3.7_cu113
           python_version: '3.7'
           wheel_docker_image: pytorch/manylinux-cuda113
+      - binary_linux_conda:
+          conda_docker_image: pytorch/conda-builder:cuda115
+          cu_version: cu115
+          name: binary_linux_conda_py3.7_cu115
+          python_version: '3.7'
+          wheel_docker_image: pytorch/manylinux-cuda115
       - binary_linux_conda:
           conda_docker_image: pytorch/conda-builder:cpu
           cu_version: cpu
@@ -1420,6 +1492,12 @@ workflows:
           python_version: '3.8'
           wheel_docker_image: pytorch/manylinux-cuda113
       - binary_linux_conda:
+          conda_docker_image: pytorch/conda-builder:cuda115
+          cu_version: cu115
+          name: binary_linux_conda_py3.8_cu115
+          python_version: '3.8'
+          wheel_docker_image: pytorch/manylinux-cuda115
+      - binary_linux_conda:
           conda_docker_image: pytorch/conda-builder:cpu
           cu_version: cpu
           name: binary_linux_conda_py3.9_cpu
@@ -1443,6 +1521,12 @@ workflows:
           name: binary_linux_conda_py3.9_cu113
           python_version: '3.9'
           wheel_docker_image: pytorch/manylinux-cuda113
+      - binary_linux_conda:
+          conda_docker_image: pytorch/conda-builder:cuda115
+          cu_version: cu115
+          name: binary_linux_conda_py3.9_cu115
+          python_version: '3.9'
+          wheel_docker_image: pytorch/manylinux-cuda115
       - binary_macos_conda:
           conda_docker_image: pytorch/conda-builder:cpu
           cu_version: cpu
@@ -1495,6 +1579,15 @@ workflows:
           name: binary_win_conda_py3.6_cu113
           python_version: '3.6'
       - binary_win_conda:
+          cu_version: cu115
+          filters:
+            branches:
+              only: main
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: binary_win_conda_py3.6_cu115
+          python_version: '3.6'
+      - binary_win_conda:
           cu_version: cpu
           filters:
             branches:
@@ -1520,6 +1613,15 @@ workflows:
             tags:
               only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
           name: binary_win_conda_py3.7_cu113
+          python_version: '3.7'
+      - binary_win_conda:
+          cu_version: cu115
+          filters:
+            branches:
+              only: main
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: binary_win_conda_py3.7_cu115
           python_version: '3.7'
       - binary_win_conda:
           cu_version: cpu
@@ -1549,6 +1651,15 @@ workflows:
           name: binary_win_conda_py3.8_cu113
           python_version: '3.8'
       - binary_win_conda:
+          cu_version: cu115
+          filters:
+            branches:
+              only: main
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: binary_win_conda_py3.8_cu115
+          python_version: '3.8'
+      - binary_win_conda:
           cu_version: cpu
           name: binary_win_conda_py3.9_cpu
           python_version: '3.9'
@@ -1563,7 +1674,16 @@ workflows:
           python_version: '3.9'
       - binary_win_conda:
           cu_version: cu113
+          filters:
+            branches:
+              only: main
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
           name: binary_win_conda_py3.9_cu113
+          python_version: '3.9'
+      - binary_win_conda:
+          cu_version: cu115
+          name: binary_win_conda_py3.9_cu115
           python_version: '3.9'
       - build_docs:
           filters:
@@ -1905,6 +2025,37 @@ workflows:
           requires:
           - nightly_binary_linux_wheel_py3.6_cu113_upload
       - binary_linux_wheel:
+          conda_docker_image: pytorch/conda-builder:cuda115
+          cu_version: cu115
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_wheel_py3.6_cu115
+          python_version: '3.6'
+          wheel_docker_image: pytorch/manylinux-cuda115
+      - binary_wheel_upload:
+          context: org-member
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_wheel_py3.6_cu115_upload
+          requires:
+          - nightly_binary_linux_wheel_py3.6_cu115
+          subfolder: cu115/
+      - smoke_test_linux_pip:
+          filters:
+            branches:
+              only:
+              - nightly
+          name: nightly_binary_linux_wheel_py3.6_cu115_smoke_test_pip
+          python_version: '3.6'
+          requires:
+          - nightly_binary_linux_wheel_py3.6_cu115_upload
+      - binary_linux_wheel:
           cu_version: rocm4.2
           filters:
             branches:
@@ -2088,6 +2239,37 @@ workflows:
           python_version: '3.7'
           requires:
           - nightly_binary_linux_wheel_py3.7_cu113_upload
+      - binary_linux_wheel:
+          conda_docker_image: pytorch/conda-builder:cuda115
+          cu_version: cu115
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_wheel_py3.7_cu115
+          python_version: '3.7'
+          wheel_docker_image: pytorch/manylinux-cuda115
+      - binary_wheel_upload:
+          context: org-member
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_wheel_py3.7_cu115_upload
+          requires:
+          - nightly_binary_linux_wheel_py3.7_cu115
+          subfolder: cu115/
+      - smoke_test_linux_pip:
+          filters:
+            branches:
+              only:
+              - nightly
+          name: nightly_binary_linux_wheel_py3.7_cu115_smoke_test_pip
+          python_version: '3.7'
+          requires:
+          - nightly_binary_linux_wheel_py3.7_cu115_upload
       - binary_linux_wheel:
           cu_version: rocm4.2
           filters:
@@ -2273,6 +2455,37 @@ workflows:
           requires:
           - nightly_binary_linux_wheel_py3.8_cu113_upload
       - binary_linux_wheel:
+          conda_docker_image: pytorch/conda-builder:cuda115
+          cu_version: cu115
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_wheel_py3.8_cu115
+          python_version: '3.8'
+          wheel_docker_image: pytorch/manylinux-cuda115
+      - binary_wheel_upload:
+          context: org-member
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_wheel_py3.8_cu115_upload
+          requires:
+          - nightly_binary_linux_wheel_py3.8_cu115
+          subfolder: cu115/
+      - smoke_test_linux_pip:
+          filters:
+            branches:
+              only:
+              - nightly
+          name: nightly_binary_linux_wheel_py3.8_cu115_smoke_test_pip
+          python_version: '3.8'
+          requires:
+          - nightly_binary_linux_wheel_py3.8_cu115_upload
+      - binary_linux_wheel:
           cu_version: rocm4.2
           filters:
             branches:
@@ -2456,6 +2669,37 @@ workflows:
           python_version: '3.9'
           requires:
           - nightly_binary_linux_wheel_py3.9_cu113_upload
+      - binary_linux_wheel:
+          conda_docker_image: pytorch/conda-builder:cuda115
+          cu_version: cu115
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_wheel_py3.9_cu115
+          python_version: '3.9'
+          wheel_docker_image: pytorch/manylinux-cuda115
+      - binary_wheel_upload:
+          context: org-member
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_wheel_py3.9_cu115_upload
+          requires:
+          - nightly_binary_linux_wheel_py3.9_cu115
+          subfolder: cu115/
+      - smoke_test_linux_pip:
+          filters:
+            branches:
+              only:
+              - nightly
+          name: nightly_binary_linux_wheel_py3.9_cu115_smoke_test_pip
+          python_version: '3.9'
+          requires:
+          - nightly_binary_linux_wheel_py3.9_cu115_upload
       - binary_linux_wheel:
           cu_version: rocm4.2
           filters:
@@ -2692,6 +2936,35 @@ workflows:
           requires:
           - nightly_binary_win_wheel_py3.6_cu113_upload
       - binary_win_wheel:
+          cu_version: cu115
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_win_wheel_py3.6_cu115
+          python_version: '3.6'
+      - binary_wheel_upload:
+          context: org-member
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_win_wheel_py3.6_cu115_upload
+          requires:
+          - nightly_binary_win_wheel_py3.6_cu115
+          subfolder: cu115/
+      - smoke_test_win_pip:
+          filters:
+            branches:
+              only:
+              - nightly
+          name: nightly_binary_win_wheel_py3.6_cu115_smoke_test_pip
+          python_version: '3.6'
+          requires:
+          - nightly_binary_win_wheel_py3.6_cu115_upload
+      - binary_win_wheel:
           cu_version: cpu
           filters:
             branches:
@@ -2778,6 +3051,35 @@ workflows:
           python_version: '3.7'
           requires:
           - nightly_binary_win_wheel_py3.7_cu113_upload
+      - binary_win_wheel:
+          cu_version: cu115
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_win_wheel_py3.7_cu115
+          python_version: '3.7'
+      - binary_wheel_upload:
+          context: org-member
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_win_wheel_py3.7_cu115_upload
+          requires:
+          - nightly_binary_win_wheel_py3.7_cu115
+          subfolder: cu115/
+      - smoke_test_win_pip:
+          filters:
+            branches:
+              only:
+              - nightly
+          name: nightly_binary_win_wheel_py3.7_cu115_smoke_test_pip
+          python_version: '3.7'
+          requires:
+          - nightly_binary_win_wheel_py3.7_cu115_upload
       - binary_win_wheel:
           cu_version: cpu
           filters:
@@ -2866,6 +3168,35 @@ workflows:
           requires:
           - nightly_binary_win_wheel_py3.8_cu113_upload
       - binary_win_wheel:
+          cu_version: cu115
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_win_wheel_py3.8_cu115
+          python_version: '3.8'
+      - binary_wheel_upload:
+          context: org-member
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_win_wheel_py3.8_cu115_upload
+          requires:
+          - nightly_binary_win_wheel_py3.8_cu115
+          subfolder: cu115/
+      - smoke_test_win_pip:
+          filters:
+            branches:
+              only:
+              - nightly
+          name: nightly_binary_win_wheel_py3.8_cu115_smoke_test_pip
+          python_version: '3.8'
+          requires:
+          - nightly_binary_win_wheel_py3.8_cu115_upload
+      - binary_win_wheel:
           cu_version: cpu
           filters:
             branches:
@@ -2952,6 +3283,35 @@ workflows:
           python_version: '3.9'
           requires:
           - nightly_binary_win_wheel_py3.9_cu113_upload
+      - binary_win_wheel:
+          cu_version: cu115
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_win_wheel_py3.9_cu115
+          python_version: '3.9'
+      - binary_wheel_upload:
+          context: org-member
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_win_wheel_py3.9_cu115_upload
+          requires:
+          - nightly_binary_win_wheel_py3.9_cu115
+          subfolder: cu115/
+      - smoke_test_win_pip:
+          filters:
+            branches:
+              only:
+              - nightly
+          name: nightly_binary_win_wheel_py3.9_cu115_smoke_test_pip
+          python_version: '3.9'
+          requires:
+          - nightly_binary_win_wheel_py3.9_cu115_upload
       - binary_linux_conda:
           conda_docker_image: pytorch/conda-builder:cpu
           cu_version: cpu
@@ -3073,6 +3433,36 @@ workflows:
           requires:
           - nightly_binary_linux_conda_py3.6_cu113_upload
       - binary_linux_conda:
+          conda_docker_image: pytorch/conda-builder:cuda115
+          cu_version: cu115
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_conda_py3.6_cu115
+          python_version: '3.6'
+          wheel_docker_image: pytorch/manylinux-cuda115
+      - binary_conda_upload:
+          context: org-member
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_conda_py3.6_cu115_upload
+          requires:
+          - nightly_binary_linux_conda_py3.6_cu115
+      - smoke_test_linux_conda:
+          filters:
+            branches:
+              only:
+              - nightly
+          name: nightly_binary_linux_conda_py3.6_cu115_smoke_test_conda
+          python_version: '3.6'
+          requires:
+          - nightly_binary_linux_conda_py3.6_cu115_upload
+      - binary_linux_conda:
           conda_docker_image: pytorch/conda-builder:cpu
           cu_version: cpu
           filters:
@@ -3192,6 +3582,36 @@ workflows:
           python_version: '3.7'
           requires:
           - nightly_binary_linux_conda_py3.7_cu113_upload
+      - binary_linux_conda:
+          conda_docker_image: pytorch/conda-builder:cuda115
+          cu_version: cu115
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_conda_py3.7_cu115
+          python_version: '3.7'
+          wheel_docker_image: pytorch/manylinux-cuda115
+      - binary_conda_upload:
+          context: org-member
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_conda_py3.7_cu115_upload
+          requires:
+          - nightly_binary_linux_conda_py3.7_cu115
+      - smoke_test_linux_conda:
+          filters:
+            branches:
+              only:
+              - nightly
+          name: nightly_binary_linux_conda_py3.7_cu115_smoke_test_conda
+          python_version: '3.7'
+          requires:
+          - nightly_binary_linux_conda_py3.7_cu115_upload
       - binary_linux_conda:
           conda_docker_image: pytorch/conda-builder:cpu
           cu_version: cpu
@@ -3313,6 +3733,36 @@ workflows:
           requires:
           - nightly_binary_linux_conda_py3.8_cu113_upload
       - binary_linux_conda:
+          conda_docker_image: pytorch/conda-builder:cuda115
+          cu_version: cu115
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_conda_py3.8_cu115
+          python_version: '3.8'
+          wheel_docker_image: pytorch/manylinux-cuda115
+      - binary_conda_upload:
+          context: org-member
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_conda_py3.8_cu115_upload
+          requires:
+          - nightly_binary_linux_conda_py3.8_cu115
+      - smoke_test_linux_conda:
+          filters:
+            branches:
+              only:
+              - nightly
+          name: nightly_binary_linux_conda_py3.8_cu115_smoke_test_conda
+          python_version: '3.8'
+          requires:
+          - nightly_binary_linux_conda_py3.8_cu115_upload
+      - binary_linux_conda:
           conda_docker_image: pytorch/conda-builder:cpu
           cu_version: cpu
           filters:
@@ -3432,6 +3882,36 @@ workflows:
           python_version: '3.9'
           requires:
           - nightly_binary_linux_conda_py3.9_cu113_upload
+      - binary_linux_conda:
+          conda_docker_image: pytorch/conda-builder:cuda115
+          cu_version: cu115
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_conda_py3.9_cu115
+          python_version: '3.9'
+          wheel_docker_image: pytorch/manylinux-cuda115
+      - binary_conda_upload:
+          context: org-member
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_conda_py3.9_cu115_upload
+          requires:
+          - nightly_binary_linux_conda_py3.9_cu115
+      - smoke_test_linux_conda:
+          filters:
+            branches:
+              only:
+              - nightly
+          name: nightly_binary_linux_conda_py3.9_cu115_smoke_test_conda
+          python_version: '3.9'
+          requires:
+          - nightly_binary_linux_conda_py3.9_cu115_upload
       - binary_macos_conda:
           conda_docker_image: pytorch/conda-builder:cpu
           cu_version: cpu
@@ -3601,6 +4081,34 @@ workflows:
           requires:
           - nightly_binary_win_conda_py3.6_cu113_upload
       - binary_win_conda:
+          cu_version: cu115
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_win_conda_py3.6_cu115
+          python_version: '3.6'
+      - binary_conda_upload:
+          context: org-member
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_win_conda_py3.6_cu115_upload
+          requires:
+          - nightly_binary_win_conda_py3.6_cu115
+      - smoke_test_win_conda:
+          filters:
+            branches:
+              only:
+              - nightly
+          name: nightly_binary_win_conda_py3.6_cu115_smoke_test_conda
+          python_version: '3.6'
+          requires:
+          - nightly_binary_win_conda_py3.6_cu115_upload
+      - binary_win_conda:
           cu_version: cpu
           filters:
             branches:
@@ -3684,6 +4192,34 @@ workflows:
           python_version: '3.7'
           requires:
           - nightly_binary_win_conda_py3.7_cu113_upload
+      - binary_win_conda:
+          cu_version: cu115
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_win_conda_py3.7_cu115
+          python_version: '3.7'
+      - binary_conda_upload:
+          context: org-member
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_win_conda_py3.7_cu115_upload
+          requires:
+          - nightly_binary_win_conda_py3.7_cu115
+      - smoke_test_win_conda:
+          filters:
+            branches:
+              only:
+              - nightly
+          name: nightly_binary_win_conda_py3.7_cu115_smoke_test_conda
+          python_version: '3.7'
+          requires:
+          - nightly_binary_win_conda_py3.7_cu115_upload
       - binary_win_conda:
           cu_version: cpu
           filters:
@@ -3769,6 +4305,34 @@ workflows:
           requires:
           - nightly_binary_win_conda_py3.8_cu113_upload
       - binary_win_conda:
+          cu_version: cu115
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_win_conda_py3.8_cu115
+          python_version: '3.8'
+      - binary_conda_upload:
+          context: org-member
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_win_conda_py3.8_cu115_upload
+          requires:
+          - nightly_binary_win_conda_py3.8_cu115
+      - smoke_test_win_conda:
+          filters:
+            branches:
+              only:
+              - nightly
+          name: nightly_binary_win_conda_py3.8_cu115_smoke_test_conda
+          python_version: '3.8'
+          requires:
+          - nightly_binary_win_conda_py3.8_cu115_upload
+      - binary_win_conda:
           cu_version: cpu
           filters:
             branches:
@@ -3852,6 +4416,34 @@ workflows:
           python_version: '3.9'
           requires:
           - nightly_binary_win_conda_py3.9_cu113_upload
+      - binary_win_conda:
+          cu_version: cu115
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_win_conda_py3.9_cu115
+          python_version: '3.9'
+      - binary_conda_upload:
+          context: org-member
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_win_conda_py3.9_cu115_upload
+          requires:
+          - nightly_binary_win_conda_py3.9_cu115
+      - smoke_test_win_conda:
+          filters:
+            branches:
+              only:
+              - nightly
+          name: nightly_binary_win_conda_py3.9_cu115_smoke_test_conda
+          python_version: '3.9'
+          requires:
+          - nightly_binary_win_conda_py3.9_cu115_upload
   docker_build:
     triggers:
       - schedule:

--- a/.circleci/regenerate.py
+++ b/.circleci/regenerate.py
@@ -32,8 +32,8 @@ def build_workflows(prefix="", filter_branch=None, upload=False, indentation=6, 
         for os_type in ["linux", "macos", "win"]:
             python_versions = PYTHON_VERSIONS
             cu_versions_dict = {
-                "linux": ["cpu", "cu102", "cu111", "cu113", "rocm4.2", "rocm4.3.1"],
-                "win": ["cpu", "cu111", "cu113"],
+                "linux": ["cpu", "cu102", "cu111", "cu113", "cu115", "rocm4.2", "rocm4.3.1"],
+                "win": ["cpu", "cu111", "cu113", "cu115"],
                 "macos": ["cpu"],
             }
             cu_versions = cu_versions_dict[os_type]
@@ -128,6 +128,7 @@ manylinux_images = {
     "cu111": "pytorch/manylinux-cuda111",
     "cu112": "pytorch/manylinux-cuda112",
     "cu113": "pytorch/manylinux-cuda113",
+    "cu115": "pytorch/manylinux-cuda115",
 }
 
 

--- a/packaging/build_conda.sh
+++ b/packaging/build_conda.sh
@@ -18,4 +18,4 @@ if [[ "$CU_VERSION" == cu115 ]]; then
     export CUDATOOLKIT_CHANNEL="conda-forge"
 fi
 
-conda build -c defaults -c conda-forge $CONDA_CHANNEL_FLAGS --no-anaconda-upload --python "$PYTHON_VERSION" packaging/torchvision
+conda build -c defaults -c $CUDATOOLKIT_CHANNEL $CONDA_CHANNEL_FLAGS --no-anaconda-upload --python "$PYTHON_VERSION" packaging/torchvision

--- a/packaging/build_conda.sh
+++ b/packaging/build_conda.sh
@@ -11,5 +11,11 @@ setup_conda_pytorch_constraint
 setup_conda_cudatoolkit_constraint
 setup_visual_studio_constraint
 setup_junit_results_folder
-# nvidia channel included for cudatoolkit >= 11
+
+# nvidia channel included for cudatoolkit >= 11 however for 11.5 we use conda-forge
+export CUDATOOLKIT_CHANNEL="nvidia"
+if [[ "$CU_VERSION" == cu115 ]]; then
+    export CUDATOOLKIT_CHANNEL="conda-forge"
+fi
+
 conda build -c defaults -c conda-forge $CONDA_CHANNEL_FLAGS --no-anaconda-upload --python "$PYTHON_VERSION" packaging/torchvision

--- a/packaging/build_conda.sh
+++ b/packaging/build_conda.sh
@@ -12,4 +12,4 @@ setup_conda_cudatoolkit_constraint
 setup_visual_studio_constraint
 setup_junit_results_folder
 # nvidia channel included for cudatoolkit >= 11
-conda build -c defaults -c nvidia $CONDA_CHANNEL_FLAGS --no-anaconda-upload --python "$PYTHON_VERSION" packaging/torchvision
+conda build -c defaults -c conda-forge $CONDA_CHANNEL_FLAGS --no-anaconda-upload --python "$PYTHON_VERSION" packaging/torchvision

--- a/packaging/pkg_helpers.bash
+++ b/packaging/pkg_helpers.bash
@@ -46,6 +46,14 @@ setup_cuda() {
 
   # Now work out the CUDA settings
   case "$CU_VERSION" in
+    cu115)
+      if [[ "$OSTYPE" == "msys" ]]; then
+        export CUDA_HOME="C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v11.5"
+      else
+        export CUDA_HOME=/usr/local/cuda-11.5/
+      fi
+      export TORCH_CUDA_ARCH_LIST="3.5;5.0+PTX;6.0;7.0;7.5;8.0;8.6"
+      ;;
     cu113)
       if [[ "$OSTYPE" == "msys" ]]; then
         export CUDA_HOME="C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v11.3"
@@ -289,6 +297,9 @@ setup_conda_cudatoolkit_constraint() {
     export CONDA_BUILD_VARIANT="cpu"
   else
     case "$CU_VERSION" in
+      cu115)
+        export CONDA_CUDATOOLKIT_CONSTRAINT="- cudatoolkit >=11.5,<11.6 # [not osx]"
+        ;;
       cu113)
         export CONDA_CUDATOOLKIT_CONSTRAINT="- cudatoolkit >=11.3,<11.4 # [not osx]"
         ;;
@@ -333,6 +344,9 @@ setup_conda_cudatoolkit_plain_constraint() {
     export CMAKE_USE_CUDA=0
   else
     case "$CU_VERSION" in
+      cu115)
+        export CONDA_CUDATOOLKIT_CONSTRAINT="cudatoolkit=11.5"
+        ;;
       cu113)
         export CONDA_CUDATOOLKIT_CONSTRAINT="cudatoolkit=11.3"
         ;;

--- a/packaging/pkg_helpers.bash
+++ b/packaging/pkg_helpers.bash
@@ -345,7 +345,7 @@ setup_conda_cudatoolkit_plain_constraint() {
   else
     case "$CU_VERSION" in
       cu115)
-        export CONDA_CUDATOOLKIT_CONSTRAINT="cuda=11.5"
+        export CONDA_CUDATOOLKIT_CONSTRAINT="cudatoolkit=11.5"
         ;;
       cu113)
         export CONDA_CUDATOOLKIT_CONSTRAINT="cudatoolkit=11.3"

--- a/packaging/pkg_helpers.bash
+++ b/packaging/pkg_helpers.bash
@@ -298,7 +298,7 @@ setup_conda_cudatoolkit_constraint() {
   else
     case "$CU_VERSION" in
       cu115)
-        export CONDA_CUDATOOLKIT_CONSTRAINT="- cudatoolkit >=11.3,<11.4 # [not osx]"
+        export CONDA_CUDATOOLKIT_CONSTRAINT="- cudatoolkit >=11.5,<11.6 # [not osx]"
         ;;
       cu113)
         export CONDA_CUDATOOLKIT_CONSTRAINT="- cudatoolkit >=11.3,<11.4 # [not osx]"
@@ -345,7 +345,7 @@ setup_conda_cudatoolkit_plain_constraint() {
   else
     case "$CU_VERSION" in
       cu115)
-        export CONDA_CUDATOOLKIT_CONSTRAINT="cudatoolkit=11.5"
+        export CONDA_CUDATOOLKIT_CONSTRAINT="cuda=11.5"
         ;;
       cu113)
         export CONDA_CUDATOOLKIT_CONSTRAINT="cudatoolkit=11.3"

--- a/packaging/pkg_helpers.bash
+++ b/packaging/pkg_helpers.bash
@@ -298,7 +298,7 @@ setup_conda_cudatoolkit_constraint() {
   else
     case "$CU_VERSION" in
       cu115)
-        export CONDA_CUDATOOLKIT_CONSTRAINT="- cudatoolkit >=11.5,<11.6 # [not osx]"
+        export CONDA_CUDATOOLKIT_CONSTRAINT="- cudatoolkit >=11.3,<11.4 # [not osx]"
         ;;
       cu113)
         export CONDA_CUDATOOLKIT_CONSTRAINT="- cudatoolkit >=11.3,<11.4 # [not osx]"

--- a/packaging/windows/internal/cuda_install.bat
+++ b/packaging/windows/internal/cuda_install.bat
@@ -21,6 +21,7 @@ set CUDA_VER_MAJOR=%CUDA_VER:~0,-1%
 set CUDA_VER_MINOR=%CUDA_VER:~-1,1%
 set CUDA_VERSION_STR=%CUDA_VER_MAJOR%.%CUDA_VER_MINOR%
 
+
 if %CUDA_VER% EQU 92 goto cuda92
 if %CUDA_VER% EQU 100 goto cuda100
 if %CUDA_VER% EQU 101 goto cuda101
@@ -29,6 +30,8 @@ if %CUDA_VER% EQU 110 goto cuda110
 if %CUDA_VER% EQU 111 goto cuda111
 if %CUDA_VER% EQU 112 goto cuda112
 if %CUDA_VER% EQU 113 goto cuda113
+if %CUDA_VER% EQU 115 goto cuda115
+
 
 echo CUDA %CUDA_VERSION_STR% is not supported
 exit /b 1
@@ -180,6 +183,25 @@ if not exist "%SRC_DIR%\temp_build\%CUDNN_INSTALL_ZIP%" (
 
 goto cuda_common
 
+:cuda115
+
+set CUDA_INSTALL_EXE=cuda_11.5.0_496.13_win10.exe
+if not exist "%SRC_DIR%\temp_build\%CUDA_INSTALL_EXE%" (
+    curl -k -L "https://ossci-windows.s3.amazonaws.com/%CUDA_INSTALL_EXE%" --output "%SRC_DIR%\temp_build\%CUDA_INSTALL_EXE%"
+    if errorlevel 1 exit /b 1
+    set "CUDA_SETUP_FILE=%SRC_DIR%\temp_build\%CUDA_INSTALL_EXE%"
+    set "ARGS=thrust_11.5 nvcc_11.5 cuobjdump_11.5 nvprune_11.5 nvprof_11.5 cupti_11.5 cublas_11.5 cublas_dev_11.5 cudart_11.5 cufft_11.5 cufft_dev_11.5 curand_11.5 curand_dev_11.5 cusolver_11.5 cusolver_dev_11.5 cusparse_11.5 cusparse_dev_11.5 npp_11.5 npp_dev_11.5 nvrtc_11.5 nvrtc_dev_11.5 nvml_dev_11.5"
+)
+
+set CUDNN_INSTALL_ZIP=cudnn-11.3-windows-x64-v8.2.0.53.zip
+if not exist "%SRC_DIR%\temp_build\%CUDNN_INSTALL_ZIP%" (
+    curl -k -L "http://s3.amazonaws.com/ossci-windows/%CUDNN_INSTALL_ZIP%" --output "%SRC_DIR%\temp_build\%CUDNN_INSTALL_ZIP%"
+    if errorlevel 1 exit /b 1
+    set "CUDNN_SETUP_FILE=%SRC_DIR%\temp_build\%CUDNN_INSTALL_ZIP%"
+)
+
+goto cuda_common
+
 :cuda_common
 
 if not exist "%SRC_DIR%\temp_build\NvToolsExt.7z" (
@@ -222,7 +244,7 @@ set "NVTOOLSEXT_PATH=%ProgramFiles%\NVIDIA Corporation\NvToolsExt\bin\x64"
 if not exist "%ProgramFiles%\NVIDIA GPU Computing Toolkit\CUDA\v%CUDA_VERSION_STR%\bin\nvcc.exe" (
     echo CUDA %CUDA_VERSION_STR% installed failed.
     echo --------- RunDll32.exe.log
-    type "%SRC_DIR%\temp_build\cuda\cuda_install_logs\LOG.RunDll32.exe.log"    
+    type "%SRC_DIR%\temp_build\cuda\cuda_install_logs\LOG.RunDll32.exe.log"
     echo --------- setup.exe.log -------
     type "%SRC_DIR%\temp_build\cuda\cuda_install_logs\LOG.setup.exe.log"
     exit /b 1


### PR DESCRIPTION
Fixes #69295 (Add 11.5 to torchvision CI https://github.com/pytorch/pytorch/issues/69295) 

One of the issues discovered during this PR is that: conda install -yq -c nvidia -c pytorch cudatoolkit=11.5
Does not work following error is created:
UnsatisfiableError: The following specifications were found to be incompatible with each other:
Output in format: Requested package -> Available versions
Package libgcc-ng conflicts for:
python=3.9 -> libgcc-ng[version='>=7.3.0|>=7.5.0']
python=3.9 -> zlib[version='>=1.2.11,<1.3.0a0'] -> libgcc-ng[version='>=7.2.0']
cudatoolkit=11.5 -> libgcc-ng[version='>=9.4.0']The following specifications were found to be incompatible with your system:
 - feature:/linux-64::__glibc==2.17=0
 - feature:|@/linux-64::__glibc==2.17=0
 - python=3.9 -> libgcc-ng[version='>=7.5.0'] -> __glibc[version='>=2.17']
Your installed version is: 2.1

Workaround implemented by using conda-forge chanell