### PR TITLE
Adding schema validation for model meta-data

### DIFF
--- a/test/test_prototype_models.py
+++ b/test/test_prototype_models.py
@@ -112,7 +112,7 @@ def test_schema_meta_validation(model_fn):
         if missing_fields:
             problematic_weights[w] = missing_fields
 
-    assert len(problematic_weights) == 0, str(problematic_weights)
+    assert not problematic_weights
 
 
 @pytest.mark.parametrize("model_fn", TM.get_models_from_module(models))

--- a/test/test_prototype_models.py
+++ b/test/test_prototype_models.py
@@ -96,7 +96,7 @@ def test_schema_meta_validation(model_fn):
     defaults = {
         "all": ["interpolation", "recipe"],
         "models": classification_fields,
-        "detection": ["categories"],
+        "detection": ["categories", "map"],
         "quantization": classification_fields + ["backend", "quantization", "unquantized"],
         "segmentation": ["categories", "mIoU", "acc"],
         "video": classification_fields,

--- a/test/test_prototype_models.py
+++ b/test/test_prototype_models.py
@@ -83,6 +83,38 @@ def test_naming_conventions(model_fn):
     assert len(weights_enum) == 0 or hasattr(weights_enum, "default")
 
 
+@pytest.mark.parametrize(
+    "model_fn",
+    TM.get_models_from_module(models)
+    + TM.get_models_from_module(models.detection)
+    + TM.get_models_from_module(models.quantization)
+    + TM.get_models_from_module(models.segmentation)
+    + TM.get_models_from_module(models.video),
+)
+def test_schema_meta_validation(model_fn):
+    classification_fields = ["size", "categories", "acc@1", "acc@5"]
+    defaults = {
+        "all": ["interpolation", "recipe"],
+        "models": classification_fields,
+        "detection": ["categories"],
+        "quantization": classification_fields + ["backend", "quantization", "unquantized"],
+        "segmentation": ["categories", "mIoU", "acc"],
+        "video": classification_fields,
+    }
+    module_name = model_fn.__module__.split(".")[-2]
+    fields = set(defaults["all"] + defaults[module_name])
+
+    weights_enum = _get_model_weights(model_fn)
+
+    problematic_weights = {}
+    for w in weights_enum:
+        missing_fields = fields - set(w.meta.keys())
+        if missing_fields:
+            problematic_weights[w] = missing_fields
+
+    assert len(problematic_weights) == 0, str(problematic_weights)
+
+
 @pytest.mark.parametrize("model_fn", TM.get_models_from_module(models))
 @pytest.mark.parametrize("dev", cpu_and_gpu())
 @run_if_test_with_prototype

--- a/torchvision/prototype/models/detection/keypoint_rcnn.py
+++ b/torchvision/prototype/models/detection/keypoint_rcnn.py
@@ -37,8 +37,8 @@ class KeypointRCNN_ResNet50_FPN_Weights(WeightsEnum):
         meta={
             **_COMMON_META,
             "recipe": "https://github.com/pytorch/vision/issues/1606",
-            "box_map": 50.6,
-            "kp_map": 61.1,
+            "map": 50.6,
+            "map_kp": 61.1,
         },
     )
     Coco_V1 = Weights(
@@ -47,8 +47,8 @@ class KeypointRCNN_ResNet50_FPN_Weights(WeightsEnum):
         meta={
             **_COMMON_META,
             "recipe": "https://github.com/pytorch/vision/tree/main/references/detection#keypoint-r-cnn",
-            "box_map": 54.6,
-            "kp_map": 65.0,
+            "map": 54.6,
+            "map_kp": 65.0,
         },
     )
     default = Coco_V1

--- a/torchvision/prototype/models/detection/keypoint_rcnn.py
+++ b/torchvision/prototype/models/detection/keypoint_rcnn.py
@@ -1,6 +1,7 @@
 from typing import Any, Optional
 
 from torchvision.prototype.transforms import CocoEval
+from torchvision.transforms.functional import InterpolationMode
 
 from ....models.detection.keypoint_rcnn import (
     _resnet_fpn_extractor,
@@ -22,7 +23,11 @@ __all__ = [
 ]
 
 
-_COMMON_META = {"categories": _COCO_PERSON_CATEGORIES, "keypoint_names": _COCO_PERSON_KEYPOINT_NAMES}
+_COMMON_META = {
+    "categories": _COCO_PERSON_CATEGORIES,
+    "keypoint_names": _COCO_PERSON_KEYPOINT_NAMES,
+    "interpolation": InterpolationMode.BILINEAR,
+}
 
 
 class KeypointRCNN_ResNet50_FPN_Weights(WeightsEnum):

--- a/torchvision/prototype/models/detection/mask_rcnn.py
+++ b/torchvision/prototype/models/detection/mask_rcnn.py
@@ -31,8 +31,8 @@ class MaskRCNN_ResNet50_FPN_Weights(WeightsEnum):
             "categories": _COCO_CATEGORIES,
             "interpolation": InterpolationMode.BILINEAR,
             "recipe": "https://github.com/pytorch/vision/tree/main/references/detection#mask-r-cnn",
-            "box_map": 37.9,
-            "mask_map": 34.6,
+            "map": 37.9,
+            "map_mask": 34.6,
         },
     )
     default = Coco_V1


### PR DESCRIPTION
Adding a crude model meta-data validation. Models can define more fields but we define a minimum number of fields per model family.

There are definitely better ways to do this (create classes for meta-data rather than using dictionaries), but until it's clear what we need to store, I propose keeping a lightweight solution.

In this PR I'm also adding a missing `interpolation` meta-field from keypoint. Without this fix, the new test will fail with:
```
Traceback (most recent call last):
  File "./vision/test/test_prototype_models.py", line 115, in test_schema_meta_validation
    assert len(problematic_weights) == 0, str(problematic_weights)
AssertionError: {KeypointRCNN_ResNet50_FPN_Weights.Coco_Legacy: {'interpolation'}, KeypointRCNN_ResNet50_FPN_Weights.Coco_V1: {'interpolation'}}
assert 2 == 0
```

cc @datumbox @bjuncek