### PR TITLE
Removing Win CU11.1 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1283,15 +1283,6 @@ workflows:
           name: binary_win_wheel_py3.7_cpu
           python_version: '3.7'
       - binary_win_wheel:
-          cu_version: cu111
-          filters:
-            branches:
-              only: main
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: binary_win_wheel_py3.7_cu111
-          python_version: '3.7'
-      - binary_win_wheel:
           cu_version: cu113
           filters:
             branches:
@@ -1317,15 +1308,6 @@ workflows:
             tags:
               only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
           name: binary_win_wheel_py3.8_cpu
-          python_version: '3.8'
-      - binary_win_wheel:
-          cu_version: cu111
-          filters:
-            branches:
-              only: main
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: binary_win_wheel_py3.8_cu111
           python_version: '3.8'
       - binary_win_wheel:
           cu_version: cu113
@@ -1355,15 +1337,6 @@ workflows:
           name: binary_win_wheel_py3.9_cpu
           python_version: '3.9'
       - binary_win_wheel:
-          cu_version: cu111
-          filters:
-            branches:
-              only: main
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: binary_win_wheel_py3.9_cu111
-          python_version: '3.9'
-      - binary_win_wheel:
           cu_version: cu113
           filters:
             branches:
@@ -1384,15 +1357,6 @@ workflows:
       - binary_win_wheel:
           cu_version: cpu
           name: binary_win_wheel_py3.10_cpu
-          python_version: '3.10'
-      - binary_win_wheel:
-          cu_version: cu111
-          filters:
-            branches:
-              only: main
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: binary_win_wheel_py3.10_cu111
           python_version: '3.10'
       - binary_win_wheel:
           cu_version: cu113
@@ -1561,15 +1525,6 @@ workflows:
           name: binary_win_conda_py3.7_cpu
           python_version: '3.7'
       - binary_win_conda:
-          cu_version: cu111
-          filters:
-            branches:
-              only: main
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: binary_win_conda_py3.7_cu111
-          python_version: '3.7'
-      - binary_win_conda:
           cu_version: cu113
           filters:
             branches:
@@ -1595,15 +1550,6 @@ workflows:
             tags:
               only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
           name: binary_win_conda_py3.8_cpu
-          python_version: '3.8'
-      - binary_win_conda:
-          cu_version: cu111
-          filters:
-            branches:
-              only: main
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: binary_win_conda_py3.8_cu111
           python_version: '3.8'
       - binary_win_conda:
           cu_version: cu113
@@ -1633,15 +1579,6 @@ workflows:
           name: binary_win_conda_py3.9_cpu
           python_version: '3.9'
       - binary_win_conda:
-          cu_version: cu111
-          filters:
-            branches:
-              only: main
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: binary_win_conda_py3.9_cu111
-          python_version: '3.9'
-      - binary_win_conda:
           cu_version: cu113
           filters:
             branches:
@@ -1662,15 +1599,6 @@ workflows:
       - binary_win_conda:
           cu_version: cpu
           name: binary_win_conda_py3.10_cpu
-          python_version: '3.10'
-      - binary_win_conda:
-          cu_version: cu111
-          filters:
-            branches:
-              only: main
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: binary_win_conda_py3.10_cu111
           python_version: '3.10'
       - binary_win_conda:
           cu_version: cu113
@@ -2878,35 +2806,6 @@ workflows:
           requires:
           - nightly_binary_win_wheel_py3.7_cpu_upload
       - binary_win_wheel:
-          cu_version: cu111
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_win_wheel_py3.7_cu111
-          python_version: '3.7'
-      - binary_wheel_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_win_wheel_py3.7_cu111_upload
-          requires:
-          - nightly_binary_win_wheel_py3.7_cu111
-          subfolder: cu111/
-      - smoke_test_win_pip:
-          filters:
-            branches:
-              only:
-              - nightly
-          name: nightly_binary_win_wheel_py3.7_cu111_smoke_test_pip
-          python_version: '3.7'
-          requires:
-          - nightly_binary_win_wheel_py3.7_cu111_upload
-      - binary_win_wheel:
           cu_version: cu113
           filters:
             branches:
@@ -2993,35 +2892,6 @@ workflows:
           python_version: '3.8'
           requires:
           - nightly_binary_win_wheel_py3.8_cpu_upload
-      - binary_win_wheel:
-          cu_version: cu111
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_win_wheel_py3.8_cu111
-          python_version: '3.8'
-      - binary_wheel_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_win_wheel_py3.8_cu111_upload
-          requires:
-          - nightly_binary_win_wheel_py3.8_cu111
-          subfolder: cu111/
-      - smoke_test_win_pip:
-          filters:
-            branches:
-              only:
-              - nightly
-          name: nightly_binary_win_wheel_py3.8_cu111_smoke_test_pip
-          python_version: '3.8'
-          requires:
-          - nightly_binary_win_wheel_py3.8_cu111_upload
       - binary_win_wheel:
           cu_version: cu113
           filters:
@@ -3110,35 +2980,6 @@ workflows:
           requires:
           - nightly_binary_win_wheel_py3.9_cpu_upload
       - binary_win_wheel:
-          cu_version: cu111
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_win_wheel_py3.9_cu111
-          python_version: '3.9'
-      - binary_wheel_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_win_wheel_py3.9_cu111_upload
-          requires:
-          - nightly_binary_win_wheel_py3.9_cu111
-          subfolder: cu111/
-      - smoke_test_win_pip:
-          filters:
-            branches:
-              only:
-              - nightly
-          name: nightly_binary_win_wheel_py3.9_cu111_smoke_test_pip
-          python_version: '3.9'
-          requires:
-          - nightly_binary_win_wheel_py3.9_cu111_upload
-      - binary_win_wheel:
           cu_version: cu113
           filters:
             branches:
@@ -3225,35 +3066,6 @@ workflows:
           python_version: '3.10'
           requires:
           - nightly_binary_win_wheel_py3.10_cpu_upload
-      - binary_win_wheel:
-          cu_version: cu111
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_win_wheel_py3.10_cu111
-          python_version: '3.10'
-      - binary_wheel_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_win_wheel_py3.10_cu111_upload
-          requires:
-          - nightly_binary_win_wheel_py3.10_cu111
-          subfolder: cu111/
-      - smoke_test_win_pip:
-          filters:
-            branches:
-              only:
-              - nightly
-          name: nightly_binary_win_wheel_py3.10_cu111_smoke_test_pip
-          python_version: '3.10'
-          requires:
-          - nightly_binary_win_wheel_py3.10_cu111_upload
       - binary_win_wheel:
           cu_version: cu113
           filters:
@@ -4025,34 +3837,6 @@ workflows:
           requires:
           - nightly_binary_win_conda_py3.7_cpu_upload
       - binary_win_conda:
-          cu_version: cu111
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_win_conda_py3.7_cu111
-          python_version: '3.7'
-      - binary_conda_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_win_conda_py3.7_cu111_upload
-          requires:
-          - nightly_binary_win_conda_py3.7_cu111
-      - smoke_test_win_conda:
-          filters:
-            branches:
-              only:
-              - nightly
-          name: nightly_binary_win_conda_py3.7_cu111_smoke_test_conda
-          python_version: '3.7'
-          requires:
-          - nightly_binary_win_conda_py3.7_cu111_upload
-      - binary_win_conda:
           cu_version: cu113
           filters:
             branches:
@@ -4136,34 +3920,6 @@ workflows:
           python_version: '3.8'
           requires:
           - nightly_binary_win_conda_py3.8_cpu_upload
-      - binary_win_conda:
-          cu_version: cu111
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_win_conda_py3.8_cu111
-          python_version: '3.8'
-      - binary_conda_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_win_conda_py3.8_cu111_upload
-          requires:
-          - nightly_binary_win_conda_py3.8_cu111
-      - smoke_test_win_conda:
-          filters:
-            branches:
-              only:
-              - nightly
-          name: nightly_binary_win_conda_py3.8_cu111_smoke_test_conda
-          python_version: '3.8'
-          requires:
-          - nightly_binary_win_conda_py3.8_cu111_upload
       - binary_win_conda:
           cu_version: cu113
           filters:
@@ -4249,34 +4005,6 @@ workflows:
           requires:
           - nightly_binary_win_conda_py3.9_cpu_upload
       - binary_win_conda:
-          cu_version: cu111
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_win_conda_py3.9_cu111
-          python_version: '3.9'
-      - binary_conda_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_win_conda_py3.9_cu111_upload
-          requires:
-          - nightly_binary_win_conda_py3.9_cu111
-      - smoke_test_win_conda:
-          filters:
-            branches:
-              only:
-              - nightly
-          name: nightly_binary_win_conda_py3.9_cu111_smoke_test_conda
-          python_version: '3.9'
-          requires:
-          - nightly_binary_win_conda_py3.9_cu111_upload
-      - binary_win_conda:
           cu_version: cu113
           filters:
             branches:
@@ -4360,34 +4088,6 @@ workflows:
           python_version: '3.10'
           requires:
           - nightly_binary_win_conda_py3.10_cpu_upload
-      - binary_win_conda:
-          cu_version: cu111
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_win_conda_py3.10_cu111
-          python_version: '3.10'
-      - binary_conda_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_win_conda_py3.10_cu111_upload
-          requires:
-          - nightly_binary_win_conda_py3.10_cu111
-      - smoke_test_win_conda:
-          filters:
-            branches:
-              only:
-              - nightly
-          name: nightly_binary_win_conda_py3.10_cu111_smoke_test_conda
-          python_version: '3.10'
-          requires:
-          - nightly_binary_win_conda_py3.10_cu111_upload
       - binary_win_conda:
           cu_version: cu113
           filters:

--- a/.circleci/regenerate.py
+++ b/.circleci/regenerate.py
@@ -33,7 +33,7 @@ def build_workflows(prefix="", filter_branch=None, upload=False, indentation=6, 
             python_versions = PYTHON_VERSIONS
             cu_versions_dict = {
                 "linux": ["cpu", "cu102", "cu111", "cu113", "cu115", "rocm4.3.1", "rocm4.5.2"],
-                "win": ["cpu", "cu111", "cu113", "cu115"],
+                "win": ["cpu", "cu113", "cu115"],
                 "macos": ["cpu"],
             }
             cu_versions = cu_versions_dict[os_type]


### PR DESCRIPTION
The cu111 windows binary has an issue. We are missing cuda-toolkit which was not published by nvidia on the official channel (it only exists in conda-forge). After speaking with @atalman offline he recommended to disable temporarily the job and bring this issue to Nvidia on the next meeting with them.