### PR TITLE
Standardize errors for when pre-trained weights are not available

### DIFF
--- a/test/test_prototype_models.py
+++ b/test/test_prototype_models.py
@@ -43,11 +43,8 @@ def _get_model_weights(model_fn):
 def _build_model(fn, **kwargs):
     try:
         model = fn(**kwargs)
-    except ValueError as e:
-        msg = str(e)
-        if "No checkpoint is available" in msg:
-            pytest.skip(msg)
-        raise e
+    except NotImplemented as e:
+        pytest.skip(str(e))
     return model.eval()
 
 

--- a/test/test_prototype_models.py
+++ b/test/test_prototype_models.py
@@ -43,7 +43,7 @@ def _get_model_weights(model_fn):
 def _build_model(fn, **kwargs):
     try:
         model = fn(**kwargs)
-    except NotImplemented as e:
+    except NotImplementedError as e:
         pytest.skip(str(e))
     return model.eval()
 

--- a/torchvision/models/convnext.py
+++ b/torchvision/models/convnext.py
@@ -197,7 +197,7 @@ def _convnext(
     model = ConvNeXt(block_setting, stochastic_depth_prob=stochastic_depth_prob, **kwargs)
     if pretrained:
         if arch not in _MODELS_URLS:
-            raise NotImplemented(f"No checkpoint is available for model type {arch}")
+            raise NotImplementedError(f"No checkpoint is available for model type {arch}")
         state_dict = load_state_dict_from_url(_MODELS_URLS[arch], progress=progress)
         model.load_state_dict(state_dict)
     return model

--- a/torchvision/models/convnext.py
+++ b/torchvision/models/convnext.py
@@ -197,7 +197,7 @@ def _convnext(
     model = ConvNeXt(block_setting, stochastic_depth_prob=stochastic_depth_prob, **kwargs)
     if pretrained:
         if arch not in _MODELS_URLS:
-            raise NotImplementedError(f"No checkpoint is available for model type {arch}")
+            raise NotImplementedError(f"No pre-trained weights are available for model type {arch}")
         state_dict = load_state_dict_from_url(_MODELS_URLS[arch], progress=progress)
         model.load_state_dict(state_dict)
     return model

--- a/torchvision/models/convnext.py
+++ b/torchvision/models/convnext.py
@@ -197,7 +197,7 @@ def _convnext(
     model = ConvNeXt(block_setting, stochastic_depth_prob=stochastic_depth_prob, **kwargs)
     if pretrained:
         if arch not in _MODELS_URLS:
-            raise ValueError(f"No checkpoint is available for model type {arch}")
+            raise NotImplemented(f"No checkpoint is available for model type {arch}")
         state_dict = load_state_dict_from_url(_MODELS_URLS[arch], progress=progress)
         model.load_state_dict(state_dict)
     return model

--- a/torchvision/models/detection/faster_rcnn.py
+++ b/torchvision/models/detection/faster_rcnn.py
@@ -436,7 +436,7 @@ def _fasterrcnn_mobilenet_v3_large_fpn(
     )
     if pretrained:
         if model_urls.get(arch, None) is None:
-            raise NotImplementedError(f"No checkpoint is available for model type {arch}")
+            raise NotImplementedError(f"No pre-trained weights are available for model type {arch}")
         state_dict = load_state_dict_from_url(model_urls[arch], progress=progress)
         model.load_state_dict(state_dict)
     return model

--- a/torchvision/models/detection/faster_rcnn.py
+++ b/torchvision/models/detection/faster_rcnn.py
@@ -402,7 +402,7 @@ def fasterrcnn_resnet50_fpn(
 
 
 def _fasterrcnn_mobilenet_v3_large_fpn(
-    weights_name,
+    arch,
     pretrained=False,
     progress=True,
     num_classes=91,
@@ -435,9 +435,9 @@ def _fasterrcnn_mobilenet_v3_large_fpn(
         backbone, num_classes, rpn_anchor_generator=AnchorGenerator(anchor_sizes, aspect_ratios), **kwargs
     )
     if pretrained:
-        if model_urls.get(weights_name, None) is None:
-            raise ValueError(f"No checkpoint is available for model {weights_name}")
-        state_dict = load_state_dict_from_url(model_urls[weights_name], progress=progress)
+        if model_urls.get(arch, None) is None:
+            raise NotImplemented(f"No checkpoint is available for model type {arch}")
+        state_dict = load_state_dict_from_url(model_urls[arch], progress=progress)
         model.load_state_dict(state_dict)
     return model
 

--- a/torchvision/models/detection/faster_rcnn.py
+++ b/torchvision/models/detection/faster_rcnn.py
@@ -436,7 +436,7 @@ def _fasterrcnn_mobilenet_v3_large_fpn(
     )
     if pretrained:
         if model_urls.get(arch, None) is None:
-            raise NotImplemented(f"No checkpoint is available for model type {arch}")
+            raise NotImplementedError(f"No checkpoint is available for model type {arch}")
         state_dict = load_state_dict_from_url(model_urls[arch], progress=progress)
         model.load_state_dict(state_dict)
     return model

--- a/torchvision/models/detection/ssd.py
+++ b/torchvision/models/detection/ssd.py
@@ -624,7 +624,7 @@ def ssd300_vgg16(
     if pretrained:
         arch = "ssd300_vgg16_coco"
         if model_urls.get(arch, None) is None:
-            raise NotImplementedError(f"No checkpoint is available for model type {arch}")
+            raise NotImplementedError(f"No pre-trained weights are available for model type {arch}")
         state_dict = load_state_dict_from_url(model_urls[arch], progress=progress)
         model.load_state_dict(state_dict)
     return model

--- a/torchvision/models/detection/ssd.py
+++ b/torchvision/models/detection/ssd.py
@@ -622,9 +622,9 @@ def ssd300_vgg16(
     kwargs = {**defaults, **kwargs}
     model = SSD(backbone, anchor_generator, (300, 300), num_classes, **kwargs)
     if pretrained:
-        weights_name = "ssd300_vgg16_coco"
-        if model_urls.get(weights_name, None) is None:
-            raise ValueError(f"No checkpoint is available for model {weights_name}")
-        state_dict = load_state_dict_from_url(model_urls[weights_name], progress=progress)
+        arch = "ssd300_vgg16_coco"
+        if model_urls.get(arch, None) is None:
+            raise NotImplemented(f"No checkpoint is available for model type {arch}")
+        state_dict = load_state_dict_from_url(model_urls[arch], progress=progress)
         model.load_state_dict(state_dict)
     return model

--- a/torchvision/models/detection/ssd.py
+++ b/torchvision/models/detection/ssd.py
@@ -624,7 +624,7 @@ def ssd300_vgg16(
     if pretrained:
         arch = "ssd300_vgg16_coco"
         if model_urls.get(arch, None) is None:
-            raise NotImplemented(f"No checkpoint is available for model type {arch}")
+            raise NotImplementedError(f"No checkpoint is available for model type {arch}")
         state_dict = load_state_dict_from_url(model_urls[arch], progress=progress)
         model.load_state_dict(state_dict)
     return model

--- a/torchvision/models/detection/ssdlite.py
+++ b/torchvision/models/detection/ssdlite.py
@@ -269,7 +269,7 @@ def ssdlite320_mobilenet_v3_large(
     if pretrained:
         arch = "ssdlite320_mobilenet_v3_large_coco"
         if model_urls.get(arch, None) is None:
-            raise NotImplementedError(f"No checkpoint is available for model type {arch}")
+            raise NotImplementedError(f"No pre-trained weights are available for model type {arch}")
         state_dict = load_state_dict_from_url(model_urls[arch], progress=progress)
         model.load_state_dict(state_dict)
     return model

--- a/torchvision/models/detection/ssdlite.py
+++ b/torchvision/models/detection/ssdlite.py
@@ -267,9 +267,9 @@ def ssdlite320_mobilenet_v3_large(
     )
 
     if pretrained:
-        weights_name = "ssdlite320_mobilenet_v3_large_coco"
-        if model_urls.get(weights_name, None) is None:
-            raise ValueError(f"No checkpoint is available for model {weights_name}")
-        state_dict = load_state_dict_from_url(model_urls[weights_name], progress=progress)
+        arch = "ssdlite320_mobilenet_v3_large_coco"
+        if model_urls.get(arch, None) is None:
+            raise NotImplemented(f"No checkpoint is available for model type {arch}")
+        state_dict = load_state_dict_from_url(model_urls[arch], progress=progress)
         model.load_state_dict(state_dict)
     return model

--- a/torchvision/models/detection/ssdlite.py
+++ b/torchvision/models/detection/ssdlite.py
@@ -269,7 +269,7 @@ def ssdlite320_mobilenet_v3_large(
     if pretrained:
         arch = "ssdlite320_mobilenet_v3_large_coco"
         if model_urls.get(arch, None) is None:
-            raise NotImplemented(f"No checkpoint is available for model type {arch}")
+            raise NotImplementedError(f"No checkpoint is available for model type {arch}")
         state_dict = load_state_dict_from_url(model_urls[arch], progress=progress)
         model.load_state_dict(state_dict)
     return model

--- a/torchvision/models/efficientnet.py
+++ b/torchvision/models/efficientnet.py
@@ -373,7 +373,7 @@ def _efficientnet(
     model = EfficientNet(inverted_residual_setting, dropout, last_channel=last_channel, **kwargs)
     if pretrained:
         if model_urls.get(arch, None) is None:
-            raise NotImplementedError(f"No checkpoint is available for model type {arch}")
+            raise NotImplementedError(f"No pre-trained weights are available for model type {arch}")
         state_dict = load_state_dict_from_url(model_urls[arch], progress=progress)
         model.load_state_dict(state_dict)
     return model

--- a/torchvision/models/efficientnet.py
+++ b/torchvision/models/efficientnet.py
@@ -373,7 +373,7 @@ def _efficientnet(
     model = EfficientNet(inverted_residual_setting, dropout, last_channel=last_channel, **kwargs)
     if pretrained:
         if model_urls.get(arch, None) is None:
-            raise NotImplemented(f"No checkpoint is available for model type {arch}")
+            raise NotImplementedError(f"No checkpoint is available for model type {arch}")
         state_dict = load_state_dict_from_url(model_urls[arch], progress=progress)
         model.load_state_dict(state_dict)
     return model

--- a/torchvision/models/efficientnet.py
+++ b/torchvision/models/efficientnet.py
@@ -373,7 +373,7 @@ def _efficientnet(
     model = EfficientNet(inverted_residual_setting, dropout, last_channel=last_channel, **kwargs)
     if pretrained:
         if model_urls.get(arch, None) is None:
-            raise ValueError(f"No checkpoint is available for model type {arch}")
+            raise NotImplemented(f"No checkpoint is available for model type {arch}")
         state_dict = load_state_dict_from_url(model_urls[arch], progress=progress)
         model.load_state_dict(state_dict)
     return model

--- a/torchvision/models/mnasnet.py
+++ b/torchvision/models/mnasnet.py
@@ -198,7 +198,7 @@ class MNASNet(torch.nn.Module):
 
 def _load_pretrained(arch: str, model: nn.Module, progress: bool) -> None:
     if arch not in _MODEL_URLS or _MODEL_URLS[arch] is None:
-        raise NotImplementedError(f"No checkpoint is available for model type {arch}")
+        raise NotImplementedError(f"No pre-trained weights are available for model type {arch}")
     checkpoint_url = _MODEL_URLS[arch]
     model.load_state_dict(load_state_dict_from_url(checkpoint_url, progress=progress))
 

--- a/torchvision/models/mnasnet.py
+++ b/torchvision/models/mnasnet.py
@@ -198,7 +198,7 @@ class MNASNet(torch.nn.Module):
 
 def _load_pretrained(arch: str, model: nn.Module, progress: bool) -> None:
     if arch not in _MODEL_URLS or _MODEL_URLS[arch] is None:
-        raise NotImplemented(f"No checkpoint is available for model type {arch}")
+        raise NotImplementedError(f"No checkpoint is available for model type {arch}")
     checkpoint_url = _MODEL_URLS[arch]
     model.load_state_dict(load_state_dict_from_url(checkpoint_url, progress=progress))
 

--- a/torchvision/models/mnasnet.py
+++ b/torchvision/models/mnasnet.py
@@ -196,10 +196,10 @@ class MNASNet(torch.nn.Module):
         )
 
 
-def _load_pretrained(model_name: str, model: nn.Module, progress: bool) -> None:
-    if model_name not in _MODEL_URLS or _MODEL_URLS[model_name] is None:
-        raise ValueError(f"No checkpoint is available for model type {model_name}")
-    checkpoint_url = _MODEL_URLS[model_name]
+def _load_pretrained(arch: str, model: nn.Module, progress: bool) -> None:
+    if arch not in _MODEL_URLS or _MODEL_URLS[arch] is None:
+        raise NotImplemented(f"No checkpoint is available for model type {arch}")
+    checkpoint_url = _MODEL_URLS[arch]
     model.load_state_dict(load_state_dict_from_url(checkpoint_url, progress=progress))
 
 

--- a/torchvision/models/mobilenetv3.py
+++ b/torchvision/models/mobilenetv3.py
@@ -294,7 +294,7 @@ def _mobilenet_v3(
     model = MobileNetV3(inverted_residual_setting, last_channel, **kwargs)
     if pretrained:
         if model_urls.get(arch, None) is None:
-            raise NotImplemented(f"No checkpoint is available for model type {arch}")
+            raise NotImplementedError(f"No checkpoint is available for model type {arch}")
         state_dict = load_state_dict_from_url(model_urls[arch], progress=progress)
         model.load_state_dict(state_dict)
     return model

--- a/torchvision/models/mobilenetv3.py
+++ b/torchvision/models/mobilenetv3.py
@@ -294,7 +294,7 @@ def _mobilenet_v3(
     model = MobileNetV3(inverted_residual_setting, last_channel, **kwargs)
     if pretrained:
         if model_urls.get(arch, None) is None:
-            raise NotImplementedError(f"No checkpoint is available for model type {arch}")
+            raise NotImplementedError(f"No pre-trained weights are available for model type {arch}")
         state_dict = load_state_dict_from_url(model_urls[arch], progress=progress)
         model.load_state_dict(state_dict)
     return model

--- a/torchvision/models/mobilenetv3.py
+++ b/torchvision/models/mobilenetv3.py
@@ -294,7 +294,7 @@ def _mobilenet_v3(
     model = MobileNetV3(inverted_residual_setting, last_channel, **kwargs)
     if pretrained:
         if model_urls.get(arch, None) is None:
-            raise ValueError(f"No checkpoint is available for model type {arch}")
+            raise NotImplemented(f"No checkpoint is available for model type {arch}")
         state_dict = load_state_dict_from_url(model_urls[arch], progress=progress)
         model.load_state_dict(state_dict)
     return model

--- a/torchvision/models/quantization/mobilenetv3.py
+++ b/torchvision/models/quantization/mobilenetv3.py
@@ -114,7 +114,7 @@ class QuantizableMobileNetV3(MobileNetV3):
 
 def _load_weights(arch: str, model: QuantizableMobileNetV3, model_url: Optional[str], progress: bool) -> None:
     if model_url is None:
-        raise NotImplementedError(f"No checkpoint is available for model type {arch}")
+        raise NotImplementedError(f"No pre-trained weights are available for model type {arch}")
     state_dict = load_state_dict_from_url(model_url, progress=progress)
     model.load_state_dict(state_dict)
 

--- a/torchvision/models/quantization/mobilenetv3.py
+++ b/torchvision/models/quantization/mobilenetv3.py
@@ -114,7 +114,7 @@ class QuantizableMobileNetV3(MobileNetV3):
 
 def _load_weights(arch: str, model: QuantizableMobileNetV3, model_url: Optional[str], progress: bool) -> None:
     if model_url is None:
-        raise NotImplemented(f"No checkpoint is available for model type {arch}")
+        raise NotImplementedError(f"No checkpoint is available for model type {arch}")
     state_dict = load_state_dict_from_url(model_url, progress=progress)
     model.load_state_dict(state_dict)
 

--- a/torchvision/models/quantization/mobilenetv3.py
+++ b/torchvision/models/quantization/mobilenetv3.py
@@ -114,7 +114,7 @@ class QuantizableMobileNetV3(MobileNetV3):
 
 def _load_weights(arch: str, model: QuantizableMobileNetV3, model_url: Optional[str], progress: bool) -> None:
     if model_url is None:
-        raise ValueError(f"No checkpoint is available for {arch}")
+        raise NotImplemented(f"No checkpoint is available for model type {arch}")
     state_dict = load_state_dict_from_url(model_url, progress=progress)
     model.load_state_dict(state_dict)
 

--- a/torchvision/models/regnet.py
+++ b/torchvision/models/regnet.py
@@ -395,7 +395,7 @@ def _regnet(arch: str, block_params: BlockParams, pretrained: bool, progress: bo
     model = RegNet(block_params, norm_layer=norm_layer, **kwargs)
     if pretrained:
         if arch not in model_urls:
-            raise NotImplementedError(f"No checkpoint is available for model type {arch}")
+            raise NotImplementedError(f"No pre-trained weights are available for model type {arch}")
         state_dict = load_state_dict_from_url(model_urls[arch], progress=progress)
         model.load_state_dict(state_dict)
     return model

--- a/torchvision/models/regnet.py
+++ b/torchvision/models/regnet.py
@@ -395,7 +395,7 @@ def _regnet(arch: str, block_params: BlockParams, pretrained: bool, progress: bo
     model = RegNet(block_params, norm_layer=norm_layer, **kwargs)
     if pretrained:
         if arch not in model_urls:
-            raise ValueError(f"No checkpoint is available for model type {arch}")
+            raise NotImplemented(f"No checkpoint is available for model type {arch}")
         state_dict = load_state_dict_from_url(model_urls[arch], progress=progress)
         model.load_state_dict(state_dict)
     return model

--- a/torchvision/models/regnet.py
+++ b/torchvision/models/regnet.py
@@ -395,7 +395,7 @@ def _regnet(arch: str, block_params: BlockParams, pretrained: bool, progress: bo
     model = RegNet(block_params, norm_layer=norm_layer, **kwargs)
     if pretrained:
         if arch not in model_urls:
-            raise NotImplemented(f"No checkpoint is available for model type {arch}")
+            raise NotImplementedError(f"No checkpoint is available for model type {arch}")
         state_dict = load_state_dict_from_url(model_urls[arch], progress=progress)
         model.load_state_dict(state_dict)
     return model

--- a/torchvision/models/segmentation/_utils.py
+++ b/torchvision/models/segmentation/_utils.py
@@ -40,6 +40,6 @@ class _SimpleSegmentationModel(nn.Module):
 
 def _load_weights(arch: str, model: nn.Module, model_url: Optional[str], progress: bool) -> None:
     if model_url is None:
-        raise NotImplementedError(f"No checkpoint is available for model type {arch}")
+        raise NotImplementedError(f"No pre-trained weights are available for model type {arch}")
     state_dict = load_state_dict_from_url(model_url, progress=progress)
     model.load_state_dict(state_dict)

--- a/torchvision/models/segmentation/_utils.py
+++ b/torchvision/models/segmentation/_utils.py
@@ -40,6 +40,6 @@ class _SimpleSegmentationModel(nn.Module):
 
 def _load_weights(arch: str, model: nn.Module, model_url: Optional[str], progress: bool) -> None:
     if model_url is None:
-        raise NotImplemented(f"No checkpoint is available for model type {arch}")
+        raise NotImplementedError(f"No checkpoint is available for model type {arch}")
     state_dict = load_state_dict_from_url(model_url, progress=progress)
     model.load_state_dict(state_dict)

--- a/torchvision/models/segmentation/_utils.py
+++ b/torchvision/models/segmentation/_utils.py
@@ -40,6 +40,6 @@ class _SimpleSegmentationModel(nn.Module):
 
 def _load_weights(arch: str, model: nn.Module, model_url: Optional[str], progress: bool) -> None:
     if model_url is None:
-        raise ValueError(f"No checkpoint is available for {arch}")
+        raise NotImplemented(f"No checkpoint is available for model type {arch}")
     state_dict = load_state_dict_from_url(model_url, progress=progress)
     model.load_state_dict(state_dict)

--- a/torchvision/models/shufflenetv2.py
+++ b/torchvision/models/shufflenetv2.py
@@ -162,7 +162,7 @@ def _shufflenetv2(arch: str, pretrained: bool, progress: bool, *args: Any, **kwa
     if pretrained:
         model_url = model_urls[arch]
         if model_url is None:
-            raise ValueError(f"No checkpoint is available for model type {arch}")
+            raise NotImplemented(f"No checkpoint is available for model type {arch}")
         else:
             state_dict = load_state_dict_from_url(model_url, progress=progress)
             model.load_state_dict(state_dict)

--- a/torchvision/models/shufflenetv2.py
+++ b/torchvision/models/shufflenetv2.py
@@ -162,7 +162,7 @@ def _shufflenetv2(arch: str, pretrained: bool, progress: bool, *args: Any, **kwa
     if pretrained:
         model_url = model_urls[arch]
         if model_url is None:
-            raise NotImplemented(f"No checkpoint is available for model type {arch}")
+            raise NotImplementedError(f"No checkpoint is available for model type {arch}")
         else:
             state_dict = load_state_dict_from_url(model_url, progress=progress)
             model.load_state_dict(state_dict)

--- a/torchvision/models/shufflenetv2.py
+++ b/torchvision/models/shufflenetv2.py
@@ -162,7 +162,7 @@ def _shufflenetv2(arch: str, pretrained: bool, progress: bool, *args: Any, **kwa
     if pretrained:
         model_url = model_urls[arch]
         if model_url is None:
-            raise NotImplementedError(f"No checkpoint is available for model type {arch}")
+            raise NotImplementedError(f"No pre-trained weights are available for model type {arch}")
         else:
             state_dict = load_state_dict_from_url(model_url, progress=progress)
             model.load_state_dict(state_dict)

--- a/torchvision/models/vision_transformer.py
+++ b/torchvision/models/vision_transformer.py
@@ -298,7 +298,7 @@ def _vision_transformer(
 
     if pretrained:
         if arch not in model_urls:
-            raise ValueError(f"No checkpoint is available for model type '{arch}'!")
+            raise NotImplemented(f"No checkpoint is available for model type {arch}")
         state_dict = load_state_dict_from_url(model_urls[arch], progress=progress)
         model.load_state_dict(state_dict)
 

--- a/torchvision/models/vision_transformer.py
+++ b/torchvision/models/vision_transformer.py
@@ -298,7 +298,7 @@ def _vision_transformer(
 
     if pretrained:
         if arch not in model_urls:
-            raise NotImplementedError(f"No checkpoint is available for model type {arch}")
+            raise NotImplementedError(f"No pre-trained weights are available for model type {arch}")
         state_dict = load_state_dict_from_url(model_urls[arch], progress=progress)
         model.load_state_dict(state_dict)
 

--- a/torchvision/models/vision_transformer.py
+++ b/torchvision/models/vision_transformer.py
@@ -298,7 +298,7 @@ def _vision_transformer(
 
     if pretrained:
         if arch not in model_urls:
-            raise NotImplemented(f"No checkpoint is available for model type {arch}")
+            raise NotImplementedError(f"No checkpoint is available for model type {arch}")
         state_dict = load_state_dict_from_url(model_urls[arch], progress=progress)
         model.load_state_dict(state_dict)
 


### PR DESCRIPTION
Our current implementation throws a `ValueError` if pre-trained weights are requested for an architecture that we don't offer checkpoints. In this PR we switch to `NotImplementedError` exceptions and we standardize the error messages.