### PR TITLE
[POC] add legacy interface for prototype datasets

### DIFF
--- a/torchvision/prototype/datasets/_builtin/mnist.py
+++ b/torchvision/prototype/datasets/_builtin/mnist.py
@@ -140,6 +140,14 @@ class _MNISTBase(Dataset):
 
 
 class MNIST(_MNISTBase):
+    @staticmethod
+    def _legacy_input_map(options: Dict[str, Any]) -> Dict[str, Any]:
+        return dict(split="train" if options.get("train", False) else "test")
+
+    @staticmethod
+    def _legacy_output_map(sample: Dict[str, Any]) -> Tuple[Image, Label]:
+        return sample["image"], sample["label"]
+
     def _make_info(self) -> DatasetInfo:
         return DatasetInfo(
             "mnist",
@@ -149,6 +157,8 @@ class MNIST(_MNISTBase):
             valid_options=dict(
                 split=("train", "test"),
             ),
+            legacy_input_map=self._legacy_input_map,
+            legacy_output_map=self._legacy_output_map,
         )
 
     _URL_BASE = "http://yann.lecun.com/exdb/mnist"


### PR DESCRIPTION
Proof-of-concept for #5040. With this change we can do

```python
from torchvision.prototype import datasets

for input, target in datasets.load("mnist", legacy=True, train=False):
    ...
```

whereas currently we do

```python
from torchvision import datasets

for input, target in datasets.MNIST(..., train=False):
    ...
```

This will only handle the interface, but not the return types. Meaning with `legacy=True` we would still return `Tuple[torchvision.prototype.features.Image, torchvision.prototype.features.Label]` instead of `Tuple[PIL.Image.Image, int]`.