### PR TITLE
ci: Pin av to 8.0.3

### DIFF
--- a/.circleci/unittest/linux/scripts/environment.yml
+++ b/.circleci/unittest/linux/scripts/environment.yml
@@ -13,4 +13,4 @@ dependencies:
     - future
     - pillow >=5.3.0, !=8.3.0
     - scipy
-    - av
+    - av <= 8.0.3

--- a/.circleci/unittest/windows/scripts/environment.yml
+++ b/.circleci/unittest/windows/scripts/environment.yml
@@ -13,5 +13,5 @@ dependencies:
     - future
     - pillow >=5.3.0, !=8.3.0
     - scipy
-    - av
+    - av <= 8.0.3
     - dataclasses


### PR DESCRIPTION
The newest release does not provide support for Python 3.6 so let's just
pin to a version that does support that

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

<!-- Before submitting a PR, please make sure to check our contributing guidelines regarding code formatting, tests, and documentation: https://github.com/pytorch/vision/blob/main/CONTRIBUTING.md -->
