### PR TITLE
ci Limit scope of unittest to one python version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1658,18 +1658,6 @@ workflows:
           cu_version: cpu
           name: unittest_windows_cpu_py3.7
           python_version: '3.7'
-      - unittest_windows_cpu:
-          cu_version: cpu
-          name: unittest_windows_cpu_py3.8
-          python_version: '3.8'
-      - unittest_windows_cpu:
-          cu_version: cpu
-          name: unittest_windows_cpu_py3.9
-          python_version: '3.9'
-      - unittest_windows_cpu:
-          cu_version: cpu
-          name: unittest_windows_cpu_py3.10
-          python_version: '3.10'
       - unittest_windows_gpu:
           cu_version: cu102
           filters:
@@ -1679,44 +1667,10 @@ workflows:
               - nightly
           name: unittest_windows_gpu_py3.7
           python_version: '3.7'
-      - unittest_windows_gpu:
-          cu_version: cu102
-          name: unittest_windows_gpu_py3.8
-          python_version: '3.8'
-      - unittest_windows_gpu:
-          cu_version: cu102
-          filters:
-            branches:
-              only:
-              - main
-              - nightly
-          name: unittest_windows_gpu_py3.9
-          python_version: '3.9'
-      - unittest_windows_gpu:
-          cu_version: cu102
-          filters:
-            branches:
-              only:
-              - main
-              - nightly
-          name: unittest_windows_gpu_py3.10
-          python_version: '3.10'
       - unittest_macos_cpu:
           cu_version: cpu
           name: unittest_macos_cpu_py3.7
           python_version: '3.7'
-      - unittest_macos_cpu:
-          cu_version: cpu
-          name: unittest_macos_cpu_py3.8
-          python_version: '3.8'
-      - unittest_macos_cpu:
-          cu_version: cpu
-          name: unittest_macos_cpu_py3.9
-          python_version: '3.9'
-      - unittest_macos_cpu:
-          cu_version: cpu
-          name: unittest_macos_cpu_py3.10
-          python_version: '3.10'
 
   cmake:
     jobs:

--- a/.circleci/regenerate.py
+++ b/.circleci/regenerate.py
@@ -236,13 +236,21 @@ def indent(indentation, data_list):
     return ("\n" + " " * indentation).join(yaml.dump(data_list, default_flow_style=False).splitlines())
 
 
+def unittest_python_versions(os):
+    return {
+        "windows": PYTHON_VERSIONS[:1],
+        "macos": PYTHON_VERSIONS[:1],
+        "linux": PYTHON_VERSIONS,
+    }.get(os)
+
+
 def unittest_workflows(indentation=6):
     jobs = []
     for os_type in ["linux", "windows", "macos"]:
         for device_type in ["cpu", "gpu"]:
             if os_type == "macos" and device_type == "gpu":
                 continue
-            for i, python_version in enumerate(PYTHON_VERSIONS):
+            for i, python_version in enumerate(unittest_python_versions(os_type)):
                 job = {
                     "name": f"unittest_{os_type}_{device_type}_py{python_version}",
                     "python_version": python_version,


### PR DESCRIPTION
Limits scope of unittesting to one python version for both macOS and
Windows. These types of workflows are particularly expensive and take a
long time so running them on every PR / every push is a bit wasteful
considering the value in signal between different python versions is
probably negligible.

Similar to https://github.com/pytorch/audio/pull/2256

Context: https://github.com/pytorch/audio/issues/2254

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

<!-- Before submitting a PR, please make sure to check our contributing guidelines regarding code formatting, tests, and documentation: https://github.com/pytorch/vision/blob/main/CONTRIBUTING.md -->
