### PR TITLE
Fix `draw_bounding_boxes` for tensors on GPU

### DIFF
--- a/torchvision/utils.py
+++ b/torchvision/utils.py
@@ -189,7 +189,7 @@ def draw_bounding_boxes(
     if image.size(0) == 1:
         image = torch.tile(image, (3, 1, 1))
 
-    ndarr = image.permute(1, 2, 0).numpy()
+    ndarr = image.permute(1, 2, 0).cpu().numpy()
     img_to_draw = Image.fromarray(ndarr)
 
     img_boxes = boxes.to(torch.int64).tolist()


### PR DESCRIPTION
# Background
without this PR, this happens when `image` is on a CUDA device: 
```
  File ".../my_code.py", line 186, in build_graph
    wsi_with_patches = draw_bounding_boxes(wsi, boxes)  # `wsi` is on CUDA device 0
  File ".../venv/lib/python3.8/site-packages/torch/autograd/grad_mode.py", line 28, in decorate_context
    return func(*args, **kwargs)
  File ".../venv/lib/python3.8/site-packages/torchvision/utils.py", line 188, in draw_bounding_boxes
    ndarr = image.permute(1, 2, 0).numpy()
TypeError: can't convert cuda:0 device type tensor to numpy. Use Tensor.cpu() to copy the tensor to host memory first.
```

# Notes
- not detaching the tensor because the function is decorated with `torch.no_grad`

