### PR TITLE
Added python 3.10 to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1267,12 +1267,6 @@ workflows:
           name: binary_macos_wheel_py3.9_cpu
           python_version: '3.9'
           wheel_docker_image: pytorch/manylinux-cuda102
-      - binary_macos_wheel:
-          conda_docker_image: pytorch/conda-builder:cpu
-          cu_version: cpu
-          name: binary_macos_wheel_py3.10_cpu
-          python_version: '3.10'
-          wheel_docker_image: pytorch/manylinux-cuda102
       - binary_win_wheel:
           cu_version: cpu
           filters:
@@ -1544,12 +1538,6 @@ workflows:
           cu_version: cpu
           name: binary_macos_conda_py3.9_cpu
           python_version: '3.9'
-          wheel_docker_image: pytorch/manylinux-cuda102
-      - binary_macos_conda:
-          conda_docker_image: pytorch/conda-builder:cpu
-          cu_version: cpu
-          name: binary_macos_conda_py3.10_cpu
-          python_version: '3.10'
           wheel_docker_image: pytorch/manylinux-cuda102
       - binary_win_conda:
           cu_version: cpu
@@ -2826,28 +2814,6 @@ workflows:
           requires:
           - nightly_binary_macos_wheel_py3.9_cpu
           subfolder: ''
-      - binary_macos_wheel:
-          conda_docker_image: pytorch/conda-builder:cpu
-          cu_version: cpu
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_macos_wheel_py3.10_cpu
-          python_version: '3.10'
-          wheel_docker_image: pytorch/manylinux-cuda102
-      - binary_wheel_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_macos_wheel_py3.10_cpu_upload
-          requires:
-          - nightly_binary_macos_wheel_py3.10_cpu
-          subfolder: ''
       - binary_win_wheel:
           cu_version: cpu
           filters:
@@ -3975,27 +3941,6 @@ workflows:
           name: nightly_binary_macos_conda_py3.9_cpu_upload
           requires:
           - nightly_binary_macos_conda_py3.9_cpu
-      - binary_macos_conda:
-          conda_docker_image: pytorch/conda-builder:cpu
-          cu_version: cpu
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_macos_conda_py3.10_cpu
-          python_version: '3.10'
-          wheel_docker_image: pytorch/manylinux-cuda102
-      - binary_conda_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_macos_conda_py3.10_cpu_upload
-          requires:
-          - nightly_binary_macos_conda_py3.10_cpu
       - binary_win_conda:
           cu_version: cpu
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1821,10 +1821,6 @@ workflows:
           cu_version: cpu
           name: unittest_macos_cpu_py3.9
           python_version: '3.9'
-      - unittest_macos_cpu:
-          cu_version: cpu
-          name: unittest_macos_cpu_py3.10
-          python_version: '3.10'
 
   cmake:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1209,6 +1209,46 @@ workflows:
           name: binary_linux_wheel_py3.9_rocm4.5.2
           python_version: '3.9'
           wheel_docker_image: pytorch/manylinux-rocm:4.5.2
+      - binary_linux_wheel:
+          conda_docker_image: pytorch/conda-builder:cpu
+          cu_version: cpu
+          name: binary_linux_wheel_py3.10_cpu
+          python_version: '3.10'
+          wheel_docker_image: pytorch/manylinux-cuda102
+      - binary_linux_wheel:
+          conda_docker_image: pytorch/conda-builder:cuda102
+          cu_version: cu102
+          name: binary_linux_wheel_py3.10_cu102
+          python_version: '3.10'
+          wheel_docker_image: pytorch/manylinux-cuda102
+      - binary_linux_wheel:
+          conda_docker_image: pytorch/conda-builder:cuda111
+          cu_version: cu111
+          name: binary_linux_wheel_py3.10_cu111
+          python_version: '3.10'
+          wheel_docker_image: pytorch/manylinux-cuda111
+      - binary_linux_wheel:
+          conda_docker_image: pytorch/conda-builder:cuda113
+          cu_version: cu113
+          name: binary_linux_wheel_py3.10_cu113
+          python_version: '3.10'
+          wheel_docker_image: pytorch/manylinux-cuda113
+      - binary_linux_wheel:
+          conda_docker_image: pytorch/conda-builder:cuda115
+          cu_version: cu115
+          name: binary_linux_wheel_py3.10_cu115
+          python_version: '3.10'
+          wheel_docker_image: pytorch/manylinux-cuda115
+      - binary_linux_wheel:
+          cu_version: rocm4.3.1
+          name: binary_linux_wheel_py3.10_rocm4.3.1
+          python_version: '3.10'
+          wheel_docker_image: pytorch/manylinux-rocm:4.3.1
+      - binary_linux_wheel:
+          cu_version: rocm4.5.2
+          name: binary_linux_wheel_py3.10_rocm4.5.2
+          python_version: '3.10'
+          wheel_docker_image: pytorch/manylinux-rocm:4.5.2
       - binary_macos_wheel:
           conda_docker_image: pytorch/conda-builder:cpu
           cu_version: cpu
@@ -1226,6 +1266,12 @@ workflows:
           cu_version: cpu
           name: binary_macos_wheel_py3.9_cpu
           python_version: '3.9'
+          wheel_docker_image: pytorch/manylinux-cuda102
+      - binary_macos_wheel:
+          conda_docker_image: pytorch/conda-builder:cpu
+          cu_version: cpu
+          name: binary_macos_wheel_py3.10_cpu
+          python_version: '3.10'
           wheel_docker_image: pytorch/manylinux-cuda102
       - binary_win_wheel:
           cu_version: cpu
@@ -1301,6 +1347,11 @@ workflows:
           python_version: '3.8'
       - binary_win_wheel:
           cu_version: cpu
+          filters:
+            branches:
+              only: main
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
           name: binary_win_wheel_py3.9_cpu
           python_version: '3.9'
       - binary_win_wheel:
@@ -1323,8 +1374,39 @@ workflows:
           python_version: '3.9'
       - binary_win_wheel:
           cu_version: cu115
+          filters:
+            branches:
+              only: main
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
           name: binary_win_wheel_py3.9_cu115
           python_version: '3.9'
+      - binary_win_wheel:
+          cu_version: cpu
+          name: binary_win_wheel_py3.10_cpu
+          python_version: '3.10'
+      - binary_win_wheel:
+          cu_version: cu111
+          filters:
+            branches:
+              only: main
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: binary_win_wheel_py3.10_cu111
+          python_version: '3.10'
+      - binary_win_wheel:
+          cu_version: cu113
+          filters:
+            branches:
+              only: main
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: binary_win_wheel_py3.10_cu113
+          python_version: '3.10'
+      - binary_win_wheel:
+          cu_version: cu115
+          name: binary_win_wheel_py3.10_cu115
+          python_version: '3.10'
       - binary_linux_conda:
           conda_docker_image: pytorch/conda-builder:cpu
           cu_version: cpu
@@ -1415,6 +1497,36 @@ workflows:
           name: binary_linux_conda_py3.9_cu115
           python_version: '3.9'
           wheel_docker_image: pytorch/manylinux-cuda115
+      - binary_linux_conda:
+          conda_docker_image: pytorch/conda-builder:cpu
+          cu_version: cpu
+          name: binary_linux_conda_py3.10_cpu
+          python_version: '3.10'
+          wheel_docker_image: pytorch/manylinux-cuda102
+      - binary_linux_conda:
+          conda_docker_image: pytorch/conda-builder:cuda102
+          cu_version: cu102
+          name: binary_linux_conda_py3.10_cu102
+          python_version: '3.10'
+          wheel_docker_image: pytorch/manylinux-cuda102
+      - binary_linux_conda:
+          conda_docker_image: pytorch/conda-builder:cuda111
+          cu_version: cu111
+          name: binary_linux_conda_py3.10_cu111
+          python_version: '3.10'
+          wheel_docker_image: pytorch/manylinux-cuda111
+      - binary_linux_conda:
+          conda_docker_image: pytorch/conda-builder:cuda113
+          cu_version: cu113
+          name: binary_linux_conda_py3.10_cu113
+          python_version: '3.10'
+          wheel_docker_image: pytorch/manylinux-cuda113
+      - binary_linux_conda:
+          conda_docker_image: pytorch/conda-builder:cuda115
+          cu_version: cu115
+          name: binary_linux_conda_py3.10_cu115
+          python_version: '3.10'
+          wheel_docker_image: pytorch/manylinux-cuda115
       - binary_macos_conda:
           conda_docker_image: pytorch/conda-builder:cpu
           cu_version: cpu
@@ -1432,6 +1544,12 @@ workflows:
           cu_version: cpu
           name: binary_macos_conda_py3.9_cpu
           python_version: '3.9'
+          wheel_docker_image: pytorch/manylinux-cuda102
+      - binary_macos_conda:
+          conda_docker_image: pytorch/conda-builder:cpu
+          cu_version: cpu
+          name: binary_macos_conda_py3.10_cpu
+          python_version: '3.10'
           wheel_docker_image: pytorch/manylinux-cuda102
       - binary_win_conda:
           cu_version: cpu
@@ -1507,6 +1625,11 @@ workflows:
           python_version: '3.8'
       - binary_win_conda:
           cu_version: cpu
+          filters:
+            branches:
+              only: main
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
           name: binary_win_conda_py3.9_cpu
           python_version: '3.9'
       - binary_win_conda:
@@ -1529,8 +1652,39 @@ workflows:
           python_version: '3.9'
       - binary_win_conda:
           cu_version: cu115
+          filters:
+            branches:
+              only: main
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
           name: binary_win_conda_py3.9_cu115
           python_version: '3.9'
+      - binary_win_conda:
+          cu_version: cpu
+          name: binary_win_conda_py3.10_cpu
+          python_version: '3.10'
+      - binary_win_conda:
+          cu_version: cu111
+          filters:
+            branches:
+              only: main
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: binary_win_conda_py3.10_cu111
+          python_version: '3.10'
+      - binary_win_conda:
+          cu_version: cu113
+          filters:
+            branches:
+              only: main
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: binary_win_conda_py3.10_cu113
+          python_version: '3.10'
+      - binary_win_conda:
+          cu_version: cu115
+          name: binary_win_conda_py3.10_cu115
+          python_version: '3.10'
       - build_docs:
           filters:
             branches:
@@ -1585,6 +1739,10 @@ workflows:
           cu_version: cpu
           name: unittest_linux_cpu_py3.9
           python_version: '3.9'
+      - unittest_linux_cpu:
+          cu_version: cpu
+          name: unittest_linux_cpu_py3.10
+          python_version: '3.10'
       - unittest_linux_gpu:
           cu_version: cu102
           filters:
@@ -1607,6 +1765,15 @@ workflows:
               - nightly
           name: unittest_linux_gpu_py3.9
           python_version: '3.9'
+      - unittest_linux_gpu:
+          cu_version: cu102
+          filters:
+            branches:
+              only:
+              - main
+              - nightly
+          name: unittest_linux_gpu_py3.10
+          python_version: '3.10'
       - unittest_windows_cpu:
           cu_version: cpu
           name: unittest_windows_cpu_py3.7
@@ -1619,6 +1786,10 @@ workflows:
           cu_version: cpu
           name: unittest_windows_cpu_py3.9
           python_version: '3.9'
+      - unittest_windows_cpu:
+          cu_version: cpu
+          name: unittest_windows_cpu_py3.10
+          python_version: '3.10'
       - unittest_windows_gpu:
           cu_version: cu102
           filters:
@@ -1641,6 +1812,15 @@ workflows:
               - nightly
           name: unittest_windows_gpu_py3.9
           python_version: '3.9'
+      - unittest_windows_gpu:
+          cu_version: cu102
+          filters:
+            branches:
+              only:
+              - main
+              - nightly
+          name: unittest_windows_gpu_py3.10
+          python_version: '3.10'
       - unittest_macos_cpu:
           cu_version: cpu
           name: unittest_macos_cpu_py3.7
@@ -1653,6 +1833,10 @@ workflows:
           cu_version: cpu
           name: unittest_macos_cpu_py3.9
           python_version: '3.9'
+      - unittest_macos_cpu:
+          cu_version: cpu
+          name: unittest_macos_cpu_py3.10
+          python_version: '3.10'
 
   cmake:
     jobs:
@@ -2361,6 +2545,221 @@ workflows:
           python_version: '3.9'
           requires:
           - nightly_binary_linux_wheel_py3.9_rocm4.5.2_upload
+      - binary_linux_wheel:
+          conda_docker_image: pytorch/conda-builder:cpu
+          cu_version: cpu
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_wheel_py3.10_cpu
+          python_version: '3.10'
+          wheel_docker_image: pytorch/manylinux-cuda102
+      - binary_wheel_upload:
+          context: org-member
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_wheel_py3.10_cpu_upload
+          requires:
+          - nightly_binary_linux_wheel_py3.10_cpu
+          subfolder: cpu/
+      - smoke_test_linux_pip:
+          filters:
+            branches:
+              only:
+              - nightly
+          name: nightly_binary_linux_wheel_py3.10_cpu_smoke_test_pip
+          python_version: '3.10'
+          requires:
+          - nightly_binary_linux_wheel_py3.10_cpu_upload
+      - binary_linux_wheel:
+          conda_docker_image: pytorch/conda-builder:cuda102
+          cu_version: cu102
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_wheel_py3.10_cu102
+          python_version: '3.10'
+          wheel_docker_image: pytorch/manylinux-cuda102
+      - binary_wheel_upload:
+          context: org-member
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_wheel_py3.10_cu102_upload
+          requires:
+          - nightly_binary_linux_wheel_py3.10_cu102
+          subfolder: cu102/
+      - smoke_test_linux_pip:
+          filters:
+            branches:
+              only:
+              - nightly
+          name: nightly_binary_linux_wheel_py3.10_cu102_smoke_test_pip
+          python_version: '3.10'
+          requires:
+          - nightly_binary_linux_wheel_py3.10_cu102_upload
+      - binary_linux_wheel:
+          conda_docker_image: pytorch/conda-builder:cuda111
+          cu_version: cu111
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_wheel_py3.10_cu111
+          python_version: '3.10'
+          wheel_docker_image: pytorch/manylinux-cuda111
+      - binary_wheel_upload:
+          context: org-member
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_wheel_py3.10_cu111_upload
+          requires:
+          - nightly_binary_linux_wheel_py3.10_cu111
+          subfolder: cu111/
+      - smoke_test_linux_pip:
+          filters:
+            branches:
+              only:
+              - nightly
+          name: nightly_binary_linux_wheel_py3.10_cu111_smoke_test_pip
+          python_version: '3.10'
+          requires:
+          - nightly_binary_linux_wheel_py3.10_cu111_upload
+      - binary_linux_wheel:
+          conda_docker_image: pytorch/conda-builder:cuda113
+          cu_version: cu113
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_wheel_py3.10_cu113
+          python_version: '3.10'
+          wheel_docker_image: pytorch/manylinux-cuda113
+      - binary_wheel_upload:
+          context: org-member
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_wheel_py3.10_cu113_upload
+          requires:
+          - nightly_binary_linux_wheel_py3.10_cu113
+          subfolder: cu113/
+      - smoke_test_linux_pip:
+          filters:
+            branches:
+              only:
+              - nightly
+          name: nightly_binary_linux_wheel_py3.10_cu113_smoke_test_pip
+          python_version: '3.10'
+          requires:
+          - nightly_binary_linux_wheel_py3.10_cu113_upload
+      - binary_linux_wheel:
+          conda_docker_image: pytorch/conda-builder:cuda115
+          cu_version: cu115
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_wheel_py3.10_cu115
+          python_version: '3.10'
+          wheel_docker_image: pytorch/manylinux-cuda115
+      - binary_wheel_upload:
+          context: org-member
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_wheel_py3.10_cu115_upload
+          requires:
+          - nightly_binary_linux_wheel_py3.10_cu115
+          subfolder: cu115/
+      - smoke_test_linux_pip:
+          filters:
+            branches:
+              only:
+              - nightly
+          name: nightly_binary_linux_wheel_py3.10_cu115_smoke_test_pip
+          python_version: '3.10'
+          requires:
+          - nightly_binary_linux_wheel_py3.10_cu115_upload
+      - binary_linux_wheel:
+          cu_version: rocm4.3.1
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_wheel_py3.10_rocm4.3.1
+          python_version: '3.10'
+          wheel_docker_image: pytorch/manylinux-rocm:4.3.1
+      - binary_wheel_upload:
+          context: org-member
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_wheel_py3.10_rocm4.3.1_upload
+          requires:
+          - nightly_binary_linux_wheel_py3.10_rocm4.3.1
+          subfolder: rocm4.3.1/
+      - smoke_test_linux_pip:
+          filters:
+            branches:
+              only:
+              - nightly
+          name: nightly_binary_linux_wheel_py3.10_rocm4.3.1_smoke_test_pip
+          python_version: '3.10'
+          requires:
+          - nightly_binary_linux_wheel_py3.10_rocm4.3.1_upload
+      - binary_linux_wheel:
+          cu_version: rocm4.5.2
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_wheel_py3.10_rocm4.5.2
+          python_version: '3.10'
+          wheel_docker_image: pytorch/manylinux-rocm:4.5.2
+      - binary_wheel_upload:
+          context: org-member
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_wheel_py3.10_rocm4.5.2_upload
+          requires:
+          - nightly_binary_linux_wheel_py3.10_rocm4.5.2
+          subfolder: rocm4.5.2/
+      - smoke_test_linux_pip:
+          filters:
+            branches:
+              only:
+              - nightly
+          name: nightly_binary_linux_wheel_py3.10_rocm4.5.2_smoke_test_pip
+          python_version: '3.10'
+          requires:
+          - nightly_binary_linux_wheel_py3.10_rocm4.5.2_upload
       - binary_macos_wheel:
           conda_docker_image: pytorch/conda-builder:cpu
           cu_version: cpu
@@ -2426,6 +2825,28 @@ workflows:
           name: nightly_binary_macos_wheel_py3.9_cpu_upload
           requires:
           - nightly_binary_macos_wheel_py3.9_cpu
+          subfolder: ''
+      - binary_macos_wheel:
+          conda_docker_image: pytorch/conda-builder:cpu
+          cu_version: cpu
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_macos_wheel_py3.10_cpu
+          python_version: '3.10'
+          wheel_docker_image: pytorch/manylinux-cuda102
+      - binary_wheel_upload:
+          context: org-member
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_macos_wheel_py3.10_cpu_upload
+          requires:
+          - nightly_binary_macos_wheel_py3.10_cpu
           subfolder: ''
       - binary_win_wheel:
           cu_version: cpu
@@ -2775,6 +3196,122 @@ workflows:
           python_version: '3.9'
           requires:
           - nightly_binary_win_wheel_py3.9_cu115_upload
+      - binary_win_wheel:
+          cu_version: cpu
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_win_wheel_py3.10_cpu
+          python_version: '3.10'
+      - binary_wheel_upload:
+          context: org-member
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_win_wheel_py3.10_cpu_upload
+          requires:
+          - nightly_binary_win_wheel_py3.10_cpu
+          subfolder: cpu/
+      - smoke_test_win_pip:
+          filters:
+            branches:
+              only:
+              - nightly
+          name: nightly_binary_win_wheel_py3.10_cpu_smoke_test_pip
+          python_version: '3.10'
+          requires:
+          - nightly_binary_win_wheel_py3.10_cpu_upload
+      - binary_win_wheel:
+          cu_version: cu111
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_win_wheel_py3.10_cu111
+          python_version: '3.10'
+      - binary_wheel_upload:
+          context: org-member
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_win_wheel_py3.10_cu111_upload
+          requires:
+          - nightly_binary_win_wheel_py3.10_cu111
+          subfolder: cu111/
+      - smoke_test_win_pip:
+          filters:
+            branches:
+              only:
+              - nightly
+          name: nightly_binary_win_wheel_py3.10_cu111_smoke_test_pip
+          python_version: '3.10'
+          requires:
+          - nightly_binary_win_wheel_py3.10_cu111_upload
+      - binary_win_wheel:
+          cu_version: cu113
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_win_wheel_py3.10_cu113
+          python_version: '3.10'
+      - binary_wheel_upload:
+          context: org-member
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_win_wheel_py3.10_cu113_upload
+          requires:
+          - nightly_binary_win_wheel_py3.10_cu113
+          subfolder: cu113/
+      - smoke_test_win_pip:
+          filters:
+            branches:
+              only:
+              - nightly
+          name: nightly_binary_win_wheel_py3.10_cu113_smoke_test_pip
+          python_version: '3.10'
+          requires:
+          - nightly_binary_win_wheel_py3.10_cu113_upload
+      - binary_win_wheel:
+          cu_version: cu115
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_win_wheel_py3.10_cu115
+          python_version: '3.10'
+      - binary_wheel_upload:
+          context: org-member
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_win_wheel_py3.10_cu115_upload
+          requires:
+          - nightly_binary_win_wheel_py3.10_cu115
+          subfolder: cu115/
+      - smoke_test_win_pip:
+          filters:
+            branches:
+              only:
+              - nightly
+          name: nightly_binary_win_wheel_py3.10_cu115_smoke_test_pip
+          python_version: '3.10'
+          requires:
+          - nightly_binary_win_wheel_py3.10_cu115_upload
       - binary_linux_conda:
           conda_docker_image: pytorch/conda-builder:cpu
           cu_version: cpu
@@ -3225,6 +3762,156 @@ workflows:
           python_version: '3.9'
           requires:
           - nightly_binary_linux_conda_py3.9_cu115_upload
+      - binary_linux_conda:
+          conda_docker_image: pytorch/conda-builder:cpu
+          cu_version: cpu
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_conda_py3.10_cpu
+          python_version: '3.10'
+          wheel_docker_image: pytorch/manylinux-cuda102
+      - binary_conda_upload:
+          context: org-member
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_conda_py3.10_cpu_upload
+          requires:
+          - nightly_binary_linux_conda_py3.10_cpu
+      - smoke_test_linux_conda:
+          filters:
+            branches:
+              only:
+              - nightly
+          name: nightly_binary_linux_conda_py3.10_cpu_smoke_test_conda
+          python_version: '3.10'
+          requires:
+          - nightly_binary_linux_conda_py3.10_cpu_upload
+      - binary_linux_conda:
+          conda_docker_image: pytorch/conda-builder:cuda102
+          cu_version: cu102
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_conda_py3.10_cu102
+          python_version: '3.10'
+          wheel_docker_image: pytorch/manylinux-cuda102
+      - binary_conda_upload:
+          context: org-member
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_conda_py3.10_cu102_upload
+          requires:
+          - nightly_binary_linux_conda_py3.10_cu102
+      - smoke_test_linux_conda:
+          filters:
+            branches:
+              only:
+              - nightly
+          name: nightly_binary_linux_conda_py3.10_cu102_smoke_test_conda
+          python_version: '3.10'
+          requires:
+          - nightly_binary_linux_conda_py3.10_cu102_upload
+      - binary_linux_conda:
+          conda_docker_image: pytorch/conda-builder:cuda111
+          cu_version: cu111
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_conda_py3.10_cu111
+          python_version: '3.10'
+          wheel_docker_image: pytorch/manylinux-cuda111
+      - binary_conda_upload:
+          context: org-member
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_conda_py3.10_cu111_upload
+          requires:
+          - nightly_binary_linux_conda_py3.10_cu111
+      - smoke_test_linux_conda:
+          filters:
+            branches:
+              only:
+              - nightly
+          name: nightly_binary_linux_conda_py3.10_cu111_smoke_test_conda
+          python_version: '3.10'
+          requires:
+          - nightly_binary_linux_conda_py3.10_cu111_upload
+      - binary_linux_conda:
+          conda_docker_image: pytorch/conda-builder:cuda113
+          cu_version: cu113
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_conda_py3.10_cu113
+          python_version: '3.10'
+          wheel_docker_image: pytorch/manylinux-cuda113
+      - binary_conda_upload:
+          context: org-member
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_conda_py3.10_cu113_upload
+          requires:
+          - nightly_binary_linux_conda_py3.10_cu113
+      - smoke_test_linux_conda:
+          filters:
+            branches:
+              only:
+              - nightly
+          name: nightly_binary_linux_conda_py3.10_cu113_smoke_test_conda
+          python_version: '3.10'
+          requires:
+          - nightly_binary_linux_conda_py3.10_cu113_upload
+      - binary_linux_conda:
+          conda_docker_image: pytorch/conda-builder:cuda115
+          cu_version: cu115
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_conda_py3.10_cu115
+          python_version: '3.10'
+          wheel_docker_image: pytorch/manylinux-cuda115
+      - binary_conda_upload:
+          context: org-member
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_conda_py3.10_cu115_upload
+          requires:
+          - nightly_binary_linux_conda_py3.10_cu115
+      - smoke_test_linux_conda:
+          filters:
+            branches:
+              only:
+              - nightly
+          name: nightly_binary_linux_conda_py3.10_cu115_smoke_test_conda
+          python_version: '3.10'
+          requires:
+          - nightly_binary_linux_conda_py3.10_cu115_upload
       - binary_macos_conda:
           conda_docker_image: pytorch/conda-builder:cpu
           cu_version: cpu
@@ -3288,6 +3975,27 @@ workflows:
           name: nightly_binary_macos_conda_py3.9_cpu_upload
           requires:
           - nightly_binary_macos_conda_py3.9_cpu
+      - binary_macos_conda:
+          conda_docker_image: pytorch/conda-builder:cpu
+          cu_version: cpu
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_macos_conda_py3.10_cpu
+          python_version: '3.10'
+          wheel_docker_image: pytorch/manylinux-cuda102
+      - binary_conda_upload:
+          context: org-member
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_macos_conda_py3.10_cpu_upload
+          requires:
+          - nightly_binary_macos_conda_py3.10_cpu
       - binary_win_conda:
           cu_version: cpu
           filters:
@@ -3624,6 +4332,118 @@ workflows:
           python_version: '3.9'
           requires:
           - nightly_binary_win_conda_py3.9_cu115_upload
+      - binary_win_conda:
+          cu_version: cpu
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_win_conda_py3.10_cpu
+          python_version: '3.10'
+      - binary_conda_upload:
+          context: org-member
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_win_conda_py3.10_cpu_upload
+          requires:
+          - nightly_binary_win_conda_py3.10_cpu
+      - smoke_test_win_conda:
+          filters:
+            branches:
+              only:
+              - nightly
+          name: nightly_binary_win_conda_py3.10_cpu_smoke_test_conda
+          python_version: '3.10'
+          requires:
+          - nightly_binary_win_conda_py3.10_cpu_upload
+      - binary_win_conda:
+          cu_version: cu111
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_win_conda_py3.10_cu111
+          python_version: '3.10'
+      - binary_conda_upload:
+          context: org-member
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_win_conda_py3.10_cu111_upload
+          requires:
+          - nightly_binary_win_conda_py3.10_cu111
+      - smoke_test_win_conda:
+          filters:
+            branches:
+              only:
+              - nightly
+          name: nightly_binary_win_conda_py3.10_cu111_smoke_test_conda
+          python_version: '3.10'
+          requires:
+          - nightly_binary_win_conda_py3.10_cu111_upload
+      - binary_win_conda:
+          cu_version: cu113
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_win_conda_py3.10_cu113
+          python_version: '3.10'
+      - binary_conda_upload:
+          context: org-member
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_win_conda_py3.10_cu113_upload
+          requires:
+          - nightly_binary_win_conda_py3.10_cu113
+      - smoke_test_win_conda:
+          filters:
+            branches:
+              only:
+              - nightly
+          name: nightly_binary_win_conda_py3.10_cu113_smoke_test_conda
+          python_version: '3.10'
+          requires:
+          - nightly_binary_win_conda_py3.10_cu113_upload
+      - binary_win_conda:
+          cu_version: cu115
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_win_conda_py3.10_cu115
+          python_version: '3.10'
+      - binary_conda_upload:
+          context: org-member
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_win_conda_py3.10_cu115_upload
+          requires:
+          - nightly_binary_win_conda_py3.10_cu115
+      - smoke_test_win_conda:
+          filters:
+            branches:
+              only:
+              - nightly
+          name: nightly_binary_win_conda_py3.10_cu115_smoke_test_conda
+          python_version: '3.10'
+          requires:
+          - nightly_binary_win_conda_py3.10_cu115_upload
   docker_build:
     triggers:
       - schedule:

--- a/.circleci/regenerate.py
+++ b/.circleci/regenerate.py
@@ -42,6 +42,9 @@ def build_workflows(prefix="", filter_branch=None, upload=False, indentation=6, 
                     # ROCm conda packages not yet supported
                     if cu_version.startswith("rocm") and btype == "conda":
                         continue
+                    # Skip MacOSX and python 3.10
+                    if python_version == "3.10" and os_type == "macos":
+                        continue
                     for unicode in [False]:
                         fb = filter_branch
                         if (

--- a/.circleci/regenerate.py
+++ b/.circleci/regenerate.py
@@ -21,7 +21,7 @@ import yaml
 from jinja2 import select_autoescape
 
 
-PYTHON_VERSIONS = ["3.7", "3.8", "3.9"]
+PYTHON_VERSIONS = ["3.7", "3.8", "3.9", "3.10"]
 
 RC_PATTERN = r"/v[0-9]+(\.[0-9]+)*-rc[0-9]+/"
 

--- a/.circleci/regenerate.py
+++ b/.circleci/regenerate.py
@@ -246,6 +246,9 @@ def unittest_workflows(indentation=6):
             if os_type == "macos" and device_type == "gpu":
                 continue
             for i, python_version in enumerate(PYTHON_VERSIONS):
+                # Skip MacOSX and python 3.10
+                if python_version == "3.10" and os_type == "macos":
+                    continue
                 job = {
                     "name": f"unittest_{os_type}_{device_type}_py{python_version}",
                     "python_version": python_version,

--- a/.circleci/smoke_test/docker/Dockerfile
+++ b/.circleci/smoke_test/docker/Dockerfile
@@ -28,9 +28,11 @@ ENV PATH /opt/conda/bin:$PATH
 RUN conda create -y --name python3.7 python=3.7
 RUN conda create -y --name python3.8 python=3.8
 RUN conda create -y --name python3.9 python=3.9
+RUN conda create -y --name python3.10 python=3.10
 SHELL [ "/bin/bash", "-c" ]
 RUN echo "source /usr/local/etc/profile.d/conda.sh" >> ~/.bashrc
 RUN source /usr/local/etc/profile.d/conda.sh && conda activate python3.7 && conda install -y "Pillow>=5.3.0,!=8.3.*"
 RUN source /usr/local/etc/profile.d/conda.sh && conda activate python3.8 && conda install -y "Pillow>=5.3.0,!=8.3.*"
 RUN source /usr/local/etc/profile.d/conda.sh && conda activate python3.9 && conda install -y "Pillow>=5.3.0,!=8.3.*"
+RUN source /usr/local/etc/profile.d/conda.sh && conda activate python3.10 && conda install -y "Pillow>=5.3.0,!=8.3.*"
 CMD [ "/bin/bash"]

--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ supported Python versions.
 +--------------------------+--------------------------+---------------------------------+
 | ``torch``                | ``torchvision``          | ``python``                      |
 +==========================+==========================+=================================+
-| ``main`` / ``nightly``   | ``main`` / ``nightly``   | ``>=3.7``, ``<=3.9``            |
+| ``main`` / ``nightly``   | ``main`` / ``nightly``   | ``>=3.7``, ``<=3.10``           |
 +--------------------------+--------------------------+---------------------------------+
 | ``1.10.2``               | ``0.11.3``               | ``>=3.6``, ``<=3.9``            |
 +--------------------------+--------------------------+---------------------------------+
@@ -159,8 +159,8 @@ so make sure that it is also available to cmake via the ``CMAKE_PREFIX_PATH``.
 
 For an example setup, take a look at ``examples/cpp/hello_world``.
 
-Python linking is disabled by default when compiling TorchVision with CMake, this allows you to run models without any Python 
-dependency. In some special cases where TorchVision's operators are used from Python code, you may need to link to Python. This 
+Python linking is disabled by default when compiling TorchVision with CMake, this allows you to run models without any Python
+dependency. In some special cases where TorchVision's operators are used from Python code, you may need to link to Python. This
 can be done by passing ``-DUSE_PYTHON=on`` to CMake.
 
 TorchVision Operators

--- a/packaging/pkg_helpers.bash
+++ b/packaging/pkg_helpers.bash
@@ -205,6 +205,7 @@ setup_wheel_python() {
       3.7) python_abi=cp37-cp37m ;;
       3.8) python_abi=cp38-cp38 ;;
       3.9) python_abi=cp39-cp39 ;;
+      3.10) python_abi=cp310-cp310 ;;
       *)
         echo "Unrecognized PYTHON_VERSION=$PYTHON_VERSION"
         exit 1

--- a/packaging/wheel/osx_wheel.sh
+++ b/packaging/wheel/osx_wheel.sh
@@ -21,7 +21,7 @@ rm -rf vision
 git clone https://github.com/pytorch/vision
 pushd vision
 
-desired_pythons=( "3.7" "3.8" "3.9" )
+desired_pythons=( "3.7" "3.8" "3.9" "3.10" )
 # for each python
 for desired_python in "${desired_pythons[@]}"
 do


### PR DESCRIPTION
Description:
- Added python 3.10 to CI by updating `.circleci/regenerate.py` and running it to update `.circleci/config.yml`
  - skipped macosx as no 3.10 binaries yet.
