### PR TITLE
disable ufmt pre-commit hook

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -260,14 +260,16 @@ jobs:
     steps:
       - checkout
       - pip_install:
-          args: pre-commit
+          args: pre-commit ufmt==1.3.0 black==21.9b0 usort==0.6.4
           descr: Install lint utilities
       - run:
           name: Install pre-commit hooks
           command: pre-commit install-hooks
       - run:
           name: Lint Python code and config files
-          command: pre-commit run --all-files
+          command: |
+            ufmt format .
+            pre-commit run --all-files
       - run:
           name: Required lint modifications
           when: on_fail

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -260,14 +260,16 @@ jobs:
     steps:
       - checkout
       - pip_install:
-          args: pre-commit
+          args: pre-commit ufmt==1.3.0 black==21.9b0 usort==0.6.4
           descr: Install lint utilities
       - run:
           name: Install pre-commit hooks
           command: pre-commit install-hooks
       - run:
           name: Lint Python code and config files
-          command: pre-commit run --all-files
+          command: |
+            ufmt format .
+            pre-commit run --all-files
       - run:
           name: Required lint modifications
           when: on_fail

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,20 +10,14 @@ repos:
         args: [--fix=lf]
       - id: end-of-file-fixer
 
-  # - repo: https://github.com/asottile/pyupgrade
-  #   rev: v2.29.0
-  #   hooks:
-  #     - id: pyupgrade
-  #       args: [--py37-plus]
-  #       name: Upgrade code
-
-  - repo: https://github.com/omnilib/ufmt
-    rev: v1.3.0
-    hooks:
-      - id: ufmt
-        additional_dependencies:
-          - black == 21.9b0
-          - usort == 0.6.4
+# TODO: re-enable after https://github.com/omnilib/ufmt/issues/56 is resolved
+#  - repo: https://github.com/omnilib/ufmt
+#    rev: v1.3.0
+#    hooks:
+#      - id: ufmt
+#        additional_dependencies:
+#          - black == 21.9b0
+#          - usort == 0.6.4
 
   - repo: https://gitlab.com/pycqa/flake8
     rev: 3.9.2


### PR DESCRIPTION
Until omnilib/ufmt#56 is resolved, the `ufmt` hook cannot be installed and thus breaks the whole lint CI workflow (see for example https://app.circleci.com/pipelines/github/pytorch/vision/14964/workflows/2a6aab2b-9629-44ae-bf50-2b9c42dc85ca/jobs/1205317). Thus, we should disable it for now and wait until this is fixed upstream.