### PR TITLE
Remove unnecessary PYTORCH_TEST_WITH_SLOW env

### DIFF
--- a/.circleci/unittest/linux/scripts/run_test.sh
+++ b/.circleci/unittest/linux/scripts/run_test.sh
@@ -5,6 +5,5 @@ set -e
 eval "$(./conda/bin/conda shell.bash hook)"
 conda activate ./env
 
-export PYTORCH_TEST_WITH_SLOW='1'
 python -m torch.utils.collect_env
 pytest --junitxml=test-results/junit.xml -v --durations 20

--- a/.circleci/unittest/windows/scripts/run_test.sh
+++ b/.circleci/unittest/windows/scripts/run_test.sh
@@ -8,6 +8,5 @@ conda activate ./env
 this_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 source "$this_dir/set_cuda_envs.sh"
 
-export PYTORCH_TEST_WITH_SLOW='1'
 python -m torch.utils.collect_env
 pytest --junitxml=test-results/junit.xml -v --durations 20

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -118,7 +118,7 @@ def _assert_expected(output, name, prec=None, atol=None, rtol=None):
         torch.testing.assert_close(output, expected, rtol=rtol, atol=atol, check_dtype=False)
 
 
-def _check_jit_scriptable(nn_module, args, unwrapper=None, skip=False, eager_out=None):
+def _check_jit_scriptable(nn_module, args, unwrapper=None, eager_out=None):
     """Check that a nn.Module's results in TorchScript match eager and that it can be exported"""
 
     def get_export_import_copy(m):
@@ -128,12 +128,6 @@ def _check_jit_scriptable(nn_module, args, unwrapper=None, skip=False, eager_out
             m.save(path)
             imported = torch.jit.load(path)
         return imported
-
-    if skip:
-        # TorchScript is not enabled, skip these tests
-        msg = f"The check_jit_scriptable test for {nn_module.__class__.__name__} was skipped. "
-        warnings.warn(msg, RuntimeWarning)
-        return None
 
     sm = torch.jit.script(nn_module)
 

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -129,17 +129,9 @@ def _check_jit_scriptable(nn_module, args, unwrapper=None, skip=False, eager_out
             imported = torch.jit.load(path)
         return imported
 
-    TEST_WITH_SLOW = os.getenv("PYTORCH_TEST_WITH_SLOW", "0") == "1"
-    if not TEST_WITH_SLOW or skip:
+    if skip:
         # TorchScript is not enabled, skip these tests
-        msg = (
-            f"The check_jit_scriptable test for {nn_module.__class__.__name__} was skipped. "
-            "This test checks if the module's results in TorchScript "
-            "match eager and that it can be exported. To run these "
-            "tests make sure you set the environment variable "
-            "PYTORCH_TEST_WITH_SLOW=1 and that the test is not "
-            "manually skipped."
-        )
+        msg = f"The check_jit_scriptable test for {nn_module.__class__.__name__} was skipped. "
         warnings.warn(msg, RuntimeWarning)
         return None
 


### PR DESCRIPTION
The JIT tests always execute on the CI. Making them optional doesn't make sense as JIT-scriptability is an important feature of our models. Having the test off by default also means that new contributors don't check for JIT-scriptability, which can lead to issues.

Hence I propose to remove the flag completely.