### PR TITLE
Add barriers after init_process_group() for all recipes

### DIFF
--- a/references/classification/utils.py
+++ b/references/classification/utils.py
@@ -274,6 +274,7 @@ def init_distributed_mode(args):
     torch.distributed.init_process_group(
         backend=args.dist_backend, init_method=args.dist_url, world_size=args.world_size, rank=args.rank
     )
+    torch.distributed.barrier()
     setup_for_distributed(args.rank == 0)
 
 

--- a/references/optical_flow/utils.py
+++ b/references/optical_flow/utils.py
@@ -267,6 +267,7 @@ def setup_ddp(args):
         world_size=args.world_size,
         init_method=args.dist_url,
     )
+    torch.distributed.barrier()
 
 
 def reduce_across_processes(val):

--- a/references/segmentation/utils.py
+++ b/references/segmentation/utils.py
@@ -291,4 +291,5 @@ def init_distributed_mode(args):
     torch.distributed.init_process_group(
         backend=args.dist_backend, init_method=args.dist_url, world_size=args.world_size, rank=args.rank
     )
+    torch.distributed.barrier()
     setup_for_distributed(args.rank == 0)

--- a/references/video_classification/utils.py
+++ b/references/video_classification/utils.py
@@ -250,4 +250,5 @@ def init_distributed_mode(args):
     torch.distributed.init_process_group(
         backend=args.dist_backend, init_method=args.dist_url, world_size=args.world_size, rank=args.rank
     )
+    torch.distributed.barrier()
     setup_for_distributed(args.rank == 0)


### PR DESCRIPTION
Currently only the detection recipe supports this:
https://github.com/pytorch/vision/blob/d367a01a18a3ae6bee13d8be3b63fd6a581ea46f/references/detection/utils.py#L278-L281

Adding barriers to all other recipes.