### PR TITLE
[ViT] Refactor forward function

### DIFF
--- a/torchvision/prototype/models/vision_transformer.py
+++ b/torchvision/prototype/models/vision_transformer.py
@@ -5,7 +5,7 @@
 import math
 from collections import OrderedDict
 from functools import partial
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Optional, Tuple
 
 import torch
 import torch.nn as nn
@@ -202,7 +202,7 @@ class VisionTransformer(nn.Module):
         nn.init.zeros_(self.heads.head.weight)
         nn.init.zeros_(self.heads.head.bias)
 
-    def forward(self, x: torch.Tensor):
+    def process_input(self, x: torch.Tensor) -> Tuple[int, torch.Tensor]:
         n, c, h, w = x.shape
         p = self.patch_size
         torch._assert(h == self.image_size, "Wrong image height!")
@@ -221,7 +221,13 @@ class VisionTransformer(nn.Module):
         # embedding dimension
         x = x.permute(0, 2, 1)
 
-        # Expand the class token to the full batch.
+        return n, x
+
+    def forward(self, x: torch.Tensor):
+        # Reshaping and permuting the input tensor
+        n, x = self.process_input(x)
+
+        # Expand the class token to the full batch
         batch_class_token = self.class_token.expand(n, -1, -1)
         x = torch.cat([batch_class_token, x], dim=1)
 

--- a/torchvision/prototype/models/vision_transformer.py
+++ b/torchvision/prototype/models/vision_transformer.py
@@ -5,7 +5,7 @@
 import math
 from collections import OrderedDict
 from functools import partial
-from typing import Any, Callable, Optional, Tuple
+from typing import Any, Callable, Optional
 
 import torch
 import torch.nn as nn
@@ -202,7 +202,7 @@ class VisionTransformer(nn.Module):
         nn.init.zeros_(self.heads.head.weight)
         nn.init.zeros_(self.heads.head.bias)
 
-    def process_input(self, x: torch.Tensor) -> Tuple[int, torch.Tensor]:
+    def _process_input(self, x: torch.Tensor) -> torch.Tensor:
         n, c, h, w = x.shape
         p = self.patch_size
         torch._assert(h == self.image_size, "Wrong image height!")
@@ -221,11 +221,12 @@ class VisionTransformer(nn.Module):
         # embedding dimension
         x = x.permute(0, 2, 1)
 
-        return n, x
+        return x
 
     def forward(self, x: torch.Tensor):
         # Reshaping and permuting the input tensor
-        n, x = self.process_input(x)
+        x = self._process_input(x)
+        n = x.shape[0]
 
         # Expand the class token to the full batch
         batch_class_token = self.class_token.expand(n, -1, -1)


### PR DESCRIPTION
<!-- Before submitting a PR, please make sure to check our contributing guidelines regarding code formatting, tests, and documentation: https://github.com/pytorch/vision/blob/main/CONTRIBUTING.md -->

We would like to simplify the `forward` function by moving the image reshaping and batch dimension permuting part into another function `process_input `.

### Testing
Run this command:
```
PYTHONPATH=$PYTHONPATH:`pwd` python -u ~/workspace/scripts/run_with_submitit.py --timeout 3000 --ngpus 1 --nodes 1 --partition train --model vit_b_16 --batch-size 1 --test-only --weights ViT_B_16_Weights.ImageNet1K_V1
```
Job ID: 14451

Make sure nothing is broken.

@datumbox 