### PR TITLE
Skip jpeg comparison tests with PIL

### DIFF
--- a/test/test_image.py
+++ b/test/test_image.py
@@ -478,7 +478,8 @@ def test_write_jpeg_reference(img_path, tmpdir):
     assert_equal(torch_bytes, pil_bytes)
 
 
-@pytest.mark.skipif(IS_WINDOWS, reason=("this test fails on windows because PIL uses libjpeg-turbo on windows"))
+# TODO: Remove the skip. See https://github.com/pytorch/vision/issues/5162.
+@pytest.mark.skip("this test fails because PIL uses libjpeg-turbo")
 @pytest.mark.parametrize(
     "img_path",
     [pytest.param(jpeg_path, id=_get_safe_image_name(jpeg_path)) for jpeg_path in get_images(ENCODE_JPEG, ".jpg")],
@@ -497,7 +498,8 @@ def test_encode_jpeg(img_path):
         assert_equal(encoded_jpeg_torch, encoded_jpeg_pil)
 
 
-@pytest.mark.skipif(IS_WINDOWS, reason=("this test fails on windows because PIL uses libjpeg-turbo on windows"))
+# TODO: Remove the skip. See https://github.com/pytorch/vision/issues/5162.
+@pytest.mark.skip("this test fails because PIL uses libjpeg-turbo")
 @pytest.mark.parametrize(
     "img_path",
     [pytest.param(jpeg_path, id=_get_safe_image_name(jpeg_path)) for jpeg_path in get_images(ENCODE_JPEG, ".jpg")],


### PR DESCRIPTION
Linux and MacOS CIs are failing because the latest PIL 9 version now relies on libjpeg-turbo (it used to be the case only for Windows). Torchvision relies on libjpeg, not libjpeg-turbo, hence the comparison test failures.

We skip them in this PR to put CI back to green. This is only temporary until we find a better solution, tracked in https://github.com/pytorch/vision/issues/5162.