### PR TITLE
fix RandomGrayscale for grayscale inputs

### DIFF
--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -2237,5 +2237,17 @@ def test_random_affine():
         assert t.interpolation == transforms.InterpolationMode.BILINEAR
 
 
+def test_random_grayscale_with_grayscale_input():
+    transform = transforms.RandomGrayscale(p=1.0)
+
+    image_tensor = torch.randint(0, 256, (1, 16, 16), dtype=torch.uint8)
+    output_tensor = transform(image_tensor)
+    torch.testing.assert_close(output_tensor, image_tensor)
+
+    image_pil = F.to_pil_image(image_tensor)
+    output_pil = transform(image_pil)
+    torch.testing.assert_close(F.pil_to_tensor(output_pil), image_tensor)
+
+
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
Fixes #5581. With this fix we don't need to touch `F.rgb_to_grayscale`. The mismatch between tensor and PIL kernel is still open, but somewhat irrelevant for this. The documentation as well as the name of `F.rgb_to_grayscale` clearly state that this is converting RGB inputs. Thus, having mismatching but not wrong behavior for grayscale inputs is not a major problem, since the user is already misusing the kernel. Plus, this whole issue will go away for the prototype transforms, since we will handle color space conversions in a general way there.

`RandomGrayscale` relied on the undocumented fact that `F.rgb_to_grayscale` is a no-op for grayscale PIL. As shown in #5581, this assumption  does not hold for tensor images. This patch removes this assumption and handles grayscale inputs explicitly.