### PR TITLE
Fixes device mismatch issue while building docs

### DIFF
--- a/torchvision/utils.py
+++ b/torchvision/utils.py
@@ -449,8 +449,9 @@ def _normalized_flow_to_image(normalized_flow: torch.Tensor) -> torch.Tensor:
     """
 
     N, _, H, W = normalized_flow.shape
-    flow_image = torch.zeros((N, 3, H, W), dtype=torch.uint8)
-    colorwheel = _make_colorwheel()  # shape [55x3]
+    device = normalized_flow.device
+    flow_image = torch.zeros((N, 3, H, W), dtype=torch.uint8, device=device)
+    colorwheel = _make_colorwheel().to(device)  # shape [55x3]
     num_cols = colorwheel.shape[0]
     norm = torch.sum(normalized_flow ** 2, dim=1).sqrt()
     a = torch.atan2(-normalized_flow[:, 1, :, :], -normalized_flow[:, 0, :, :]) / torch.pi


### PR DESCRIPTION
Description:

- Issue: 

While trying to build docs on a machine with GPU and optical flow gallery example is failing with device mismatch:

```python
/vision/gallery/plot_optical_flow.py failed to execute correctly: Traceback (most recent call last):
  File "/vision/gallery/plot_optical_flow.py", line 164, in <module>
    flow_imgs = flow_to_image(predicted_flows)
  File "/usr/local/lib/python3.8/dist-packages/torch/autograd/grad_mode.py", line 27, in decorate_context
    return func(*args, **kwargs)
  File "/vision/torchvision/utils.py", line 432, in flow_to_image
    img = _normalized_flow_to_image(normalized_flow)
  File "/usr/local/lib/python3.8/dist-packages/torch/autograd/grad_mode.py", line 27, in decorate_context
    return func(*args, **kwargs)
  File "/vision/torchvision/utils.py", line 467, in _normalized_flow_to_image
    col = (1 - f) * col0 + f * col1
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!
```

Here is minimal fix