### PR TITLE
Docs: build with Sphinx 5

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,8 +2,6 @@ matplotlib
 numpy
 sphinx-copybutton>=0.3.1
 sphinx-gallery>=0.9.0
-sphinx==3.5.4
+sphinx==5.0.0
 tabulate
-# This pin is only needed for sphinx<4.0.2. See https://github.com/pytorch/vision/issues/5673 for details
-Jinja2<3.1.*
 -e git+https://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -103,7 +103,7 @@ if VERSION:
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.


### PR DESCRIPTION
Companion to https://github.com/pytorch/pytorch/pull/70309. See https://github.com/pytorch/pytorch/issues/60979, https://github.com/pytorch/pytorch/pull/61045, and https://github.com/sphinx-doc/sphinx/issues/9395 for discussion.

I _believe_ the reason that we were previously pinning to Sphinx 3 was because of issues with pytorch_sphinx_theme and Sphinx 4 support, but these seem to have been resolved now. See https://torchgeo.readthedocs.io/ for an example of docs built with pytorch_sphinx_theme and Sphinx 4.