### PR TITLE
Fix torchvision.utils.make_grid's pad_value variable type hint: int -> float

### DIFF
--- a/torchvision/utils.py
+++ b/torchvision/utils.py
@@ -19,7 +19,7 @@ def make_grid(
     normalize: bool = False,
     value_range: Optional[Tuple[int, int]] = None,
     scale_each: bool = False,
-    pad_value: int = 0,
+    pad_value: float = 0.0,
     **kwargs,
 ) -> torch.Tensor:
     """


### PR DESCRIPTION
The `pad_value` variable for `torchvision.utils.make_grid` was incorrectly type hinted as an `int` instead of `float`.
