### PR TITLE
Fix `binary_libtorchvision_ops_android` job

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -15,7 +15,7 @@ allprojects {
             androidSupportAppCompatV7Version = "28.0.0"
             fbjniJavaOnlyVersion = "0.0.3"
             soLoaderNativeLoaderVersion = "0.8.0"
-            pytorchAndroidVersion = "1.10.0-SNAPSHOT"
+            pytorchAndroidVersion = "1.10.0"
         }
 
         repositories {

--- a/android/ops/CMakeLists.txt
+++ b/android/ops/CMakeLists.txt
@@ -35,7 +35,7 @@ target_compile_options(${TARGET} PRIVATE
 
 set(BUILD_SUBDIR ${ANDROID_ABI})
 
-find_library(PYTORCH_LIBRARY pytorch_jni_lite
+find_library(PYTORCH_LIBRARY pytorch_jni
   PATHS ${PYTORCH_LINK_DIRS}
   NO_CMAKE_FIND_ROOT_PATH)
 


### PR DESCRIPTION
Fixes the [CI failure](https://app.circleci.com/pipelines/github/pytorch/vision/13240/workflows/4dcc58a8-2fcc-4d56-a72c-cf7ac54d5058/jobs/1057456) by switching `pytorchAndroidVersion` to non-snapshot

Cherrypicks https://github.com/pytorch/vision/pull/4926


cc @seemethere