### PR TITLE
Add raft_large weights fined-tuned on Kitti

### DIFF
--- a/torchvision/prototype/models/optical_flow/raft.py
+++ b/torchvision/prototype/models/optical_flow/raft.py
@@ -79,18 +79,30 @@ class Raft_Large_Weights(WeightsEnum):
         },
     )
 
-    # C_T_SKHT_K_V1 = Weights(
-    #     # Chairs + Things + Sintel fine-tuning + Kitti fine-tuning i.e.:
-    #     # Chairs + Things + (Sintel + Kitti + HD1K + Things_clean) + Kitti
-    #     # Same as CT_SKHT with extra fine-tuning on Kitti
-    #     # Corresponds to the C+T+S+K+H on paper with fine-tuning on Sintel and then on Kitti
-    #     url="",
-    #     transforms=RaftEval,
-    #     meta={
-    #         "recipe": "",
-    #         "epe": -1234,
-    #     },
-    # )
+    C_T_SKHT_K_V1 = Weights(
+        # Chairs + Things + Sintel fine-tuning + Kitti fine-tuning, ported from the original repo (sintel-kitti.pth)
+        url="https://download.pytorch.org/models/raft_large_C_T_SKHT_K_V1-4a6a5039.pth",
+        transforms=RaftEval,
+        meta={
+            **_COMMON_META,
+            "recipe": "https://github.com/princeton-vl/RAFT",
+            "kitti_train_f1-all": 5.10,
+        },
+    )
+
+    C_T_SKHT_K_V2 = Weights(
+        # Chairs + Things + Sintel fine-tuning + Kitti fine-tuning i.e.:
+        # Chairs + Things + (Sintel + Kitti + HD1K + Things_clean) + Kitti
+        # Same as CT_SKHT with extra fine-tuning on Kitti
+        # Corresponds to the C+T+S+K+H on paper with fine-tuning on Sintel and then on Kitti
+        url="https://download.pytorch.org/models/raft_large_C_T_SKHT_K_V2-b5c70766.pth",
+        transforms=RaftEval,
+        meta={
+            **_COMMON_META,
+            "recipe": "https://github.com/pytorch/vision/tree/main/references/optical_flow",
+            "kitti_train_f1-all": 5.19,
+        },
+    )
 
     default = C_T_V2
 

--- a/torchvision/prototype/models/optical_flow/raft.py
+++ b/torchvision/prototype/models/optical_flow/raft.py
@@ -86,7 +86,7 @@ class Raft_Large_Weights(WeightsEnum):
         meta={
             **_COMMON_META,
             "recipe": "https://github.com/princeton-vl/RAFT",
-            "kitti_train_f1-all": 5.10,
+            "kitti_test_f1-all": 5.10,
         },
     )
 
@@ -100,7 +100,7 @@ class Raft_Large_Weights(WeightsEnum):
         meta={
             **_COMMON_META,
             "recipe": "https://github.com/pytorch/vision/tree/main/references/optical_flow",
-            "kitti_train_f1-all": 5.19,
+            "kitti_test_f1-all": 5.19,
         },
     )
 


### PR DESCRIPTION
This PR adds pre-trained weights for raft-large, fine-tuned on Kitti.

I'm publishing both our weights and the original weights. The Kitti authors kindly allowed us to submit our code for evaluation on Kitti-test.

Our f1-epe on Kitti-test is 5.19 wheras the original is 5.10. We're a tiny bit higher (i.e. worse), but still significantly better than the other baselines that are compared against in the paper (next best one is 6.10).

There are submission restrictions, so to keep consistency with the C_T and C_T_SKHT weights, I just submitted the model that we already used in both (after kitti-specific fine-tuning). In other words these weights are litterally the current `C_T_SKHT_V` with the last fine-tuning step on Kitti.

Evaluated on kitti train:

```
(raft) ➜  vision git:(raft_kitti_weights) ✗ torchrun --nproc_per_node 8 --nnodes 1 references/optical_flow/train.py --val-dataset kitti --batch-size 10 --model raft_large --dataset-root ../downloads --weights Raft_Large_Weights.C_T_SKHT_K_V1

Kitti val epe: 0.6262	1px: 0.8732	3px: 0.9696	5px: 0.9859	per_image_epe: 0.6303	f1: 1.4712

(raft) ➜  vision git:(raft_kitti_weights) ✗ torchrun --nproc_per_node 8 --nnodes 1 references/optical_flow/train.py --val-dataset kitti --batch-size 10 --model raft_large --dataset-root ../downloads --weights Raft_Large_Weights.C_T_SKHT_K_V2

Kitti val epe: 0.6283	1px: 0.8752	3px: 0.9689	5px: 0.9852	per_image_epe: 0.6347	f1: 1.5217

```


kitti test submission:

![Screenshot 2021-12-09 at 13-22-36 The KITTI Vision Benchmark Suite](https://user-images.githubusercontent.com/1190450/145410028-99023f7e-0702-4eed-bcb1-bf9417ca715b.png)


cc @datumbox