### PR TITLE
Remove unnecessary initialisation

### DIFF
--- a/torchvision/csrc/io/decoder/gpu/gpu_decoder.cpp
+++ b/torchvision/csrc/io/decoder/gpu/gpu_decoder.cpp
@@ -29,8 +29,7 @@ torch::Tensor GPUDecoder::decode() {
   unsigned long videoBytes = 0;
   uint8_t* video = nullptr;
   at::cuda::CUDAGuard device_guard(device);
-  auto options = torch::TensorOptions().dtype(torch::kU8).device(torch::kCUDA);
-  torch::Tensor frame = torch::zeros({0}, options);
+  torch::Tensor frame;
   do {
     demuxer.demux(&video, &videoBytes);
     decoder.decode(video, videoBytes);


### PR DESCRIPTION
This initialisation is unnecessary as `frame` tensor would always get overwritten in the do-while loop. In case there are no decoded frames, [fetch_frame()](https://github.com/pytorch/vision/blob/f9fbc104c02f277f9485d9f8727f3d99a1cf5f0b/torchvision/csrc/io/decoder/gpu/decoder.cpp#L86) returns a zero tensor.
Discussion: https://github.com/pytorch/vision/pull/5019#discussion_r776807411