### PR TITLE
call tensor-only kernels from prototype kernels if possible

### DIFF
--- a/torchvision/prototype/transforms/kernels/_color.py
+++ b/torchvision/prototype/transforms/kernels/_color.py
@@ -1,14 +1,14 @@
-from torchvision.transforms import functional as _F
+from torchvision.transforms import functional_tensor as _FT
 
 
-adjust_brightness_image = _F.adjust_brightness
-adjust_saturation_image = _F.adjust_saturation
-adjust_contrast_image = _F.adjust_contrast
-adjust_sharpness_image = _F.adjust_sharpness
-posterize_image = _F.posterize
-solarize_image = _F.solarize
-autocontrast_image = _F.autocontrast
-equalize_image = _F.equalize
-invert_image = _F.invert
-adjust_hue_image = _F.adjust_hue
-adjust_gamma_image = _F.adjust_gamma
+adjust_brightness_image = _FT.adjust_brightness
+adjust_saturation_image = _FT.adjust_saturation
+adjust_contrast_image = _FT.adjust_contrast
+adjust_sharpness_image = _FT.adjust_sharpness
+posterize_image = _FT.posterize
+solarize_image = _FT.solarize
+autocontrast_image = _FT.autocontrast
+equalize_image = _FT.equalize
+invert_image = _FT.invert
+adjust_hue_image = _FT.adjust_hue
+adjust_gamma_image = _FT.adjust_gamma

--- a/torchvision/prototype/transforms/kernels/_geometry.py
+++ b/torchvision/prototype/transforms/kernels/_geometry.py
@@ -2,7 +2,7 @@ from typing import Tuple, List, Optional, TypeVar
 
 import torch
 from torchvision.prototype import features
-from torchvision.transforms import functional as _F, InterpolationMode
+from torchvision.transforms import functional as _F, functional_tensor as _FT, InterpolationMode
 
 from ._meta_conversion import convert_bounding_box_format
 
@@ -10,7 +10,7 @@ from ._meta_conversion import convert_bounding_box_format
 T = TypeVar("T", bound=features._Feature)
 
 
-horizontal_flip_image = _F.hflip
+horizontal_flip_image = _FT.hflip
 
 
 def horizontal_flip_bounding_box(
@@ -39,10 +39,10 @@ def resize_image(
     new_height, new_width = size
     num_channels, old_height, old_width = image.shape[-3:]
     batch_shape = image.shape[:-3]
-    return _F.resize(
+    return _FT.resize(
         image.reshape((-1, num_channels, old_height, old_width)),
         size=size,
-        interpolation=interpolation,
+        interpolation=interpolation.value,
         max_size=max_size,
         antialias=antialias,
     ).reshape(batch_shape + (num_channels, new_height, new_width))
@@ -66,11 +66,11 @@ def resize_bounding_box(bounding_box: torch.Tensor, *, size: List[int], image_si
 
 center_crop_image = _F.center_crop
 resized_crop_image = _F.resized_crop
-affine_image = _F.affine
-rotate_image = _F.rotate
-pad_image = _F.pad
-crop_image = _F.crop
-perspective_image = _F.perspective
-vertical_flip_image = _F.vflip
+affine_image = _FT.affine
+rotate_image = _FT.rotate
+pad_image = _FT.pad
+crop_image = _FT.crop
+perspective_image = _FT.perspective
+vertical_flip_image = _FT.vflip
 five_crop_image = _F.five_crop
 ten_crop_image = _F.ten_crop

--- a/torchvision/prototype/transforms/kernels/_meta_conversion.py
+++ b/torchvision/prototype/transforms/kernels/_meta_conversion.py
@@ -1,6 +1,6 @@
 import torch
 from torchvision.prototype.features import BoundingBoxFormat, ColorSpace
-from torchvision.transforms.functional_tensor import rgb_to_grayscale as _rgb_to_grayscale
+from torchvision.transforms import functional_tensor as _FT
 
 
 def _xywh_to_xyxy(xywh: torch.Tensor) -> torch.Tensor:
@@ -64,6 +64,6 @@ def convert_color_space(image: torch.Tensor, old_color_space: ColorSpace, new_co
         image = _grayscale_to_rgb(image)
 
     if new_color_space == ColorSpace.GRAYSCALE:
-        image = _rgb_to_grayscale(image)
+        image = _FT.rgb_to_grayscale(image)
 
     return image

--- a/torchvision/prototype/transforms/kernels/_misc.py
+++ b/torchvision/prototype/transforms/kernels/_misc.py
@@ -1,5 +1,5 @@
-from torchvision.transforms import functional as _F
+from torchvision.transforms import functional as _F, functional_tensor as _FT
 
 
 normalize_image = _F.normalize
-gaussian_blur_image = _F.gaussian_blur
+gaussian_blur_image = _FT.gaussian_blur


### PR DESCRIPTION
Addresses the first part of https://github.com/pytorch/vision/pull/5421#discussion_r811798298. The idea behind this change is to make it more clear that our low-level kernels are tensor only and thus cannot use the same route as PIL images in the dispatch. There are two caveats:

1. Some old kernels are only implemented for tensors and thus the kernel is implemented in `torchvision.transforms.functional` directly:
    - `erase`
    - `normalize`
2. Some kernels are composite and thus don't have a PIL or tensor implementation and thus are also only implemented in `torchvision.transforms.functional`
    - `center_crop`
    - `resized_crop`
    - `ten_crop`
    - `five_crop`

