### PR TITLE
NOMRG Initial draft of models docs revamp

### DIFF
--- a/.circleci/unittest/linux/scripts/install.sh
+++ b/.circleci/unittest/linux/scripts/install.sh
@@ -38,3 +38,4 @@ fi
 
 printf "* Installing torchvision\n"
 python setup.py develop
+pip install git+https://github.com/pytorch/data.git

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ docs/build
 docs/source/auto_examples/
 docs/source/gen_modules/
 docs/source/generated/
+docs/source/prototype_models/generated/
 # pytorch-sphinx-theme gets installed here
 docs/src
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -6,7 +6,7 @@ ifneq ($(EXAMPLES_PATTERN),)
 endif
 
 # You can set these variables from the command line.
-SPHINXOPTS    = -W -j auto $(EXAMPLES_PATTERN_OPTS)
+SPHINXOPTS    = -j auto $(EXAMPLES_PATTERN_OPTS)
 SPHINXBUILD   = sphinx-build
 SPHINXPROJ    = torchvision
 SOURCEDIR     = source

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -33,6 +33,7 @@ clean:
 	rm -rf $(SOURCEDIR)/auto_examples/  # sphinx-gallery
 	rm -rf $(SOURCEDIR)/gen_modules/  # sphinx-gallery
 	rm -rf $(SOURCEDIR)/generated/  # autosummary
+	rm -rf $(SOURCEDIR)/prototype_models/generated # autosummary
 
 .PHONY: help Makefile docset
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -33,6 +33,7 @@ architectures, and common image transformations for computer vision.
 
    transforms
    models
+   prototype_models
    datasets
    utils
    ops

--- a/docs/source/prototype_models.rst
+++ b/docs/source/prototype_models.rst
@@ -1,0 +1,23 @@
+.. _prototype_models:
+
+Prototype Models
+################
+
+Classification
+==============
+
+The following classification models are available, with or without pre-trained
+weights:
+
+.. toctree::
+   :maxdepth: 1
+
+   prototype_models/resnet
+   prototype_models/vgg
+
+TODO: put accuracy table here, possibly auto-generated.
+
+Object Detection, Instance Segmentation and Person Keypoint Detection
+=====================================================================
+
+TODO: Something similar to classification models

--- a/docs/source/prototype_models/resnet.rst
+++ b/docs/source/prototype_models/resnet.rst
@@ -1,0 +1,28 @@
+ResNet
+======
+
+The ResNet model is based on the `Deep Residual Learning for Image Recognition
+<https://arxiv.org/abs/1512.03385>`_ paper.
+
+
+Model builders
+--------------
+
+The following model builders can be used to instanciate a ResNet model, with or
+without pre-trained weights. All the model buidlers internally rely on the
+``torchvision.models.resnet.ResNet`` base class. Please refer to the `source
+code
+<https://github.com/pytorch/vision/blob/main/torchvision/models/resnet.py>`_ for
+more details about this class.
+
+.. currentmodule:: torchvision.prototype.models
+
+.. autosummary::
+    :toctree: generated/
+    :template: function.rst
+
+    resnet18
+    resnet34
+    resnet50
+    resnet101
+    resnet152

--- a/docs/source/prototype_models/vgg.rst
+++ b/docs/source/prototype_models/vgg.rst
@@ -1,0 +1,30 @@
+VGG
+===
+
+The VGG model is based on the `Very Deep Convolutional Networks for Large-Scale
+Image Recognition <https://arxiv.org/abs/1409.1556>`_ paper.
+
+
+Model builders
+--------------
+
+The following model builders can be used to instanciate a VGG model, with or
+without pre-trained weights. All the model buidlers internally rely on the
+``torchvision.models.vgg.VGG`` base class. Please refer to the `source code
+<https://github.com/pytorch/vision/blob/main/torchvision/models/vgg.py>`_ for
+more details about this class.
+
+.. currentmodule:: torchvision.prototype.models
+
+.. autosummary::
+    :toctree: generated/
+    :template: function.rst
+
+    vgg11
+    vgg11_bn
+    vgg13
+    vgg13_bn
+    vgg16
+    vgg16_bn
+    vgg19
+    vgg19_bn

--- a/torchvision/prototype/models/resnet.py
+++ b/torchvision/prototype/models/resnet.py
@@ -306,6 +306,7 @@ class Wide_ResNet101_2_Weights(WeightsEnum):
 
 @handle_legacy_interface(weights=("pretrained", ResNet18_Weights.IMAGENET1K_V1))
 def resnet18(*, weights: Optional[ResNet18_Weights] = None, progress: bool = True, **kwargs: Any) -> ResNet:
+    """TODO docstring"""
     weights = ResNet18_Weights.verify(weights)
 
     return _resnet(BasicBlock, [2, 2, 2, 2], weights, progress, **kwargs)
@@ -313,6 +314,7 @@ def resnet18(*, weights: Optional[ResNet18_Weights] = None, progress: bool = Tru
 
 @handle_legacy_interface(weights=("pretrained", ResNet34_Weights.IMAGENET1K_V1))
 def resnet34(*, weights: Optional[ResNet34_Weights] = None, progress: bool = True, **kwargs: Any) -> ResNet:
+    """TODO docstring"""
     weights = ResNet34_Weights.verify(weights)
 
     return _resnet(BasicBlock, [3, 4, 6, 3], weights, progress, **kwargs)
@@ -320,6 +322,7 @@ def resnet34(*, weights: Optional[ResNet34_Weights] = None, progress: bool = Tru
 
 @handle_legacy_interface(weights=("pretrained", ResNet50_Weights.IMAGENET1K_V1))
 def resnet50(*, weights: Optional[ResNet50_Weights] = None, progress: bool = True, **kwargs: Any) -> ResNet:
+    """TODO docstring"""
     weights = ResNet50_Weights.verify(weights)
 
     return _resnet(Bottleneck, [3, 4, 6, 3], weights, progress, **kwargs)
@@ -327,6 +330,7 @@ def resnet50(*, weights: Optional[ResNet50_Weights] = None, progress: bool = Tru
 
 @handle_legacy_interface(weights=("pretrained", ResNet101_Weights.IMAGENET1K_V1))
 def resnet101(*, weights: Optional[ResNet101_Weights] = None, progress: bool = True, **kwargs: Any) -> ResNet:
+    """TODO docstring"""
     weights = ResNet101_Weights.verify(weights)
 
     return _resnet(Bottleneck, [3, 4, 23, 3], weights, progress, **kwargs)
@@ -334,6 +338,7 @@ def resnet101(*, weights: Optional[ResNet101_Weights] = None, progress: bool = T
 
 @handle_legacy_interface(weights=("pretrained", ResNet152_Weights.IMAGENET1K_V1))
 def resnet152(*, weights: Optional[ResNet152_Weights] = None, progress: bool = True, **kwargs: Any) -> ResNet:
+    """TODO docstring"""
     weights = ResNet152_Weights.verify(weights)
 
     return _resnet(Bottleneck, [3, 8, 36, 3], weights, progress, **kwargs)
@@ -343,6 +348,7 @@ def resnet152(*, weights: Optional[ResNet152_Weights] = None, progress: bool = T
 def resnext50_32x4d(
     *, weights: Optional[ResNeXt50_32X4D_Weights] = None, progress: bool = True, **kwargs: Any
 ) -> ResNet:
+    """TODO docstring"""
     weights = ResNeXt50_32X4D_Weights.verify(weights)
 
     _ovewrite_named_param(kwargs, "groups", 32)
@@ -354,6 +360,7 @@ def resnext50_32x4d(
 def resnext101_32x8d(
     *, weights: Optional[ResNeXt101_32X8D_Weights] = None, progress: bool = True, **kwargs: Any
 ) -> ResNet:
+    """TODO docstring"""
     weights = ResNeXt101_32X8D_Weights.verify(weights)
 
     _ovewrite_named_param(kwargs, "groups", 32)
@@ -365,6 +372,7 @@ def resnext101_32x8d(
 def wide_resnet50_2(
     *, weights: Optional[Wide_ResNet50_2_Weights] = None, progress: bool = True, **kwargs: Any
 ) -> ResNet:
+    """TODO docstring"""
     weights = Wide_ResNet50_2_Weights.verify(weights)
 
     _ovewrite_named_param(kwargs, "width_per_group", 64 * 2)
@@ -375,6 +383,7 @@ def wide_resnet50_2(
 def wide_resnet101_2(
     *, weights: Optional[Wide_ResNet101_2_Weights] = None, progress: bool = True, **kwargs: Any
 ) -> ResNet:
+    """TODO docstring"""
     weights = Wide_ResNet101_2_Weights.verify(weights)
 
     _ovewrite_named_param(kwargs, "width_per_group", 64 * 2)

--- a/torchvision/prototype/models/vgg.py
+++ b/torchvision/prototype/models/vgg.py
@@ -186,6 +186,7 @@ class VGG19_BN_Weights(WeightsEnum):
 
 @handle_legacy_interface(weights=("pretrained", VGG11_Weights.IMAGENET1K_V1))
 def vgg11(*, weights: Optional[VGG11_Weights] = None, progress: bool = True, **kwargs: Any) -> VGG:
+    """TODO docstring"""
     weights = VGG11_Weights.verify(weights)
 
     return _vgg("A", False, weights, progress, **kwargs)
@@ -193,6 +194,7 @@ def vgg11(*, weights: Optional[VGG11_Weights] = None, progress: bool = True, **k
 
 @handle_legacy_interface(weights=("pretrained", VGG11_BN_Weights.IMAGENET1K_V1))
 def vgg11_bn(*, weights: Optional[VGG11_BN_Weights] = None, progress: bool = True, **kwargs: Any) -> VGG:
+    """TODO docstring"""
     weights = VGG11_BN_Weights.verify(weights)
 
     return _vgg("A", True, weights, progress, **kwargs)
@@ -200,6 +202,7 @@ def vgg11_bn(*, weights: Optional[VGG11_BN_Weights] = None, progress: bool = Tru
 
 @handle_legacy_interface(weights=("pretrained", VGG13_Weights.IMAGENET1K_V1))
 def vgg13(*, weights: Optional[VGG13_Weights] = None, progress: bool = True, **kwargs: Any) -> VGG:
+    """TODO docstring"""
     weights = VGG13_Weights.verify(weights)
 
     return _vgg("B", False, weights, progress, **kwargs)
@@ -207,6 +210,7 @@ def vgg13(*, weights: Optional[VGG13_Weights] = None, progress: bool = True, **k
 
 @handle_legacy_interface(weights=("pretrained", VGG13_BN_Weights.IMAGENET1K_V1))
 def vgg13_bn(*, weights: Optional[VGG13_BN_Weights] = None, progress: bool = True, **kwargs: Any) -> VGG:
+    """TODO docstring"""
     weights = VGG13_BN_Weights.verify(weights)
 
     return _vgg("B", True, weights, progress, **kwargs)
@@ -214,6 +218,7 @@ def vgg13_bn(*, weights: Optional[VGG13_BN_Weights] = None, progress: bool = Tru
 
 @handle_legacy_interface(weights=("pretrained", VGG16_Weights.IMAGENET1K_V1))
 def vgg16(*, weights: Optional[VGG16_Weights] = None, progress: bool = True, **kwargs: Any) -> VGG:
+    """TODO docstring"""
     weights = VGG16_Weights.verify(weights)
 
     return _vgg("D", False, weights, progress, **kwargs)
@@ -221,6 +226,7 @@ def vgg16(*, weights: Optional[VGG16_Weights] = None, progress: bool = True, **k
 
 @handle_legacy_interface(weights=("pretrained", VGG16_BN_Weights.IMAGENET1K_V1))
 def vgg16_bn(*, weights: Optional[VGG16_BN_Weights] = None, progress: bool = True, **kwargs: Any) -> VGG:
+    """TODO docstring"""
     weights = VGG16_BN_Weights.verify(weights)
 
     return _vgg("D", True, weights, progress, **kwargs)
@@ -228,6 +234,7 @@ def vgg16_bn(*, weights: Optional[VGG16_BN_Weights] = None, progress: bool = Tru
 
 @handle_legacy_interface(weights=("pretrained", VGG19_Weights.IMAGENET1K_V1))
 def vgg19(*, weights: Optional[VGG19_Weights] = None, progress: bool = True, **kwargs: Any) -> VGG:
+    """TODO docstring"""
     weights = VGG19_Weights.verify(weights)
 
     return _vgg("E", False, weights, progress, **kwargs)
@@ -235,6 +242,7 @@ def vgg19(*, weights: Optional[VGG19_Weights] = None, progress: bool = True, **k
 
 @handle_legacy_interface(weights=("pretrained", VGG19_BN_Weights.IMAGENET1K_V1))
 def vgg19_bn(*, weights: Optional[VGG19_BN_Weights] = None, progress: bool = True, **kwargs: Any) -> VGG:
+    """TODO docstring"""
     weights = VGG19_BN_Weights.verify(weights)
 
     return _vgg("E", True, weights, progress, **kwargs)


### PR DESCRIPTION
This is an initial draft of a proposal for revamping the models docs. The basic structure would be:

- a [main Models page](https://1251474-73328905-gh.circle-artifacts.com/0/docs/prototype_models.html) with a similar structure to what we have now (classification, detection, optical flow, etc.). This page contains links to:
    - [One page per model](https://1251474-73328905-gh.circle-artifacts.com/0/docs/prototype_models/resnet.html) - i.e. one page for Resnet, one for VGG, etc. Each of these pages contain links to
        - [one page per model builder](https://1251474-73328905-gh.circle-artifacts.com/0/docs/prototype_models/generated/torchvision.prototype.models.resnet18.html#torchvision.prototype.models.resnet18). The model builders would document the possible Weights that can be passed as parameter. The way this would be done is TBD.