### PR TITLE
Add build to the set of secondary labels

### DIFF
--- a/.github/process_commit.py
+++ b/.github/process_commit.py
@@ -43,6 +43,7 @@ SECONDARY_LABELS = {
     "module: video",
     "Perf",
     "Revert(ed)",
+    "topic: build",
 }
 
 


### PR DESCRIPTION
Adding `topic: build` to the set of secondary labels as there are PRs related to build(example: https://github.com/pytorch/vision/pull/5190), that don't necessarily belong to any other category.
Discussion: https://github.com/pytorch/vision/pull/5190#issuecomment-1014460716