### PR TITLE
fix: Fixed custom anchor generator for fasterrcnn_mobilenet*

### DIFF
--- a/torchvision/models/detection/faster_rcnn.py
+++ b/torchvision/models/detection/faster_rcnn.py
@@ -421,7 +421,7 @@ def _fasterrcnn_mobilenet_v3_large_fpn(
     )
     backbone = _mobilenet_extractor(backbone, True, trainable_backbone_layers)
 
-    if kwargs.get('rpn_anchor_generator') is None:
+    if kwargs.get("rpn_anchor_generator") is None:
 
         anchor_sizes = (
             (
@@ -433,7 +433,7 @@ def _fasterrcnn_mobilenet_v3_large_fpn(
             ),
         ) * 3
         aspect_ratios = ((0.5, 1.0, 2.0),) * len(anchor_sizes)
-        kwargs['rpn_anchor_generator'] = AnchorGenerator(anchor_sizes, aspect_ratios)
+        kwargs["rpn_anchor_generator"] = AnchorGenerator(anchor_sizes, aspect_ratios)
 
     model = FasterRCNN(backbone, num_classes, **kwargs)
     if pretrained:

--- a/torchvision/models/detection/faster_rcnn.py
+++ b/torchvision/models/detection/faster_rcnn.py
@@ -421,20 +421,21 @@ def _fasterrcnn_mobilenet_v3_large_fpn(
     )
     backbone = _mobilenet_extractor(backbone, True, trainable_backbone_layers)
 
-    anchor_sizes = (
-        (
-            32,
-            64,
-            128,
-            256,
-            512,
-        ),
-    ) * 3
-    aspect_ratios = ((0.5, 1.0, 2.0),) * len(anchor_sizes)
+    if kwargs.get('rpn_anchor_generator') is None:
 
-    model = FasterRCNN(
-        backbone, num_classes, rpn_anchor_generator=AnchorGenerator(anchor_sizes, aspect_ratios), **kwargs
-    )
+        anchor_sizes = (
+            (
+                32,
+                64,
+                128,
+                256,
+                512,
+            ),
+        ) * 3
+        aspect_ratios = ((0.5, 1.0, 2.0),) * len(anchor_sizes)
+        kwargs['rpn_anchor_generator'] = AnchorGenerator(anchor_sizes, aspect_ratios)
+
+    model = FasterRCNN(backbone, num_classes, **kwargs)
     if pretrained:
         if model_urls.get(weights_name, None) is None:
             raise ValueError(f"No checkpoint is available for model {weights_name}")


### PR DESCRIPTION
Hello team :wave: 

I was playing with faster rcnn, and changing the anchor generator on the multiple alternate versions supported by torchvision. In doing so, I encountered an issue with the ones having a mobilenet backbone.

The following snippet:
```python
from torchvision.models.detection import fasterrcnn_mobilenet_v3_large_fpn
from torchvision.models.detection.anchor_utils import AnchorGenerator

anchor_sizes = ((32,), (64,), (128,), (256,), (512,))
aspect_ratios = ((0.5, 1.0, 2.0),) * len(anchor_sizes)
model = fasterrcnn_mobilenet_v3_large_fpn(rpn_anchor_generator=AnchorGenerator(anchor_sizes, aspect_ratios))
```

was producing:
```
---------------------------------------------------------------------------
NameError                                 Traceback (most recent call last)
<ipython-input-1-c1e70ffded92> in <module>
      4 anchor_sizes = ((32,), (64,), (128,), (256,), (512,))
      5 aspect_ratios = ((0.5, 1.0, 2.0),) * len(anchor_sizes)
----> 6 model = fasterrcnn_mobilenet_v3_large_fpn(rpn_anchor_generator=AnchorGenerator(anchor_sizes, anchor_ratios))

NameError: name 'anchor_ratios' is not defined

In [2]: from torchvision.models.detection import fasterrcnn_mobilenet_v3_large_fpn
   ...: from torchvision.models.detection.anchor_utils import AnchorGenerator
   ...: 
   ...: anchor_sizes = ((32,), (64,), (128,), (256,), (512,))
   ...: aspect_ratios = ((0.5, 1.0, 2.0),) * len(anchor_sizes)
   ...: model = fasterrcnn_mobilenet_v3_large_fpn(rpn_anchor_generator=AnchorGenerator(anchor_sizes,
   ...: aspect_ratios))
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-2-6e6703521a1f> in <module>
      4 anchor_sizes = ((32,), (64,), (128,), (256,), (512,))
      5 aspect_ratios = ((0.5, 1.0, 2.0),) * len(anchor_sizes)
----> 6 model = fasterrcnn_mobilenet_v3_large_fpn(rpn_anchor_generator=AnchorGenerator(anchor_sizes, aspect_ratios))

~/miniconda3/lib/python3.8/site-packages/torchvision/models/detection/faster_rcnn.py in fasterrcnn_mobilenet_v3_large_fpn(pretrained, progress, num_classes, pretrained_backbone, trainable_backbone_layers, **kwargs)
    468 
    469     kwargs = {**defaults, **kwargs}
--> 470     return _fasterrcnn_mobilenet_v3_large_fpn(weights_name, pretrained=pretrained, progress=progress,
    471                                               num_classes=num_classes, pretrained_backbone=pretrained_backbone,
    472                                               trainable_backbone_layers=trainable_backbone_layers, **kwargs)

~/miniconda3/lib/python3.8/site-packages/torchvision/models/detection/faster_rcnn.py in _fasterrcnn_mobilenet_v3_large_fpn(weights_name, pretrained, progress, num_classes, pretrained_backbone, trainable_backbone_layers, **kwargs)
    391     aspect_ratios = ((0.5, 1.0, 2.0),) * len(anchor_sizes)
    392 
--> 393     model = FasterRCNN(backbone, num_classes, rpn_anchor_generator=AnchorGenerator(anchor_sizes, aspect_ratios),
    394                        **kwargs)
    395     if pretrained:

TypeError: type object got multiple values for keyword argument 'rpn_anchor_generator'
```

The reason behind this is the hardcoded passing of the anchor generator for those over here: https://github.com/pytorch/vision/blob/main/torchvision/models/detection/faster_rcnn.py#L436

This PR simply checks whether the kwargs have an anchor generator before overriding it :+1: 

Any feedback is welcome!