### PR TITLE
fail test suite on unexpected passes

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -10,3 +10,4 @@ addopts =
     --ignore-glob=test/test_prototype_*.py
 testpaths =
     test
+xfail_strict = True

--- a/test/test_prototype_builtin_datasets.py
+++ b/test/test_prototype_builtin_datasets.py
@@ -107,14 +107,7 @@ class TestCommon:
 
         next(iter(dataset.map(transforms.Identity())))
 
-    @parametrize_dataset_mocks(
-        DATASET_MOCKS,
-        marks={
-            "cub200": pytest.mark.xfail(
-                reason="See https://github.com/pytorch/vision/pull/5187#issuecomment-1015479165"
-            )
-        },
-    )
+    @parametrize_dataset_mocks(DATASET_MOCKS)
     def test_traversable(self, test_home, dataset_mock, config):
         dataset_mock.prepare(test_home, config)
 
@@ -122,14 +115,7 @@ class TestCommon:
 
         traverse(dataset)
 
-    @parametrize_dataset_mocks(
-        DATASET_MOCKS,
-        marks={
-            "cub200": pytest.mark.xfail(
-                reason="See https://github.com/pytorch/vision/pull/5187#issuecomment-1015479165"
-            )
-        },
-    )
+    @parametrize_dataset_mocks(DATASET_MOCKS)
     @pytest.mark.parametrize("annotation_dp_type", (Shuffler, ShardingFilter))
     def test_has_annotations(self, test_home, dataset_mock, config, annotation_dp_type):
         def scan(graph):


### PR DESCRIPTION
I didn't know before that just using adding `@pytest.mark.xfail` to a test will *not* fail the test suite if the test passes unexpectedly. In such a case `pytest` will only report the test as `xpassed`, but I'm guessing no one looks at the actual report if the CI indicator is green.

This PR adds a configuration option to fail by default in such a case. If for some reason we want the other behavior, we can still override it locally with `@pytest.mark.xfail(..., strict=False)`.