### PR TITLE
Adding improved MobileNetV2 weights

### DIFF
--- a/torchvision/prototype/models/mobilenetv2.py
+++ b/torchvision/prototype/models/mobilenetv2.py
@@ -42,8 +42,8 @@ class MobileNet_V2_Weights(WeightsEnum):
         meta={
             **_COMMON_META,
             "recipe": "https://github.com/pytorch/vision/issues/3995#new-recipe-with-reg-tuning",
-            "acc@1": 72.144,
-            "acc@5": 90.818,
+            "acc@1": 72.154,
+            "acc@5": 90.822,
         },
     )
     DEFAULT = IMAGENET1K_V2

--- a/torchvision/prototype/models/mobilenetv2.py
+++ b/torchvision/prototype/models/mobilenetv2.py
@@ -38,7 +38,7 @@ class MobileNet_V2_Weights(WeightsEnum):
     )
     IMAGENET1K_V2 = Weights(
         url="https://download.pytorch.org/models/mobilenet_v2-7ebf99e0.pth",
-        transforms=partial(ImageNetEval, crop_size=224),
+        transforms=partial(ImageNetEval, crop_size=224, resize_size=232),
         meta={
             **_COMMON_META,
             "recipe": "https://github.com/pytorch/vision/issues/3995#new-recipe-with-reg-tuning",

--- a/torchvision/prototype/models/mobilenetv2.py
+++ b/torchvision/prototype/models/mobilenetv2.py
@@ -13,25 +13,40 @@ from ._utils import handle_legacy_interface, _ovewrite_named_param
 __all__ = ["MobileNetV2", "MobileNet_V2_Weights", "mobilenet_v2"]
 
 
+_COMMON_META = {
+    "task": "image_classification",
+    "architecture": "MobileNetV2",
+    "publication_year": 2018,
+    "num_params": 3504872,
+    "size": (224, 224),
+    "min_size": (1, 1),
+    "categories": _IMAGENET_CATEGORIES,
+    "interpolation": InterpolationMode.BILINEAR,
+}
+
+
 class MobileNet_V2_Weights(WeightsEnum):
     IMAGENET1K_V1 = Weights(
         url="https://download.pytorch.org/models/mobilenet_v2-b0353104.pth",
         transforms=partial(ImageNetEval, crop_size=224),
         meta={
-            "task": "image_classification",
-            "architecture": "MobileNetV2",
-            "publication_year": 2018,
-            "num_params": 3504872,
-            "size": (224, 224),
-            "min_size": (1, 1),
-            "categories": _IMAGENET_CATEGORIES,
-            "interpolation": InterpolationMode.BILINEAR,
+            **_COMMON_META,
             "recipe": "https://github.com/pytorch/vision/tree/main/references/classification#mobilenetv2",
             "acc@1": 71.878,
             "acc@5": 90.286,
         },
     )
-    DEFAULT = IMAGENET1K_V1
+    IMAGENET1K_V2 = Weights(
+        url="https://download.pytorch.org/models/mobilenet_v2-7ebf99e0.pth",
+        transforms=partial(ImageNetEval, crop_size=224),
+        meta={
+            **_COMMON_META,
+            "recipe": "https://github.com/pytorch/vision/issues/3995#new-recipe-with-reg-tuning",
+            "acc@1": 72.144,
+            "acc@5": 90.818,
+        },
+    )
+    DEFAULT = IMAGENET1K_V2
 
 
 @handle_legacy_interface(weights=("pretrained", MobileNet_V2_Weights.IMAGENET1K_V1))


### PR DESCRIPTION
Fixes #3995 

Updating the weights of MobileNetV2 using the [new recipe](https://pytorch.org/blog/how-to-train-state-of-the-art-models-using-torchvision-latest-primitives/):
```
torchrun --nproc_per_node=8 train.py --model mobilenet_v2 --batch-size 128 --lr 0.5 \
--lr-scheduler cosineannealinglr --lr-warmup-epochs 5 --lr-warmup-method linear --auto-augment ta_wide \
--epochs 600 --random-erase 0.1 --label-smoothing 0.1 --mixup-alpha 0.2 --cutmix-alpha 1.0 \
--weight-decay 0.00002 --norm-weight-decay 0.0 --train-crop-size 176 --model-ema --val-resize-size 232 \
--ra-sampler --ra-reps 4
```

Validated with:
```
torchrun --nproc_per_node=1 train.py --test-only --prototype --weights MobileNet_V2_Weights.IMAGENET1K_V2 --model mobilenet_v2 -b 1
Acc@1 72.154 Acc@5 90.822
```