### PR TITLE
Revert exposing convNormActivation in ops

### DIFF
--- a/docs/source/ops.rst
+++ b/docs/source/ops.rst
@@ -45,5 +45,4 @@ Operators
     FeaturePyramidNetwork
     StochasticDepth
     FrozenBatchNorm2d
-    ConvNormActivation
     SqueezeExcitation

--- a/torchvision/models/optical_flow/raft.py
+++ b/torchvision/models/optical_flow/raft.py
@@ -6,7 +6,7 @@ import torch.nn.functional as F
 from torch import Tensor
 from torch.nn.modules.batchnorm import BatchNorm2d
 from torch.nn.modules.instancenorm import InstanceNorm2d
-from torchvision.ops import ConvNormActivation
+from torchvision.ops.misc import ConvNormActivation
 
 from ..._internally_replaced_utils import load_state_dict_from_url
 from ...utils import _log_api_usage_once

--- a/torchvision/ops/__init__.py
+++ b/torchvision/ops/__init__.py
@@ -14,7 +14,7 @@ from .deform_conv import deform_conv2d, DeformConv2d
 from .feature_pyramid_network import FeaturePyramidNetwork
 from .focal_loss import sigmoid_focal_loss
 from .giou_loss import generalized_box_iou_loss
-from .misc import FrozenBatchNorm2d, ConvNormActivation, SqueezeExcitation
+from .misc import FrozenBatchNorm2d, SqueezeExcitation
 from .poolers import MultiScaleRoIAlign
 from .ps_roi_align import ps_roi_align, PSRoIAlign
 from .ps_roi_pool import ps_roi_pool, PSRoIPool
@@ -51,7 +51,6 @@ __all__ = [
     "stochastic_depth",
     "StochasticDepth",
     "FrozenBatchNorm2d",
-    "ConvNormActivation",
     "SqueezeExcitation",
     "generalized_box_iou_loss",
 ]


### PR DESCRIPTION
And remove references in documentation

This change will be cherrypicked for the v12.0 release