### PR TITLE
Add raft builders and presets in prototypes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,1 @@
+<!-- Before submitting a PR, please make sure to check our contributing guidelines regarding code formatting, tests, and documentation: https://github.com/pytorch/vision/blob/main/CONTRIBUTING.md -->

--- a/test/test_prototype_models.py
+++ b/test/test_prototype_models.py
@@ -120,7 +120,7 @@ def test_video_model(model_fn, dev):
 
 
 @needs_cuda
-@pytest.mark.parametrize("model_builder", (models.optical_flow.raft_large, models.optical_flow.raft_small))
+@pytest.mark.parametrize("model_builder", TM.get_models_from_module(models.optical_flow))
 @pytest.mark.parametrize("scripted", (False, True))
 @run_if_test_with_prototype
 def test_raft(model_builder, scripted):

--- a/torchvision/models/optical_flow/raft.py
+++ b/torchvision/models/optical_flow/raft.py
@@ -585,7 +585,7 @@ def raft_large(*, pretrained=False, progress=True, **kwargs):
     """
 
     if pretrained:
-        raise ValueError("Pretrained weights aren't available yet")
+        raise ValueError("No checkpoint is available for raft_large")
 
     return _raft(
         # Feature encoder
@@ -631,7 +631,7 @@ def raft_small(*, pretrained=False, progress=True, **kwargs):
     """
 
     if pretrained:
-        raise ValueError("Pretrained weights aren't available yet")
+        raise ValueError("No checkpoint is available for raft_small")
 
     return _raft(
         # Feature encoder

--- a/torchvision/prototype/models/__init__.py
+++ b/torchvision/prototype/models/__init__.py
@@ -12,6 +12,7 @@ from .squeezenet import *
 from .vgg import *
 from .vision_transformer import *
 from . import detection
+from . import optical_flow
 from . import quantization
 from . import segmentation
 from . import video

--- a/torchvision/prototype/models/optical_flow/__init__.py
+++ b/torchvision/prototype/models/optical_flow/__init__.py
@@ -1,0 +1,1 @@
+from .raft import RAFT, raft_large, raft_small

--- a/torchvision/prototype/models/optical_flow/__init__.py
+++ b/torchvision/prototype/models/optical_flow/__init__.py
@@ -1,1 +1,1 @@
-from .raft import RAFT, raft_large, raft_small
+from .raft import RAFT, raft_large, raft_small, Raft_Large_Weights, Raft_Small_Weights

--- a/torchvision/prototype/models/optical_flow/raft.py
+++ b/torchvision/prototype/models/optical_flow/raft.py
@@ -7,6 +7,7 @@ from torchvision.models.optical_flow.raft import _raft, BottleneckBlock, Residua
 from torchvision.prototype.transforms import RaftEval
 
 from .._api import WeightsEnum, Weights
+from .._utils import handle_legacy_interface
 
 
 __all__ = (
@@ -17,57 +18,60 @@ __all__ = (
 
 
 class Raft_Large_Weights(WeightsEnum):
-    C_T = Weights(
-        # Chairs + Things
-        url="",
-        transforms=RaftEval,
-        meta={
-            "recipe": "",
-            "epe": -1234,
-        },
-    )
+    pass
+    # C_T_V1 = Weights(
+    #     # Chairs + Things
+    #     url="",
+    #     transforms=RaftEval,
+    #     meta={
+    #         "recipe": "",
+    #         "epe": -1234,
+    #     },
+    # )
 
-    C_T_SKHT = Weights(
-        # Chairs + Things + Sintel fine-tuning, i.e.:
-        # Chairs + Things + (Sintel + Kitti + HD1K + Things_clean)
-        # Corresponds to the C+T+S+K+H on paper with fine-tuning on Sintel
-        url="",
-        transforms=RaftEval,
-        meta={
-            "recipe": "",
-            "epe": -1234,
-        },
-    )
+    # C_T_SKHT_V1 = Weights(
+    #     # Chairs + Things + Sintel fine-tuning, i.e.:
+    #     # Chairs + Things + (Sintel + Kitti + HD1K + Things_clean)
+    #     # Corresponds to the C+T+S+K+H on paper with fine-tuning on Sintel
+    #     url="",
+    #     transforms=RaftEval,
+    #     meta={
+    #         "recipe": "",
+    #         "epe": -1234,
+    #     },
+    # )
 
-    C_T_SKHT_K = Weights(
-        # Chairs + Things + Sintel fine-tuning + Kitti fine-tuning i.e.:
-        # Chairs + Things + (Sintel + Kitti + HD1K + Things_clean) + Kitti
-        # Same as CT_SKHT with extra fine-tuning on Kitti
-        # Corresponds to the C+T+S+K+H on paper with fine-tuning on Sintel and then on Kitti
-        url="",
-        transforms=RaftEval,
-        meta={
-            "recipe": "",
-            "epe": -1234,
-        },
-    )
+    # C_T_SKHT_K_V1 = Weights(
+    #     # Chairs + Things + Sintel fine-tuning + Kitti fine-tuning i.e.:
+    #     # Chairs + Things + (Sintel + Kitti + HD1K + Things_clean) + Kitti
+    #     # Same as CT_SKHT with extra fine-tuning on Kitti
+    #     # Corresponds to the C+T+S+K+H on paper with fine-tuning on Sintel and then on Kitti
+    #     url="",
+    #     transforms=RaftEval,
+    #     meta={
+    #         "recipe": "",
+    #         "epe": -1234,
+    #     },
+    # )
 
-    default = C_T
+    # default = C_T_V1
 
 
 class Raft_Small_Weights(WeightsEnum):
-    C_T = Weights(
-        url="",  # TODO
-        transforms=RaftEval,
-        meta={
-            "recipe": "",
-            "epe": -1234,
-        },
-    )
-    default = C_T
+    pass
+    # C_T_V1 = Weights(
+    #     url="",  # TODO
+    #     transforms=RaftEval,
+    #     meta={
+    #         "recipe": "",
+    #         "epe": -1234,
+    #     },
+    # )
+    # default = C_T_V1
 
 
-def raft_large(weights: Optional[Raft_Large_Weights] = None, progress=True, **kwargs):
+@handle_legacy_interface(weights=("pretrained", None))
+def raft_large(*, weights: Optional[Raft_Large_Weights] = None, progress=True, **kwargs):
     """RAFT model from
     `RAFT: Recurrent All Pairs Field Transforms for Optical Flow <https://arxiv.org/abs/2003.12039>`_.
 
@@ -82,7 +86,7 @@ def raft_large(weights: Optional[Raft_Large_Weights] = None, progress=True, **kw
     """
 
     if weights is not None:
-        raise ValueError("Pretrained weights aren't available yet")
+        raise ValueError("No checkpoint is available for raft_large")
 
     weights = Raft_Large_Weights.verify(weights)
 
@@ -114,7 +118,8 @@ def raft_large(weights: Optional[Raft_Large_Weights] = None, progress=True, **kw
     )
 
 
-def raft_small(weights: Optional[Raft_Small_Weights] = None, progress=True, **kwargs):
+@handle_legacy_interface(weights=("pretrained", None))
+def raft_small(*, weights: Optional[Raft_Small_Weights] = None, progress=True, **kwargs):
     """RAFT "small" model from
     `RAFT: Recurrent All Pairs Field Transforms for Optical Flow <https://arxiv.org/abs/2003.12039>`_.
 
@@ -130,7 +135,7 @@ def raft_small(weights: Optional[Raft_Small_Weights] = None, progress=True, **kw
     """
 
     if weights is not None:
-        raise ValueError("Pretrained weights aren't available yet")
+        raise ValueError("No checkpoint is available for raft_small")
 
     weights = Raft_Small_Weights.verify(weights)
 

--- a/torchvision/prototype/models/optical_flow/raft.py
+++ b/torchvision/prototype/models/optical_flow/raft.py
@@ -2,8 +2,8 @@ from typing import Optional
 
 from torch.nn.modules.batchnorm import BatchNorm2d
 from torch.nn.modules.instancenorm import InstanceNorm2d
-from torchvision.models.optical_flow import RAFT, BottleneckBlock, ResidualBlock
-from torchvision.models.optical_flow.raft import _raft
+from torchvision.models.optical_flow import RAFT
+from torchvision.models.optical_flow.raft import _raft, BottleneckBlock, ResidualBlock
 from torchvision.prototype.transforms import RaftEval
 
 from .._api import WeightsEnum, Weights

--- a/torchvision/prototype/models/optical_flow/raft.py
+++ b/torchvision/prototype/models/optical_flow/raft.py
@@ -4,9 +4,9 @@ from torch.nn.modules.batchnorm import BatchNorm2d
 from torch.nn.modules.instancenorm import InstanceNorm2d
 from torchvision.models.optical_flow import RAFT
 from torchvision.models.optical_flow.raft import _raft, BottleneckBlock, ResidualBlock
-from torchvision.prototype.transforms import RaftEval
+# from torchvision.prototype.transforms import RaftEval
 
-from .._api import WeightsEnum, Weights
+# from .._api import WeightsEnum, Weights
 from .._utils import handle_legacy_interface
 
 

--- a/torchvision/prototype/models/optical_flow/raft.py
+++ b/torchvision/prototype/models/optical_flow/raft.py
@@ -1,0 +1,162 @@
+from typing import Optional
+
+from torch.nn.modules.batchnorm import BatchNorm2d
+from torch.nn.modules.instancenorm import InstanceNorm2d
+from torchvision.models.optical_flow import RAFT, BottleneckBlock, ResidualBlock
+from torchvision.models.optical_flow.raft import _raft
+from torchvision.prototype.transforms import RaftEval
+
+from .._api import WeightsEnum, Weights
+
+
+__all__ = (
+    "RAFT",
+    "raft_large",
+    "raft_small",
+)
+
+
+class Raft_Large_Weights(WeightsEnum):
+    C_T = Weights(
+        # Chairs + Things
+        url="",
+        transforms=RaftEval,
+        meta={
+            "recipe": "",
+            "epe": -1234,
+        },
+    )
+
+    C_T_SKHT = Weights(
+        # Chairs + Things + Sintel fine-tuning, i.e.:
+        # Chairs + Things + (Sintel + Kitti + HD1K + Things_clean)
+        # Corresponds to the C+T+S+K+H on paper with fine-tuning on Sintel
+        url="",
+        transforms=RaftEval,
+        meta={
+            "recipe": "",
+            "epe": -1234,
+        },
+    )
+
+    C_T_SKHT_K = Weights(
+        # Chairs + Things + Sintel fine-tuning + Kitti fine-tuning i.e.:
+        # Chairs + Things + (Sintel + Kitti + HD1K + Things_clean) + Kitti
+        # Same as CT_SKHT with extra fine-tuning on Kitti
+        # Corresponds to the C+T+S+K+H on paper with fine-tuning on Sintel and then on Kitti
+        url="",
+        transforms=RaftEval,
+        meta={
+            "recipe": "",
+            "epe": -1234,
+        },
+    )
+
+    default = C_T
+
+
+class Raft_Small_Weights(WeightsEnum):
+    C_T = Weights(
+        url="",  # TODO
+        transforms=RaftEval,
+        meta={
+            "recipe": "",
+            "epe": -1234,
+        },
+    )
+    default = C_T
+
+
+def raft_large(weights: Optional[Raft_Large_Weights] = None, progress=True, **kwargs):
+    """RAFT model from
+    `RAFT: Recurrent All Pairs Field Transforms for Optical Flow <https://arxiv.org/abs/2003.12039>`_.
+
+    Args:
+        weights(Raft_Large_weights, optinal): TODO not implemented yet
+        progress (bool): If True, displays a progress bar of the download to stderr
+        kwargs (dict): Parameters that will be passed to the :class:`~torchvision.models.optical_flow.RAFT` class
+            to override any default.
+
+    Returns:
+        nn.Module: The model.
+    """
+
+    if weights is not None:
+        raise ValueError("Pretrained weights aren't available yet")
+
+    weights = Raft_Large_Weights.verify(weights)
+
+    return _raft(
+        # Feature encoder
+        feature_encoder_layers=(64, 64, 96, 128, 256),
+        feature_encoder_block=ResidualBlock,
+        feature_encoder_norm_layer=InstanceNorm2d,
+        # Context encoder
+        context_encoder_layers=(64, 64, 96, 128, 256),
+        context_encoder_block=ResidualBlock,
+        context_encoder_norm_layer=BatchNorm2d,
+        # Correlation block
+        corr_block_num_levels=4,
+        corr_block_radius=4,
+        # Motion encoder
+        motion_encoder_corr_layers=(256, 192),
+        motion_encoder_flow_layers=(128, 64),
+        motion_encoder_out_channels=128,
+        # Recurrent block
+        recurrent_block_hidden_state_size=128,
+        recurrent_block_kernel_size=((1, 5), (5, 1)),
+        recurrent_block_padding=((0, 2), (2, 0)),
+        # Flow head
+        flow_head_hidden_size=256,
+        # Mask predictor
+        use_mask_predictor=True,
+        **kwargs,
+    )
+
+
+def raft_small(weights: Optional[Raft_Small_Weights] = None, progress=True, **kwargs):
+    """RAFT "small" model from
+    `RAFT: Recurrent All Pairs Field Transforms for Optical Flow <https://arxiv.org/abs/2003.12039>`_.
+
+    Args:
+        weights(Raft_Small_weights, optinal): TODO not implemented yet
+        progress (bool): If True, displays a progress bar of the download to stderr
+        kwargs (dict): Parameters that will be passed to the :class:`~torchvision.models.optical_flow.RAFT` class
+            to override any default.
+
+    Returns:
+        nn.Module: The model.
+
+    """
+
+    if weights is not None:
+        raise ValueError("Pretrained weights aren't available yet")
+
+    weights = Raft_Small_Weights.verify(weights)
+
+    return _raft(
+        # Feature encoder
+        feature_encoder_layers=(32, 32, 64, 96, 128),
+        feature_encoder_block=BottleneckBlock,
+        feature_encoder_norm_layer=InstanceNorm2d,
+        # Context encoder
+        context_encoder_layers=(32, 32, 64, 96, 160),
+        context_encoder_block=BottleneckBlock,
+        context_encoder_norm_layer=None,
+        # Correlation block
+        corr_block_num_levels=4,
+        corr_block_radius=3,
+        # Motion encoder
+        motion_encoder_corr_layers=(96,),
+        motion_encoder_flow_layers=(64, 32),
+        motion_encoder_out_channels=82,
+        # Recurrent block
+        recurrent_block_hidden_state_size=96,
+        recurrent_block_kernel_size=(3,),
+        recurrent_block_padding=(1,),
+        # Flow head
+        flow_head_hidden_size=128,
+        # Mask predictor
+        use_mask_predictor=False,
+        **kwargs,
+    )

--- a/torchvision/prototype/models/optical_flow/raft.py
+++ b/torchvision/prototype/models/optical_flow/raft.py
@@ -6,7 +6,8 @@ from torchvision.models.optical_flow import RAFT
 from torchvision.models.optical_flow.raft import _raft, BottleneckBlock, ResidualBlock
 # from torchvision.prototype.transforms import RaftEval
 
-# from .._api import WeightsEnum, Weights
+from .._api import WeightsEnum
+# from .._api import Weights
 from .._utils import handle_legacy_interface
 
 

--- a/torchvision/prototype/models/optical_flow/raft.py
+++ b/torchvision/prototype/models/optical_flow/raft.py
@@ -4,9 +4,11 @@ from torch.nn.modules.batchnorm import BatchNorm2d
 from torch.nn.modules.instancenorm import InstanceNorm2d
 from torchvision.models.optical_flow import RAFT
 from torchvision.models.optical_flow.raft import _raft, BottleneckBlock, ResidualBlock
+
 # from torchvision.prototype.transforms import RaftEval
 
 from .._api import WeightsEnum
+
 # from .._api import Weights
 from .._utils import handle_legacy_interface
 
@@ -15,6 +17,8 @@ __all__ = (
     "RAFT",
     "raft_large",
     "raft_small",
+    "Raft_Large_Weights",
+    "Raft_Small_Weights",
 )
 
 
@@ -86,9 +90,6 @@ def raft_large(*, weights: Optional[Raft_Large_Weights] = None, progress=True, *
         nn.Module: The model.
     """
 
-    if weights is not None:
-        raise ValueError("No checkpoint is available for raft_large")
-
     weights = Raft_Large_Weights.verify(weights)
 
     return _raft(
@@ -134,9 +135,6 @@ def raft_small(*, weights: Optional[Raft_Small_Weights] = None, progress=True, *
         nn.Module: The model.
 
     """
-
-    if weights is not None:
-        raise ValueError("No checkpoint is available for raft_small")
 
     weights = Raft_Small_Weights.verify(weights)
 

--- a/torchvision/prototype/transforms/__init__.py
+++ b/torchvision/prototype/transforms/__init__.py
@@ -3,4 +3,4 @@ from ._container import Compose, RandomApply, RandomChoice, RandomOrder  # usort
 
 from ._geometry import Resize, RandomResize, HorizontalFlip, Crop, CenterCrop, RandomCrop
 from ._misc import Identity, Normalize
-from ._presets import CocoEval, ImageNetEval, VocEval, Kinect400Eval
+from ._presets import CocoEval, ImageNetEval, VocEval, Kinect400Eval, RaftEval

--- a/torchvision/prototype/transforms/_presets.py
+++ b/torchvision/prototype/transforms/_presets.py
@@ -1,6 +1,5 @@
 from typing import Dict, Optional, Tuple
 
-import numpy as np
 import torch
 from torch import Tensor, nn
 
@@ -111,23 +110,25 @@ class RaftEval(nn.Module):
         img2 = F.convert_image_dtype(img2, torch.float32)
 
         # map [0, 1] into [-1, 1]
-        img1 = F.normalize(img1, mean=0.5, std=0.5)
-        img2 = F.normalize(img2, mean=0.5, std=0.5)
+        img1 = F.normalize(img1, mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5])
+        img2 = F.normalize(img2, mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5])
 
         img1 = img1.contiguous()
         img2 = img2.contiguous()
 
         return img1, img2, flow, valid_flow_mask
 
-    def _pil_or_numpy_to_tensor(self, img1: Tensor, img2: Tensor, flow: Optional[Tensor], valid_flow_mask: Optional[Tensor])-> Tuple[Tensor, Tensor, Optional[Tensor], Optional[Tensor]]:
+    def _pil_or_numpy_to_tensor(
+        self, img1: Tensor, img2: Tensor, flow: Optional[Tensor], valid_flow_mask: Optional[Tensor]
+    ) -> Tuple[Tensor, Tensor, Optional[Tensor], Optional[Tensor]]:
         if not isinstance(img1, Tensor):
             img1 = F.pil_to_tensor(img1)
         if not isinstance(img2, Tensor):
             img2 = F.pil_to_tensor(img2)
 
-        if flow is not None and not isinstance(flow, np.ndarray):
+        if flow is not None and not isinstance(flow, Tensor):
             flow = torch.from_numpy(flow)
-        if valid_flow_mask is not None and not isinstance(flow, np.ndarray):
+        if valid_flow_mask is not None and not isinstance(flow, Tensor):
             valid_flow_mask = torch.from_numpy(valid_flow_mask)
 
         return img1, img2, flow, valid_flow_mask

--- a/torchvision/prototype/transforms/_presets.py
+++ b/torchvision/prototype/transforms/_presets.py
@@ -6,7 +6,7 @@ from torch import Tensor, nn
 from ...transforms import functional as F, InterpolationMode
 
 
-__all__ = ["CocoEval", "ImageNetEval", "Kinect400Eval", "VocEval"]
+__all__ = ["CocoEval", "ImageNetEval", "Kinect400Eval", "VocEval", "RaftEval"]
 
 
 class CocoEval(nn.Module):

--- a/torchvision/prototype/transforms/_presets.py
+++ b/torchvision/prototype/transforms/_presets.py
@@ -128,7 +128,7 @@ class RaftEval(nn.Module):
 
         if flow is not None and not isinstance(flow, Tensor):
             flow = torch.from_numpy(flow)
-        if valid_flow_mask is not None and not isinstance(flow, Tensor):
+        if valid_flow_mask is not None and not isinstance(valid_flow_mask, Tensor):
             valid_flow_mask = torch.from_numpy(valid_flow_mask)
 
         return img1, img2, flow, valid_flow_mask


### PR DESCRIPTION
Towards https://github.com/pytorch/vision/issues/4644

This PR adds the `raft_large()` and `raft_small()` builders, following the new model prototype API.

cc @datumbox @bjuncek