### PR TITLE
NOMRG Models docs revamp -- v2

### DIFF
--- a/.circleci/unittest/linux/scripts/install.sh
+++ b/.circleci/unittest/linux/scripts/install.sh
@@ -38,3 +38,4 @@ fi
 
 printf "* Installing torchvision\n"
 python setup.py develop
+pip install git+https://github.com/pytorch/data.git

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ docs/build
 docs/source/auto_examples/
 docs/source/gen_modules/
 docs/source/generated/
+docs/source/prototype_models/generated/
 # pytorch-sphinx-theme gets installed here
 docs/src
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -6,7 +6,7 @@ ifneq ($(EXAMPLES_PATTERN),)
 endif
 
 # You can set these variables from the command line.
-SPHINXOPTS    = -W -j auto $(EXAMPLES_PATTERN_OPTS)
+SPHINXOPTS    = -j auto $(EXAMPLES_PATTERN_OPTS)
 SPHINXBUILD   = sphinx-build
 SPHINXPROJ    = torchvision
 SOURCEDIR     = source

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -33,6 +33,7 @@ clean:
 	rm -rf $(SOURCEDIR)/auto_examples/  # sphinx-gallery
 	rm -rf $(SOURCEDIR)/gen_modules/  # sphinx-gallery
 	rm -rf $(SOURCEDIR)/generated/  # autosummary
+	rm -rf $(SOURCEDIR)/prototype_models/generated # autosummary
 
 .PHONY: help Makefile docset
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -285,5 +285,24 @@ def inject_minigalleries(app, what, name, obj, options, lines):
         lines.append("\n")
 
 
+def inject_weight_metadata(app, what, name, obj, options, lines):
+
+    if obj.__name__.endswith("Weights"):
+        lines[:] = ["A Weights object with the following allowed fields:"]
+        lines.append("")
+        lines.append(
+            "Note: rendering is a bit ugly but it's still in POC status.  It's likely that using tabulate would generate much prettier output. Also we can filter out more stuff if we want to."
+        )
+        lines.append("")
+        for field in obj:
+            lines.append(f"``{str(field)}``:")
+            lines.append("")
+            for k, v in field.meta.items():
+                if k != "categories":
+                    lines.append(f"|   {k}: {v}")
+            lines.append("")
+
+
 def setup(app):
     app.connect("autodoc-process-docstring", inject_minigalleries)
+    app.connect("autodoc-process-docstring", inject_weight_metadata)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -33,6 +33,7 @@ architectures, and common image transformations for computer vision.
 
    transforms
    models
+   prototype_models
    datasets
    utils
    ops

--- a/docs/source/prototype_models.rst
+++ b/docs/source/prototype_models.rst
@@ -1,0 +1,23 @@
+.. _prototype_models:
+
+Prototype Models
+################
+
+Classification
+==============
+
+The following classification models are available, with or without pre-trained
+weights:
+
+.. toctree::
+   :maxdepth: 1
+
+   prototype_models/resnet
+   prototype_models/vgg
+
+TODO: put accuracy table here, possibly auto-generated.
+
+Object Detection, Instance Segmentation and Person Keypoint Detection
+=====================================================================
+
+TODO: Something similar to classification models

--- a/docs/source/prototype_models/resnet.rst
+++ b/docs/source/prototype_models/resnet.rst
@@ -26,25 +26,3 @@ more details about this class.
     resnet50
     resnet101
     resnet152
-
-
-
-
-
-Model builder weights
----------------------
-
-It bothers me that we have to display these in this page. I wish there was a way
-to not have this section in this page, and just have these weights sort of
-inlined in their respective model buidlers page (instead of having a separate
-page for them.)
-
-.. autosummary::
-    :toctree: generated/
-    :template: class.rst
-
-    ResNet18_Weights
-    ResNet34_Weights
-    ResNet50_Weights
-    ResNet101_Weights
-    ResNet152_Weights

--- a/docs/source/prototype_models/resnet.rst
+++ b/docs/source/prototype_models/resnet.rst
@@ -9,7 +9,7 @@ Model builders
 --------------
 
 The following model builders can be used to instanciate a ResNet model, with or
-without pre-trained weights. All the model buidlers internally rely on the
+without pre-trained weights. All the model builders internally rely on the
 ``torchvision.models.resnet.ResNet`` base class. Please refer to the `source
 code
 <https://github.com/pytorch/vision/blob/main/torchvision/models/resnet.py>`_ for
@@ -26,3 +26,25 @@ more details about this class.
     resnet50
     resnet101
     resnet152
+
+
+
+
+
+Model builder weights
+---------------------
+
+It bothers me that we have to display these in this page. I wish there was a way
+to not have this section in this page, and just have these weights sort of
+inlined in their respective model buidlers page (instead of having a separate
+page for them.)
+
+.. autosummary::
+    :toctree: generated/
+    :template: class.rst
+
+    ResNet18_Weights
+    ResNet34_Weights
+    ResNet50_Weights
+    ResNet101_Weights
+    ResNet152_Weights

--- a/docs/source/prototype_models/resnet.rst
+++ b/docs/source/prototype_models/resnet.rst
@@ -1,0 +1,28 @@
+ResNet
+======
+
+The ResNet model is based on the `Deep Residual Learning for Image Recognition
+<https://arxiv.org/abs/1512.03385>`_ paper.
+
+
+Model builders
+--------------
+
+The following model builders can be used to instanciate a ResNet model, with or
+without pre-trained weights. All the model buidlers internally rely on the
+``torchvision.models.resnet.ResNet`` base class. Please refer to the `source
+code
+<https://github.com/pytorch/vision/blob/main/torchvision/models/resnet.py>`_ for
+more details about this class.
+
+.. currentmodule:: torchvision.prototype.models
+
+.. autosummary::
+    :toctree: generated/
+    :template: function.rst
+
+    resnet18
+    resnet34
+    resnet50
+    resnet101
+    resnet152

--- a/docs/source/prototype_models/vgg.rst
+++ b/docs/source/prototype_models/vgg.rst
@@ -1,0 +1,30 @@
+VGG
+===
+
+The VGG model is based on the `Very Deep Convolutional Networks for Large-Scale
+Image Recognition <https://arxiv.org/abs/1409.1556>`_ paper.
+
+
+Model builders
+--------------
+
+The following model builders can be used to instanciate a VGG model, with or
+without pre-trained weights. All the model buidlers internally rely on the
+``torchvision.models.vgg.VGG`` base class. Please refer to the `source code
+<https://github.com/pytorch/vision/blob/main/torchvision/models/vgg.py>`_ for
+more details about this class.
+
+.. currentmodule:: torchvision.prototype.models
+
+.. autosummary::
+    :toctree: generated/
+    :template: function.rst
+
+    vgg11
+    vgg11_bn
+    vgg13
+    vgg13_bn
+    vgg16
+    vgg16_bn
+    vgg19
+    vgg19_bn

--- a/docs/source/prototype_models/vgg.rst
+++ b/docs/source/prototype_models/vgg.rst
@@ -28,3 +28,26 @@ more details about this class.
     vgg16_bn
     vgg19
     vgg19_bn
+
+
+
+Model builder weights
+---------------------
+
+It bothers me that we have to display these in this page. I wish there was a way
+to not have this section in this page, and just have these weights sort of
+inlined in their respective model buidlers page (instead of having a separate
+page for them.)
+
+.. autosummary::
+    :toctree: generated/
+    :template: class.rst
+
+    VGG11_Weights
+    VGG11_BN_Weights
+    VGG13_Weights
+    VGG13_BN_Weights
+    VGG16_Weights
+    VGG16_BN_Weights
+    VGG19_Weights
+    VGG19_BN_Weights

--- a/docs/source/prototype_models/vgg.rst
+++ b/docs/source/prototype_models/vgg.rst
@@ -28,26 +28,3 @@ more details about this class.
     vgg16_bn
     vgg19
     vgg19_bn
-
-
-
-Model builder weights
----------------------
-
-It bothers me that we have to display these in this page. I wish there was a way
-to not have this section in this page, and just have these weights sort of
-inlined in their respective model buidlers page (instead of having a separate
-page for them.)
-
-.. autosummary::
-    :toctree: generated/
-    :template: class.rst
-
-    VGG11_Weights
-    VGG11_BN_Weights
-    VGG13_Weights
-    VGG13_BN_Weights
-    VGG16_Weights
-    VGG16_BN_Weights
-    VGG19_Weights
-    VGG19_BN_Weights

--- a/torchvision/prototype/models/_utils.py
+++ b/torchvision/prototype/models/_utils.py
@@ -106,12 +106,3 @@ def _ovewrite_value_param(param: Optional[V], new_value: V) -> V:
         if param != new_value:
             raise ValueError(f"The parameter '{param}' expected value {new_value} but got {param} instead.")
     return new_value
-
-
-def set_docstring(doc):
-    # basic decorator that sets the __doc__ attribute of a function
-    def wrapper(f):
-        f.__doc__ = doc
-        return f
-
-    return wrapper

--- a/torchvision/prototype/models/_utils.py
+++ b/torchvision/prototype/models/_utils.py
@@ -106,3 +106,13 @@ def _ovewrite_value_param(param: Optional[V], new_value: V) -> V:
         if param != new_value:
             raise ValueError(f"The parameter '{param}' expected value {new_value} but got {param} instead.")
     return new_value
+
+
+def set_docstring(doc):
+    # basic decorator that sets the __doc__ attribute of a function
+    # would be put somewhere in utils
+    def wrapper(f):
+        f.__doc__ = doc
+        return f
+
+    return wrapper

--- a/torchvision/prototype/models/_utils.py
+++ b/torchvision/prototype/models/_utils.py
@@ -110,7 +110,6 @@ def _ovewrite_value_param(param: Optional[V], new_value: V) -> V:
 
 def set_docstring(doc):
     # basic decorator that sets the __doc__ attribute of a function
-    # would be put somewhere in utils
     def wrapper(f):
         f.__doc__ = doc
         return f

--- a/torchvision/prototype/models/resnet.py
+++ b/torchvision/prototype/models/resnet.py
@@ -303,64 +303,130 @@ class Wide_ResNet101_2_Weights(WeightsEnum):
     )
     DEFAULT = IMAGENET1K_V2
 
-import re
-def _make_resnet_docstring(weights):
-    # TODO maybe, maybe not: unify that with _make_vgg_docstring.
-    name = weights.__name__
-    suffix = re.search("ResNet(.+)_Weights", name).groups()[0]
-    allowed_values = ", ".join(f"``{v}``" for v in weights)
 
-    return f"""ResNet-{suffix} from `Deep Residual Learning for Image Recognition <https://arxiv.org/pdf/1512.03385.pdf>`__.
-
-    Args:
-        weights (:class:`~torchvision.prototype.models.{name}`, optional): The
-            pretrained weights to use. Possible values are {allowed_values}.
-            See :class:`~torchvision.prototype.models.{name}` below for more
-            details.
-        progress (bool, optional): Whether to print some stuff.
-        **kwargs: Some other stuff
-
-    .. autoclass:: torchvision.prototype.models.{name}
-        :members:
-
-    """
-
-
-@set_docstring(_make_resnet_docstring(ResNet18_Weights))
 @handle_legacy_interface(weights=("pretrained", ResNet18_Weights.IMAGENET1K_V1))
 def resnet18(*, weights: Optional[ResNet18_Weights] = None, progress: bool = True, **kwargs: Any) -> ResNet:
+    """ResNet-18 from `Deep Residual Learning for Image Recognition <https://arxiv.org/pdf/1512.03385.pdf>`__.
+
+    Args:
+        weights (:class:`~torchvision.prototype.models.ResNet18_Weights`, optional): The
+            pretrained weights to use. See
+            :class:`~torchvision.prototype.models.ResNet18_Weights` below for
+            more details, and possible values. By default, no pre-trained
+            weights are used.
+        progress (bool, optional): If True, displays a progress bar of the
+            download to stderr. Default is True.
+        **kwargs: parameters passed to the ``torchvision.models.resnet.ResNet``
+            base class. Please refer to the `source code
+            <https://github.com/pytorch/vision/blob/main/torchvision/models/resnet.py>`_
+            for more details about this class.
+
+    .. autoclass:: torchvision.prototype.models.ResNet18_Weights
+        :members:
+    """
     weights = ResNet18_Weights.verify(weights)
 
     return _resnet(BasicBlock, [2, 2, 2, 2], weights, progress, **kwargs)
 
 
-@set_docstring(_make_resnet_docstring(ResNet34_Weights))
+# resnet18.__doc__
+
+
 @handle_legacy_interface(weights=("pretrained", ResNet34_Weights.IMAGENET1K_V1))
 def resnet34(*, weights: Optional[ResNet34_Weights] = None, progress: bool = True, **kwargs: Any) -> ResNet:
+    """ResNet-34 from `Deep Residual Learning for Image Recognition <https://arxiv.org/pdf/1512.03385.pdf>`__.
+
+    Args:
+        weights (:class:`~torchvision.prototype.models.ResNet34_Weights`, optional): The
+            pretrained weights to use. See
+            :class:`~torchvision.prototype.models.ResNet34_Weights` below for
+            more details, and possible values. By default, no pre-trained
+            weights are used.
+        progress (bool, optional): If True, displays a progress bar of the
+            download to stderr. Default is True.
+        **kwargs: parameters passed to the ``torchvision.models.resnet.ResNet``
+            base class. Please refer to the `source code
+            <https://github.com/pytorch/vision/blob/main/torchvision/models/resnet.py>`_
+            for more details about this class.
+
+    .. autoclass:: torchvision.prototype.models.ResNet34_Weights
+        :members:
+    """
     weights = ResNet34_Weights.verify(weights)
 
     return _resnet(BasicBlock, [3, 4, 6, 3], weights, progress, **kwargs)
 
 
-@set_docstring(_make_resnet_docstring(ResNet50_Weights))
 @handle_legacy_interface(weights=("pretrained", ResNet50_Weights.IMAGENET1K_V1))
 def resnet50(*, weights: Optional[ResNet50_Weights] = None, progress: bool = True, **kwargs: Any) -> ResNet:
+    """ResNet-50 from `Deep Residual Learning for Image Recognition <https://arxiv.org/pdf/1512.03385.pdf>`__.
+
+    Args:
+        weights (:class:`~torchvision.prototype.models.ResNet50_Weights`, optional): The
+            pretrained weights to use. See
+            :class:`~torchvision.prototype.models.ResNet50_Weights` below for
+            more details, and possible values. By default, no pre-trained
+            weights are used.
+        progress (bool, optional): If True, displays a progress bar of the
+            download to stderr. Default is True.
+        **kwargs: parameters passed to the ``torchvision.models.resnet.ResNet``
+            base class. Please refer to the `source code
+            <https://github.com/pytorch/vision/blob/main/torchvision/models/resnet.py>`_
+            for more details about this class.
+
+    .. autoclass:: torchvision.prototype.models.ResNet50_Weights
+        :members:
+    """
     weights = ResNet50_Weights.verify(weights)
 
     return _resnet(Bottleneck, [3, 4, 6, 3], weights, progress, **kwargs)
 
 
-@set_docstring(_make_resnet_docstring(ResNet101_Weights))
 @handle_legacy_interface(weights=("pretrained", ResNet101_Weights.IMAGENET1K_V1))
 def resnet101(*, weights: Optional[ResNet101_Weights] = None, progress: bool = True, **kwargs: Any) -> ResNet:
+    """ResNet-101 from `Deep Residual Learning for Image Recognition <https://arxiv.org/pdf/1512.03385.pdf>`__.
+
+    Args:
+        weights (:class:`~torchvision.prototype.models.ResNet101_Weights`, optional): The
+            pretrained weights to use. See
+            :class:`~torchvision.prototype.models.ResNet101_Weights` below for
+            more details, and possible values. By default, no pre-trained
+            weights are used.
+        progress (bool, optional): If True, displays a progress bar of the
+            download to stderr. Default is True.
+        **kwargs: parameters passed to the ``torchvision.models.resnet.ResNet``
+            base class. Please refer to the `source code
+            <https://github.com/pytorch/vision/blob/main/torchvision/models/resnet.py>`_
+            for more details about this class.
+
+    .. autoclass:: torchvision.prototype.models.ResNet101_Weights
+        :members:
+    """
     weights = ResNet101_Weights.verify(weights)
 
     return _resnet(Bottleneck, [3, 4, 23, 3], weights, progress, **kwargs)
 
 
-@set_docstring(_make_resnet_docstring(ResNet152_Weights))
 @handle_legacy_interface(weights=("pretrained", ResNet152_Weights.IMAGENET1K_V1))
 def resnet152(*, weights: Optional[ResNet152_Weights] = None, progress: bool = True, **kwargs: Any) -> ResNet:
+    """ResNet-152 from `Deep Residual Learning for Image Recognition <https://arxiv.org/pdf/1512.03385.pdf>`__.
+
+    Args:
+        weights (:class:`~torchvision.prototype.models.ResNet152_Weights`, optional): The
+            pretrained weights to use. See
+            :class:`~torchvision.prototype.models.ResNet152_Weights` below for
+            more details, and possible values. By default, no pre-trained
+            weights are used.
+        progress (bool, optional): If True, displays a progress bar of the
+            download to stderr. Default is True.
+        **kwargs: parameters passed to the ``torchvision.models.resnet.ResNet``
+            base class. Please refer to the `source code
+            <https://github.com/pytorch/vision/blob/main/torchvision/models/resnet.py>`_
+            for more details about this class.
+
+    .. autoclass:: torchvision.prototype.models.ResNet152_Weights
+        :members:
+    """
     weights = ResNet152_Weights.verify(weights)
 
     return _resnet(Bottleneck, [3, 8, 36, 3], weights, progress, **kwargs)

--- a/torchvision/prototype/models/resnet.py
+++ b/torchvision/prototype/models/resnet.py
@@ -318,8 +318,31 @@ Args:
 
 """
 
+import re
+def _make_resnet_docstring(weights):
+    # TODO maybe, maybe not: unify that with _make_vgg_docstring.
+    name = weights.__name__
+    suffix = re.search("ResNet(.+)_Weights", name).groups()[0]
+    allowed_values = ", ".join(f"``{v}``" for v in weights)
 
-@set_docstring(_RESNET_DOC.format(num_layers=18, weight_name=ResNet18_Weights.__name__))
+    return f"""ResNet-{suffix} from `Deep Residual Learning for Image Recognition <https://arxiv.org/pdf/1512.03385.pdf>`__.
+    Image Recognition <https://arxiv.org/abs/1409.1556>`__.
+
+    Args:
+        weights (:class:`~torchvision.prototype.models.{name}`, optional): The
+            pretrained weights to use. Possible values are {allowed_values}.
+            See :class:`~torchvision.prototype.models.{name}` below for more
+            details.
+        progress (bool, optional): Whether to print some stuff.
+        **kwargs: Some other stuff
+
+    .. autoclass:: torchvision.prototype.models.{name}
+        :members:
+
+    """
+
+
+@set_docstring(_make_resnet_docstring(ResNet18_Weights))
 @handle_legacy_interface(weights=("pretrained", ResNet18_Weights.IMAGENET1K_V1))
 def resnet18(*, weights: Optional[ResNet18_Weights] = None, progress: bool = True, **kwargs: Any) -> ResNet:
     weights = ResNet18_Weights.verify(weights)
@@ -327,7 +350,7 @@ def resnet18(*, weights: Optional[ResNet18_Weights] = None, progress: bool = Tru
     return _resnet(BasicBlock, [2, 2, 2, 2], weights, progress, **kwargs)
 
 
-@set_docstring(_RESNET_DOC.format(num_layers=34, weight_name=ResNet34_Weights.__name__))
+@set_docstring(_make_resnet_docstring(ResNet34_Weights))
 @handle_legacy_interface(weights=("pretrained", ResNet34_Weights.IMAGENET1K_V1))
 def resnet34(*, weights: Optional[ResNet34_Weights] = None, progress: bool = True, **kwargs: Any) -> ResNet:
     """TODO docstring"""
@@ -336,7 +359,7 @@ def resnet34(*, weights: Optional[ResNet34_Weights] = None, progress: bool = Tru
     return _resnet(BasicBlock, [3, 4, 6, 3], weights, progress, **kwargs)
 
 
-@set_docstring(_RESNET_DOC.format(num_layers=50, weight_name=ResNet50_Weights.__name__))
+@set_docstring(_make_resnet_docstring(ResNet50_Weights))
 @handle_legacy_interface(weights=("pretrained", ResNet50_Weights.IMAGENET1K_V1))
 def resnet50(*, weights: Optional[ResNet50_Weights] = None, progress: bool = True, **kwargs: Any) -> ResNet:
     weights = ResNet50_Weights.verify(weights)
@@ -344,7 +367,7 @@ def resnet50(*, weights: Optional[ResNet50_Weights] = None, progress: bool = Tru
     return _resnet(Bottleneck, [3, 4, 6, 3], weights, progress, **kwargs)
 
 
-@set_docstring(_RESNET_DOC.format(num_layers=101, weight_name=ResNet101_Weights.__name__))
+@set_docstring(_make_resnet_docstring(ResNet101_Weights))
 @handle_legacy_interface(weights=("pretrained", ResNet101_Weights.IMAGENET1K_V1))
 def resnet101(*, weights: Optional[ResNet101_Weights] = None, progress: bool = True, **kwargs: Any) -> ResNet:
     """TODO docstring"""
@@ -353,7 +376,7 @@ def resnet101(*, weights: Optional[ResNet101_Weights] = None, progress: bool = T
     return _resnet(Bottleneck, [3, 4, 23, 3], weights, progress, **kwargs)
 
 
-@set_docstring(_RESNET_DOC.format(num_layers=152, weight_name=ResNet152_Weights.__name__))
+@set_docstring(_make_resnet_docstring(ResNet152_Weights))
 @handle_legacy_interface(weights=("pretrained", ResNet152_Weights.IMAGENET1K_V1))
 def resnet152(*, weights: Optional[ResNet152_Weights] = None, progress: bool = True, **kwargs: Any) -> ResNet:
     """TODO docstring"""

--- a/torchvision/prototype/models/resnet.py
+++ b/torchvision/prototype/models/resnet.py
@@ -306,6 +306,7 @@ class Wide_ResNet101_2_Weights(WeightsEnum):
 
 @handle_legacy_interface(weights=("pretrained", ResNet18_Weights.IMAGENET1K_V1))
 def resnet18(*, weights: Optional[ResNet18_Weights] = None, progress: bool = True, **kwargs: Any) -> ResNet:
+    """TODO docstring"""
     weights = ResNet18_Weights.verify(weights)
 
     return _resnet(BasicBlock, [2, 2, 2, 2], weights, progress, **kwargs)
@@ -313,6 +314,7 @@ def resnet18(*, weights: Optional[ResNet18_Weights] = None, progress: bool = Tru
 
 @handle_legacy_interface(weights=("pretrained", ResNet34_Weights.IMAGENET1K_V1))
 def resnet34(*, weights: Optional[ResNet34_Weights] = None, progress: bool = True, **kwargs: Any) -> ResNet:
+    """TODO docstring"""
     weights = ResNet34_Weights.verify(weights)
 
     return _resnet(BasicBlock, [3, 4, 6, 3], weights, progress, **kwargs)
@@ -320,6 +322,7 @@ def resnet34(*, weights: Optional[ResNet34_Weights] = None, progress: bool = Tru
 
 @handle_legacy_interface(weights=("pretrained", ResNet50_Weights.IMAGENET1K_V1))
 def resnet50(*, weights: Optional[ResNet50_Weights] = None, progress: bool = True, **kwargs: Any) -> ResNet:
+    """TODO docstring"""
     weights = ResNet50_Weights.verify(weights)
 
     return _resnet(Bottleneck, [3, 4, 6, 3], weights, progress, **kwargs)
@@ -327,6 +330,7 @@ def resnet50(*, weights: Optional[ResNet50_Weights] = None, progress: bool = Tru
 
 @handle_legacy_interface(weights=("pretrained", ResNet101_Weights.IMAGENET1K_V1))
 def resnet101(*, weights: Optional[ResNet101_Weights] = None, progress: bool = True, **kwargs: Any) -> ResNet:
+    """TODO docstring"""
     weights = ResNet101_Weights.verify(weights)
 
     return _resnet(Bottleneck, [3, 4, 23, 3], weights, progress, **kwargs)
@@ -334,6 +338,7 @@ def resnet101(*, weights: Optional[ResNet101_Weights] = None, progress: bool = T
 
 @handle_legacy_interface(weights=("pretrained", ResNet152_Weights.IMAGENET1K_V1))
 def resnet152(*, weights: Optional[ResNet152_Weights] = None, progress: bool = True, **kwargs: Any) -> ResNet:
+    """TODO docstring"""
     weights = ResNet152_Weights.verify(weights)
 
     return _resnet(Bottleneck, [3, 8, 36, 3], weights, progress, **kwargs)
@@ -343,6 +348,7 @@ def resnet152(*, weights: Optional[ResNet152_Weights] = None, progress: bool = T
 def resnext50_32x4d(
     *, weights: Optional[ResNeXt50_32X4D_Weights] = None, progress: bool = True, **kwargs: Any
 ) -> ResNet:
+    """TODO docstring"""
     weights = ResNeXt50_32X4D_Weights.verify(weights)
 
     _ovewrite_named_param(kwargs, "groups", 32)
@@ -354,6 +360,7 @@ def resnext50_32x4d(
 def resnext101_32x8d(
     *, weights: Optional[ResNeXt101_32X8D_Weights] = None, progress: bool = True, **kwargs: Any
 ) -> ResNet:
+    """TODO docstring"""
     weights = ResNeXt101_32X8D_Weights.verify(weights)
 
     _ovewrite_named_param(kwargs, "groups", 32)
@@ -365,6 +372,7 @@ def resnext101_32x8d(
 def wide_resnet50_2(
     *, weights: Optional[Wide_ResNet50_2_Weights] = None, progress: bool = True, **kwargs: Any
 ) -> ResNet:
+    """TODO docstring"""
     weights = Wide_ResNet50_2_Weights.verify(weights)
 
     _ovewrite_named_param(kwargs, "width_per_group", 64 * 2)
@@ -375,6 +383,7 @@ def wide_resnet50_2(
 def wide_resnet101_2(
     *, weights: Optional[Wide_ResNet101_2_Weights] = None, progress: bool = True, **kwargs: Any
 ) -> ResNet:
+    """TODO docstring"""
     weights = Wide_ResNet101_2_Weights.verify(weights)
 
     _ovewrite_named_param(kwargs, "width_per_group", 64 * 2)

--- a/torchvision/prototype/models/resnet.py
+++ b/torchvision/prototype/models/resnet.py
@@ -2,12 +2,13 @@ from functools import partial
 from typing import Any, List, Optional, Type, Union
 
 from torchvision.prototype.transforms import ImageClassificationEval
+from torchvision.prototype.utils._internal import sequence_to_str
 from torchvision.transforms.functional import InterpolationMode
 
 from ...models.resnet import BasicBlock, Bottleneck, ResNet
 from ._api import WeightsEnum, Weights
 from ._meta import _IMAGENET_CATEGORIES
-from ._utils import handle_legacy_interface, _ovewrite_named_param
+from ._utils import handle_legacy_interface, _ovewrite_named_param, set_docstring
 
 
 __all__ = [
@@ -304,14 +305,29 @@ class Wide_ResNet101_2_Weights(WeightsEnum):
     DEFAULT = IMAGENET1K_V2
 
 
+# It may or may not be a good idea to somehow unify that with _VGG_DOC . It's
+# too early to decide yet.
+_RESNET_DOC = """ResNet-{num_layers} from `Deep Residual Learning for Image Recognition <https://arxiv.org/pdf/1512.03385.pdf>`__.
+
+Args:
+    weights (:class:`~torchvision.prototype.models.{weight_name}`, optional): The
+        pretrained weights to use. See :class:`~torchvision.prototype.models.{weight_name}`
+        for possible values and details about each set of weight.
+    progress (bool, optional): Whether to print some stuff.
+    **kwargs: Some other stuff
+
+"""
+
+
+@set_docstring(_RESNET_DOC.format(num_layers=18, weight_name=ResNet18_Weights.__name__))
 @handle_legacy_interface(weights=("pretrained", ResNet18_Weights.IMAGENET1K_V1))
 def resnet18(*, weights: Optional[ResNet18_Weights] = None, progress: bool = True, **kwargs: Any) -> ResNet:
-    """TODO docstring"""
     weights = ResNet18_Weights.verify(weights)
 
     return _resnet(BasicBlock, [2, 2, 2, 2], weights, progress, **kwargs)
 
 
+@set_docstring(_RESNET_DOC.format(num_layers=34, weight_name=ResNet34_Weights.__name__))
 @handle_legacy_interface(weights=("pretrained", ResNet34_Weights.IMAGENET1K_V1))
 def resnet34(*, weights: Optional[ResNet34_Weights] = None, progress: bool = True, **kwargs: Any) -> ResNet:
     """TODO docstring"""
@@ -320,14 +336,15 @@ def resnet34(*, weights: Optional[ResNet34_Weights] = None, progress: bool = Tru
     return _resnet(BasicBlock, [3, 4, 6, 3], weights, progress, **kwargs)
 
 
+@set_docstring(_RESNET_DOC.format(num_layers=50, weight_name=ResNet50_Weights.__name__))
 @handle_legacy_interface(weights=("pretrained", ResNet50_Weights.IMAGENET1K_V1))
 def resnet50(*, weights: Optional[ResNet50_Weights] = None, progress: bool = True, **kwargs: Any) -> ResNet:
-    """TODO docstring"""
     weights = ResNet50_Weights.verify(weights)
 
     return _resnet(Bottleneck, [3, 4, 6, 3], weights, progress, **kwargs)
 
 
+@set_docstring(_RESNET_DOC.format(num_layers=101, weight_name=ResNet101_Weights.__name__))
 @handle_legacy_interface(weights=("pretrained", ResNet101_Weights.IMAGENET1K_V1))
 def resnet101(*, weights: Optional[ResNet101_Weights] = None, progress: bool = True, **kwargs: Any) -> ResNet:
     """TODO docstring"""
@@ -336,6 +353,7 @@ def resnet101(*, weights: Optional[ResNet101_Weights] = None, progress: bool = T
     return _resnet(Bottleneck, [3, 4, 23, 3], weights, progress, **kwargs)
 
 
+@set_docstring(_RESNET_DOC.format(num_layers=152, weight_name=ResNet152_Weights.__name__))
 @handle_legacy_interface(weights=("pretrained", ResNet152_Weights.IMAGENET1K_V1))
 def resnet152(*, weights: Optional[ResNet152_Weights] = None, progress: bool = True, **kwargs: Any) -> ResNet:
     """TODO docstring"""

--- a/torchvision/prototype/models/resnet.py
+++ b/torchvision/prototype/models/resnet.py
@@ -304,20 +304,6 @@ class Wide_ResNet101_2_Weights(WeightsEnum):
     )
     DEFAULT = IMAGENET1K_V2
 
-
-# It may or may not be a good idea to somehow unify that with _VGG_DOC . It's
-# too early to decide yet.
-_RESNET_DOC = """ResNet-{num_layers} from `Deep Residual Learning for Image Recognition <https://arxiv.org/pdf/1512.03385.pdf>`__.
-
-Args:
-    weights (:class:`~torchvision.prototype.models.{weight_name}`, optional): The
-        pretrained weights to use. See :class:`~torchvision.prototype.models.{weight_name}`
-        for possible values and details about each set of weight.
-    progress (bool, optional): Whether to print some stuff.
-    **kwargs: Some other stuff
-
-"""
-
 import re
 def _make_resnet_docstring(weights):
     # TODO maybe, maybe not: unify that with _make_vgg_docstring.
@@ -326,7 +312,6 @@ def _make_resnet_docstring(weights):
     allowed_values = ", ".join(f"``{v}``" for v in weights)
 
     return f"""ResNet-{suffix} from `Deep Residual Learning for Image Recognition <https://arxiv.org/pdf/1512.03385.pdf>`__.
-    Image Recognition <https://arxiv.org/abs/1409.1556>`__.
 
     Args:
         weights (:class:`~torchvision.prototype.models.{name}`, optional): The
@@ -353,7 +338,6 @@ def resnet18(*, weights: Optional[ResNet18_Weights] = None, progress: bool = Tru
 @set_docstring(_make_resnet_docstring(ResNet34_Weights))
 @handle_legacy_interface(weights=("pretrained", ResNet34_Weights.IMAGENET1K_V1))
 def resnet34(*, weights: Optional[ResNet34_Weights] = None, progress: bool = True, **kwargs: Any) -> ResNet:
-    """TODO docstring"""
     weights = ResNet34_Weights.verify(weights)
 
     return _resnet(BasicBlock, [3, 4, 6, 3], weights, progress, **kwargs)
@@ -370,7 +354,6 @@ def resnet50(*, weights: Optional[ResNet50_Weights] = None, progress: bool = Tru
 @set_docstring(_make_resnet_docstring(ResNet101_Weights))
 @handle_legacy_interface(weights=("pretrained", ResNet101_Weights.IMAGENET1K_V1))
 def resnet101(*, weights: Optional[ResNet101_Weights] = None, progress: bool = True, **kwargs: Any) -> ResNet:
-    """TODO docstring"""
     weights = ResNet101_Weights.verify(weights)
 
     return _resnet(Bottleneck, [3, 4, 23, 3], weights, progress, **kwargs)
@@ -379,7 +362,6 @@ def resnet101(*, weights: Optional[ResNet101_Weights] = None, progress: bool = T
 @set_docstring(_make_resnet_docstring(ResNet152_Weights))
 @handle_legacy_interface(weights=("pretrained", ResNet152_Weights.IMAGENET1K_V1))
 def resnet152(*, weights: Optional[ResNet152_Weights] = None, progress: bool = True, **kwargs: Any) -> ResNet:
-    """TODO docstring"""
     weights = ResNet152_Weights.verify(weights)
 
     return _resnet(Bottleneck, [3, 8, 36, 3], weights, progress, **kwargs)
@@ -389,7 +371,6 @@ def resnet152(*, weights: Optional[ResNet152_Weights] = None, progress: bool = T
 def resnext50_32x4d(
     *, weights: Optional[ResNeXt50_32X4D_Weights] = None, progress: bool = True, **kwargs: Any
 ) -> ResNet:
-    """TODO docstring"""
     weights = ResNeXt50_32X4D_Weights.verify(weights)
 
     _ovewrite_named_param(kwargs, "groups", 32)
@@ -401,7 +382,6 @@ def resnext50_32x4d(
 def resnext101_32x8d(
     *, weights: Optional[ResNeXt101_32X8D_Weights] = None, progress: bool = True, **kwargs: Any
 ) -> ResNet:
-    """TODO docstring"""
     weights = ResNeXt101_32X8D_Weights.verify(weights)
 
     _ovewrite_named_param(kwargs, "groups", 32)
@@ -413,7 +393,6 @@ def resnext101_32x8d(
 def wide_resnet50_2(
     *, weights: Optional[Wide_ResNet50_2_Weights] = None, progress: bool = True, **kwargs: Any
 ) -> ResNet:
-    """TODO docstring"""
     weights = Wide_ResNet50_2_Weights.verify(weights)
 
     _ovewrite_named_param(kwargs, "width_per_group", 64 * 2)
@@ -424,7 +403,6 @@ def wide_resnet50_2(
 def wide_resnet101_2(
     *, weights: Optional[Wide_ResNet101_2_Weights] = None, progress: bool = True, **kwargs: Any
 ) -> ResNet:
-    """TODO docstring"""
     weights = Wide_ResNet101_2_Weights.verify(weights)
 
     _ovewrite_named_param(kwargs, "width_per_group", 64 * 2)

--- a/torchvision/prototype/models/resnet.py
+++ b/torchvision/prototype/models/resnet.py
@@ -2,7 +2,6 @@ from functools import partial
 from typing import Any, List, Optional, Type, Union
 
 from torchvision.prototype.transforms import ImageClassificationEval
-from torchvision.prototype.utils._internal import sequence_to_str
 from torchvision.transforms.functional import InterpolationMode
 
 from ...models.resnet import BasicBlock, Bottleneck, ResNet

--- a/torchvision/prototype/models/resnet.py
+++ b/torchvision/prototype/models/resnet.py
@@ -7,7 +7,7 @@ from torchvision.transforms.functional import InterpolationMode
 from ...models.resnet import BasicBlock, Bottleneck, ResNet
 from ._api import WeightsEnum, Weights
 from ._meta import _IMAGENET_CATEGORIES
-from ._utils import handle_legacy_interface, _ovewrite_named_param, set_docstring
+from ._utils import handle_legacy_interface, _ovewrite_named_param
 
 
 __all__ = [

--- a/torchvision/prototype/models/vgg.py
+++ b/torchvision/prototype/models/vgg.py
@@ -7,7 +7,7 @@ from torchvision.transforms.functional import InterpolationMode
 from ...models.vgg import VGG, make_layers, cfgs
 from ._api import WeightsEnum, Weights
 from ._meta import _IMAGENET_CATEGORIES
-from ._utils import handle_legacy_interface, _ovewrite_named_param, set_docstring
+from ._utils import handle_legacy_interface, _ovewrite_named_param
 
 
 __all__ = [

--- a/torchvision/prototype/models/vgg.py
+++ b/torchvision/prototype/models/vgg.py
@@ -184,22 +184,32 @@ class VGG19_BN_Weights(WeightsEnum):
     DEFAULT = IMAGENET1K_V1
 
 
-# It may or may not be a good idea to somehow unify that with _RESNET_DOC . It's
-# too early to decide yet.
-_VGG_DOC = """VGG-{suffix} from `Very Deep Convolutional Networks for Large-Scale
-Image Recognition <https://arxiv.org/abs/1409.1556>`__.
+import re
+def _make_vgg_docstring(weights):
+    # TODO maybe, maybe not: unify that with _make_resnet_docstring.
+    name = weights.__name__
+    suffix = re.search("VGG(.+)_Weights", name).groups()[0]
+    allowed_values = ", ".join(f"``{v}``" for v in weights)
 
-Args:
-    weights (:class:`~torchvision.prototype.models.{weight_name}`, optional): The
-        pretrained weights to use. See :class:`~torchvision.prototype.models.{weight_name}`
-        for possible values and details about each set of weight.
-    progress (bool, optional): Whether to print some stuff.
-    **kwargs: Some other stuff
+    return f"""VGG-{suffix} from `Very Deep Convolutional Networks for Large-Scale
+    Image Recognition <https://arxiv.org/abs/1409.1556>`__.
 
-"""
+    Args:
+        weights (:class:`~torchvision.prototype.models.{name}`, optional): The
+            pretrained weights to use. Possible values are {allowed_values}.
+            See :class:`~torchvision.prototype.models.{name}` below for more
+            details.
+        progress (bool, optional): Whether to print some stuff.
+        **kwargs: Some other stuff
+
+    .. autoclass:: torchvision.prototype.models.{name}
+        :members:
+
+    """
 
 
-@set_docstring(_VGG_DOC.format(suffix="11", weight_name=VGG11_Weights.__name__))
+
+@set_docstring(_make_vgg_docstring(weights=VGG11_Weights))
 @handle_legacy_interface(weights=("pretrained", VGG11_Weights.IMAGENET1K_V1))
 def vgg11(*, weights: Optional[VGG11_Weights] = None, progress: bool = True, **kwargs: Any) -> VGG:
     weights = VGG11_Weights.verify(weights)
@@ -207,7 +217,7 @@ def vgg11(*, weights: Optional[VGG11_Weights] = None, progress: bool = True, **k
     return _vgg("A", False, weights, progress, **kwargs)
 
 
-@set_docstring(_VGG_DOC.format(suffix="11-BN", weight_name=VGG11_BN_Weights.__name__))
+@set_docstring(_make_vgg_docstring(weights=VGG11_BN_Weights))
 @handle_legacy_interface(weights=("pretrained", VGG11_BN_Weights.IMAGENET1K_V1))
 def vgg11_bn(*, weights: Optional[VGG11_BN_Weights] = None, progress: bool = True, **kwargs: Any) -> VGG:
     weights = VGG11_BN_Weights.verify(weights)
@@ -215,7 +225,7 @@ def vgg11_bn(*, weights: Optional[VGG11_BN_Weights] = None, progress: bool = Tru
     return _vgg("A", True, weights, progress, **kwargs)
 
 
-@set_docstring(_VGG_DOC.format(suffix="13", weight_name=VGG13_Weights.__name__))
+@set_docstring(_make_vgg_docstring(weights=VGG13_Weights))
 @handle_legacy_interface(weights=("pretrained", VGG13_Weights.IMAGENET1K_V1))
 def vgg13(*, weights: Optional[VGG13_Weights] = None, progress: bool = True, **kwargs: Any) -> VGG:
     weights = VGG13_Weights.verify(weights)
@@ -223,7 +233,7 @@ def vgg13(*, weights: Optional[VGG13_Weights] = None, progress: bool = True, **k
     return _vgg("B", False, weights, progress, **kwargs)
 
 
-@set_docstring(_VGG_DOC.format(suffix="13-BN", weight_name=VGG13_BN_Weights.__name__))
+@set_docstring(_make_vgg_docstring(weights=VGG13_BN_Weights))
 @handle_legacy_interface(weights=("pretrained", VGG13_BN_Weights.IMAGENET1K_V1))
 def vgg13_bn(*, weights: Optional[VGG13_BN_Weights] = None, progress: bool = True, **kwargs: Any) -> VGG:
     weights = VGG13_BN_Weights.verify(weights)
@@ -231,7 +241,7 @@ def vgg13_bn(*, weights: Optional[VGG13_BN_Weights] = None, progress: bool = Tru
     return _vgg("B", True, weights, progress, **kwargs)
 
 
-@set_docstring(_VGG_DOC.format(suffix="16", weight_name=VGG16_Weights.__name__))
+@set_docstring(_make_vgg_docstring(weights=VGG16_Weights))
 @handle_legacy_interface(weights=("pretrained", VGG16_Weights.IMAGENET1K_V1))
 def vgg16(*, weights: Optional[VGG16_Weights] = None, progress: bool = True, **kwargs: Any) -> VGG:
     weights = VGG16_Weights.verify(weights)
@@ -239,7 +249,7 @@ def vgg16(*, weights: Optional[VGG16_Weights] = None, progress: bool = True, **k
     return _vgg("D", False, weights, progress, **kwargs)
 
 
-@set_docstring(_VGG_DOC.format(suffix="16-BN", weight_name=VGG16_BN_Weights.__name__))
+@set_docstring(_make_vgg_docstring(weights=VGG16_BN_Weights))
 @handle_legacy_interface(weights=("pretrained", VGG16_BN_Weights.IMAGENET1K_V1))
 def vgg16_bn(*, weights: Optional[VGG16_BN_Weights] = None, progress: bool = True, **kwargs: Any) -> VGG:
     weights = VGG16_BN_Weights.verify(weights)
@@ -247,7 +257,7 @@ def vgg16_bn(*, weights: Optional[VGG16_BN_Weights] = None, progress: bool = Tru
     return _vgg("D", True, weights, progress, **kwargs)
 
 
-@set_docstring(_VGG_DOC.format(suffix="19", weight_name=VGG19_Weights.__name__))
+@set_docstring(_make_vgg_docstring(weights=VGG19_Weights))
 @handle_legacy_interface(weights=("pretrained", VGG19_Weights.IMAGENET1K_V1))
 def vgg19(*, weights: Optional[VGG19_Weights] = None, progress: bool = True, **kwargs: Any) -> VGG:
     weights = VGG19_Weights.verify(weights)
@@ -255,7 +265,7 @@ def vgg19(*, weights: Optional[VGG19_Weights] = None, progress: bool = True, **k
     return _vgg("E", False, weights, progress, **kwargs)
 
 
-@set_docstring(_VGG_DOC.format(suffix="19-BN", weight_name=VGG19_BN_Weights.__name__))
+@set_docstring(_make_vgg_docstring(weights=VGG19_BN_Weights))
 @handle_legacy_interface(weights=("pretrained", VGG19_BN_Weights.IMAGENET1K_V1))
 def vgg19_bn(*, weights: Optional[VGG19_BN_Weights] = None, progress: bool = True, **kwargs: Any) -> VGG:
     weights = VGG19_BN_Weights.verify(weights)

--- a/torchvision/prototype/models/vgg.py
+++ b/torchvision/prototype/models/vgg.py
@@ -186,6 +186,7 @@ class VGG19_BN_Weights(WeightsEnum):
 
 @handle_legacy_interface(weights=("pretrained", VGG11_Weights.IMAGENET1K_V1))
 def vgg11(*, weights: Optional[VGG11_Weights] = None, progress: bool = True, **kwargs: Any) -> VGG:
+    """TODO docstring"""
     weights = VGG11_Weights.verify(weights)
 
     return _vgg("A", False, weights, progress, **kwargs)
@@ -193,6 +194,7 @@ def vgg11(*, weights: Optional[VGG11_Weights] = None, progress: bool = True, **k
 
 @handle_legacy_interface(weights=("pretrained", VGG11_BN_Weights.IMAGENET1K_V1))
 def vgg11_bn(*, weights: Optional[VGG11_BN_Weights] = None, progress: bool = True, **kwargs: Any) -> VGG:
+    """TODO docstring"""
     weights = VGG11_BN_Weights.verify(weights)
 
     return _vgg("A", True, weights, progress, **kwargs)
@@ -200,6 +202,7 @@ def vgg11_bn(*, weights: Optional[VGG11_BN_Weights] = None, progress: bool = Tru
 
 @handle_legacy_interface(weights=("pretrained", VGG13_Weights.IMAGENET1K_V1))
 def vgg13(*, weights: Optional[VGG13_Weights] = None, progress: bool = True, **kwargs: Any) -> VGG:
+    """TODO docstring"""
     weights = VGG13_Weights.verify(weights)
 
     return _vgg("B", False, weights, progress, **kwargs)
@@ -207,6 +210,7 @@ def vgg13(*, weights: Optional[VGG13_Weights] = None, progress: bool = True, **k
 
 @handle_legacy_interface(weights=("pretrained", VGG13_BN_Weights.IMAGENET1K_V1))
 def vgg13_bn(*, weights: Optional[VGG13_BN_Weights] = None, progress: bool = True, **kwargs: Any) -> VGG:
+    """TODO docstring"""
     weights = VGG13_BN_Weights.verify(weights)
 
     return _vgg("B", True, weights, progress, **kwargs)
@@ -214,6 +218,7 @@ def vgg13_bn(*, weights: Optional[VGG13_BN_Weights] = None, progress: bool = Tru
 
 @handle_legacy_interface(weights=("pretrained", VGG16_Weights.IMAGENET1K_V1))
 def vgg16(*, weights: Optional[VGG16_Weights] = None, progress: bool = True, **kwargs: Any) -> VGG:
+    """TODO docstring"""
     weights = VGG16_Weights.verify(weights)
 
     return _vgg("D", False, weights, progress, **kwargs)
@@ -221,6 +226,7 @@ def vgg16(*, weights: Optional[VGG16_Weights] = None, progress: bool = True, **k
 
 @handle_legacy_interface(weights=("pretrained", VGG16_BN_Weights.IMAGENET1K_V1))
 def vgg16_bn(*, weights: Optional[VGG16_BN_Weights] = None, progress: bool = True, **kwargs: Any) -> VGG:
+    """TODO docstring"""
     weights = VGG16_BN_Weights.verify(weights)
 
     return _vgg("D", True, weights, progress, **kwargs)
@@ -228,6 +234,7 @@ def vgg16_bn(*, weights: Optional[VGG16_BN_Weights] = None, progress: bool = Tru
 
 @handle_legacy_interface(weights=("pretrained", VGG19_Weights.IMAGENET1K_V1))
 def vgg19(*, weights: Optional[VGG19_Weights] = None, progress: bool = True, **kwargs: Any) -> VGG:
+    """TODO docstring"""
     weights = VGG19_Weights.verify(weights)
 
     return _vgg("E", False, weights, progress, **kwargs)
@@ -235,6 +242,7 @@ def vgg19(*, weights: Optional[VGG19_Weights] = None, progress: bool = True, **k
 
 @handle_legacy_interface(weights=("pretrained", VGG19_BN_Weights.IMAGENET1K_V1))
 def vgg19_bn(*, weights: Optional[VGG19_BN_Weights] = None, progress: bool = True, **kwargs: Any) -> VGG:
+    """TODO docstring"""
     weights = VGG19_BN_Weights.verify(weights)
 
     return _vgg("E", True, weights, progress, **kwargs)

--- a/torchvision/prototype/models/vgg.py
+++ b/torchvision/prototype/models/vgg.py
@@ -184,90 +184,201 @@ class VGG19_BN_Weights(WeightsEnum):
     DEFAULT = IMAGENET1K_V1
 
 
-import re
-def _make_vgg_docstring(weights):
-    # TODO maybe, maybe not: unify that with _make_resnet_docstring.
-    name = weights.__name__
-    suffix = re.search("VGG(.+)_Weights", name).groups()[0]
-    allowed_values = ", ".join(f"``{v}``" for v in weights)
-
-    return f"""VGG-{suffix} from `Very Deep Convolutional Networks for Large-Scale
-    Image Recognition <https://arxiv.org/abs/1409.1556>`__.
-
-    Args:
-        weights (:class:`~torchvision.prototype.models.{name}`, optional): The
-            pretrained weights to use. Possible values are {allowed_values}.
-            See :class:`~torchvision.prototype.models.{name}` below for more
-            details.
-        progress (bool, optional): Whether to print some stuff.
-        **kwargs: Some other stuff
-
-    .. autoclass:: torchvision.prototype.models.{name}
-        :members:
-
-    """
-
-
-
-@set_docstring(_make_vgg_docstring(weights=VGG11_Weights))
 @handle_legacy_interface(weights=("pretrained", VGG11_Weights.IMAGENET1K_V1))
 def vgg11(*, weights: Optional[VGG11_Weights] = None, progress: bool = True, **kwargs: Any) -> VGG:
+    """VGG-11 from `Very Deep Convolutional Networks for Large-Scale Image Recognition <https://arxiv.org/abs/1409.1556>`__.
+
+    Args:
+        weights (:class:`~torchvision.prototype.models.VGG11_Weights`, optional): The
+            pretrained weights to use. See
+            :class:`~torchvision.prototype.models.VGG11_Weights` below for
+            more details, and possible values. By default, no pre-trained
+            weights are used.
+        progress (bool, optional): If True, displays a progress bar of the
+            download to stderr. Default is True.
+        **kwargs: parameters passed to the ``torchvision.models.vgg.VGG``
+            base class. Please refer to the `source code
+            <https://github.com/pytorch/vision/blob/main/torchvision/models/vgg.py>`_
+            for more details about this class.
+
+    .. autoclass:: torchvision.prototype.models.VGG11_Weights
+        :members:
+    """
     weights = VGG11_Weights.verify(weights)
 
     return _vgg("A", False, weights, progress, **kwargs)
 
 
-@set_docstring(_make_vgg_docstring(weights=VGG11_BN_Weights))
 @handle_legacy_interface(weights=("pretrained", VGG11_BN_Weights.IMAGENET1K_V1))
 def vgg11_bn(*, weights: Optional[VGG11_BN_Weights] = None, progress: bool = True, **kwargs: Any) -> VGG:
+    """VGG-11-BN from `Very Deep Convolutional Networks for Large-Scale Image Recognition <https://arxiv.org/abs/1409.1556>`__.
+
+    Args:
+        weights (:class:`~torchvision.prototype.models.VGG11_BN_Weights`, optional): The
+            pretrained weights to use. See
+            :class:`~torchvision.prototype.models.VGG11_BN_Weights` below for
+            more details, and possible values. By default, no pre-trained
+            weights are used.
+        progress (bool, optional): If True, displays a progress bar of the
+            download to stderr. Default is True.
+        **kwargs: parameters passed to the ``torchvision.models.vgg.VGG``
+            base class. Please refer to the `source code
+            <https://github.com/pytorch/vision/blob/main/torchvision/models/vgg.py>`_
+            for more details about this class.
+
+    .. autoclass:: torchvision.prototype.models.VGG11_BN_Weights
+        :members:
+    """
     weights = VGG11_BN_Weights.verify(weights)
 
     return _vgg("A", True, weights, progress, **kwargs)
 
 
-@set_docstring(_make_vgg_docstring(weights=VGG13_Weights))
 @handle_legacy_interface(weights=("pretrained", VGG13_Weights.IMAGENET1K_V1))
 def vgg13(*, weights: Optional[VGG13_Weights] = None, progress: bool = True, **kwargs: Any) -> VGG:
+    """VGG-13 from `Very Deep Convolutional Networks for Large-Scale Image Recognition <https://arxiv.org/abs/1409.1556>`__.
+
+    Args:
+        weights (:class:`~torchvision.prototype.models.VGG13_Weights`, optional): The
+            pretrained weights to use. See
+            :class:`~torchvision.prototype.models.VGG13_Weights` below for
+            more details, and possible values. By default, no pre-trained
+            weights are used.
+        progress (bool, optional): If True, displays a progress bar of the
+            download to stderr. Default is True.
+        **kwargs: parameters passed to the ``torchvision.models.vgg.VGG``
+            base class. Please refer to the `source code
+            <https://github.com/pytorch/vision/blob/main/torchvision/models/vgg.py>`_
+            for more details about this class.
+
+    .. autoclass:: torchvision.prototype.models.VGG13_Weights
+        :members:
+    """
     weights = VGG13_Weights.verify(weights)
 
     return _vgg("B", False, weights, progress, **kwargs)
 
 
-@set_docstring(_make_vgg_docstring(weights=VGG13_BN_Weights))
 @handle_legacy_interface(weights=("pretrained", VGG13_BN_Weights.IMAGENET1K_V1))
 def vgg13_bn(*, weights: Optional[VGG13_BN_Weights] = None, progress: bool = True, **kwargs: Any) -> VGG:
+    """VGG-13-BN from `Very Deep Convolutional Networks for Large-Scale Image Recognition <https://arxiv.org/abs/1409.1556>`__.
+
+    Args:
+        weights (:class:`~torchvision.prototype.models.VGG13_BN_Weights`, optional): The
+            pretrained weights to use. See
+            :class:`~torchvision.prototype.models.VGG13_BN_Weights` below for
+            more details, and possible values. By default, no pre-trained
+            weights are used.
+        progress (bool, optional): If True, displays a progress bar of the
+            download to stderr. Default is True.
+        **kwargs: parameters passed to the ``torchvision.models.vgg.VGG``
+            base class. Please refer to the `source code
+            <https://github.com/pytorch/vision/blob/main/torchvision/models/vgg.py>`_
+            for more details about this class.
+
+    .. autoclass:: torchvision.prototype.models.VGG13_BN_Weights
+        :members:
+    """
     weights = VGG13_BN_Weights.verify(weights)
 
     return _vgg("B", True, weights, progress, **kwargs)
 
 
-@set_docstring(_make_vgg_docstring(weights=VGG16_Weights))
 @handle_legacy_interface(weights=("pretrained", VGG16_Weights.IMAGENET1K_V1))
 def vgg16(*, weights: Optional[VGG16_Weights] = None, progress: bool = True, **kwargs: Any) -> VGG:
+    """VGG-16 from `Very Deep Convolutional Networks for Large-Scale Image Recognition <https://arxiv.org/abs/1409.1556>`__.
+
+    Args:
+        weights (:class:`~torchvision.prototype.models.VGG16_Weights`, optional): The
+            pretrained weights to use. See
+            :class:`~torchvision.prototype.models.VGG16_Weights` below for
+            more details, and possible values. By default, no pre-trained
+            weights are used.
+        progress (bool, optional): If True, displays a progress bar of the
+            download to stderr. Default is True.
+        **kwargs: parameters passed to the ``torchvision.models.vgg.VGG``
+            base class. Please refer to the `source code
+            <https://github.com/pytorch/vision/blob/main/torchvision/models/vgg.py>`_
+            for more details about this class.
+
+    .. autoclass:: torchvision.prototype.models.VGG16_Weights
+        :members:
+    """
     weights = VGG16_Weights.verify(weights)
 
     return _vgg("D", False, weights, progress, **kwargs)
 
 
-@set_docstring(_make_vgg_docstring(weights=VGG16_BN_Weights))
 @handle_legacy_interface(weights=("pretrained", VGG16_BN_Weights.IMAGENET1K_V1))
 def vgg16_bn(*, weights: Optional[VGG16_BN_Weights] = None, progress: bool = True, **kwargs: Any) -> VGG:
+    """VGG-16-BN from `Very Deep Convolutional Networks for Large-Scale Image Recognition <https://arxiv.org/abs/1409.1556>`__.
+
+    Args:
+        weights (:class:`~torchvision.prototype.models.VGG16_BN_Weights`, optional): The
+            pretrained weights to use. See
+            :class:`~torchvision.prototype.models.VGG16_BN_Weights` below for
+            more details, and possible values. By default, no pre-trained
+            weights are used.
+        progress (bool, optional): If True, displays a progress bar of the
+            download to stderr. Default is True.
+        **kwargs: parameters passed to the ``torchvision.models.vgg.VGG``
+            base class. Please refer to the `source code
+            <https://github.com/pytorch/vision/blob/main/torchvision/models/vgg.py>`_
+            for more details about this class.
+
+    .. autoclass:: torchvision.prototype.models.VGG16_BN_Weights
+        :members:
+    """
     weights = VGG16_BN_Weights.verify(weights)
 
     return _vgg("D", True, weights, progress, **kwargs)
 
 
-@set_docstring(_make_vgg_docstring(weights=VGG19_Weights))
 @handle_legacy_interface(weights=("pretrained", VGG19_Weights.IMAGENET1K_V1))
 def vgg19(*, weights: Optional[VGG19_Weights] = None, progress: bool = True, **kwargs: Any) -> VGG:
+    """VGG-19 from `Very Deep Convolutional Networks for Large-Scale Image Recognition <https://arxiv.org/abs/1409.1556>`__.
+
+    Args:
+        weights (:class:`~torchvision.prototype.models.VGG19_Weights`, optional): The
+            pretrained weights to use. See
+            :class:`~torchvision.prototype.models.VGG19_Weights` below for
+            more details, and possible values. By default, no pre-trained
+            weights are used.
+        progress (bool, optional): If True, displays a progress bar of the
+            download to stderr. Default is True.
+        **kwargs: parameters passed to the ``torchvision.models.vgg.VGG``
+            base class. Please refer to the `source code
+            <https://github.com/pytorch/vision/blob/main/torchvision/models/vgg.py>`_
+            for more details about this class.
+
+    .. autoclass:: torchvision.prototype.models.VGG19_Weights
+        :members:
+    """
     weights = VGG19_Weights.verify(weights)
 
     return _vgg("E", False, weights, progress, **kwargs)
 
 
-@set_docstring(_make_vgg_docstring(weights=VGG19_BN_Weights))
 @handle_legacy_interface(weights=("pretrained", VGG19_BN_Weights.IMAGENET1K_V1))
 def vgg19_bn(*, weights: Optional[VGG19_BN_Weights] = None, progress: bool = True, **kwargs: Any) -> VGG:
+    """VGG-19_BN from `Very Deep Convolutional Networks for Large-Scale Image Recognition <https://arxiv.org/abs/1409.1556>`__.
+
+    Args:
+        weights (:class:`~torchvision.prototype.models.VGG19_BN_Weights`, optional): The
+            pretrained weights to use. See
+            :class:`~torchvision.prototype.models.VGG19_BN_Weights` below for
+            more details, and possible values. By default, no pre-trained
+            weights are used.
+        progress (bool, optional): If True, displays a progress bar of the
+            download to stderr. Default is True.
+        **kwargs: parameters passed to the ``torchvision.models.vgg.VGG``
+            base class. Please refer to the `source code
+            <https://github.com/pytorch/vision/blob/main/torchvision/models/vgg.py>`_
+            for more details about this class.
+
+    .. autoclass:: torchvision.prototype.models.VGG19_BN_Weights
+        :members:
+    """
     weights = VGG19_BN_Weights.verify(weights)
 
     return _vgg("E", True, weights, progress, **kwargs)

--- a/torchvision/prototype/models/vgg.py
+++ b/torchvision/prototype/models/vgg.py
@@ -7,7 +7,7 @@ from torchvision.transforms.functional import InterpolationMode
 from ...models.vgg import VGG, make_layers, cfgs
 from ._api import WeightsEnum, Weights
 from ._meta import _IMAGENET_CATEGORIES
-from ._utils import handle_legacy_interface, _ovewrite_named_param
+from ._utils import handle_legacy_interface, _ovewrite_named_param, set_docstring
 
 
 __all__ = [
@@ -184,65 +184,80 @@ class VGG19_BN_Weights(WeightsEnum):
     DEFAULT = IMAGENET1K_V1
 
 
+# It may or may not be a good idea to somehow unify that with _RESNET_DOC . It's
+# too early to decide yet.
+_VGG_DOC = """VGG-{suffix} from `Very Deep Convolutional Networks for Large-Scale
+Image Recognition <https://arxiv.org/abs/1409.1556>`__.
+
+Args:
+    weights (:class:`~torchvision.prototype.models.{weight_name}`, optional): The
+        pretrained weights to use. See :class:`~torchvision.prototype.models.{weight_name}`
+        for possible values and details about each set of weight.
+    progress (bool, optional): Whether to print some stuff.
+    **kwargs: Some other stuff
+
+"""
+
+
+@set_docstring(_VGG_DOC.format(suffix="11", weight_name=VGG11_Weights.__name__))
 @handle_legacy_interface(weights=("pretrained", VGG11_Weights.IMAGENET1K_V1))
 def vgg11(*, weights: Optional[VGG11_Weights] = None, progress: bool = True, **kwargs: Any) -> VGG:
-    """TODO docstring"""
     weights = VGG11_Weights.verify(weights)
 
     return _vgg("A", False, weights, progress, **kwargs)
 
 
+@set_docstring(_VGG_DOC.format(suffix="11-BN", weight_name=VGG11_BN_Weights.__name__))
 @handle_legacy_interface(weights=("pretrained", VGG11_BN_Weights.IMAGENET1K_V1))
 def vgg11_bn(*, weights: Optional[VGG11_BN_Weights] = None, progress: bool = True, **kwargs: Any) -> VGG:
-    """TODO docstring"""
     weights = VGG11_BN_Weights.verify(weights)
 
     return _vgg("A", True, weights, progress, **kwargs)
 
 
+@set_docstring(_VGG_DOC.format(suffix="13", weight_name=VGG13_Weights.__name__))
 @handle_legacy_interface(weights=("pretrained", VGG13_Weights.IMAGENET1K_V1))
 def vgg13(*, weights: Optional[VGG13_Weights] = None, progress: bool = True, **kwargs: Any) -> VGG:
-    """TODO docstring"""
     weights = VGG13_Weights.verify(weights)
 
     return _vgg("B", False, weights, progress, **kwargs)
 
 
+@set_docstring(_VGG_DOC.format(suffix="13-BN", weight_name=VGG13_BN_Weights.__name__))
 @handle_legacy_interface(weights=("pretrained", VGG13_BN_Weights.IMAGENET1K_V1))
 def vgg13_bn(*, weights: Optional[VGG13_BN_Weights] = None, progress: bool = True, **kwargs: Any) -> VGG:
-    """TODO docstring"""
     weights = VGG13_BN_Weights.verify(weights)
 
     return _vgg("B", True, weights, progress, **kwargs)
 
 
+@set_docstring(_VGG_DOC.format(suffix="16", weight_name=VGG16_Weights.__name__))
 @handle_legacy_interface(weights=("pretrained", VGG16_Weights.IMAGENET1K_V1))
 def vgg16(*, weights: Optional[VGG16_Weights] = None, progress: bool = True, **kwargs: Any) -> VGG:
-    """TODO docstring"""
     weights = VGG16_Weights.verify(weights)
 
     return _vgg("D", False, weights, progress, **kwargs)
 
 
+@set_docstring(_VGG_DOC.format(suffix="16-BN", weight_name=VGG16_BN_Weights.__name__))
 @handle_legacy_interface(weights=("pretrained", VGG16_BN_Weights.IMAGENET1K_V1))
 def vgg16_bn(*, weights: Optional[VGG16_BN_Weights] = None, progress: bool = True, **kwargs: Any) -> VGG:
-    """TODO docstring"""
     weights = VGG16_BN_Weights.verify(weights)
 
     return _vgg("D", True, weights, progress, **kwargs)
 
 
+@set_docstring(_VGG_DOC.format(suffix="19", weight_name=VGG19_Weights.__name__))
 @handle_legacy_interface(weights=("pretrained", VGG19_Weights.IMAGENET1K_V1))
 def vgg19(*, weights: Optional[VGG19_Weights] = None, progress: bool = True, **kwargs: Any) -> VGG:
-    """TODO docstring"""
     weights = VGG19_Weights.verify(weights)
 
     return _vgg("E", False, weights, progress, **kwargs)
 
 
+@set_docstring(_VGG_DOC.format(suffix="19-BN", weight_name=VGG19_BN_Weights.__name__))
 @handle_legacy_interface(weights=("pretrained", VGG19_BN_Weights.IMAGENET1K_V1))
 def vgg19_bn(*, weights: Optional[VGG19_BN_Weights] = None, progress: bool = True, **kwargs: Any) -> VGG:
-    """TODO docstring"""
     weights = VGG19_BN_Weights.verify(weights)
 
     return _vgg("E", True, weights, progress, **kwargs)


### PR DESCRIPTION
Follow up to https://github.com/pytorch/vision/pull/5575, adding documentation for the Weight enums.

The Weight docs is embedded in the same page as their corresponding model builders: https://1256058-73328905-gh.circle-artifacts.com/0/docs/prototype_models/generated/torchvision.prototype.models.resnet50.html#torchvision.prototype.models.resnet50
![image](https://user-images.githubusercontent.com/1190450/157645299-96fc1252-10ce-4ebb-807c-d1b5fe32a481.png)