### PR TITLE
Add pretrained weights on Chairs and Things for raft_large

### DIFF
--- a/references/optical_flow/README.md
+++ b/references/optical_flow/README.md
@@ -16,6 +16,7 @@ recipe from https://github.com/princeton-vl/RAFT.
 torchrun --nproc_per_node 8 --nnodes 1 train.py \
     --dataset-root $dataset_root \
     --name $name_chairs \
+    --model raft_large \
     --train-dataset chairs \
     --batch-size 2 \
     --lr 0.0004 \
@@ -28,6 +29,7 @@ torchrun --nproc_per_node 8 --nnodes 1 train.py \
 torchrun --nproc_per_node 8 --nnodes 1 train.py \
     --dataset-root $dataset_root \
     --name $name_things \
+    --model raft_large \
     --train-dataset things \
     --batch-size 2 \
     --lr 0.000125 \
@@ -42,14 +44,14 @@ torchrun --nproc_per_node 8 --nnodes 1 train.py \
 ### Evaluation
 
 ```
-torchrun --nproc_per_node 8 --nnodes 1 train.py --val-dataset sintel --batch-size 10 --dataset-root $dataset_root --model raft_large --pretrained
+torchrun --nproc_per_node 1 --nnodes 1 train.py --val-dataset sintel --batch-size 1 --dataset-root $dataset_root --model raft_large --pretrained
 ```
 
-This should give an epe of about 1.3825 on the clean pass and 2.7148 on the
+This should give an epe of about 1.3822 on the clean pass and 2.7161 on the
 final pass of Sintel. Results may vary slightly depending on the batch size and
-the number of GPUs. For the most accurate resuts use 1 GPU and `--batch-size 1`.
+the number of GPUs. For the most accurate resuts use 1 GPU and `--batch-size 1`:
 
 ```
-Sintel val clean epe: 1.3825	1px: 0.9028	3px: 0.9573	5px: 0.9697	per_image_epe: 1.3782	f1: 4.0234
-Sintel val final epe: 2.7148	1px: 0.8526	3px: 0.9203	5px: 0.9392	per_image_epe: 2.7199	f1: 7.6100
+Sintel val clean epe: 1.3822	1px: 0.9028	3px: 0.9573	5px: 0.9697	per_image_epe: 1.3822	f1: 4.0248
+Sintel val final epe: 2.7161	1px: 0.8528	3px: 0.9204	5px: 0.9392	per_image_epe: 2.7161	f1: 7.5964
 ```

--- a/references/optical_flow/README.md
+++ b/references/optical_flow/README.md
@@ -1,0 +1,55 @@
+# Optical flow reference training scripts
+
+This folder contains reference training scripts for optical flow.
+They serve as a log of how to train specific models, so as to provide baseline
+training and evaluation scripts to quickly bootstrap research.
+
+
+### RAFT Large
+
+The RAFT large model was trained on Flying Chairs and then on Flying Things.
+Both used 8 A100 GPUs and a batch size of 2 (so effective batch size is 16). The
+rest of the hyper-parameters are exactly the same as the original RAFT training
+recipe from https://github.com/princeton-vl/RAFT.
+
+```
+torchrun --nproc_per_node 8 --nnodes 1 train.py \
+    --dataset-root $dataset_root \
+    --name $name_chairs \
+    --train-dataset chairs \
+    --batch-size 2 \
+    --lr 0.0004 \
+    --weight-decay 0.0001 \
+    --num-steps 100000 \
+    --output-dir $chairs_dir
+```
+
+```
+torchrun --nproc_per_node 8 --nnodes 1 train.py \
+    --dataset-root $dataset_root \
+    --name $name_things \
+    --train-dataset things \
+    --batch-size 2 \
+    --lr 0.000125 \
+    --weight-decay 0.0001 \
+    --num-steps 100000 \
+    --freeze-batch-norm \
+    --output-dir $things_dir\
+    --resume $chairs_dir/$name_chairs.pth
+```
+
+
+### Evaluation
+
+```
+torchrun --nproc_per_node 8 --nnodes 1 train.py --val-dataset sintel --batch-size 10 --dataset-root $dataset_root --model raft_large --pretrained
+```
+
+This should give an epe of about 1.3825 on the clean pass and 2.7148 on the
+final pass of Sintel. Results may vary slightly depending on the batch size and
+the number of GPUs. For the most accurate resuts use 1 GPU and `--batch-size 1`.
+
+```
+Sintel val clean epe: 1.3825	1px: 0.9028	3px: 0.9573	5px: 0.9697	per_image_epe: 1.3782	f1: 4.0234
+Sintel val final epe: 2.7148	1px: 0.8526	3px: 0.9203	5px: 0.9392	per_image_epe: 2.7199	f1: 7.6100
+```

--- a/references/optical_flow/train.py
+++ b/references/optical_flow/train.py
@@ -12,7 +12,7 @@ try:
     from torchvision.prototype import models as PM
     from torchvision.prototype.models import optical_flow as PMOF
 except ImportError:
-    PM = None
+    PM = PMOF = None
 
 
 def get_train_dataset(stage, dataset_root):

--- a/test/test_prototype_models.py
+++ b/test/test_prototype_models.py
@@ -201,13 +201,18 @@ def test_old_vs_new_factory(model_fn, dev):
     if module_name == "detection":
         x = [x]
 
+    if module_name == "optical_flow":
+        args = [x, x]  # RAFT model requires img1, img2 as input
+    else:
+        args = [x]
+
     # compare with new model builder parameterized in the old fashion way
     try:
         model_old = _build_model(_get_original_model(model_fn), **kwargs).to(device=dev)
         model_new = _build_model(model_fn, **kwargs).to(device=dev)
     except ModuleNotFoundError:
         pytest.skip(f"Model '{model_name}' not available in both modules.")
-    torch.testing.assert_close(model_new(x), model_old(x), rtol=0.0, atol=0.0, check_dtype=False)
+    torch.testing.assert_close(model_new(*args), model_old(*args), rtol=0.0, atol=0.0, check_dtype=False)
 
 
 def test_smoke():

--- a/test/test_prototype_models.py
+++ b/test/test_prototype_models.py
@@ -91,7 +91,8 @@ def test_naming_conventions(model_fn):
     + TM.get_models_from_module(models.detection)
     + TM.get_models_from_module(models.quantization)
     + TM.get_models_from_module(models.segmentation)
-    + TM.get_models_from_module(models.video),
+    + TM.get_models_from_module(models.video)
+    + TM.get_models_from_module(models.optical_flow),
 )
 def test_schema_meta_validation(model_fn):
     classification_fields = ["size", "categories", "acc@1", "acc@5"]
@@ -102,6 +103,7 @@ def test_schema_meta_validation(model_fn):
         "quantization": classification_fields + ["backend", "quantization", "unquantized"],
         "segmentation": ["categories", "mIoU", "acc"],
         "video": classification_fields,
+        "optical_flow": [],
     }
     module_name = model_fn.__module__.split(".")[-2]
     fields = set(defaults["all"] + defaults[module_name])

--- a/torchvision/models/optical_flow/raft.py
+++ b/torchvision/models/optical_flow/raft.py
@@ -8,6 +8,7 @@ from torch.nn.modules.batchnorm import BatchNorm2d
 from torch.nn.modules.instancenorm import InstanceNorm2d
 from torchvision.ops import ConvNormActivation
 
+from ..._internally_replaced_utils import load_state_dict_from_url
 from ...utils import _log_api_usage_once
 from ._utils import grid_sample, make_coords_grid, upsample_flow
 
@@ -17,6 +18,9 @@ __all__ = (
     "raft_large",
     "raft_small",
 )
+
+
+_MODELS_URLS = {"raft_large": "https://download.pytorch.org/models/raft_large_C_T_V2-1bb1363a.pth"}
 
 
 class ResidualBlock(nn.Module):
@@ -474,8 +478,8 @@ class RAFT(nn.Module):
         hidden_state = torch.tanh(hidden_state)
         context = F.relu(context)
 
-        coords0 = make_coords_grid(batch_size, h // 8, w // 8).cuda()
-        coords1 = make_coords_grid(batch_size, h // 8, w // 8).cuda()
+        coords0 = make_coords_grid(batch_size, h // 8, w // 8).to(fmap1.device)
+        coords1 = make_coords_grid(batch_size, h // 8, w // 8).to(fmap1.device)
 
         flow_predictions = []
         for _ in range(num_flow_updates):
@@ -496,6 +500,9 @@ class RAFT(nn.Module):
 
 def _raft(
     *,
+    arch=None,
+    pretrained=False,
+    progress=False,
     # Feature encoder
     feature_encoder_layers,
     feature_encoder_block,
@@ -560,7 +567,7 @@ def _raft(
             multiplier=0.25,  # See comment in MaskPredictor about this
         )
 
-    return RAFT(
+    model = RAFT(
         feature_encoder=feature_encoder,
         context_encoder=context_encoder,
         corr_block=corr_block,
@@ -568,6 +575,11 @@ def _raft(
         mask_predictor=mask_predictor,
         **kwargs,  # not really needed, all params should be consumed by now
     )
+    if pretrained:
+        state_dict = load_state_dict_from_url(_MODELS_URLS[arch], progress=progress)
+        model.load_state_dict(state_dict)
+
+    return model
 
 
 def raft_large(*, pretrained=False, progress=True, **kwargs):
@@ -584,10 +596,10 @@ def raft_large(*, pretrained=False, progress=True, **kwargs):
         nn.Module: The model.
     """
 
-    if pretrained:
-        raise ValueError("No checkpoint is available for raft_large")
-
     return _raft(
+        arch="raft_large",
+        pretrained=pretrained,
+        progress=progress,
         # Feature encoder
         feature_encoder_layers=(64, 64, 96, 128, 256),
         feature_encoder_block=ResidualBlock,
@@ -629,11 +641,13 @@ def raft_small(*, pretrained=False, progress=True, **kwargs):
         nn.Module: The model.
 
     """
-
     if pretrained:
         raise ValueError("No checkpoint is available for raft_small")
 
     return _raft(
+        arch="raft_small",
+        pretrained=pretrained,
+        progress=progress,
         # Feature encoder
         feature_encoder_layers=(32, 32, 64, 96, 128),
         feature_encoder_block=BottleneckBlock,

--- a/torchvision/prototype/models/optical_flow/raft.py
+++ b/torchvision/prototype/models/optical_flow/raft.py
@@ -5,6 +5,7 @@ from torch.nn.modules.instancenorm import InstanceNorm2d
 from torchvision.models.optical_flow import RAFT
 from torchvision.models.optical_flow.raft import _raft, BottleneckBlock, ResidualBlock
 from torchvision.prototype.transforms import RaftEval
+from torchvision.transforms.functional import InterpolationMode
 
 from .._api import WeightsEnum
 from .._api import Weights
@@ -20,12 +21,16 @@ __all__ = (
 )
 
 
+_COMMON_META = {"interpolation": InterpolationMode.BILINEAR}
+
+
 class Raft_Large_Weights(WeightsEnum):
     C_T_V1 = Weights(
         # Chairs + Things, ported from original paper repo (raft-things.pth)
         url="https://download.pytorch.org/models/raft_large_C_T_V1-22a6c225.pth",
         transforms=RaftEval,
         meta={
+            **_COMMON_META,
             "recipe": "https://github.com/princeton-vl/RAFT",
             "sintel_train_cleanpass_epe": 1.4411,
             "sintel_train_finalpass_epe": 2.7894,
@@ -37,7 +42,8 @@ class Raft_Large_Weights(WeightsEnum):
         url="https://download.pytorch.org/models/raft_large_C_T_V2-1bb1363a.pth",
         transforms=RaftEval,
         meta={
-            "recipe": "",  # TODO
+            **_COMMON_META,
+            "recipe": "https://github.com/pytorch/vision/tree/main/references/optical_flow",
             "sintel_train_cleanpass_epe": 1.3822,
             "sintel_train_finalpass_epe": 2.7161,
         },
@@ -84,68 +90,6 @@ class Raft_Small_Weights(WeightsEnum):
     # default = C_T_V1
 
 
-def _raft_builder(
-    *,
-    weights,
-    progress,
-    # Feature encoder
-    feature_encoder_layers,
-    feature_encoder_block,
-    feature_encoder_norm_layer,
-    # Context encoder
-    context_encoder_layers,
-    context_encoder_block,
-    context_encoder_norm_layer,
-    # Correlation block
-    corr_block_num_levels,
-    corr_block_radius,
-    # Motion encoder
-    motion_encoder_corr_layers,
-    motion_encoder_flow_layers,
-    motion_encoder_out_channels,
-    # Recurrent block
-    recurrent_block_hidden_state_size,
-    recurrent_block_kernel_size,
-    recurrent_block_padding,
-    # Flow Head
-    flow_head_hidden_size,
-    # Mask predictor
-    use_mask_predictor,
-    **kwargs,
-):
-    model = _raft(
-        # Feature encoder
-        feature_encoder_layers=feature_encoder_layers,
-        feature_encoder_block=feature_encoder_block,
-        feature_encoder_norm_layer=feature_encoder_norm_layer,
-        # Context encoder
-        context_encoder_layers=context_encoder_layers,
-        context_encoder_block=context_encoder_block,
-        context_encoder_norm_layer=context_encoder_norm_layer,
-        # Correlation block
-        corr_block_num_levels=corr_block_num_levels,
-        corr_block_radius=corr_block_radius,
-        # Motion encoder
-        motion_encoder_corr_layers=motion_encoder_corr_layers,
-        motion_encoder_flow_layers=motion_encoder_flow_layers,
-        motion_encoder_out_channels=motion_encoder_out_channels,
-        # Recurrent block
-        recurrent_block_hidden_state_size=recurrent_block_hidden_state_size,
-        recurrent_block_kernel_size=recurrent_block_kernel_size,
-        recurrent_block_padding=recurrent_block_padding,
-        # Flow head
-        flow_head_hidden_size=flow_head_hidden_size,
-        # Mask predictor
-        use_mask_predictor=use_mask_predictor,
-        **kwargs,
-    )
-
-    if weights is not None:
-        model.load_state_dict(weights.get_state_dict(progress=progress))
-
-    return model
-
-
 @handle_legacy_interface(weights=("pretrained", Raft_Large_Weights.C_T_V2))
 def raft_large(*, weights: Optional[Raft_Large_Weights] = None, progress=True, **kwargs):
     """RAFT model from
@@ -163,9 +107,7 @@ def raft_large(*, weights: Optional[Raft_Large_Weights] = None, progress=True, *
 
     weights = Raft_Large_Weights.verify(weights)
 
-    return _raft_builder(
-        weights=weights,
-        progress=progress,
+    model = _raft(
         # Feature encoder
         feature_encoder_layers=(64, 64, 96, 128, 256),
         feature_encoder_block=ResidualBlock,
@@ -192,6 +134,11 @@ def raft_large(*, weights: Optional[Raft_Large_Weights] = None, progress=True, *
         **kwargs,
     )
 
+    if weights is not None:
+        model.load_state_dict(weights.get_state_dict(progress=progress))
+
+    return model
+
 
 @handle_legacy_interface(weights=("pretrained", None))
 def raft_small(*, weights: Optional[Raft_Small_Weights] = None, progress=True, **kwargs):
@@ -211,9 +158,7 @@ def raft_small(*, weights: Optional[Raft_Small_Weights] = None, progress=True, *
 
     weights = Raft_Small_Weights.verify(weights)
 
-    return _raft_builder(
-        weights=weights,
-        progress=progress,
+    model = _raft(
         # Feature encoder
         feature_encoder_layers=(32, 32, 64, 96, 128),
         feature_encoder_block=BottleneckBlock,
@@ -239,3 +184,7 @@ def raft_small(*, weights: Optional[Raft_Small_Weights] = None, progress=True, *
         use_mask_predictor=False,
         **kwargs,
     )
+
+    if weights is not None:
+        model.load_state_dict(weights.get_state_dict(progress=progress))
+    return model

--- a/torchvision/prototype/models/optical_flow/raft.py
+++ b/torchvision/prototype/models/optical_flow/raft.py
@@ -21,6 +21,17 @@ __all__ = (
 
 
 class Raft_Large_Weights(WeightsEnum):
+    C_T_V1 = Weights(
+        # Chairs + Things, ported from original paper repo (raft-things.pth)
+        url="https://download.pytorch.org/models/raft_large_C_T_V1-22a6c225.pth",
+        transforms=RaftEval,
+        meta={
+            "recipe": "https://github.com/princeton-vl/RAFT",
+            "sintel_train_cleanpass_epe": 1.4411,
+            "sintel_train_finalpass_epe": 2.7894,
+        },
+    )
+
     C_T_V2 = Weights(
         # Chairs + Things
         url="https://download.pytorch.org/models/raft_large_C_T_V2-1bb1363a.pth",


### PR DESCRIPTION
This PR:

- adds pretrained weights for the raft_large arch (both from our training recipe and also from the original paper's repo)
- add these weights on the prototype model builders
- add a readme in the training ref
- replace `--small` with `--model` in the training ref as per https://github.com/pytorch/vision/issues/5056
- add `--weights` and `--pretrained` in the training ref as per https://github.com/pytorch/vision/issues/5056
- fix a bug that would only allow the model to run on CUDA

The weights  are trained on Chairs + Things and can be evaluated on the training set of Sintel or Kitti.

----


Some manual tests making sure all works fine:

Using `--weights Raft_Large_Weights.C_T_V2`

```
(raft) ➜  vision git:(raft_pretrained_CT) ✗ torchrun --nproc_per_node 8 --nnodes 1 references/optical_flow/train.py --val-dataset sintel --batch-size 10 --dataset-root /data/home/nicolashug/cluster/work/downloads --model raft_large --weights Raft_Large_Weights.C_T_V2
Sintel val clean Total time: 0:00:15
Batch-processed 1040 / 1041 samples. Going to process the remaining samples individually, if any.
Sintel val clean epe: 1.3825	1px: 0.9028	3px: 0.9573	5px: 0.9697	per_image_epe: 1.3782	f1: 4.0234
Sintel val final Total time: 0:00:12
Batch-processed 1040 / 1041 samples. Going to process the remaining samples individually, if any.
Sintel val final epe: 2.7148	1px: 0.8526	3px: 0.9203	5px: 0.9392	per_image_epe: 2.7199	f1: 7.6100
```

Using `--pretrained`

```
(raft) ➜  vision git:(raft_pretrained_CT) ✗ torchrun --nproc_per_node 8 --nnodes 1 references/optical_flow/train.py --val-dataset sintel --batch-size 10 --dataset-root /data/home/nicolashug/cluster/work/downloads --model raft_large --pretrained
Sintel val clean Total time: 0:00:14
Batch-processed 1040 / 1041 samples. Going to process the remaining samples individually, if any.
Sintel val clean epe: 1.3825	1px: 0.9028	3px: 0.9573	5px: 0.9697	per_image_epe: 1.3782	f1: 4.0234
Sintel val final Total time: 0:00:12
Batch-processed 1040 / 1041 samples. Going to process the remaining samples individually, if any.
Sintel val final epe: 2.7148	1px: 0.8526	3px: 0.9203	5px: 0.9392	per_image_epe: 2.7199	f1: 7.6100
```

Using `--weights Raft_Large_Weights.C_T_V1` (Original weights)

```
Sintel val clean Total time: 0:04:06
Batch-processed 1041 / 1041 samples. Going to process the remaining samples individually, if any.
Sintel val clean epe: 1.4411	1px: 0.9016	3px: 0.9560	5px: 0.9684	per_image_epe: 1.4411	f1: 4.1593
Sintel val final Total time: 0:04:02
Batch-processed 1041 / 1041 samples. Going to process the remaining samples individually, if any.
Sintel val final epe: 2.7894	1px: 0.8528	3px: 0.9190	5px: 0.9381	per_image_epe: 2.7894	f1: 7.7217
```


```py
from torchvision.prototype.models.optical_flow import raft_large, Raft_Large_Weights
assert not next(raft_large(weights="Raft_Large_Weights.C_T_V2").parameters()).is_cuda
assert not next(raft_large(weights=Raft_Large_Weights.C_T_V2).parameters()).is_cuda
```



For my own sanity as for reference, here's the slurm script that I used (obviously these weights corresponds to the ones in things/raft-things.pth)

<details>

```bash
#!/bin/bash
#SBATCH --partition=train
#SBATCH --cpus-per-task=96  # 12 CPUs per GPU
#SBATCH --gpus-per-node=8
#SBATCH --nodes=1
#SBATCH --time=70:00:00
#SBATCH --output=/data/home/nicolashug/cluster/experiments/slurm-%j.out
#SBATCH --error=/data/home/nicolashug/cluster/experiments/slurm-%j.err



n_gpus=8  # If you modify these, also update the equivalent above.
n_nodes=1

output_dir=~/cluster/experiments/id_$SLURM_JOB_ID
mkdir -p $output_dir

this_script=./train.sh  # depends where you call it from
cp $this_script $output_dir

function unused_port() {
    # Find a random unused port. It's needed if you run multiple sbatches on the same node
    N=${1:-1}
    comm -23 \
        <(seq "1025" "65535" | sort) \
        <(ss -Htan |
            awk '{print $4}' |
            cut -d':' -f2 |
            sort -u) |
        shuf |
        head -n "$N"
}
master_port=$(unused_port)

dataset_root=/data/home/nicolashug/cluster/work/downloads

# FlyingChairs
batch_size_chairs=2
lr_chairs=0.0004
num_steps_chairs=100000
name_chairs=raft_chairs
wdecay_chairs=0.0001

chairs_dir=$output_dir/chairs
mkdir -p $chairs_dir
torchrun --nproc_per_node $n_gpus --nnodes $n_nodes --master_port $master_port references/optical_flow/train.py \
    --dataset-root $dataset_root \
    --name $name_chairs \
    --train-dataset chairs \
    --batch-size $batch_size_chairs \
    --lr $lr_chairs \
    --weight-decay $wdecay_chairs \
    --num-steps $num_steps_chairs \
    --output-dir $chairs_dir

# FlyingThings3D
batch_size_things=2
lr_things=0.000125
num_steps_things=100000
name_things=raft_things
wdecay_things=0.0001

things_dir=$output_dir/things
mkdir -p $things_dir
torchrun --nproc_per_node $n_gpus --nnodes $n_nodes --master_port $master_port references/optical_flow/train.py \
    --dataset-root $dataset_root \
    --name $name_things \
    --train-dataset things \
    --batch-size $batch_size_things \
    --lr $lr_things \
    --weight-decay $wdecay_things \
    --num-steps $num_steps_things \
    --freeze-batch-norm \
    --output-dir $things_dir\
    --resume $chairs_dir/$name_chairs.pth

# Sintel S+K+H
batch_size_sintel_skh=2
lr_sintel_skh=0.000125
num_steps_sintel_skh=100000
name_sintel_skh=raft_sintel_skh
wdecay_sintel_skh=0.00001
gamma_sintel_skh=0.85

sintel_skh_dir=$output_dir/sintel_skh
mkdir -p $sintel_skh_dir
torchrun --nproc_per_node $n_gpus --nnodes $n_nodes --master_port $master_port references/optical_flow/train.py \
    --dataset-root $dataset_root \
    --name $name_sintel_skh \
    --train-dataset sintel_SKH \
    --batch-size $batch_size_sintel_skh \
    --lr $lr_sintel_skh \
    --weight-decay $wdecay_sintel_skh \
    --gamma $gamma_sintel_skh \
    --num-steps $num_steps_sintel_skh \
    --freeze-batch-norm \
    --output-dir $sintel_skh_dir\
    --resume $things_dir/$name_things.pth

# Kitti
batch_size_kitti=2
lr_kitti=0.0001
num_steps_kitti=50000
name_kitti=raft_kitti
wdecay_kitti=0.00001
gamma_kitti=0.85

kitti_dir=$output_dir/kitti
mkdir -p $kitti_dir
torchrun --nproc_per_node $n_gpus --nnodes $n_nodes --master_port $master_port references/optical_flow/train.py \
    --dataset-root $dataset_root \
    --name $name_kitti \
    --train-dataset kitti \
    --batch-size $batch_size_kitti \
    --lr $lr_kitti \
    --weight-decay $wdecay_kitti \
    --gamma $gamma_kitti \
    --num-steps $num_steps_kitti \
    --freeze-batch-norm \
    --output-dir $kitti_dir \
    --resume $sintel_skh_dir/$name_sintel_skh.pth
```

</details>

The code to map the original paper's weights to ours is

<details>

```py
def map_orig_to_ours(orig, mine=None):
    # TODO: remove
    d = {}
    used_s_orig = set()
    used_s_mine = set()

    def assert_and_add(s_orig, s_mine):
        # print(s_orig, s_mine)
        # print(orig[s_orig].shape, mine[s_mine].shape)

        assert s_orig not in used_s_orig
        assert s_mine not in used_s_mine

        if mine is not None:
            assert s_mine in mine
        assert s_orig in orig
        if mine is not None:
            assert orig[s_orig].shape == mine[s_mine].shape
        d["module." + s_mine] = orig[s_orig]
        used_s_orig.add(s_orig)
        used_s_mine.add(s_mine)

    for encoder_orig, encoder_mine in (
        ("fnet", "feature_encoder"),
        ("cnet", "context_encoder"),
    ):
        for attr in ("bias", "weight"):
            s_orig = f"module.{encoder_orig}.conv1.{attr}"
            s_mine = f"{encoder_mine}.convnormrelu.0.{attr}"
            assert_and_add(s_orig, s_mine)

            s_orig = f"module.{encoder_orig}.conv2.{attr}"
            s_mine = f"{encoder_mine}.conv.{attr}"
            assert_and_add(s_orig, s_mine)

            for layer in (1, 2, 3):
                for block in (0, 1):
                    for conv in (1, 2):
                        s_orig = f"module.{encoder_orig}.layer{layer}.{block}.conv{conv}.{attr}"
                        s_mine = f"{encoder_mine}.layer{layer}.{block}.convnormrelu{conv}.0.{attr}"
                        assert_and_add(s_orig, s_mine)

            for layer in (2, 3):
                s_orig = f"module.{encoder_orig}.layer{layer}.0.downsample.0.{attr}"
                s_mine = f"{encoder_mine}.layer{layer}.0.downsample.0.{attr}"
                assert_and_add(s_orig, s_mine)

    encoder_orig, encoder_mine = "cnet", "context_encoder"
    for attr in (
        "bias",
        "weight",
        "running_mean",
        "running_var",
        "num_batches_tracked",
    ):
        s_orig = f"module.{encoder_orig}.norm1.{attr}"
        s_mine = f"{encoder_mine}.convnormrelu.1.{attr}"
        assert_and_add(s_orig, s_mine)
        for layer in (1, 2, 3):
            for block in (0, 1):
                for norm in (1, 2):
                    s_orig = f"module.{encoder_orig}.layer{layer}.{block}.norm{norm}.{attr}"
                    s_mine = f"{encoder_mine}.layer{layer}.{block}.convnormrelu{norm}.1.{attr}"
                    assert_and_add(s_orig, s_mine)
        for layer in (2, 3):
            s_orig = f"module.{encoder_orig}.layer{layer}.0.downsample.1.{attr}"
            s_mine = f"{encoder_mine}.layer{layer}.0.downsample.1.{attr}"
            assert_and_add(s_orig, s_mine)

    corr_orig, corr_mine = (
        "module.update_block.encoder.",
        "update_block.motion_encoder.",
    )
    for attr in ("bias", "weight"):
        for i in (1, 2):
            s_orig = f"{corr_orig}convc{i}.{attr}"
            s_mine = f"{corr_mine}convcorr{i}.0.{attr}"
            assert_and_add(s_orig, s_mine)
            s_orig = f"{corr_orig}convf{i}.{attr}"
            s_mine = f"{corr_mine}convflow{i}.0.{attr}"
            assert_and_add(s_orig, s_mine)
        s_orig = f"{corr_orig}conv.{attr}"
        s_mine = f"{corr_mine}conv.0.{attr}"
        assert_and_add(s_orig, s_mine)

    rec_orig, rec_mine = "module.update_block.gru", "update_block.recurrent_block"
    for attr in ("bias", "weight"):
        for i in (1, 2):
            for conv in ("convz", "convr", "convq"):
                s_orig = f"{rec_orig}.{conv}{i}.{attr}"
                s_mine = f"{rec_mine}.convgru{i}.{conv}.{attr}"
                assert_and_add(s_orig, s_mine)

    flow_orig, flow_mine = "module.update_block.flow_head", "update_block.flow_head"
    for attr in ("bias", "weight"):
        for i in (1, 2):
            s_orig = f"{flow_orig}.conv{i}.{attr}"
            s_mine = f"{flow_mine}.conv{i}.{attr}"
            assert_and_add(s_orig, s_mine)
    for s_orig, s_mine in zip(
        (
            "module.update_block.mask.0.weight",
            "module.update_block.mask.0.bias",
            "module.update_block.mask.2.weight",
            "module.update_block.mask.2.bias",
        ),
        (
            "mask_predictor.convrelu.0.weight",
            "mask_predictor.convrelu.0.bias",
            "mask_predictor.conv.weight",
            "mask_predictor.conv.bias",
        ),
    ):
        assert_and_add(s_orig, s_mine)

    if mine is not None:
        print(len(d), len(orig), len(mine))
        assert not (set(mine.keys()) - set(d.keys()))
    return d
```

</details>

cc @datumbox