### PR TITLE
Bump up LibTorchvision version number for Podspec to release Cocoapods

### DIFF
--- a/ios/LibTorchvision.podspec
+++ b/ios/LibTorchvision.podspec
@@ -1,8 +1,8 @@
-pytorch_version = '1.10.0'
+pytorch_version = '1.11.0'
 
 Pod::Spec.new do |s|
     s.name             = 'LibTorchvision'
-    s.version          = '0.11.1'
+    s.version          = '0.12.0'
     s.authors          = 'PyTorch Team'
     s.license          = { :type => 'BSD' }
     s.homepage         = 'https://github.com/pytorch/vision'


### PR DESCRIPTION
As in the title. 

Currently the LibTorch pod 1.11 is failing with pod LibTorchvision 0.11.1