### PR TITLE
Add topk min function for trace and onnx

### DIFF
--- a/torchvision/models/detection/_utils.py
+++ b/torchvision/models/detection/_utils.py
@@ -1,6 +1,6 @@
 import math
 from collections import OrderedDict
-from typing import List, Tuple, cast
+from typing import List, Tuple
 
 import torch
 from torch import Tensor, nn
@@ -491,6 +491,4 @@ def _topk_min(input: Tensor, orig_kval: int, axis: int) -> int:
     """
     axis_dim_val = torch._shape_as_tensor(input)[axis].unsqueeze(0)
     min_kval = torch.min(torch.cat((torch.tensor([orig_kval], dtype=axis_dim_val.dtype), axis_dim_val), 0))
-
-    # for mypy we cast at runtime
-    return cast(int, min_kval)
+    return min_kval  # type: ignore[arg-type]

--- a/torchvision/models/detection/_utils.py
+++ b/torchvision/models/detection/_utils.py
@@ -470,7 +470,7 @@ def retrieve_out_channels(model: nn.Module, size: Tuple[int, int]) -> List[int]:
     return out_channels
 
 
-def _topk_min(input: Tensor, orig_kval: int, axis: int) -> int:
+def _topk_min(input: Tensor, orig_kval: int, axis: int) -> Tensor:
     """
     ONNX spec requires the k-value to be less than or equal to the number of inputs along
     provided dim. Certain models use the number of elements along a particular axis instead of K
@@ -487,7 +487,7 @@ def _topk_min(input: Tensor, orig_kval: int, axis: int) -> int:
         axis(int): Axis along which we retreive the input size.
 
     Returns:
-        min_kval (int): Appropriately selected k-value.
+        min_kval (Tensor): Appropriately selected k-value.
     """
     axis_dim_val = torch._shape_as_tensor(input)[axis].unsqueeze(0)
     min_kval = torch.min(torch.cat((torch.tensor([orig_kval], dtype=axis_dim_val.dtype), axis_dim_val), 0))

--- a/torchvision/models/detection/fcos.py
+++ b/torchvision/models/detection/fcos.py
@@ -503,7 +503,7 @@ class FCOS(nn.Module):
 
                 # keep only topk scoring predictions
                 if torchvision._is_tracing():
-                    _, num_topk = det_utils._onnx_tracing_topk_min(topk_idxs, self.topk_candidates, 0)
+                    num_topk = det_utils._topk_min(topk_idxs, self.topk_candidates, 0)
                 else:
                     num_topk = min(self.topk_candidates, topk_idxs.size(0))
                 scores_per_level, idxs = scores_per_level.topk(num_topk)

--- a/torchvision/models/detection/fcos.py
+++ b/torchvision/models/detection/fcos.py
@@ -5,7 +5,6 @@ from functools import partial
 from typing import Callable, Dict, List, Tuple, Optional
 
 import torch
-import torchvision
 from torch import nn, Tensor
 
 from ..._internally_replaced_utils import load_state_dict_from_url
@@ -502,10 +501,7 @@ class FCOS(nn.Module):
                 topk_idxs = torch.where(keep_idxs)[0]
 
                 # keep only topk scoring predictions
-                if torchvision._is_tracing():
-                    num_topk = det_utils._topk_min(topk_idxs, self.topk_candidates, 0)
-                else:
-                    num_topk = min(self.topk_candidates, topk_idxs.size(0))
+                num_topk = det_utils._topk_min(topk_idxs, self.topk_candidates, 0)
                 scores_per_level, idxs = scores_per_level.topk(num_topk)
                 topk_idxs = topk_idxs[idxs]
 

--- a/torchvision/models/detection/fcos.py
+++ b/torchvision/models/detection/fcos.py
@@ -5,6 +5,7 @@ from functools import partial
 from typing import Callable, Dict, List, Tuple, Optional
 
 import torch
+import torchvision
 from torch import nn, Tensor
 
 from ..._internally_replaced_utils import load_state_dict_from_url
@@ -501,7 +502,10 @@ class FCOS(nn.Module):
                 topk_idxs = torch.where(keep_idxs)[0]
 
                 # keep only topk scoring predictions
-                num_topk = min(self.topk_candidates, topk_idxs.size(0))
+                if torchvision._is_tracing():
+                    _, num_topk = det_utils._onnx_tracing_topk_min(topk_idxs, self.topk_candidates, 0)
+                else:
+                    num_topk = min(self.topk_candidates, topk_idxs.size(0))
                 scores_per_level, idxs = scores_per_level.topk(num_topk)
                 topk_idxs = topk_idxs[idxs]
 

--- a/torchvision/models/detection/retinanet.py
+++ b/torchvision/models/detection/retinanet.py
@@ -4,6 +4,7 @@ from collections import OrderedDict
 from typing import Dict, List, Tuple, Optional
 
 import torch
+import torchvision
 from torch import nn, Tensor
 
 from ..._internally_replaced_utils import load_state_dict_from_url
@@ -436,7 +437,10 @@ class RetinaNet(nn.Module):
                 topk_idxs = torch.where(keep_idxs)[0]
 
                 # keep only topk scoring predictions
-                num_topk = min(self.topk_candidates, topk_idxs.size(0))
+                if torchvision._is_tracing():
+                    _, num_topk = det_utils._onnx_tracing_topk_min(topk_idxs, self.topk_candidates, 0)
+                else:
+                    num_topk = min(self.topk_candidates, topk_idxs.size(0))
                 scores_per_level, idxs = scores_per_level.topk(num_topk)
                 topk_idxs = topk_idxs[idxs]
 

--- a/torchvision/models/detection/retinanet.py
+++ b/torchvision/models/detection/retinanet.py
@@ -4,7 +4,6 @@ from collections import OrderedDict
 from typing import Dict, List, Tuple, Optional
 
 import torch
-import torchvision
 from torch import nn, Tensor
 
 from ..._internally_replaced_utils import load_state_dict_from_url
@@ -437,10 +436,7 @@ class RetinaNet(nn.Module):
                 topk_idxs = torch.where(keep_idxs)[0]
 
                 # keep only topk scoring predictions
-                if torchvision._is_tracing():
-                    num_topk = det_utils._topk_min(topk_idxs, self.topk_candidates, 0)
-                else:
-                    num_topk = min(self.topk_candidates, topk_idxs.size(0))
+                num_topk = det_utils._topk_min(topk_idxs, self.topk_candidates, 0)
                 scores_per_level, idxs = scores_per_level.topk(num_topk)
                 topk_idxs = topk_idxs[idxs]
 

--- a/torchvision/models/detection/retinanet.py
+++ b/torchvision/models/detection/retinanet.py
@@ -438,7 +438,7 @@ class RetinaNet(nn.Module):
 
                 # keep only topk scoring predictions
                 if torchvision._is_tracing():
-                    _, num_topk = det_utils._onnx_tracing_topk_min(topk_idxs, self.topk_candidates, 0)
+                    num_topk = det_utils._topk_min(topk_idxs, self.topk_candidates, 0)
                 else:
                     num_topk = min(self.topk_candidates, topk_idxs.size(0))
                 scores_per_level, idxs = scores_per_level.topk(num_topk)

--- a/torchvision/models/detection/rpn.py
+++ b/torchvision/models/detection/rpn.py
@@ -195,11 +195,8 @@ class RegionProposalNetwork(torch.nn.Module):
         r = []
         offset = 0
         for ob in objectness.split(num_anchors_per_level, 1):
-            if torchvision._is_tracing():
-                pre_nms_top_n = det_utils._topk_min(ob, self.pre_nms_top_n(), 1)
-            else:
-                pre_nms_top_n = min(self.pre_nms_top_n(), num_anchors)
             num_anchors = ob.shape[1]
+            pre_nms_top_n = det_utils._topk_min(ob, self.pre_nms_top_n(), 1)
             _, top_n_idx = ob.topk(pre_nms_top_n, dim=1)
             r.append(top_n_idx + offset)
             offset += num_anchors

--- a/torchvision/models/detection/rpn.py
+++ b/torchvision/models/detection/rpn.py
@@ -1,7 +1,6 @@
 from typing import List, Optional, Dict, Tuple
 
 import torch
-import torchvision
 from torch import nn, Tensor
 from torch.nn import functional as F
 from torchvision.ops import boxes as box_ops

--- a/torchvision/models/detection/rpn.py
+++ b/torchvision/models/detection/rpn.py
@@ -13,17 +13,6 @@ from .anchor_utils import AnchorGenerator  # noqa: 401
 from .image_list import ImageList
 
 
-@torch.jit.unused
-def _onnx_get_num_anchors_and_pre_nms_top_n(ob: Tensor, orig_pre_nms_top_n: int) -> Tuple[int, int]:
-    from torch.onnx import operators
-
-    num_anchors = operators.shape_as_tensor(ob)[1].unsqueeze(0)
-    pre_nms_top_n = torch.min(torch.cat((torch.tensor([orig_pre_nms_top_n], dtype=num_anchors.dtype), num_anchors), 0))
-
-    # for mypy we cast at runtime
-    return cast(int, num_anchors), cast(int, pre_nms_top_n)
-
-
 class RPNHead(nn.Module):
     """
     Adds a simple RPN Head with classification and regression heads
@@ -207,7 +196,7 @@ class RegionProposalNetwork(torch.nn.Module):
         offset = 0
         for ob in objectness.split(num_anchors_per_level, 1):
             if torchvision._is_tracing():
-                num_anchors, pre_nms_top_n = _onnx_get_num_anchors_and_pre_nms_top_n(ob, self.pre_nms_top_n())
+                num_anchors, pre_nms_top_n = det_utils._onnx_tracing_topk_min(ob, self.pre_nms_top_n(), 1)
             else:
                 num_anchors = ob.shape[1]
                 pre_nms_top_n = min(self.pre_nms_top_n(), num_anchors)

--- a/torchvision/models/detection/rpn.py
+++ b/torchvision/models/detection/rpn.py
@@ -196,10 +196,10 @@ class RegionProposalNetwork(torch.nn.Module):
         offset = 0
         for ob in objectness.split(num_anchors_per_level, 1):
             if torchvision._is_tracing():
-                num_anchors, pre_nms_top_n = det_utils._onnx_tracing_topk_min(ob, self.pre_nms_top_n(), 1)
+                pre_nms_top_n = det_utils._topk_min(ob, self.pre_nms_top_n(), 1)
             else:
-                num_anchors = ob.shape[1]
                 pre_nms_top_n = min(self.pre_nms_top_n(), num_anchors)
+            num_anchors = ob.shape[1]
             _, top_n_idx = ob.topk(pre_nms_top_n, dim=1)
             r.append(top_n_idx + offset)
             offset += num_anchors

--- a/torchvision/models/detection/rpn.py
+++ b/torchvision/models/detection/rpn.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Dict, Tuple, cast
+from typing import List, Optional, Dict, Tuple
 
 import torch
 import torchvision

--- a/torchvision/models/detection/ssd.py
+++ b/torchvision/models/detection/ssd.py
@@ -3,8 +3,8 @@ from collections import OrderedDict
 from typing import Any, Dict, List, Optional, Tuple
 
 import torch
-import torchvision
 import torch.nn.functional as F
+import torchvision
 from torch import nn, Tensor
 
 from ..._internally_replaced_utils import load_state_dict_from_url

--- a/torchvision/models/detection/ssd.py
+++ b/torchvision/models/detection/ssd.py
@@ -409,7 +409,7 @@ class SSD(nn.Module):
 
                 # keep only topk scoring predictions
                 if torchvision._is_tracing():
-                    _, num_topk = det_utils._onnx_tracing_topk_min(score, self.topk_candidates, 0)
+                    num_topk = det_utils._topk_min(score, self.topk_candidates, 0)
                 else:
                     num_topk = min(self.topk_candidates, score.size(0))
                 score, idxs = score.topk(num_topk)

--- a/torchvision/models/detection/ssd.py
+++ b/torchvision/models/detection/ssd.py
@@ -3,6 +3,7 @@ from collections import OrderedDict
 from typing import Any, Dict, List, Optional, Tuple
 
 import torch
+import torchvision
 import torch.nn.functional as F
 from torch import nn, Tensor
 
@@ -407,7 +408,10 @@ class SSD(nn.Module):
                 box = boxes[keep_idxs]
 
                 # keep only topk scoring predictions
-                num_topk = min(self.topk_candidates, score.size(0))
+                if torchvision._is_tracing():
+                    _, num_topk = det_utils._onnx_tracing_topk_min(score, self.topk_candidates, 0)
+                else:
+                    num_topk = min(self.topk_candidates, score.size(0))
                 score, idxs = score.topk(num_topk)
                 box = box[idxs]
 

--- a/torchvision/models/detection/ssd.py
+++ b/torchvision/models/detection/ssd.py
@@ -4,7 +4,6 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import torch
 import torch.nn.functional as F
-import torchvision
 from torch import nn, Tensor
 
 from ..._internally_replaced_utils import load_state_dict_from_url
@@ -408,10 +407,7 @@ class SSD(nn.Module):
                 box = boxes[keep_idxs]
 
                 # keep only topk scoring predictions
-                if torchvision._is_tracing():
-                    num_topk = det_utils._topk_min(score, self.topk_candidates, 0)
-                else:
-                    num_topk = min(self.topk_candidates, score.size(0))
+                num_topk = det_utils._topk_min(score, self.topk_candidates, 0)
                 score, idxs = score.topk(num_topk)
                 box = box[idxs]
 


### PR DESCRIPTION
ONNX spec requires the k-value to be less than or equal to the number of inputs along provided dim. Certain models use the number of elements along a particular axis instead of K if K exceeds the number of elements along that axis. Previously, python's min() function was used to determine whether to use the provided k-value or the specified dim axis value.

However in cases where the model is being exported in tracing mode, python min() is static causing the model to be traced incorrectly and eventually fail at the topk node. In order to avoid this situation, in tracing mode, torch.min() is used instead.