### PR TITLE
check that prototype datasets are serializable

### DIFF
--- a/test/test_prototype_builtin_datasets.py
+++ b/test/test_prototype_builtin_datasets.py
@@ -1,5 +1,6 @@
 import functools
 import io
+import pickle
 from pathlib import Path
 
 import pytest
@@ -115,12 +116,12 @@ class TestCommon:
             )
         },
     )
-    def test_traversable(self, test_home, dataset_mock, config):
+    def test_serializable(self, test_home, dataset_mock, config):
         dataset_mock.prepare(test_home, config)
 
         dataset = datasets.load(dataset_mock.name, **config)
 
-        traverse(dataset)
+        pickle.dumps(dataset)
 
     @parametrize_dataset_mocks(
         DATASET_MOCKS,


### PR DESCRIPTION
As discussed in our latest sync, we need to be more strict about what is allowed in our prototype datasets and what is not. For example, without this patch local functions will not fail the test suite, but are incompatible with the `DataLoader2`.

@NicolasHug: After some offline discussion with @ejguan, we realized that just setting a flag on `traverse` as proposed in the meeting is not sufficient to trigger the failure.

@ejguan: Should we use `pickle.dumps` or can we also use `DataLoader2` and try to draw a sample?