### PR TITLE
(temporary) add `pyyaml` to unittest requirements

### DIFF
--- a/.circleci/unittest/linux/scripts/environment.yml
+++ b/.circleci/unittest/linux/scripts/environment.yml
@@ -9,6 +9,7 @@ dependencies:
   - libpng
   - jpeg
   - ca-certificates
+  - pyyaml
   - pip:
     - future
     - pillow >=5.3.0, !=8.3.*

--- a/.circleci/unittest/linux/scripts/environment.yml
+++ b/.circleci/unittest/linux/scripts/environment.yml
@@ -9,6 +9,7 @@ dependencies:
   - libpng
   - jpeg
   - ca-certificates
+  # TODO: remove this after https://github.com/pytorch/pytorch/issues/69905 is resolved
   - pyyaml
   - pip:
     - future

--- a/.circleci/unittest/windows/scripts/environment.yml
+++ b/.circleci/unittest/windows/scripts/environment.yml
@@ -9,6 +9,7 @@ dependencies:
   - libpng
   - jpeg
   - ca-certificates
+  - pyyaml
   - pip:
     - future
     - pillow >=5.3.0, !=8.3.*

--- a/.circleci/unittest/windows/scripts/environment.yml
+++ b/.circleci/unittest/windows/scripts/environment.yml
@@ -9,6 +9,7 @@ dependencies:
   - libpng
   - jpeg
   - ca-certificates
+  # TODO: remove this after https://github.com/pytorch/pytorch/issues/69905 is resolved
   - pyyaml
   - pip:
     - future


### PR DESCRIPTION
pytorch/pytorch#68772 added `pyyaml` as dependency and with pytorch/pytorch#68773 it is now a hard dependency when using `torch.jit.load`. Since it is not listed in `torch`'s dependency, we need to install it manually. 

I propose to merge this PR now and revert it as soon as this is resolved upstream.


cc @seemethere @tugsbayasgalan @gmagogsfm