### PR TITLE
ci: Bump pytorch 1.10.1 -> 1.10.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ binary_common: &binary_common
     pytorch_version:
       description: "PyTorch version to build against; by default, use a nightly"
       type: string
-      default: "1.10.1"
+      default: "1.10.2"
     # Don't edit these
     python_version:
       description: "Python version to build against (e.g., 3.7)"

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -105,7 +105,7 @@ binary_common: &binary_common
     pytorch_version:
       description: "PyTorch version to build against; by default, use a nightly"
       type: string
-      default: "1.10.1"
+      default: "1.10.2"
     # Don't edit these
     python_version:
       description: "Python version to build against (e.g., 3.7)"


### PR DESCRIPTION
For the 1.10.2 release

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

<!-- Before submitting a PR, please make sure to check our contributing guidelines regarding code formatting, tests, and documentation: https://github.com/pytorch/vision/blob/main/CONTRIBUTING.md -->
