### PR TITLE
Reinstate ufmt pre commit hook

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -260,16 +260,14 @@ jobs:
     steps:
       - checkout
       - pip_install:
-          args: pre-commit ufmt==1.3.0 black==21.9b0 usort==0.6.4
+          args: pre-commit
           descr: Install lint utilities
       - run:
           name: Install pre-commit hooks
           command: pre-commit install-hooks
       - run:
           name: Lint Python code and config files
-          command: |
-            ufmt format .
-            pre-commit run --all-files
+          command: pre-commit run --all-files
       - run:
           name: Required lint modifications
           when: on_fail

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -260,16 +260,14 @@ jobs:
     steps:
       - checkout
       - pip_install:
-          args: pre-commit ufmt==1.3.0 black==21.9b0 usort==0.6.4
+          args: pre-commit
           descr: Install lint utilities
       - run:
           name: Install pre-commit hooks
           command: pre-commit install-hooks
       - run:
           name: Lint Python code and config files
-          command: |
-            ufmt format .
-            pre-commit run --all-files
+          command: pre-commit run --all-files
       - run:
           name: Required lint modifications
           when: on_fail

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,15 +10,8 @@ repos:
         args: [--fix=lf]
       - id: end-of-file-fixer
 
-  # - repo: https://github.com/asottile/pyupgrade
-  #   rev: v2.29.0
-  #   hooks:
-  #     - id: pyupgrade
-  #       args: [--py37-plus]
-  #       name: Upgrade code
-
   - repo: https://github.com/omnilib/ufmt
-    rev: v1.3.0
+    rev: v1.3.2
     hooks:
       - id: ufmt
         additional_dependencies:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,14 +10,20 @@ repos:
         args: [--fix=lf]
       - id: end-of-file-fixer
 
-# TODO: re-enable after https://github.com/omnilib/ufmt/issues/56 is resolved
-#  - repo: https://github.com/omnilib/ufmt
-#    rev: v1.3.0
-#    hooks:
-#      - id: ufmt
-#        additional_dependencies:
-#          - black == 21.9b0
-#          - usort == 0.6.4
+  # - repo: https://github.com/asottile/pyupgrade
+  #   rev: v2.29.0
+  #   hooks:
+  #     - id: pyupgrade
+  #       args: [--py37-plus]
+  #       name: Upgrade code
+
+  - repo: https://github.com/omnilib/ufmt
+    rev: v1.3.0
+    hooks:
+      - id: ufmt
+        additional_dependencies:
+          - black == 21.9b0
+          - usort == 0.6.4
 
   - repo: https://gitlab.com/pycqa/flake8
     rev: 3.9.2


### PR DESCRIPTION
Reverts #5454 since omnilib/ufmt#56 was fixed in `ufmt==1.3.2`.