### PR TITLE
Fix a bug and document RandomZoomOut

### DIFF
--- a/references/detection/transforms.py
+++ b/references/detection/transforms.py
@@ -189,7 +189,7 @@ class RandomZoomOut(nn.Module):
             elif image.ndimension() == 2:
                 image = image.unsqueeze(0)
 
-        if torch.rand(1) < self.p:
+        if torch.rand(1) >= self.p:
             return image, target
 
         orig_w, orig_h = F.get_image_size(image)
@@ -211,6 +211,7 @@ class RandomZoomOut(nn.Module):
 
         image = F.pad(image, [left, top, right, bottom], fill=fill)
         if isinstance(image, torch.Tensor):
+            # PyTorch's pad supports only integers on fill. So we need to overwrite the colour
             v = torch.tensor(self.fill, device=image.device, dtype=image.dtype).view(-1, 1, 1)
             image[..., :top, :] = image[..., :, :left] = image[..., (top + orig_h) :, :] = image[
                 ..., :, (left + orig_w) :


### PR DESCRIPTION
While investigating a user question in relation to the RandomZoomOut transform at https://github.com/pytorch/vision/pull/3403#issuecomment-982640253, I noticed that the `torch.rand(1)` check is flipped the other way around. It had no effects on the training of SSD because we use `p=0.5` but the bug needs to be fixed.

Moreover I've added a comment to explain why an extra bit is necessary on the transform. I think the comment is necessary since I also have forgotten why the extra code is necessary and almost removed it.