### PR TITLE
add lazily filled dict for prototype datasets

### DIFF
--- a/test/test_prototype_builtin_datasets.py
+++ b/test/test_prototype_builtin_datasets.py
@@ -3,6 +3,7 @@ import io
 import pytest
 import torch
 from builtin_dataset_mocks import parametrize_dataset_mocks, DATASET_MOCKS
+from torch.utils.data.dataloader_experimental import DataLoader2
 from torch.utils.data.datapipes.iter.grouping import ShardingFilterIterDataPipe as ShardingFilter
 from torch.utils.data.graph import traverse
 from torchdata.datapipes.iter import IterDataPipe, Shuffler
@@ -103,11 +104,13 @@ class TestCommon:
             raise AssertionError(f"The dataset doesn't comprise a {annotation_dp_type.__name__}() datapipe.")
 
     @parametrize_dataset_mocks(DATASET_MOCKS)
-    def test_cycle(self, dataset_mock, config):
+    def test_multi_epoch(self, dataset_mock, config):
         dataset, _ = dataset_mock.load(config)
+        data_loader = DataLoader2(dataset)
 
-        for _ in dataset.cycle(2):
-            pass
+        for epoch in range(2):
+            for _ in data_loader:
+                pass
 
 
 @parametrize_dataset_mocks(DATASET_MOCKS["qmnist"])

--- a/test/test_prototype_builtin_datasets.py
+++ b/test/test_prototype_builtin_datasets.py
@@ -102,6 +102,13 @@ class TestCommon:
         else:
             raise AssertionError(f"The dataset doesn't comprise a {annotation_dp_type.__name__}() datapipe.")
 
+    @parametrize_dataset_mocks(DATASET_MOCKS)
+    def test_cycle(self, dataset_mock, config):
+        dataset, _ = dataset_mock.load(config)
+
+        for _ in dataset.cycle(2):
+            pass
+
 
 @parametrize_dataset_mocks(DATASET_MOCKS["qmnist"])
 class TestQMNIST:

--- a/test/test_prototype_builtin_datasets.py
+++ b/test/test_prototype_builtin_datasets.py
@@ -80,27 +80,13 @@ class TestCommon:
 
         next(iter(dataset.map(transforms.Identity())))
 
-    @parametrize_dataset_mocks(
-        DATASET_MOCKS,
-        marks={
-            "cub200": pytest.mark.xfail(
-                reason="See https://github.com/pytorch/vision/pull/5187#issuecomment-1015479165"
-            )
-        },
-    )
+    @parametrize_dataset_mocks(DATASET_MOCKS)
     def test_traversable(self, dataset_mock, config):
         dataset, _ = dataset_mock.load(config)
 
         traverse(dataset)
 
-    @parametrize_dataset_mocks(
-        DATASET_MOCKS,
-        marks={
-            "cub200": pytest.mark.xfail(
-                reason="See https://github.com/pytorch/vision/pull/5187#issuecomment-1015479165"
-            )
-        },
-    )
+    @parametrize_dataset_mocks(DATASET_MOCKS)
     @pytest.mark.parametrize("annotation_dp_type", (Shuffler, ShardingFilter), ids=lambda type: type.__name__)
     def test_has_annotations(self, dataset_mock, config, annotation_dp_type):
         def scan(graph):

--- a/torchvision/prototype/datasets/_builtin/cub200.py
+++ b/torchvision/prototype/datasets/_builtin/cub200.py
@@ -31,6 +31,7 @@ from torchvision.prototype.datasets.utils._internal import (
     getitem,
     path_comparator,
     path_accessor,
+    LazyDict,
 )
 from torchvision.prototype.features import Label, BoundingBox, Feature
 
@@ -93,6 +94,9 @@ class CUB200(Dataset):
             return 3
         else:
             return None
+
+    def _2011_image_key(self, rel_posix_path: str) -> str:
+        return rel_posix_path.rsplit("/", 1)[1]
 
     def _2011_filter_split(self, row: List[str], *, split: str) -> bool:
         _, split_id = row
@@ -173,9 +177,8 @@ class CUB200(Dataset):
             )
 
             image_files_dp = CSVParser(image_files_dp, dialect="cub200")
-            image_files_map = dict(
-                (image_id, rel_posix_path.rsplit("/", maxsplit=1)[1]) for image_id, rel_posix_path in image_files_dp
-            )
+            image_files_dp = Mapper(image_files_dp, self._2011_image_key, input_col=1)
+            image_files_map = LazyDict(image_files_dp)
 
             split_dp = CSVParser(split_dp, dialect="cub200")
             split_dp = Filter(split_dp, functools.partial(self._2011_filter_split, split=config.split))


### PR DESCRIPTION
This is my proposed solution to https://github.com/pytorch/vision/pull/5187#issuecomment-1015479165. Since we only need the mapping during iteration, we can also delay its instantiation until then. Thoughts?

cc @pmeier @bjuncek