### PR TITLE
Revert "(temporary) add `pyyaml` to unittest requirements"

### DIFF
--- a/.circleci/unittest/linux/scripts/environment.yml
+++ b/.circleci/unittest/linux/scripts/environment.yml
@@ -9,8 +9,6 @@ dependencies:
   - libpng
   - jpeg
   - ca-certificates
-  # TODO: remove this after https://github.com/pytorch/pytorch/issues/69905 is resolved
-  - pyyaml
   - pip:
     - future
     - pillow >=5.3.0, !=8.3.*

--- a/.circleci/unittest/windows/scripts/environment.yml
+++ b/.circleci/unittest/windows/scripts/environment.yml
@@ -9,8 +9,6 @@ dependencies:
   - libpng
   - jpeg
   - ca-certificates
-  # TODO: remove this after https://github.com/pytorch/pytorch/issues/69905 is resolved
-  - pyyaml
   - pip:
     - future
     - pillow >=5.3.0, !=8.3.*


### PR DESCRIPTION
Reverts pytorch/vision#5099

Fix no longer needed as per https://github.com/pytorch/vision/pull/5099#issuecomment-997161924