### PR TITLE
merge prototype dataset register decorators

### DIFF
--- a/test/test_prototype_builtin_datasets.py
+++ b/test/test_prototype_builtin_datasets.py
@@ -34,16 +34,6 @@ def test_coverage():
 
 
 class TestCommon:
-    @pytest.mark.parametrize("name", datasets.list_datasets())
-    def test_info(self, name):
-        try:
-            info = datasets.info(name)
-        except ValueError:
-            raise AssertionError("No info available.") from None
-
-        if not (isinstance(info, dict) and all(isinstance(key, str) for key in info.keys())):
-            raise AssertionError("Info should be a dictionary with string keys.")
-
     @parametrize_dataset_mocks(DATASET_MOCKS)
     def test_smoke(self, test_home, dataset_mock, config):
         dataset_mock.prepare(test_home, config)

--- a/torchvision/prototype/datasets/__init__.py
+++ b/torchvision/prototype/datasets/__init__.py
@@ -11,6 +11,6 @@ from . import utils
 from ._home import home
 
 # Load this last, since some parts depend on the above being loaded first
-from ._api import list_datasets, info, load, register_info, register_dataset  # usort: skip
+from ._api import list_datasets, info, load, register_dataset  # usort: skip
 from ._folder import from_data_folder, from_image_folder
 from ._builtin import *

--- a/torchvision/prototype/datasets/_api.py
+++ b/torchvision/prototype/datasets/_api.py
@@ -12,20 +12,20 @@ D = TypeVar("D", bound=Type[Dataset2])
 BUILTIN_INFOS: Dict[str, Dict[str, Any]] = {}
 
 
-def register_info(name: str) -> Callable[[Callable[[], Dict[str, Any]]], Callable[[], Dict[str, Any]]]:
-    def wrapper(fn: Callable[[], Dict[str, Any]]) -> Callable[[], Dict[str, Any]]:
-        BUILTIN_INFOS[name] = fn()
-        return fn
-
-    return wrapper
-
-
 BUILTIN_DATASETS = {}
 
 
-def register_dataset(name: str) -> Callable[[D], D]:
+def register_dataset(name: str, *, info: Optional[Dict[str, Any]] = None) -> Callable[[D], D]:
+    if info is None:
+        info = dict()
+
     def wrapper(dataset_cls: D) -> D:
+        BUILTIN_INFOS[name] = info  # type: ignore[assignment]
         BUILTIN_DATASETS[name] = dataset_cls
+
+        dataset_cls._NAME = name
+        dataset_cls._INFO = info  # type: ignore[assignment]
+
         return dataset_cls
 
     return wrapper

--- a/torchvision/prototype/datasets/_builtin/imagenet.py
+++ b/torchvision/prototype/datasets/_builtin/imagenet.py
@@ -23,16 +23,7 @@ from torchvision.prototype.datasets.utils._internal import (
 )
 from torchvision.prototype.features import Label, EncodedImage
 
-from .._api import register_dataset, register_info
-
-
-NAME = "imagenet"
-
-
-@register_info(NAME)
-def _info() -> Dict[str, Any]:
-    categories, wnids = zip(*DatasetInfo.read_categories_file(BUILTIN_DIR / f"{NAME}.categories"))
-    return dict(categories=categories, wnids=wnids)
+from .._api import register_dataset
 
 
 class ImageNetResource(ManualDownloadResource):
@@ -40,13 +31,15 @@ class ImageNetResource(ManualDownloadResource):
         super().__init__("Register on https://image-net.org/ and follow the instructions there.", **kwargs)
 
 
-@register_dataset(NAME)
+CATEGORIES, WNIDS = zip(*DatasetInfo.read_categories_file(BUILTIN_DIR / "imagenet.categories"))
+
+
+@register_dataset("imagenet", info=dict(categories=CATEGORIES, wnids=WNIDS))
 class ImageNet(Dataset2):
     def __init__(self, root: Union[str, pathlib.Path], *, split: str = "train") -> None:
         self._split = self._verify_str_arg(split, "split", {"train", "val", "test"})
 
-        info = _info()
-        categories, wnids = info["categories"], info["wnids"]
+        categories, wnids = self._INFO["categories"], self._INFO["wnids"]
         self._categories: List[str] = categories
         self._wnids: List[str] = wnids
         self._wnid_to_category = dict(zip(wnids, categories))

--- a/torchvision/prototype/datasets/utils/_dataset.py
+++ b/torchvision/prototype/datasets/utils/_dataset.py
@@ -185,6 +185,10 @@ class Dataset(abc.ABC):
 
 
 class Dataset2(IterDataPipe[Dict[str, Any]], abc.ABC):
+    # These fields will be set on subclasses by the `@register_dataset` decorator
+    _NAME: str
+    _INFO: Dict[str, Any]
+
     @staticmethod
     def _verify_str_arg(
         value: str,


### PR DESCRIPTION
Given that the info is static anyway, there is no reason to have them separate other than having access to it from within the dataset class. We can achieve the same by letting the register decorator set a private class variable.