### PR TITLE
Updated the example for fasterrcnn_resnet50

### DIFF
--- a/torchvision/models/detection/faster_rcnn.py
+++ b/torchvision/models/detection/faster_rcnn.py
@@ -356,6 +356,7 @@ def fasterrcnn_resnet50_fpn(
         >>> model = torchvision.models.detection.fasterrcnn_resnet50_fpn(pretrained=True)
         >>> # For training
         >>> images, boxes = torch.rand(4, 3, 600, 1200), torch.rand(4, 11, 4)
+        >>> boxes[:, :, 2:4] = boxes[:, :, 0:2] + boxes[:, :, 2:4]
         >>> labels = torch.randint(1, 91, (4, 11))
         >>> images = list(image for image in images)
         >>> targets = []


### PR DESCRIPTION
Fixes #5163


Updated the example for the fasterrcnn_resnet50_fpn model.
Previously there was an error for the output during training phase because the bboxes were initialized randomly, and not matching the coordinate criteria for fasterrcnn.
With this update, the coordinates of bboxes are fixed.
