### PR TITLE
Add numpy as explicit dependency to build_cmake.sh (#4987)

### DIFF
--- a/packaging/build_cmake.sh
+++ b/packaging/build_cmake.sh
@@ -36,7 +36,7 @@ else
   MKL_CONSTRAINT=''
 fi
 
-conda install -yq \pytorch=$PYTORCH_VERSION $CONDA_CUDATOOLKIT_CONSTRAINT $CONDA_CPUONLY_FEATURE $MKL_CONSTRAINT -c "pytorch-${UPLOAD_CHANNEL}"
+conda install -yq \pytorch=$PYTORCH_VERSION $CONDA_CUDATOOLKIT_CONSTRAINT $CONDA_CPUONLY_FEATURE $MKL_CONSTRAINT numpy -c "pytorch-${UPLOAD_CHANNEL}"
 TORCH_PATH=$(dirname $(python -c "import torch; print(torch.__file__)"))
 
 if [[ "$(uname)" == Darwin || "$OSTYPE" == "msys" ]]; then


### PR DESCRIPTION
Fixes the [CI failure](https://app.circleci.com/pipelines/github/pytorch/vision/13240/workflows/c5c4c399-5c1c-454e-aa5c-1e3de3bf9eac/jobs/1057482) by adding numpy as explicit dependency to build_cmake.sh

Cherrypicks #4987

cc @seemethere