### PR TITLE
revert changes to assert_equal

### DIFF
--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -192,7 +192,10 @@ def _assert_approx_equal_tensor_to_pil(
 
 def _test_fn_on_batch(batch_tensors, fn, scripted_fn_atol=1e-8, **fn_kwargs):
     transformed_batch = fn(batch_tensors, **fn_kwargs)
-    assert_equal(transformed_batch.split(1), [fn(img_tensor, **fn_kwargs) for img_tensor in batch_tensors.split(1)])
+    for i in range(len(batch_tensors)):
+        img_tensor = batch_tensors[i, ...]
+        transformed_img = fn(img_tensor, **fn_kwargs)
+        torch.testing.assert_close(transformed_img, transformed_batch[i, ...], rtol=0, atol=1e-6)
 
     if scripted_fn_atol >= 0:
         scripted_fn = torch.jit.script(fn)

--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -137,7 +137,7 @@ def _create_data_batch(height=3, width=3, channels=3, num_samples=4, device="cpu
     return batch_tensor
 
 
-assert_equal = functools.partial(torch.testing.assert_close, rtol=0, atol=1e-6)
+assert_equal = functools.partial(torch.testing.assert_close, rtol=0, atol=0)
 
 
 def get_list_of_videos(tmpdir, num_videos=5, sizes=None, fps=None):
@@ -192,10 +192,7 @@ def _assert_approx_equal_tensor_to_pil(
 
 def _test_fn_on_batch(batch_tensors, fn, scripted_fn_atol=1e-8, **fn_kwargs):
     transformed_batch = fn(batch_tensors, **fn_kwargs)
-    for i in range(len(batch_tensors)):
-        img_tensor = batch_tensors[i, ...]
-        transformed_img = fn(img_tensor, **fn_kwargs)
-        assert_equal(transformed_img, transformed_batch[i, ...])
+    assert_equal(transformed_batch.split(1), [fn(img_tensor, **fn_kwargs) for img_tensor in batch_tensors.split(1)])
 
     if scripted_fn_atol >= 0:
         scripted_fn = torch.jit.script(fn)


### PR DESCRIPTION
#4480 added a default tolerance to `assert_equal` although this function is specifically designed to be an equality check. This change hides the fact that 

https://github.com/pytorch/vision/blob/a8bde78130fd8c956780d85693d0f51912013732/test/test_functional_tensor.py#L836

fails the batch vs single test

https://github.com/pytorch/vision/blob/a8bde78130fd8c956780d85693d0f51912013732/test/common_utils.py#L194-L198