### PR TITLE
fix docstring by removing ResNet

### DIFF
--- a/torchvision/models/detection/backbone_utils.py
+++ b/torchvision/models/detection/backbone_utils.py
@@ -84,7 +84,7 @@ def resnet_fpn_backbone(
         >>>    ('pool', torch.Size([1, 256, 1, 1]))]
 
     Args:
-        backbone_name (string): resnet architecture. Possible values are 'ResNet', 'resnet18', 'resnet34', 'resnet50',
+        backbone_name (string): resnet architecture. Possible values are 'resnet18', 'resnet34', 'resnet50',
              'resnet101', 'resnet152', 'resnext50_32x4d', 'resnext101_32x8d', 'wide_resnet50_2', 'wide_resnet101_2'
         pretrained (bool): If True, returns a model with backbone pre-trained on Imagenet
         norm_layer (callable): it is recommended to use the default value. For details visit:


### PR DESCRIPTION
<!-- Before submitting a PR, please make sure to check our contributing guidelines regarding code formatting, tests, and documentation: https://github.com/pytorch/vision/blob/main/CONTRIBUTING.md -->

The PR fixes the documentation bug discussed in issue #5209.

I tried to follow the instructions in the file [CONTRIBUTING.md](https://github.com/pytorch/vision/blob/main/CONTRIBUTING.md).

The tool `ufmt` makes several changes in several modules. So, I did not include the changes in this PR. I can add them if it is necessary.

Building the documentation using the command `make html` results in a runtime error (maybe it is a problem on my side).

However, running `make html-noplot` finishes with no error.
