### PR TITLE
Replace "main" with "0.12" in published 0.12 docs title pages

### DIFF
--- a/0.12/_modules/index.html
+++ b/0.12/_modules/index.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Overview: module code &mdash; Torchvision main documentation</title>
+  <title>Overview: module code &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision.html
+++ b/0.12/_modules/torchvision.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision &mdash; Torchvision main documentation</title>
+  <title>torchvision &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/datasets/_optical_flow.html
+++ b/0.12/_modules/torchvision/datasets/_optical_flow.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets._optical_flow &mdash; Torchvision main documentation</title>
+  <title>torchvision.datasets._optical_flow &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/datasets/caltech.html
+++ b/0.12/_modules/torchvision/datasets/caltech.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.caltech &mdash; Torchvision main documentation</title>
+  <title>torchvision.datasets.caltech &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/datasets/celeba.html
+++ b/0.12/_modules/torchvision/datasets/celeba.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.celeba &mdash; Torchvision main documentation</title>
+  <title>torchvision.datasets.celeba &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/datasets/cifar.html
+++ b/0.12/_modules/torchvision/datasets/cifar.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.cifar &mdash; Torchvision main documentation</title>
+  <title>torchvision.datasets.cifar &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/datasets/cityscapes.html
+++ b/0.12/_modules/torchvision/datasets/cityscapes.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.cityscapes &mdash; Torchvision main documentation</title>
+  <title>torchvision.datasets.cityscapes &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/datasets/coco.html
+++ b/0.12/_modules/torchvision/datasets/coco.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.coco &mdash; Torchvision main documentation</title>
+  <title>torchvision.datasets.coco &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/datasets/country211.html
+++ b/0.12/_modules/torchvision/datasets/country211.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.country211 &mdash; Torchvision main documentation</title>
+  <title>torchvision.datasets.country211 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/datasets/dtd.html
+++ b/0.12/_modules/torchvision/datasets/dtd.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.dtd &mdash; Torchvision main documentation</title>
+  <title>torchvision.datasets.dtd &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/datasets/eurosat.html
+++ b/0.12/_modules/torchvision/datasets/eurosat.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.eurosat &mdash; Torchvision main documentation</title>
+  <title>torchvision.datasets.eurosat &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/datasets/fakedata.html
+++ b/0.12/_modules/torchvision/datasets/fakedata.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.fakedata &mdash; Torchvision main documentation</title>
+  <title>torchvision.datasets.fakedata &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/datasets/fer2013.html
+++ b/0.12/_modules/torchvision/datasets/fer2013.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.fer2013 &mdash; Torchvision main documentation</title>
+  <title>torchvision.datasets.fer2013 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/datasets/fgvc_aircraft.html
+++ b/0.12/_modules/torchvision/datasets/fgvc_aircraft.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.fgvc_aircraft &mdash; Torchvision main documentation</title>
+  <title>torchvision.datasets.fgvc_aircraft &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/datasets/flickr.html
+++ b/0.12/_modules/torchvision/datasets/flickr.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.flickr &mdash; Torchvision main documentation</title>
+  <title>torchvision.datasets.flickr &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/datasets/flowers102.html
+++ b/0.12/_modules/torchvision/datasets/flowers102.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.flowers102 &mdash; Torchvision main documentation</title>
+  <title>torchvision.datasets.flowers102 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/datasets/folder.html
+++ b/0.12/_modules/torchvision/datasets/folder.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.folder &mdash; Torchvision main documentation</title>
+  <title>torchvision.datasets.folder &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/datasets/food101.html
+++ b/0.12/_modules/torchvision/datasets/food101.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.food101 &mdash; Torchvision main documentation</title>
+  <title>torchvision.datasets.food101 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/datasets/gtsrb.html
+++ b/0.12/_modules/torchvision/datasets/gtsrb.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.gtsrb &mdash; Torchvision main documentation</title>
+  <title>torchvision.datasets.gtsrb &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/datasets/hmdb51.html
+++ b/0.12/_modules/torchvision/datasets/hmdb51.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.hmdb51 &mdash; Torchvision main documentation</title>
+  <title>torchvision.datasets.hmdb51 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/datasets/imagenet.html
+++ b/0.12/_modules/torchvision/datasets/imagenet.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.imagenet &mdash; Torchvision main documentation</title>
+  <title>torchvision.datasets.imagenet &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/datasets/inaturalist.html
+++ b/0.12/_modules/torchvision/datasets/inaturalist.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.inaturalist &mdash; Torchvision main documentation</title>
+  <title>torchvision.datasets.inaturalist &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/datasets/kinetics.html
+++ b/0.12/_modules/torchvision/datasets/kinetics.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.kinetics &mdash; Torchvision main documentation</title>
+  <title>torchvision.datasets.kinetics &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/datasets/kitti.html
+++ b/0.12/_modules/torchvision/datasets/kitti.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.kitti &mdash; Torchvision main documentation</title>
+  <title>torchvision.datasets.kitti &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/datasets/lfw.html
+++ b/0.12/_modules/torchvision/datasets/lfw.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.lfw &mdash; Torchvision main documentation</title>
+  <title>torchvision.datasets.lfw &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/datasets/lsun.html
+++ b/0.12/_modules/torchvision/datasets/lsun.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.lsun &mdash; Torchvision main documentation</title>
+  <title>torchvision.datasets.lsun &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/datasets/mnist.html
+++ b/0.12/_modules/torchvision/datasets/mnist.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.mnist &mdash; Torchvision main documentation</title>
+  <title>torchvision.datasets.mnist &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/datasets/omniglot.html
+++ b/0.12/_modules/torchvision/datasets/omniglot.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.omniglot &mdash; Torchvision main documentation</title>
+  <title>torchvision.datasets.omniglot &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/datasets/oxford_iiit_pet.html
+++ b/0.12/_modules/torchvision/datasets/oxford_iiit_pet.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.oxford_iiit_pet &mdash; Torchvision main documentation</title>
+  <title>torchvision.datasets.oxford_iiit_pet &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/datasets/pcam.html
+++ b/0.12/_modules/torchvision/datasets/pcam.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.pcam &mdash; Torchvision main documentation</title>
+  <title>torchvision.datasets.pcam &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/datasets/phototour.html
+++ b/0.12/_modules/torchvision/datasets/phototour.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.phototour &mdash; Torchvision main documentation</title>
+  <title>torchvision.datasets.phototour &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/datasets/places365.html
+++ b/0.12/_modules/torchvision/datasets/places365.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.places365 &mdash; Torchvision main documentation</title>
+  <title>torchvision.datasets.places365 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/datasets/rendered_sst2.html
+++ b/0.12/_modules/torchvision/datasets/rendered_sst2.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.rendered_sst2 &mdash; Torchvision main documentation</title>
+  <title>torchvision.datasets.rendered_sst2 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/datasets/sbd.html
+++ b/0.12/_modules/torchvision/datasets/sbd.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.sbd &mdash; Torchvision main documentation</title>
+  <title>torchvision.datasets.sbd &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/datasets/sbu.html
+++ b/0.12/_modules/torchvision/datasets/sbu.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.sbu &mdash; Torchvision main documentation</title>
+  <title>torchvision.datasets.sbu &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/datasets/semeion.html
+++ b/0.12/_modules/torchvision/datasets/semeion.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.semeion &mdash; Torchvision main documentation</title>
+  <title>torchvision.datasets.semeion &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/datasets/stanford_cars.html
+++ b/0.12/_modules/torchvision/datasets/stanford_cars.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.stanford_cars &mdash; Torchvision main documentation</title>
+  <title>torchvision.datasets.stanford_cars &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/datasets/stl10.html
+++ b/0.12/_modules/torchvision/datasets/stl10.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.stl10 &mdash; Torchvision main documentation</title>
+  <title>torchvision.datasets.stl10 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/datasets/sun397.html
+++ b/0.12/_modules/torchvision/datasets/sun397.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.sun397 &mdash; Torchvision main documentation</title>
+  <title>torchvision.datasets.sun397 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/datasets/svhn.html
+++ b/0.12/_modules/torchvision/datasets/svhn.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.svhn &mdash; Torchvision main documentation</title>
+  <title>torchvision.datasets.svhn &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/datasets/ucf101.html
+++ b/0.12/_modules/torchvision/datasets/ucf101.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.ucf101 &mdash; Torchvision main documentation</title>
+  <title>torchvision.datasets.ucf101 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/datasets/usps.html
+++ b/0.12/_modules/torchvision/datasets/usps.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.usps &mdash; Torchvision main documentation</title>
+  <title>torchvision.datasets.usps &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/datasets/vision.html
+++ b/0.12/_modules/torchvision/datasets/vision.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.vision &mdash; Torchvision main documentation</title>
+  <title>torchvision.datasets.vision &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/datasets/voc.html
+++ b/0.12/_modules/torchvision/datasets/voc.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.voc &mdash; Torchvision main documentation</title>
+  <title>torchvision.datasets.voc &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/datasets/widerface.html
+++ b/0.12/_modules/torchvision/datasets/widerface.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.widerface &mdash; Torchvision main documentation</title>
+  <title>torchvision.datasets.widerface &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/io.html
+++ b/0.12/_modules/torchvision/io.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.io &mdash; Torchvision main documentation</title>
+  <title>torchvision.io &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/io/image.html
+++ b/0.12/_modules/torchvision/io/image.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.io.image &mdash; Torchvision main documentation</title>
+  <title>torchvision.io.image &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/io/video.html
+++ b/0.12/_modules/torchvision/io/video.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.io.video &mdash; Torchvision main documentation</title>
+  <title>torchvision.io.video &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/models/alexnet.html
+++ b/0.12/_modules/torchvision/models/alexnet.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.models.alexnet &mdash; Torchvision main documentation</title>
+  <title>torchvision.models.alexnet &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/models/convnext.html
+++ b/0.12/_modules/torchvision/models/convnext.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.models.convnext &mdash; Torchvision main documentation</title>
+  <title>torchvision.models.convnext &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/models/densenet.html
+++ b/0.12/_modules/torchvision/models/densenet.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.models.densenet &mdash; Torchvision main documentation</title>
+  <title>torchvision.models.densenet &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/models/detection/faster_rcnn.html
+++ b/0.12/_modules/torchvision/models/detection/faster_rcnn.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.models.detection.faster_rcnn &mdash; Torchvision main documentation</title>
+  <title>torchvision.models.detection.faster_rcnn &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/models/detection/fcos.html
+++ b/0.12/_modules/torchvision/models/detection/fcos.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.models.detection.fcos &mdash; Torchvision main documentation</title>
+  <title>torchvision.models.detection.fcos &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/models/detection/keypoint_rcnn.html
+++ b/0.12/_modules/torchvision/models/detection/keypoint_rcnn.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.models.detection.keypoint_rcnn &mdash; Torchvision main documentation</title>
+  <title>torchvision.models.detection.keypoint_rcnn &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/models/detection/mask_rcnn.html
+++ b/0.12/_modules/torchvision/models/detection/mask_rcnn.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.models.detection.mask_rcnn &mdash; Torchvision main documentation</title>
+  <title>torchvision.models.detection.mask_rcnn &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/models/detection/retinanet.html
+++ b/0.12/_modules/torchvision/models/detection/retinanet.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.models.detection.retinanet &mdash; Torchvision main documentation</title>
+  <title>torchvision.models.detection.retinanet &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/models/detection/ssd.html
+++ b/0.12/_modules/torchvision/models/detection/ssd.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.models.detection.ssd &mdash; Torchvision main documentation</title>
+  <title>torchvision.models.detection.ssd &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/models/detection/ssdlite.html
+++ b/0.12/_modules/torchvision/models/detection/ssdlite.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.models.detection.ssdlite &mdash; Torchvision main documentation</title>
+  <title>torchvision.models.detection.ssdlite &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/models/efficientnet.html
+++ b/0.12/_modules/torchvision/models/efficientnet.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.models.efficientnet &mdash; Torchvision main documentation</title>
+  <title>torchvision.models.efficientnet &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/models/feature_extraction.html
+++ b/0.12/_modules/torchvision/models/feature_extraction.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.models.feature_extraction &mdash; Torchvision main documentation</title>
+  <title>torchvision.models.feature_extraction &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/models/googlenet.html
+++ b/0.12/_modules/torchvision/models/googlenet.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.models.googlenet &mdash; Torchvision main documentation</title>
+  <title>torchvision.models.googlenet &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/models/inception.html
+++ b/0.12/_modules/torchvision/models/inception.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.models.inception &mdash; Torchvision main documentation</title>
+  <title>torchvision.models.inception &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/models/mnasnet.html
+++ b/0.12/_modules/torchvision/models/mnasnet.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.models.mnasnet &mdash; Torchvision main documentation</title>
+  <title>torchvision.models.mnasnet &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/models/mobilenetv2.html
+++ b/0.12/_modules/torchvision/models/mobilenetv2.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.models.mobilenetv2 &mdash; Torchvision main documentation</title>
+  <title>torchvision.models.mobilenetv2 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/models/mobilenetv3.html
+++ b/0.12/_modules/torchvision/models/mobilenetv3.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.models.mobilenetv3 &mdash; Torchvision main documentation</title>
+  <title>torchvision.models.mobilenetv3 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/models/optical_flow/raft.html
+++ b/0.12/_modules/torchvision/models/optical_flow/raft.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.models.optical_flow.raft &mdash; Torchvision main documentation</title>
+  <title>torchvision.models.optical_flow.raft &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/models/regnet.html
+++ b/0.12/_modules/torchvision/models/regnet.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.models.regnet &mdash; Torchvision main documentation</title>
+  <title>torchvision.models.regnet &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/models/resnet.html
+++ b/0.12/_modules/torchvision/models/resnet.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.models.resnet &mdash; Torchvision main documentation</title>
+  <title>torchvision.models.resnet &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/models/segmentation/deeplabv3.html
+++ b/0.12/_modules/torchvision/models/segmentation/deeplabv3.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.models.segmentation.deeplabv3 &mdash; Torchvision main documentation</title>
+  <title>torchvision.models.segmentation.deeplabv3 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/models/segmentation/fcn.html
+++ b/0.12/_modules/torchvision/models/segmentation/fcn.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.models.segmentation.fcn &mdash; Torchvision main documentation</title>
+  <title>torchvision.models.segmentation.fcn &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/models/segmentation/lraspp.html
+++ b/0.12/_modules/torchvision/models/segmentation/lraspp.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.models.segmentation.lraspp &mdash; Torchvision main documentation</title>
+  <title>torchvision.models.segmentation.lraspp &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/models/shufflenetv2.html
+++ b/0.12/_modules/torchvision/models/shufflenetv2.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.models.shufflenetv2 &mdash; Torchvision main documentation</title>
+  <title>torchvision.models.shufflenetv2 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/models/squeezenet.html
+++ b/0.12/_modules/torchvision/models/squeezenet.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.models.squeezenet &mdash; Torchvision main documentation</title>
+  <title>torchvision.models.squeezenet &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/models/vgg.html
+++ b/0.12/_modules/torchvision/models/vgg.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.models.vgg &mdash; Torchvision main documentation</title>
+  <title>torchvision.models.vgg &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/models/video/resnet.html
+++ b/0.12/_modules/torchvision/models/video/resnet.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.models.video.resnet &mdash; Torchvision main documentation</title>
+  <title>torchvision.models.video.resnet &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/models/vision_transformer.html
+++ b/0.12/_modules/torchvision/models/vision_transformer.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.models.vision_transformer &mdash; Torchvision main documentation</title>
+  <title>torchvision.models.vision_transformer &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/ops/boxes.html
+++ b/0.12/_modules/torchvision/ops/boxes.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.ops.boxes &mdash; Torchvision main documentation</title>
+  <title>torchvision.ops.boxes &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/ops/deform_conv.html
+++ b/0.12/_modules/torchvision/ops/deform_conv.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.ops.deform_conv &mdash; Torchvision main documentation</title>
+  <title>torchvision.ops.deform_conv &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/ops/feature_pyramid_network.html
+++ b/0.12/_modules/torchvision/ops/feature_pyramid_network.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.ops.feature_pyramid_network &mdash; Torchvision main documentation</title>
+  <title>torchvision.ops.feature_pyramid_network &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/ops/focal_loss.html
+++ b/0.12/_modules/torchvision/ops/focal_loss.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.ops.focal_loss &mdash; Torchvision main documentation</title>
+  <title>torchvision.ops.focal_loss &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/ops/giou_loss.html
+++ b/0.12/_modules/torchvision/ops/giou_loss.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.ops.giou_loss &mdash; Torchvision main documentation</title>
+  <title>torchvision.ops.giou_loss &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/ops/misc.html
+++ b/0.12/_modules/torchvision/ops/misc.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.ops.misc &mdash; Torchvision main documentation</title>
+  <title>torchvision.ops.misc &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/ops/poolers.html
+++ b/0.12/_modules/torchvision/ops/poolers.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.ops.poolers &mdash; Torchvision main documentation</title>
+  <title>torchvision.ops.poolers &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/ops/ps_roi_align.html
+++ b/0.12/_modules/torchvision/ops/ps_roi_align.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.ops.ps_roi_align &mdash; Torchvision main documentation</title>
+  <title>torchvision.ops.ps_roi_align &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/ops/ps_roi_pool.html
+++ b/0.12/_modules/torchvision/ops/ps_roi_pool.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.ops.ps_roi_pool &mdash; Torchvision main documentation</title>
+  <title>torchvision.ops.ps_roi_pool &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/ops/roi_align.html
+++ b/0.12/_modules/torchvision/ops/roi_align.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.ops.roi_align &mdash; Torchvision main documentation</title>
+  <title>torchvision.ops.roi_align &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/ops/roi_pool.html
+++ b/0.12/_modules/torchvision/ops/roi_pool.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.ops.roi_pool &mdash; Torchvision main documentation</title>
+  <title>torchvision.ops.roi_pool &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/ops/stochastic_depth.html
+++ b/0.12/_modules/torchvision/ops/stochastic_depth.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.ops.stochastic_depth &mdash; Torchvision main documentation</title>
+  <title>torchvision.ops.stochastic_depth &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/transforms/autoaugment.html
+++ b/0.12/_modules/torchvision/transforms/autoaugment.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.transforms.autoaugment &mdash; Torchvision main documentation</title>
+  <title>torchvision.transforms.autoaugment &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/transforms/functional.html
+++ b/0.12/_modules/torchvision/transforms/functional.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.transforms.functional &mdash; Torchvision main documentation</title>
+  <title>torchvision.transforms.functional &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/transforms/transforms.html
+++ b/0.12/_modules/torchvision/transforms/transforms.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.transforms.transforms &mdash; Torchvision main documentation</title>
+  <title>torchvision.transforms.transforms &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/_modules/torchvision/utils.html
+++ b/0.12/_modules/torchvision/utils.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.utils &mdash; Torchvision main documentation</title>
+  <title>torchvision.utils &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/auto_examples/index.html
+++ b/0.12/auto_examples/index.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Example gallery &mdash; Torchvision main documentation</title>
+  <title>Example gallery &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/auto_examples/plot_optical_flow.html
+++ b/0.12/auto_examples/plot_optical_flow.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Optical Flow: Predicting movement with the RAFT model &mdash; Torchvision main documentation</title>
+  <title>Optical Flow: Predicting movement with the RAFT model &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/auto_examples/plot_repurposing_annotations.html
+++ b/0.12/auto_examples/plot_repurposing_annotations.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Repurposing masks into bounding boxes &mdash; Torchvision main documentation</title>
+  <title>Repurposing masks into bounding boxes &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/auto_examples/plot_scripted_tensor_transforms.html
+++ b/0.12/auto_examples/plot_scripted_tensor_transforms.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Tensor transforms and JIT &mdash; Torchvision main documentation</title>
+  <title>Tensor transforms and JIT &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/auto_examples/plot_transforms.html
+++ b/0.12/auto_examples/plot_transforms.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Illustration of transforms &mdash; Torchvision main documentation</title>
+  <title>Illustration of transforms &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/auto_examples/plot_video_api.html
+++ b/0.12/auto_examples/plot_video_api.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Video API &mdash; Torchvision main documentation</title>
+  <title>Video API &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/auto_examples/plot_visualization_utils.html
+++ b/0.12/auto_examples/plot_visualization_utils.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Visualization utilities &mdash; Torchvision main documentation</title>
+  <title>Visualization utilities &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/auto_examples/sg_execution_times.html
+++ b/0.12/auto_examples/sg_execution_times.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Computation times &mdash; Torchvision main documentation</title>
+  <title>Computation times &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/datasets.html
+++ b/0.12/datasets.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Datasets &mdash; Torchvision main documentation</title>
+  <title>Datasets &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/feature_extraction.html
+++ b/0.12/feature_extraction.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Feature extraction for model inspection &mdash; Torchvision main documentation</title>
+  <title>Feature extraction for model inspection &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.datasets.CIFAR10.html
+++ b/0.12/generated/torchvision.datasets.CIFAR10.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>CIFAR10 &mdash; Torchvision main documentation</title>
+  <title>CIFAR10 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.datasets.CIFAR100.html
+++ b/0.12/generated/torchvision.datasets.CIFAR100.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>CIFAR100 &mdash; Torchvision main documentation</title>
+  <title>CIFAR100 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.datasets.Caltech101.html
+++ b/0.12/generated/torchvision.datasets.Caltech101.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Caltech101 &mdash; Torchvision main documentation</title>
+  <title>Caltech101 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.datasets.Caltech256.html
+++ b/0.12/generated/torchvision.datasets.Caltech256.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Caltech256 &mdash; Torchvision main documentation</title>
+  <title>Caltech256 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.datasets.CelebA.html
+++ b/0.12/generated/torchvision.datasets.CelebA.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>CelebA &mdash; Torchvision main documentation</title>
+  <title>CelebA &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.datasets.Cityscapes.html
+++ b/0.12/generated/torchvision.datasets.Cityscapes.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Cityscapes &mdash; Torchvision main documentation</title>
+  <title>Cityscapes &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.datasets.CocoCaptions.html
+++ b/0.12/generated/torchvision.datasets.CocoCaptions.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>CocoCaptions &mdash; Torchvision main documentation</title>
+  <title>CocoCaptions &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.datasets.CocoDetection.html
+++ b/0.12/generated/torchvision.datasets.CocoDetection.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>CocoDetection &mdash; Torchvision main documentation</title>
+  <title>CocoDetection &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.datasets.Country211.html
+++ b/0.12/generated/torchvision.datasets.Country211.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Country211 &mdash; Torchvision main documentation</title>
+  <title>Country211 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.datasets.DTD.html
+++ b/0.12/generated/torchvision.datasets.DTD.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>DTD &mdash; Torchvision main documentation</title>
+  <title>DTD &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.datasets.DatasetFolder.html
+++ b/0.12/generated/torchvision.datasets.DatasetFolder.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>DatasetFolder &mdash; Torchvision main documentation</title>
+  <title>DatasetFolder &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.datasets.EMNIST.html
+++ b/0.12/generated/torchvision.datasets.EMNIST.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>EMNIST &mdash; Torchvision main documentation</title>
+  <title>EMNIST &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.datasets.EuroSAT.html
+++ b/0.12/generated/torchvision.datasets.EuroSAT.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>EuroSAT &mdash; Torchvision main documentation</title>
+  <title>EuroSAT &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.datasets.FER2013.html
+++ b/0.12/generated/torchvision.datasets.FER2013.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>FER2013 &mdash; Torchvision main documentation</title>
+  <title>FER2013 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.datasets.FGVCAircraft.html
+++ b/0.12/generated/torchvision.datasets.FGVCAircraft.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>FGVCAircraft &mdash; Torchvision main documentation</title>
+  <title>FGVCAircraft &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.datasets.FakeData.html
+++ b/0.12/generated/torchvision.datasets.FakeData.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>FakeData &mdash; Torchvision main documentation</title>
+  <title>FakeData &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.datasets.FashionMNIST.html
+++ b/0.12/generated/torchvision.datasets.FashionMNIST.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>FashionMNIST &mdash; Torchvision main documentation</title>
+  <title>FashionMNIST &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.datasets.Flickr30k.html
+++ b/0.12/generated/torchvision.datasets.Flickr30k.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Flickr30k &mdash; Torchvision main documentation</title>
+  <title>Flickr30k &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.datasets.Flickr8k.html
+++ b/0.12/generated/torchvision.datasets.Flickr8k.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Flickr8k &mdash; Torchvision main documentation</title>
+  <title>Flickr8k &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.datasets.Flowers102.html
+++ b/0.12/generated/torchvision.datasets.Flowers102.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Flowers102 &mdash; Torchvision main documentation</title>
+  <title>Flowers102 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.datasets.FlyingChairs.html
+++ b/0.12/generated/torchvision.datasets.FlyingChairs.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>FlyingChairs &mdash; Torchvision main documentation</title>
+  <title>FlyingChairs &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.datasets.FlyingThings3D.html
+++ b/0.12/generated/torchvision.datasets.FlyingThings3D.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>FlyingThings3D &mdash; Torchvision main documentation</title>
+  <title>FlyingThings3D &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.datasets.Food101.html
+++ b/0.12/generated/torchvision.datasets.Food101.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Food101 &mdash; Torchvision main documentation</title>
+  <title>Food101 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.datasets.GTSRB.html
+++ b/0.12/generated/torchvision.datasets.GTSRB.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>GTSRB &mdash; Torchvision main documentation</title>
+  <title>GTSRB &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.datasets.HD1K.html
+++ b/0.12/generated/torchvision.datasets.HD1K.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>HD1K &mdash; Torchvision main documentation</title>
+  <title>HD1K &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.datasets.HMDB51.html
+++ b/0.12/generated/torchvision.datasets.HMDB51.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>HMDB51 &mdash; Torchvision main documentation</title>
+  <title>HMDB51 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.datasets.INaturalist.html
+++ b/0.12/generated/torchvision.datasets.INaturalist.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>INaturalist &mdash; Torchvision main documentation</title>
+  <title>INaturalist &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.datasets.ImageFolder.html
+++ b/0.12/generated/torchvision.datasets.ImageFolder.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>ImageFolder &mdash; Torchvision main documentation</title>
+  <title>ImageFolder &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.datasets.ImageNet.html
+++ b/0.12/generated/torchvision.datasets.ImageNet.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>ImageNet &mdash; Torchvision main documentation</title>
+  <title>ImageNet &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.datasets.KMNIST.html
+++ b/0.12/generated/torchvision.datasets.KMNIST.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>KMNIST &mdash; Torchvision main documentation</title>
+  <title>KMNIST &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.datasets.Kinetics.html
+++ b/0.12/generated/torchvision.datasets.Kinetics.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Kinetics &mdash; Torchvision main documentation</title>
+  <title>Kinetics &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.datasets.Kinetics400.html
+++ b/0.12/generated/torchvision.datasets.Kinetics400.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Kinetics400 &mdash; Torchvision main documentation</title>
+  <title>Kinetics400 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.datasets.Kitti.html
+++ b/0.12/generated/torchvision.datasets.Kitti.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Kitti &mdash; Torchvision main documentation</title>
+  <title>Kitti &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.datasets.KittiFlow.html
+++ b/0.12/generated/torchvision.datasets.KittiFlow.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>KittiFlow &mdash; Torchvision main documentation</title>
+  <title>KittiFlow &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.datasets.LFWPairs.html
+++ b/0.12/generated/torchvision.datasets.LFWPairs.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>LFWPairs &mdash; Torchvision main documentation</title>
+  <title>LFWPairs &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.datasets.LFWPeople.html
+++ b/0.12/generated/torchvision.datasets.LFWPeople.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>LFWPeople &mdash; Torchvision main documentation</title>
+  <title>LFWPeople &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.datasets.LSUN.html
+++ b/0.12/generated/torchvision.datasets.LSUN.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>LSUN &mdash; Torchvision main documentation</title>
+  <title>LSUN &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.datasets.MNIST.html
+++ b/0.12/generated/torchvision.datasets.MNIST.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>MNIST &mdash; Torchvision main documentation</title>
+  <title>MNIST &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.datasets.Omniglot.html
+++ b/0.12/generated/torchvision.datasets.Omniglot.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Omniglot &mdash; Torchvision main documentation</title>
+  <title>Omniglot &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.datasets.OxfordIIITPet.html
+++ b/0.12/generated/torchvision.datasets.OxfordIIITPet.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>OxfordIIITPet &mdash; Torchvision main documentation</title>
+  <title>OxfordIIITPet &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.datasets.PCAM.html
+++ b/0.12/generated/torchvision.datasets.PCAM.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>PCAM &mdash; Torchvision main documentation</title>
+  <title>PCAM &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.datasets.PhotoTour.html
+++ b/0.12/generated/torchvision.datasets.PhotoTour.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>PhotoTour &mdash; Torchvision main documentation</title>
+  <title>PhotoTour &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.datasets.Places365.html
+++ b/0.12/generated/torchvision.datasets.Places365.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Places365 &mdash; Torchvision main documentation</title>
+  <title>Places365 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.datasets.QMNIST.html
+++ b/0.12/generated/torchvision.datasets.QMNIST.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>QMNIST &mdash; Torchvision main documentation</title>
+  <title>QMNIST &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.datasets.RenderedSST2.html
+++ b/0.12/generated/torchvision.datasets.RenderedSST2.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>RenderedSST2 &mdash; Torchvision main documentation</title>
+  <title>RenderedSST2 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.datasets.SBDataset.html
+++ b/0.12/generated/torchvision.datasets.SBDataset.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>SBDataset &mdash; Torchvision main documentation</title>
+  <title>SBDataset &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.datasets.SBU.html
+++ b/0.12/generated/torchvision.datasets.SBU.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>SBU &mdash; Torchvision main documentation</title>
+  <title>SBU &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.datasets.SEMEION.html
+++ b/0.12/generated/torchvision.datasets.SEMEION.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>SEMEION &mdash; Torchvision main documentation</title>
+  <title>SEMEION &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.datasets.STL10.html
+++ b/0.12/generated/torchvision.datasets.STL10.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>STL10 &mdash; Torchvision main documentation</title>
+  <title>STL10 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.datasets.SUN397.html
+++ b/0.12/generated/torchvision.datasets.SUN397.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>SUN397 &mdash; Torchvision main documentation</title>
+  <title>SUN397 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.datasets.SVHN.html
+++ b/0.12/generated/torchvision.datasets.SVHN.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>SVHN &mdash; Torchvision main documentation</title>
+  <title>SVHN &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.datasets.Sintel.html
+++ b/0.12/generated/torchvision.datasets.Sintel.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Sintel &mdash; Torchvision main documentation</title>
+  <title>Sintel &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.datasets.StanfordCars.html
+++ b/0.12/generated/torchvision.datasets.StanfordCars.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>StanfordCars &mdash; Torchvision main documentation</title>
+  <title>StanfordCars &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.datasets.UCF101.html
+++ b/0.12/generated/torchvision.datasets.UCF101.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>UCF101 &mdash; Torchvision main documentation</title>
+  <title>UCF101 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.datasets.USPS.html
+++ b/0.12/generated/torchvision.datasets.USPS.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>USPS &mdash; Torchvision main documentation</title>
+  <title>USPS &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.datasets.VOCDetection.html
+++ b/0.12/generated/torchvision.datasets.VOCDetection.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>VOCDetection &mdash; Torchvision main documentation</title>
+  <title>VOCDetection &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.datasets.VOCSegmentation.html
+++ b/0.12/generated/torchvision.datasets.VOCSegmentation.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>VOCSegmentation &mdash; Torchvision main documentation</title>
+  <title>VOCSegmentation &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.datasets.VisionDataset.html
+++ b/0.12/generated/torchvision.datasets.VisionDataset.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>VisionDataset &mdash; Torchvision main documentation</title>
+  <title>VisionDataset &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.datasets.WIDERFace.html
+++ b/0.12/generated/torchvision.datasets.WIDERFace.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>WIDERFace &mdash; Torchvision main documentation</title>
+  <title>WIDERFace &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.io.ImageReadMode.html
+++ b/0.12/generated/torchvision.io.ImageReadMode.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>ImageReadMode &mdash; Torchvision main documentation</title>
+  <title>ImageReadMode &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.io.VideoReader.html
+++ b/0.12/generated/torchvision.io.VideoReader.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>VideoReader &mdash; Torchvision main documentation</title>
+  <title>VideoReader &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.io.decode_image.html
+++ b/0.12/generated/torchvision.io.decode_image.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>decode_image &mdash; Torchvision main documentation</title>
+  <title>decode_image &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.io.decode_jpeg.html
+++ b/0.12/generated/torchvision.io.decode_jpeg.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>decode_jpeg &mdash; Torchvision main documentation</title>
+  <title>decode_jpeg &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.io.decode_png.html
+++ b/0.12/generated/torchvision.io.decode_png.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>decode_png &mdash; Torchvision main documentation</title>
+  <title>decode_png &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.io.encode_jpeg.html
+++ b/0.12/generated/torchvision.io.encode_jpeg.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>encode_jpeg &mdash; Torchvision main documentation</title>
+  <title>encode_jpeg &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.io.encode_png.html
+++ b/0.12/generated/torchvision.io.encode_png.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>encode_png &mdash; Torchvision main documentation</title>
+  <title>encode_png &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.io.read_file.html
+++ b/0.12/generated/torchvision.io.read_file.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>read_file &mdash; Torchvision main documentation</title>
+  <title>read_file &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.io.read_image.html
+++ b/0.12/generated/torchvision.io.read_image.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>read_image &mdash; Torchvision main documentation</title>
+  <title>read_image &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.io.read_video.html
+++ b/0.12/generated/torchvision.io.read_video.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>read_video &mdash; Torchvision main documentation</title>
+  <title>read_video &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.io.read_video_timestamps.html
+++ b/0.12/generated/torchvision.io.read_video_timestamps.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>read_video_timestamps &mdash; Torchvision main documentation</title>
+  <title>read_video_timestamps &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.io.write_file.html
+++ b/0.12/generated/torchvision.io.write_file.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>write_file &mdash; Torchvision main documentation</title>
+  <title>write_file &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.io.write_jpeg.html
+++ b/0.12/generated/torchvision.io.write_jpeg.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>write_jpeg &mdash; Torchvision main documentation</title>
+  <title>write_jpeg &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.io.write_png.html
+++ b/0.12/generated/torchvision.io.write_png.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>write_png &mdash; Torchvision main documentation</title>
+  <title>write_png &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.io.write_video.html
+++ b/0.12/generated/torchvision.io.write_video.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>write_video &mdash; Torchvision main documentation</title>
+  <title>write_video &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.alexnet.html
+++ b/0.12/generated/torchvision.models.alexnet.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>alexnet &mdash; Torchvision main documentation</title>
+  <title>alexnet &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.convnext_base.html
+++ b/0.12/generated/torchvision.models.convnext_base.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>convnext_base &mdash; Torchvision main documentation</title>
+  <title>convnext_base &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.convnext_large.html
+++ b/0.12/generated/torchvision.models.convnext_large.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>convnext_large &mdash; Torchvision main documentation</title>
+  <title>convnext_large &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.convnext_small.html
+++ b/0.12/generated/torchvision.models.convnext_small.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>convnext_small &mdash; Torchvision main documentation</title>
+  <title>convnext_small &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.convnext_tiny.html
+++ b/0.12/generated/torchvision.models.convnext_tiny.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>convnext_tiny &mdash; Torchvision main documentation</title>
+  <title>convnext_tiny &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.densenet121.html
+++ b/0.12/generated/torchvision.models.densenet121.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>densenet121 &mdash; Torchvision main documentation</title>
+  <title>densenet121 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.densenet161.html
+++ b/0.12/generated/torchvision.models.densenet161.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>densenet161 &mdash; Torchvision main documentation</title>
+  <title>densenet161 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.densenet169.html
+++ b/0.12/generated/torchvision.models.densenet169.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>densenet169 &mdash; Torchvision main documentation</title>
+  <title>densenet169 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.densenet201.html
+++ b/0.12/generated/torchvision.models.densenet201.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>densenet201 &mdash; Torchvision main documentation</title>
+  <title>densenet201 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.detection.fasterrcnn_mobilenet_v3_large_320_fpn.html
+++ b/0.12/generated/torchvision.models.detection.fasterrcnn_mobilenet_v3_large_320_fpn.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>fasterrcnn_mobilenet_v3_large_320_fpn &mdash; Torchvision main documentation</title>
+  <title>fasterrcnn_mobilenet_v3_large_320_fpn &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.detection.fasterrcnn_mobilenet_v3_large_fpn.html
+++ b/0.12/generated/torchvision.models.detection.fasterrcnn_mobilenet_v3_large_fpn.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>fasterrcnn_mobilenet_v3_large_fpn &mdash; Torchvision main documentation</title>
+  <title>fasterrcnn_mobilenet_v3_large_fpn &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.detection.fasterrcnn_resnet50_fpn.html
+++ b/0.12/generated/torchvision.models.detection.fasterrcnn_resnet50_fpn.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>fasterrcnn_resnet50_fpn &mdash; Torchvision main documentation</title>
+  <title>fasterrcnn_resnet50_fpn &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.detection.fcos_resnet50_fpn.html
+++ b/0.12/generated/torchvision.models.detection.fcos_resnet50_fpn.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>fcos_resnet50_fpn &mdash; Torchvision main documentation</title>
+  <title>fcos_resnet50_fpn &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.detection.keypointrcnn_resnet50_fpn.html
+++ b/0.12/generated/torchvision.models.detection.keypointrcnn_resnet50_fpn.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>keypointrcnn_resnet50_fpn &mdash; Torchvision main documentation</title>
+  <title>keypointrcnn_resnet50_fpn &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.detection.maskrcnn_resnet50_fpn.html
+++ b/0.12/generated/torchvision.models.detection.maskrcnn_resnet50_fpn.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>maskrcnn_resnet50_fpn &mdash; Torchvision main documentation</title>
+  <title>maskrcnn_resnet50_fpn &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.detection.retinanet_resnet50_fpn.html
+++ b/0.12/generated/torchvision.models.detection.retinanet_resnet50_fpn.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>retinanet_resnet50_fpn &mdash; Torchvision main documentation</title>
+  <title>retinanet_resnet50_fpn &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.detection.ssd300_vgg16.html
+++ b/0.12/generated/torchvision.models.detection.ssd300_vgg16.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>ssd300_vgg16 &mdash; Torchvision main documentation</title>
+  <title>ssd300_vgg16 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.detection.ssdlite320_mobilenet_v3_large.html
+++ b/0.12/generated/torchvision.models.detection.ssdlite320_mobilenet_v3_large.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>ssdlite320_mobilenet_v3_large &mdash; Torchvision main documentation</title>
+  <title>ssdlite320_mobilenet_v3_large &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.efficientnet_b0.html
+++ b/0.12/generated/torchvision.models.efficientnet_b0.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>efficientnet_b0 &mdash; Torchvision main documentation</title>
+  <title>efficientnet_b0 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.efficientnet_b1.html
+++ b/0.12/generated/torchvision.models.efficientnet_b1.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>efficientnet_b1 &mdash; Torchvision main documentation</title>
+  <title>efficientnet_b1 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.efficientnet_b2.html
+++ b/0.12/generated/torchvision.models.efficientnet_b2.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>efficientnet_b2 &mdash; Torchvision main documentation</title>
+  <title>efficientnet_b2 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.efficientnet_b3.html
+++ b/0.12/generated/torchvision.models.efficientnet_b3.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>efficientnet_b3 &mdash; Torchvision main documentation</title>
+  <title>efficientnet_b3 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.efficientnet_b4.html
+++ b/0.12/generated/torchvision.models.efficientnet_b4.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>efficientnet_b4 &mdash; Torchvision main documentation</title>
+  <title>efficientnet_b4 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.efficientnet_b5.html
+++ b/0.12/generated/torchvision.models.efficientnet_b5.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>efficientnet_b5 &mdash; Torchvision main documentation</title>
+  <title>efficientnet_b5 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.efficientnet_b6.html
+++ b/0.12/generated/torchvision.models.efficientnet_b6.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>efficientnet_b6 &mdash; Torchvision main documentation</title>
+  <title>efficientnet_b6 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.efficientnet_b7.html
+++ b/0.12/generated/torchvision.models.efficientnet_b7.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>efficientnet_b7 &mdash; Torchvision main documentation</title>
+  <title>efficientnet_b7 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.feature_extraction.create_feature_extractor.html
+++ b/0.12/generated/torchvision.models.feature_extraction.create_feature_extractor.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>create_feature_extractor &mdash; Torchvision main documentation</title>
+  <title>create_feature_extractor &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.feature_extraction.get_graph_node_names.html
+++ b/0.12/generated/torchvision.models.feature_extraction.get_graph_node_names.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>get_graph_node_names &mdash; Torchvision main documentation</title>
+  <title>get_graph_node_names &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.googlenet.html
+++ b/0.12/generated/torchvision.models.googlenet.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>googlenet &mdash; Torchvision main documentation</title>
+  <title>googlenet &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.inception_v3.html
+++ b/0.12/generated/torchvision.models.inception_v3.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>inception_v3 &mdash; Torchvision main documentation</title>
+  <title>inception_v3 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.mnasnet0_5.html
+++ b/0.12/generated/torchvision.models.mnasnet0_5.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>mnasnet0_5 &mdash; Torchvision main documentation</title>
+  <title>mnasnet0_5 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.mnasnet0_75.html
+++ b/0.12/generated/torchvision.models.mnasnet0_75.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>mnasnet0_75 &mdash; Torchvision main documentation</title>
+  <title>mnasnet0_75 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.mnasnet1_0.html
+++ b/0.12/generated/torchvision.models.mnasnet1_0.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>mnasnet1_0 &mdash; Torchvision main documentation</title>
+  <title>mnasnet1_0 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.mnasnet1_3.html
+++ b/0.12/generated/torchvision.models.mnasnet1_3.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>mnasnet1_3 &mdash; Torchvision main documentation</title>
+  <title>mnasnet1_3 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.mobilenet_v2.html
+++ b/0.12/generated/torchvision.models.mobilenet_v2.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>mobilenet_v2 &mdash; Torchvision main documentation</title>
+  <title>mobilenet_v2 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.mobilenet_v3_large.html
+++ b/0.12/generated/torchvision.models.mobilenet_v3_large.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>mobilenet_v3_large &mdash; Torchvision main documentation</title>
+  <title>mobilenet_v3_large &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.mobilenet_v3_small.html
+++ b/0.12/generated/torchvision.models.mobilenet_v3_small.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>mobilenet_v3_small &mdash; Torchvision main documentation</title>
+  <title>mobilenet_v3_small &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.optical_flow.raft_large.html
+++ b/0.12/generated/torchvision.models.optical_flow.raft_large.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>raft_large &mdash; Torchvision main documentation</title>
+  <title>raft_large &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.optical_flow.raft_small.html
+++ b/0.12/generated/torchvision.models.optical_flow.raft_small.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>raft_small &mdash; Torchvision main documentation</title>
+  <title>raft_small &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.regnet_x_16gf.html
+++ b/0.12/generated/torchvision.models.regnet_x_16gf.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>regnet_x_16gf &mdash; Torchvision main documentation</title>
+  <title>regnet_x_16gf &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.regnet_x_1_6gf.html
+++ b/0.12/generated/torchvision.models.regnet_x_1_6gf.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>regnet_x_1_6gf &mdash; Torchvision main documentation</title>
+  <title>regnet_x_1_6gf &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.regnet_x_32gf.html
+++ b/0.12/generated/torchvision.models.regnet_x_32gf.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>regnet_x_32gf &mdash; Torchvision main documentation</title>
+  <title>regnet_x_32gf &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.regnet_x_3_2gf.html
+++ b/0.12/generated/torchvision.models.regnet_x_3_2gf.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>regnet_x_3_2gf &mdash; Torchvision main documentation</title>
+  <title>regnet_x_3_2gf &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.regnet_x_400mf.html
+++ b/0.12/generated/torchvision.models.regnet_x_400mf.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>regnet_x_400mf &mdash; Torchvision main documentation</title>
+  <title>regnet_x_400mf &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.regnet_x_800mf.html
+++ b/0.12/generated/torchvision.models.regnet_x_800mf.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>regnet_x_800mf &mdash; Torchvision main documentation</title>
+  <title>regnet_x_800mf &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.regnet_x_8gf.html
+++ b/0.12/generated/torchvision.models.regnet_x_8gf.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>regnet_x_8gf &mdash; Torchvision main documentation</title>
+  <title>regnet_x_8gf &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.regnet_y_128gf.html
+++ b/0.12/generated/torchvision.models.regnet_y_128gf.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>regnet_y_128gf &mdash; Torchvision main documentation</title>
+  <title>regnet_y_128gf &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.regnet_y_16gf.html
+++ b/0.12/generated/torchvision.models.regnet_y_16gf.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>regnet_y_16gf &mdash; Torchvision main documentation</title>
+  <title>regnet_y_16gf &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.regnet_y_1_6gf.html
+++ b/0.12/generated/torchvision.models.regnet_y_1_6gf.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>regnet_y_1_6gf &mdash; Torchvision main documentation</title>
+  <title>regnet_y_1_6gf &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.regnet_y_32gf.html
+++ b/0.12/generated/torchvision.models.regnet_y_32gf.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>regnet_y_32gf &mdash; Torchvision main documentation</title>
+  <title>regnet_y_32gf &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.regnet_y_3_2gf.html
+++ b/0.12/generated/torchvision.models.regnet_y_3_2gf.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>regnet_y_3_2gf &mdash; Torchvision main documentation</title>
+  <title>regnet_y_3_2gf &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.regnet_y_400mf.html
+++ b/0.12/generated/torchvision.models.regnet_y_400mf.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>regnet_y_400mf &mdash; Torchvision main documentation</title>
+  <title>regnet_y_400mf &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.regnet_y_800mf.html
+++ b/0.12/generated/torchvision.models.regnet_y_800mf.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>regnet_y_800mf &mdash; Torchvision main documentation</title>
+  <title>regnet_y_800mf &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.regnet_y_8gf.html
+++ b/0.12/generated/torchvision.models.regnet_y_8gf.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>regnet_y_8gf &mdash; Torchvision main documentation</title>
+  <title>regnet_y_8gf &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.resnet101.html
+++ b/0.12/generated/torchvision.models.resnet101.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>resnet101 &mdash; Torchvision main documentation</title>
+  <title>resnet101 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.resnet152.html
+++ b/0.12/generated/torchvision.models.resnet152.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>resnet152 &mdash; Torchvision main documentation</title>
+  <title>resnet152 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.resnet18.html
+++ b/0.12/generated/torchvision.models.resnet18.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>resnet18 &mdash; Torchvision main documentation</title>
+  <title>resnet18 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.resnet34.html
+++ b/0.12/generated/torchvision.models.resnet34.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>resnet34 &mdash; Torchvision main documentation</title>
+  <title>resnet34 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.resnet50.html
+++ b/0.12/generated/torchvision.models.resnet50.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>resnet50 &mdash; Torchvision main documentation</title>
+  <title>resnet50 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.resnext101_32x8d.html
+++ b/0.12/generated/torchvision.models.resnext101_32x8d.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>resnext101_32x8d &mdash; Torchvision main documentation</title>
+  <title>resnext101_32x8d &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.resnext50_32x4d.html
+++ b/0.12/generated/torchvision.models.resnext50_32x4d.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>resnext50_32x4d &mdash; Torchvision main documentation</title>
+  <title>resnext50_32x4d &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.segmentation.deeplabv3_mobilenet_v3_large.html
+++ b/0.12/generated/torchvision.models.segmentation.deeplabv3_mobilenet_v3_large.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>deeplabv3_mobilenet_v3_large &mdash; Torchvision main documentation</title>
+  <title>deeplabv3_mobilenet_v3_large &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.segmentation.deeplabv3_resnet101.html
+++ b/0.12/generated/torchvision.models.segmentation.deeplabv3_resnet101.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>deeplabv3_resnet101 &mdash; Torchvision main documentation</title>
+  <title>deeplabv3_resnet101 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.segmentation.deeplabv3_resnet50.html
+++ b/0.12/generated/torchvision.models.segmentation.deeplabv3_resnet50.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>deeplabv3_resnet50 &mdash; Torchvision main documentation</title>
+  <title>deeplabv3_resnet50 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.segmentation.fcn_resnet101.html
+++ b/0.12/generated/torchvision.models.segmentation.fcn_resnet101.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>fcn_resnet101 &mdash; Torchvision main documentation</title>
+  <title>fcn_resnet101 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.segmentation.fcn_resnet50.html
+++ b/0.12/generated/torchvision.models.segmentation.fcn_resnet50.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>fcn_resnet50 &mdash; Torchvision main documentation</title>
+  <title>fcn_resnet50 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.segmentation.lraspp_mobilenet_v3_large.html
+++ b/0.12/generated/torchvision.models.segmentation.lraspp_mobilenet_v3_large.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>lraspp_mobilenet_v3_large &mdash; Torchvision main documentation</title>
+  <title>lraspp_mobilenet_v3_large &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.shufflenet_v2_x0_5.html
+++ b/0.12/generated/torchvision.models.shufflenet_v2_x0_5.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>shufflenet_v2_x0_5 &mdash; Torchvision main documentation</title>
+  <title>shufflenet_v2_x0_5 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.shufflenet_v2_x1_0.html
+++ b/0.12/generated/torchvision.models.shufflenet_v2_x1_0.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>shufflenet_v2_x1_0 &mdash; Torchvision main documentation</title>
+  <title>shufflenet_v2_x1_0 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.shufflenet_v2_x1_5.html
+++ b/0.12/generated/torchvision.models.shufflenet_v2_x1_5.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>shufflenet_v2_x1_5 &mdash; Torchvision main documentation</title>
+  <title>shufflenet_v2_x1_5 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.shufflenet_v2_x2_0.html
+++ b/0.12/generated/torchvision.models.shufflenet_v2_x2_0.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>shufflenet_v2_x2_0 &mdash; Torchvision main documentation</title>
+  <title>shufflenet_v2_x2_0 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.squeezenet1_0.html
+++ b/0.12/generated/torchvision.models.squeezenet1_0.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>squeezenet1_0 &mdash; Torchvision main documentation</title>
+  <title>squeezenet1_0 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.squeezenet1_1.html
+++ b/0.12/generated/torchvision.models.squeezenet1_1.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>squeezenet1_1 &mdash; Torchvision main documentation</title>
+  <title>squeezenet1_1 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.vgg11.html
+++ b/0.12/generated/torchvision.models.vgg11.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>vgg11 &mdash; Torchvision main documentation</title>
+  <title>vgg11 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.vgg11_bn.html
+++ b/0.12/generated/torchvision.models.vgg11_bn.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>vgg11_bn &mdash; Torchvision main documentation</title>
+  <title>vgg11_bn &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.vgg13.html
+++ b/0.12/generated/torchvision.models.vgg13.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>vgg13 &mdash; Torchvision main documentation</title>
+  <title>vgg13 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.vgg13_bn.html
+++ b/0.12/generated/torchvision.models.vgg13_bn.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>vgg13_bn &mdash; Torchvision main documentation</title>
+  <title>vgg13_bn &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.vgg16.html
+++ b/0.12/generated/torchvision.models.vgg16.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>vgg16 &mdash; Torchvision main documentation</title>
+  <title>vgg16 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.vgg16_bn.html
+++ b/0.12/generated/torchvision.models.vgg16_bn.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>vgg16_bn &mdash; Torchvision main documentation</title>
+  <title>vgg16_bn &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.vgg19.html
+++ b/0.12/generated/torchvision.models.vgg19.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>vgg19 &mdash; Torchvision main documentation</title>
+  <title>vgg19 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.vgg19_bn.html
+++ b/0.12/generated/torchvision.models.vgg19_bn.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>vgg19_bn &mdash; Torchvision main documentation</title>
+  <title>vgg19_bn &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.video.mc3_18.html
+++ b/0.12/generated/torchvision.models.video.mc3_18.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>mc3_18 &mdash; Torchvision main documentation</title>
+  <title>mc3_18 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.video.r2plus1d_18.html
+++ b/0.12/generated/torchvision.models.video.r2plus1d_18.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>r2plus1d_18 &mdash; Torchvision main documentation</title>
+  <title>r2plus1d_18 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.video.r3d_18.html
+++ b/0.12/generated/torchvision.models.video.r3d_18.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>r3d_18 &mdash; Torchvision main documentation</title>
+  <title>r3d_18 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.vit_b_16.html
+++ b/0.12/generated/torchvision.models.vit_b_16.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>vit_b_16 &mdash; Torchvision main documentation</title>
+  <title>vit_b_16 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.vit_b_32.html
+++ b/0.12/generated/torchvision.models.vit_b_32.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>vit_b_32 &mdash; Torchvision main documentation</title>
+  <title>vit_b_32 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.vit_l_16.html
+++ b/0.12/generated/torchvision.models.vit_l_16.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>vit_l_16 &mdash; Torchvision main documentation</title>
+  <title>vit_l_16 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.vit_l_32.html
+++ b/0.12/generated/torchvision.models.vit_l_32.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>vit_l_32 &mdash; Torchvision main documentation</title>
+  <title>vit_l_32 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.wide_resnet101_2.html
+++ b/0.12/generated/torchvision.models.wide_resnet101_2.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>wide_resnet101_2 &mdash; Torchvision main documentation</title>
+  <title>wide_resnet101_2 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.models.wide_resnet50_2.html
+++ b/0.12/generated/torchvision.models.wide_resnet50_2.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>wide_resnet50_2 &mdash; Torchvision main documentation</title>
+  <title>wide_resnet50_2 &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.ops.DeformConv2d.html
+++ b/0.12/generated/torchvision.ops.DeformConv2d.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>DeformConv2d &mdash; Torchvision main documentation</title>
+  <title>DeformConv2d &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.ops.FeaturePyramidNetwork.html
+++ b/0.12/generated/torchvision.ops.FeaturePyramidNetwork.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>FeaturePyramidNetwork &mdash; Torchvision main documentation</title>
+  <title>FeaturePyramidNetwork &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.ops.FrozenBatchNorm2d.html
+++ b/0.12/generated/torchvision.ops.FrozenBatchNorm2d.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>FrozenBatchNorm2d &mdash; Torchvision main documentation</title>
+  <title>FrozenBatchNorm2d &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.ops.MultiScaleRoIAlign.html
+++ b/0.12/generated/torchvision.ops.MultiScaleRoIAlign.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>MultiScaleRoIAlign &mdash; Torchvision main documentation</title>
+  <title>MultiScaleRoIAlign &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.ops.PSRoIAlign.html
+++ b/0.12/generated/torchvision.ops.PSRoIAlign.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>PSRoIAlign &mdash; Torchvision main documentation</title>
+  <title>PSRoIAlign &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.ops.PSRoIPool.html
+++ b/0.12/generated/torchvision.ops.PSRoIPool.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>PSRoIPool &mdash; Torchvision main documentation</title>
+  <title>PSRoIPool &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.ops.RoIAlign.html
+++ b/0.12/generated/torchvision.ops.RoIAlign.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>RoIAlign &mdash; Torchvision main documentation</title>
+  <title>RoIAlign &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.ops.RoIPool.html
+++ b/0.12/generated/torchvision.ops.RoIPool.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>RoIPool &mdash; Torchvision main documentation</title>
+  <title>RoIPool &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.ops.SqueezeExcitation.html
+++ b/0.12/generated/torchvision.ops.SqueezeExcitation.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>SqueezeExcitation &mdash; Torchvision main documentation</title>
+  <title>SqueezeExcitation &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.ops.StochasticDepth.html
+++ b/0.12/generated/torchvision.ops.StochasticDepth.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>StochasticDepth &mdash; Torchvision main documentation</title>
+  <title>StochasticDepth &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.ops.batched_nms.html
+++ b/0.12/generated/torchvision.ops.batched_nms.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>batched_nms &mdash; Torchvision main documentation</title>
+  <title>batched_nms &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.ops.box_area.html
+++ b/0.12/generated/torchvision.ops.box_area.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>box_area &mdash; Torchvision main documentation</title>
+  <title>box_area &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.ops.box_convert.html
+++ b/0.12/generated/torchvision.ops.box_convert.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>box_convert &mdash; Torchvision main documentation</title>
+  <title>box_convert &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.ops.box_iou.html
+++ b/0.12/generated/torchvision.ops.box_iou.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>box_iou &mdash; Torchvision main documentation</title>
+  <title>box_iou &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.ops.clip_boxes_to_image.html
+++ b/0.12/generated/torchvision.ops.clip_boxes_to_image.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>clip_boxes_to_image &mdash; Torchvision main documentation</title>
+  <title>clip_boxes_to_image &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.ops.deform_conv2d.html
+++ b/0.12/generated/torchvision.ops.deform_conv2d.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>deform_conv2d &mdash; Torchvision main documentation</title>
+  <title>deform_conv2d &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.ops.generalized_box_iou.html
+++ b/0.12/generated/torchvision.ops.generalized_box_iou.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>generalized_box_iou &mdash; Torchvision main documentation</title>
+  <title>generalized_box_iou &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.ops.generalized_box_iou_loss.html
+++ b/0.12/generated/torchvision.ops.generalized_box_iou_loss.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>generalized_box_iou_loss &mdash; Torchvision main documentation</title>
+  <title>generalized_box_iou_loss &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.ops.masks_to_boxes.html
+++ b/0.12/generated/torchvision.ops.masks_to_boxes.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>masks_to_boxes &mdash; Torchvision main documentation</title>
+  <title>masks_to_boxes &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.ops.nms.html
+++ b/0.12/generated/torchvision.ops.nms.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>nms &mdash; Torchvision main documentation</title>
+  <title>nms &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.ops.ps_roi_align.html
+++ b/0.12/generated/torchvision.ops.ps_roi_align.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>ps_roi_align &mdash; Torchvision main documentation</title>
+  <title>ps_roi_align &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.ops.ps_roi_pool.html
+++ b/0.12/generated/torchvision.ops.ps_roi_pool.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>ps_roi_pool &mdash; Torchvision main documentation</title>
+  <title>ps_roi_pool &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.ops.remove_small_boxes.html
+++ b/0.12/generated/torchvision.ops.remove_small_boxes.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>remove_small_boxes &mdash; Torchvision main documentation</title>
+  <title>remove_small_boxes &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.ops.roi_align.html
+++ b/0.12/generated/torchvision.ops.roi_align.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>roi_align &mdash; Torchvision main documentation</title>
+  <title>roi_align &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.ops.roi_pool.html
+++ b/0.12/generated/torchvision.ops.roi_pool.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>roi_pool &mdash; Torchvision main documentation</title>
+  <title>roi_pool &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.ops.sigmoid_focal_loss.html
+++ b/0.12/generated/torchvision.ops.sigmoid_focal_loss.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>sigmoid_focal_loss &mdash; Torchvision main documentation</title>
+  <title>sigmoid_focal_loss &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.ops.stochastic_depth.html
+++ b/0.12/generated/torchvision.ops.stochastic_depth.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>stochastic_depth &mdash; Torchvision main documentation</title>
+  <title>stochastic_depth &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.AutoAugment.html
+++ b/0.12/generated/torchvision.transforms.AutoAugment.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>AutoAugment &mdash; Torchvision main documentation</title>
+  <title>AutoAugment &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.AutoAugmentPolicy.html
+++ b/0.12/generated/torchvision.transforms.AutoAugmentPolicy.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>AutoAugmentPolicy &mdash; Torchvision main documentation</title>
+  <title>AutoAugmentPolicy &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.CenterCrop.html
+++ b/0.12/generated/torchvision.transforms.CenterCrop.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>CenterCrop &mdash; Torchvision main documentation</title>
+  <title>CenterCrop &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.ColorJitter.html
+++ b/0.12/generated/torchvision.transforms.ColorJitter.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>ColorJitter &mdash; Torchvision main documentation</title>
+  <title>ColorJitter &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.Compose.html
+++ b/0.12/generated/torchvision.transforms.Compose.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Compose &mdash; Torchvision main documentation</title>
+  <title>Compose &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.ConvertImageDtype.html
+++ b/0.12/generated/torchvision.transforms.ConvertImageDtype.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>ConvertImageDtype &mdash; Torchvision main documentation</title>
+  <title>ConvertImageDtype &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.FiveCrop.html
+++ b/0.12/generated/torchvision.transforms.FiveCrop.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>FiveCrop &mdash; Torchvision main documentation</title>
+  <title>FiveCrop &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.GaussianBlur.html
+++ b/0.12/generated/torchvision.transforms.GaussianBlur.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>GaussianBlur &mdash; Torchvision main documentation</title>
+  <title>GaussianBlur &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.Grayscale.html
+++ b/0.12/generated/torchvision.transforms.Grayscale.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Grayscale &mdash; Torchvision main documentation</title>
+  <title>Grayscale &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.Lambda.html
+++ b/0.12/generated/torchvision.transforms.Lambda.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Lambda &mdash; Torchvision main documentation</title>
+  <title>Lambda &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.LinearTransformation.html
+++ b/0.12/generated/torchvision.transforms.LinearTransformation.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>LinearTransformation &mdash; Torchvision main documentation</title>
+  <title>LinearTransformation &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.Normalize.html
+++ b/0.12/generated/torchvision.transforms.Normalize.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Normalize &mdash; Torchvision main documentation</title>
+  <title>Normalize &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.PILToTensor.html
+++ b/0.12/generated/torchvision.transforms.PILToTensor.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>PILToTensor &mdash; Torchvision main documentation</title>
+  <title>PILToTensor &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.Pad.html
+++ b/0.12/generated/torchvision.transforms.Pad.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Pad &mdash; Torchvision main documentation</title>
+  <title>Pad &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.RandAugment.html
+++ b/0.12/generated/torchvision.transforms.RandAugment.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>RandAugment &mdash; Torchvision main documentation</title>
+  <title>RandAugment &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.RandomAdjustSharpness.html
+++ b/0.12/generated/torchvision.transforms.RandomAdjustSharpness.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>RandomAdjustSharpness &mdash; Torchvision main documentation</title>
+  <title>RandomAdjustSharpness &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.RandomAffine.html
+++ b/0.12/generated/torchvision.transforms.RandomAffine.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>RandomAffine &mdash; Torchvision main documentation</title>
+  <title>RandomAffine &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.RandomApply.html
+++ b/0.12/generated/torchvision.transforms.RandomApply.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>RandomApply &mdash; Torchvision main documentation</title>
+  <title>RandomApply &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.RandomAutocontrast.html
+++ b/0.12/generated/torchvision.transforms.RandomAutocontrast.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>RandomAutocontrast &mdash; Torchvision main documentation</title>
+  <title>RandomAutocontrast &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.RandomChoice.html
+++ b/0.12/generated/torchvision.transforms.RandomChoice.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>RandomChoice &mdash; Torchvision main documentation</title>
+  <title>RandomChoice &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.RandomCrop.html
+++ b/0.12/generated/torchvision.transforms.RandomCrop.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>RandomCrop &mdash; Torchvision main documentation</title>
+  <title>RandomCrop &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.RandomEqualize.html
+++ b/0.12/generated/torchvision.transforms.RandomEqualize.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>RandomEqualize &mdash; Torchvision main documentation</title>
+  <title>RandomEqualize &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.RandomErasing.html
+++ b/0.12/generated/torchvision.transforms.RandomErasing.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>RandomErasing &mdash; Torchvision main documentation</title>
+  <title>RandomErasing &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.RandomGrayscale.html
+++ b/0.12/generated/torchvision.transforms.RandomGrayscale.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>RandomGrayscale &mdash; Torchvision main documentation</title>
+  <title>RandomGrayscale &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.RandomHorizontalFlip.html
+++ b/0.12/generated/torchvision.transforms.RandomHorizontalFlip.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>RandomHorizontalFlip &mdash; Torchvision main documentation</title>
+  <title>RandomHorizontalFlip &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.RandomInvert.html
+++ b/0.12/generated/torchvision.transforms.RandomInvert.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>RandomInvert &mdash; Torchvision main documentation</title>
+  <title>RandomInvert &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.RandomOrder.html
+++ b/0.12/generated/torchvision.transforms.RandomOrder.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>RandomOrder &mdash; Torchvision main documentation</title>
+  <title>RandomOrder &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.RandomPerspective.html
+++ b/0.12/generated/torchvision.transforms.RandomPerspective.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>RandomPerspective &mdash; Torchvision main documentation</title>
+  <title>RandomPerspective &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.RandomPosterize.html
+++ b/0.12/generated/torchvision.transforms.RandomPosterize.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>RandomPosterize &mdash; Torchvision main documentation</title>
+  <title>RandomPosterize &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.RandomResizedCrop.html
+++ b/0.12/generated/torchvision.transforms.RandomResizedCrop.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>RandomResizedCrop &mdash; Torchvision main documentation</title>
+  <title>RandomResizedCrop &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.RandomRotation.html
+++ b/0.12/generated/torchvision.transforms.RandomRotation.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>RandomRotation &mdash; Torchvision main documentation</title>
+  <title>RandomRotation &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.RandomSolarize.html
+++ b/0.12/generated/torchvision.transforms.RandomSolarize.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>RandomSolarize &mdash; Torchvision main documentation</title>
+  <title>RandomSolarize &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.RandomVerticalFlip.html
+++ b/0.12/generated/torchvision.transforms.RandomVerticalFlip.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>RandomVerticalFlip &mdash; Torchvision main documentation</title>
+  <title>RandomVerticalFlip &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.Resize.html
+++ b/0.12/generated/torchvision.transforms.Resize.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Resize &mdash; Torchvision main documentation</title>
+  <title>Resize &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.TenCrop.html
+++ b/0.12/generated/torchvision.transforms.TenCrop.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>TenCrop &mdash; Torchvision main documentation</title>
+  <title>TenCrop &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.ToPILImage.html
+++ b/0.12/generated/torchvision.transforms.ToPILImage.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>ToPILImage &mdash; Torchvision main documentation</title>
+  <title>ToPILImage &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.ToTensor.html
+++ b/0.12/generated/torchvision.transforms.ToTensor.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>ToTensor &mdash; Torchvision main documentation</title>
+  <title>ToTensor &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.TrivialAugmentWide.html
+++ b/0.12/generated/torchvision.transforms.TrivialAugmentWide.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>TrivialAugmentWide &mdash; Torchvision main documentation</title>
+  <title>TrivialAugmentWide &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.functional.adjust_brightness.html
+++ b/0.12/generated/torchvision.transforms.functional.adjust_brightness.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>adjust_brightness &mdash; Torchvision main documentation</title>
+  <title>adjust_brightness &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.functional.adjust_contrast.html
+++ b/0.12/generated/torchvision.transforms.functional.adjust_contrast.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>adjust_contrast &mdash; Torchvision main documentation</title>
+  <title>adjust_contrast &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.functional.adjust_gamma.html
+++ b/0.12/generated/torchvision.transforms.functional.adjust_gamma.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>adjust_gamma &mdash; Torchvision main documentation</title>
+  <title>adjust_gamma &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.functional.adjust_hue.html
+++ b/0.12/generated/torchvision.transforms.functional.adjust_hue.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>adjust_hue &mdash; Torchvision main documentation</title>
+  <title>adjust_hue &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.functional.adjust_saturation.html
+++ b/0.12/generated/torchvision.transforms.functional.adjust_saturation.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>adjust_saturation &mdash; Torchvision main documentation</title>
+  <title>adjust_saturation &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.functional.adjust_sharpness.html
+++ b/0.12/generated/torchvision.transforms.functional.adjust_sharpness.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>adjust_sharpness &mdash; Torchvision main documentation</title>
+  <title>adjust_sharpness &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.functional.affine.html
+++ b/0.12/generated/torchvision.transforms.functional.affine.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>affine &mdash; Torchvision main documentation</title>
+  <title>affine &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.functional.autocontrast.html
+++ b/0.12/generated/torchvision.transforms.functional.autocontrast.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>autocontrast &mdash; Torchvision main documentation</title>
+  <title>autocontrast &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.functional.center_crop.html
+++ b/0.12/generated/torchvision.transforms.functional.center_crop.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>center_crop &mdash; Torchvision main documentation</title>
+  <title>center_crop &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.functional.convert_image_dtype.html
+++ b/0.12/generated/torchvision.transforms.functional.convert_image_dtype.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>convert_image_dtype &mdash; Torchvision main documentation</title>
+  <title>convert_image_dtype &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.functional.crop.html
+++ b/0.12/generated/torchvision.transforms.functional.crop.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>crop &mdash; Torchvision main documentation</title>
+  <title>crop &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.functional.equalize.html
+++ b/0.12/generated/torchvision.transforms.functional.equalize.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>equalize &mdash; Torchvision main documentation</title>
+  <title>equalize &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.functional.erase.html
+++ b/0.12/generated/torchvision.transforms.functional.erase.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>erase &mdash; Torchvision main documentation</title>
+  <title>erase &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.functional.five_crop.html
+++ b/0.12/generated/torchvision.transforms.functional.five_crop.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>five_crop &mdash; Torchvision main documentation</title>
+  <title>five_crop &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.functional.gaussian_blur.html
+++ b/0.12/generated/torchvision.transforms.functional.gaussian_blur.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>gaussian_blur &mdash; Torchvision main documentation</title>
+  <title>gaussian_blur &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.functional.get_image_num_channels.html
+++ b/0.12/generated/torchvision.transforms.functional.get_image_num_channels.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>get_image_num_channels &mdash; Torchvision main documentation</title>
+  <title>get_image_num_channels &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.functional.get_image_size.html
+++ b/0.12/generated/torchvision.transforms.functional.get_image_size.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>get_image_size &mdash; Torchvision main documentation</title>
+  <title>get_image_size &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.functional.hflip.html
+++ b/0.12/generated/torchvision.transforms.functional.hflip.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>hflip &mdash; Torchvision main documentation</title>
+  <title>hflip &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.functional.invert.html
+++ b/0.12/generated/torchvision.transforms.functional.invert.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>invert &mdash; Torchvision main documentation</title>
+  <title>invert &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.functional.normalize.html
+++ b/0.12/generated/torchvision.transforms.functional.normalize.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>normalize &mdash; Torchvision main documentation</title>
+  <title>normalize &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.functional.pad.html
+++ b/0.12/generated/torchvision.transforms.functional.pad.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>pad &mdash; Torchvision main documentation</title>
+  <title>pad &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.functional.perspective.html
+++ b/0.12/generated/torchvision.transforms.functional.perspective.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>perspective &mdash; Torchvision main documentation</title>
+  <title>perspective &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.functional.pil_to_tensor.html
+++ b/0.12/generated/torchvision.transforms.functional.pil_to_tensor.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>pil_to_tensor &mdash; Torchvision main documentation</title>
+  <title>pil_to_tensor &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.functional.posterize.html
+++ b/0.12/generated/torchvision.transforms.functional.posterize.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>posterize &mdash; Torchvision main documentation</title>
+  <title>posterize &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.functional.resize.html
+++ b/0.12/generated/torchvision.transforms.functional.resize.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>resize &mdash; Torchvision main documentation</title>
+  <title>resize &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.functional.resized_crop.html
+++ b/0.12/generated/torchvision.transforms.functional.resized_crop.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>resized_crop &mdash; Torchvision main documentation</title>
+  <title>resized_crop &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.functional.rgb_to_grayscale.html
+++ b/0.12/generated/torchvision.transforms.functional.rgb_to_grayscale.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>rgb_to_grayscale &mdash; Torchvision main documentation</title>
+  <title>rgb_to_grayscale &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.functional.rotate.html
+++ b/0.12/generated/torchvision.transforms.functional.rotate.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>rotate &mdash; Torchvision main documentation</title>
+  <title>rotate &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.functional.solarize.html
+++ b/0.12/generated/torchvision.transforms.functional.solarize.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>solarize &mdash; Torchvision main documentation</title>
+  <title>solarize &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.functional.ten_crop.html
+++ b/0.12/generated/torchvision.transforms.functional.ten_crop.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>ten_crop &mdash; Torchvision main documentation</title>
+  <title>ten_crop &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.functional.to_grayscale.html
+++ b/0.12/generated/torchvision.transforms.functional.to_grayscale.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>to_grayscale &mdash; Torchvision main documentation</title>
+  <title>to_grayscale &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.functional.to_pil_image.html
+++ b/0.12/generated/torchvision.transforms.functional.to_pil_image.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>to_pil_image &mdash; Torchvision main documentation</title>
+  <title>to_pil_image &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.functional.to_tensor.html
+++ b/0.12/generated/torchvision.transforms.functional.to_tensor.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>to_tensor &mdash; Torchvision main documentation</title>
+  <title>to_tensor &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.transforms.functional.vflip.html
+++ b/0.12/generated/torchvision.transforms.functional.vflip.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>vflip &mdash; Torchvision main documentation</title>
+  <title>vflip &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.utils.draw_bounding_boxes.html
+++ b/0.12/generated/torchvision.utils.draw_bounding_boxes.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>draw_bounding_boxes &mdash; Torchvision main documentation</title>
+  <title>draw_bounding_boxes &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.utils.draw_keypoints.html
+++ b/0.12/generated/torchvision.utils.draw_keypoints.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>draw_keypoints &mdash; Torchvision main documentation</title>
+  <title>draw_keypoints &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.utils.draw_segmentation_masks.html
+++ b/0.12/generated/torchvision.utils.draw_segmentation_masks.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>draw_segmentation_masks &mdash; Torchvision main documentation</title>
+  <title>draw_segmentation_masks &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.utils.flow_to_image.html
+++ b/0.12/generated/torchvision.utils.flow_to_image.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>flow_to_image &mdash; Torchvision main documentation</title>
+  <title>flow_to_image &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.utils.make_grid.html
+++ b/0.12/generated/torchvision.utils.make_grid.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>make_grid &mdash; Torchvision main documentation</title>
+  <title>make_grid &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/generated/torchvision.utils.save_image.html
+++ b/0.12/generated/torchvision.utils.save_image.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>save_image &mdash; Torchvision main documentation</title>
+  <title>save_image &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/genindex.html
+++ b/0.12/genindex.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Index &mdash; Torchvision main documentation</title>
+  <title>Index &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/index.html
+++ b/0.12/index.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision &mdash; Torchvision main documentation</title>
+  <title>torchvision &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/io.html
+++ b/0.12/io.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Reading/Writing images and videos &mdash; Torchvision main documentation</title>
+  <title>Reading/Writing images and videos &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/models.html
+++ b/0.12/models.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Models and pre-trained weights &mdash; Torchvision main documentation</title>
+  <title>Models and pre-trained weights &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/ops.html
+++ b/0.12/ops.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Operators &mdash; Torchvision main documentation</title>
+  <title>Operators &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/py-modindex.html
+++ b/0.12/py-modindex.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Python Module Index &mdash; Torchvision main documentation</title>
+  <title>Python Module Index &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/search.html
+++ b/0.12/search.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Search &mdash; Torchvision main documentation</title>
+  <title>Search &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/training_references.html
+++ b/0.12/training_references.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Training references &mdash; Torchvision main documentation</title>
+  <title>Training references &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/transforms.html
+++ b/0.12/transforms.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Transforming and augmenting images &mdash; Torchvision main documentation</title>
+  <title>Transforming and augmenting images &mdash; Torchvision 0.12 documentation</title>
   
 
   

--- a/0.12/utils.html
+++ b/0.12/utils.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Utils &mdash; Torchvision main documentation</title>
+  <title>Utils &mdash; Torchvision 0.12 documentation</title>
   
 
   


### PR DESCRIPTION
Closes https://github.com/pytorch/vision/issues/5582 and addresses this missing bit: https://github.com/pytorch/vision/pull/5588#issuecomment-1064458058

I just ran 

```
find . -type f  | xargs sed -i "s/Torchvision main documentation/Torchvision 0.12 documentation/g"
```

in the `0.12` folder.

@mattip does this look good to you? Thanks!