### PR TITLE
remove extraced archive if flag was set

### DIFF
--- a/torchvision/datasets/utils.py
+++ b/torchvision/datasets/utils.py
@@ -407,6 +407,8 @@ def extract_archive(from_path: str, to_path: Optional[str] = None, remove_finish
     extractor = _ARCHIVE_EXTRACTORS[archive_type]
 
     extractor(from_path, to_path, compression)
+    if remove_finished:
+        os.remove(from_path)
 
     return to_path
 


### PR DESCRIPTION
Without this patch, the `remove_finished` flag is not honored unless we are only decompressing a file rather than extracting it.

cc @pmeier