### PR TITLE
Adds EuroSAT to the list of supported datasets

### DIFF
--- a/docs/source/datasets.rst
+++ b/docs/source/datasets.rst
@@ -39,6 +39,7 @@ You can also create your own datasets using the provided :ref:`base classes <bas
     CocoCaptions
     CocoDetection
     EMNIST
+    EuroSAT
     FakeData
     FashionMNIST
     Flickr8k

--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -2168,5 +2168,23 @@ class HD1KTestCase(KittiFlowTestCase):
         return num_sequences * (num_examples_per_sequence - 1)
 
 
+class EuroSATTestCase(datasets_utils.ImageDatasetTestCase):
+    DATASET_CLASS = datasets.EuroSAT
+
+    def inject_fake_data(self, tmpdir, config):
+        tmpdir = pathlib.Path(tmpdir)
+
+        wnid = "AnnualCrop"
+        num_examples = 3
+        datasets_utils.create_image_folder(
+            root=tmpdir,
+            name=tmpdir / wnid / wnid,
+            file_name_fn=lambda image_idx: f"{wnid}_{image_idx}.JPEG",
+            num_examples=num_examples,
+        )
+
+        return num_examples
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/torchvision/datasets/__init__.py
+++ b/torchvision/datasets/__init__.py
@@ -4,6 +4,7 @@ from .celeba import CelebA
 from .cifar import CIFAR10, CIFAR100
 from .cityscapes import Cityscapes
 from .coco import CocoCaptions, CocoDetection
+from .eurosat import EuroSAT
 from .fakedata import FakeData
 from .flickr import Flickr8k, Flickr30k
 from .folder import ImageFolder, DatasetFolder
@@ -77,4 +78,5 @@ __all__ = (
     "FlyingChairs",
     "FlyingThings3D",
     "HD1K",
+    "EuroSAT",
 )

--- a/torchvision/datasets/eurosat.py
+++ b/torchvision/datasets/eurosat.py
@@ -1,0 +1,76 @@
+import os
+from typing import Any
+
+from .folder import ImageFolder
+from .utils import download_and_extract_archive, check_integrity
+
+
+class EuroSAT(ImageFolder):
+    """`EuroSAT <https://arxiv.org/pdf/1709.00029.pdf>`_ Dataset.
+
+    Args:
+        root (string): Root directory of dataset where ``EuroSAT.zip`` exists.
+        download (bool, optional): If True, downloads the dataset from the internet and
+            puts it in root directory. If dataset is already downloaded, it is not
+            downloaded again.
+        transform (callable, optional): A function/transform that  takes in an PIL image
+            and returns a transformed version. E.g, ``transforms.RandomCrop``
+        target_transform (callable, optional): A function/transform that takes in the
+            target and transforms it.
+    """
+
+    url = "https://madm.dfki.de/files/sentinel/EuroSAT.zip"
+    md5 = "c8fa014336c82ac7804f0398fcb19387"
+    filename = "EuroSAT.zip"
+
+    _classes = [
+        "Annual Crop",
+        "Forest",
+        "Herbaceous Vegetation",
+        "Highway",
+        "Industrial Buildings",
+        "Pasture",
+        "Permanent Crop",
+        "Residential Buildings",
+        "River",
+        "Sea & Lake",
+    ]
+
+    def __init__(
+        self,
+        root: str,
+        download: bool = False,
+        **kwargs: Any,
+    ) -> None:
+        self.root = os.path.expanduser(root)
+
+        # Download
+        if download:
+            self.download()
+        if not self._check_exists():
+            raise RuntimeError("Dataset not found. You can use download=True to download it")
+
+        # ImageFolder
+        super().__init__(os.path.join(self.data_folder, "2750"), **kwargs)
+        self.classes = self._classes
+        self.class_to_idx = {_class: i for i, _class in enumerate(self.classes)}
+
+    def __len__(self) -> int:
+        return len(self.data)
+
+    @property
+    def data_folder(self) -> str:
+        return os.path.join(self.root, self.__class__.__name__)
+
+    def _check_exists(self) -> bool:
+        return check_integrity(os.path.join(self.data_folder, self.filename))
+
+    def download(self) -> None:
+        """Download the EuroSAT data if it doesn't exist already."""
+
+        if self._check_exists():
+            return
+
+        os.makedirs(self.data_folder, exist_ok=True)
+        print(f"Downloading {self.url}")
+        download_and_extract_archive(self.url, download_root=self.data_folder, filename=self.filename, md5=self.md5)

--- a/torchvision/datasets/eurosat.py
+++ b/torchvision/datasets/eurosat.py
@@ -6,7 +6,7 @@ from .utils import download_and_extract_archive, check_integrity
 
 
 class EuroSAT(ImageFolder):
-    """`EuroSAT <https://arxiv.org/pdf/1709.00029.pdf>`_ Dataset.
+    """RGB version of the `EuroSAT <https://arxiv.org/pdf/1709.00029.pdf>`_ Dataset.
 
     Args:
         root (string): Root directory of dataset where ``EuroSAT.zip`` exists.
@@ -44,9 +44,10 @@ class EuroSAT(ImageFolder):
     ) -> None:
         self.root = os.path.expanduser(root)
 
-        # Download
+        # Download the dataset
         if download:
             self.download()
+
         if not self._check_exists():
             raise RuntimeError("Dataset not found. You can use download=True to download it")
 


### PR DESCRIPTION
Following up on #5108, this PR introduces the following modifications:
- adds the EuroSAT dataset to the list of supported datasets (please note that there is no train/test split)
- adds a corresponding unittest
- adds the corresponding entry in the documentation

Any feedback is welcome!
