### PR TITLE
expand legacy model builder wrapper for default weights_backbone behavior

### DIFF
--- a/torchvision/models/_utils.py
+++ b/torchvision/models/_utils.py
@@ -148,81 +148,106 @@ M = TypeVar("M", bound=nn.Module)
 V = TypeVar("V")
 
 
-def handle_legacy_interface(**weights: Tuple[str, Union[Optional[W], Callable[[Dict[str, Any]], Optional[W]]]]):
+def handle_legacy_interface(
+    *,
+    weights: Tuple[str, Union[Optional[W], Callable[[Dict[str, Any]], Optional[W]]]],
+    weights_backbone: Optional[Tuple[str, Union[Optional[W], Callable[[Dict[str, Any]], Optional[W]]]]] = None,
+):
     """Decorates a model builder with the new interface to make it compatible with the old.
 
-    In particular this handles two things:
+    In particular this handles three things:
 
     1. Allows positional parameters again, but emits a deprecation warning in case they are used. See
         :func:`torchvision.prototype.utils._internal.kwonly_to_pos_or_kw` for details.
     2. Handles the default value change from ``pretrained=False`` to ``weights=None`` and ``pretrained=True`` to
         ``weights=Weights`` and emits a deprecation warning with instructions for the new interface.
+    3. If the builder takes ``weights_backbone``, emits a deprecation warning that the default value will change in the
+        future.
 
     Args:
-        **weights (Tuple[str, Union[Optional[W], Callable[[Dict[str, Any]], Optional[W]]]]): Deprecated parameter
-            name and default value for the legacy ``pretrained=True``. The default value can be a callable in which
-            case it will be called with a dictionary of the keyword arguments. The only key that is guaranteed to be in
-            the dictionary is the deprecated parameter name passed as first element in the tuple. All other parameters
-            should be accessed with :meth:`~dict.get`.
+        weights (Tuple[str, Union[Optional[W], Callable[[Dict[str, Any]], Optional[W]]]]): Deprecated parameter
+            name (usually ``"pretrained"``) and default value for the legacy ``pretrained=True``. The default value can
+            be a callable in which case it will be called with a dictionary of the keyword arguments. The only key that
+            is guaranteed to be in the dictionary is the deprecated parameter name passed as first element in the
+            tuple. All other parameters should be accessed with :meth:`~dict.get`.
+        weights_backbone (Optional[Tuple[str, Union[Optional[W], Callable[[Dict[str, Any]], Optional[W]]]]]): Optional
+            deprecated parameter name (usually ``"pretrained_backbone"``) and default value for the legacy
+            ``pretrained_backbone=True``. See ``weights`` for details.
     """
 
     def outer_wrapper(builder: Callable[..., M]) -> Callable[..., M]:
+        def process_kwargs(kwargs, weights_param, pretrained_param, default):
+            # If neither the weights nor the pretrained parameter as passed, or the weights argument already uses
+            # the new style arguments, there is nothing to do. Note that we cannot use `None` as sentinel for the
+            # weight argument, since it is a valid value.
+            sentinel = object()
+            weights_arg = kwargs.get(weights_param, sentinel)
+            if (
+                (weights_param not in kwargs and pretrained_param not in kwargs)
+                or isinstance(weights_arg, WeightsEnum)
+                or (isinstance(weights_arg, str) and weights_arg != "legacy")
+                or weights_arg is None
+            ):
+                return
+
+            # If the pretrained parameter was passed as positional argument, it is now mapped to
+            # `kwargs[weights_param]`. This happens because the @kwonly_to_pos_or_kw decorator uses the current
+            # signature to infer the names of positionally passed arguments and thus has no knowledge that there
+            # used to be a pretrained parameter.
+            pretrained_positional = weights_arg is not sentinel
+            if pretrained_positional:
+                # We put the pretrained argument under its legacy name in the keyword argument dictionary to have a
+                # unified access to the value if the default value is a callable.
+                kwargs[pretrained_param] = pretrained_arg = kwargs.pop(weights_param)
+            else:
+                pretrained_arg = kwargs[pretrained_param]
+
+            if pretrained_arg:
+                default_weights_arg = default(kwargs) if callable(default) else default
+                if not isinstance(default_weights_arg, WeightsEnum):
+                    raise ValueError(f"No weights available for model {builder.__name__}")
+            else:
+                default_weights_arg = None
+
+            if not pretrained_positional:
+                warnings.warn(
+                    f"The parameter '{pretrained_param}' is deprecated, please use '{weights_param}' instead."
+                )
+
+            msg = (
+                f"Arguments other than a weight enum or `None` for '{weights_param}' are deprecated. "
+                f"The current behavior is equivalent to passing `{weights_param}={default_weights_arg}`."
+            )
+            if pretrained_arg:
+                msg = (
+                    f"{msg} You can also use `{weights_param}={type(default_weights_arg).__name__}.DEFAULT` "
+                    f"to get the most up-to-date weights."
+                )
+            warnings.warn(msg)
+
+            del kwargs[pretrained_param]
+            kwargs[weights_param] = default_weights_arg
+
         @kwonly_to_pos_or_kw
         @functools.wraps(builder)
-        def inner_wrapper(*args: Any, **kwargs: Any) -> M:
-            for weights_param, (pretrained_param, default) in weights.items():  # type: ignore[union-attr]
-                # If neither the weights nor the pretrained parameter as passed, or the weights argument already use
-                # the new style arguments, there is nothing to do. Note that we cannot use `None` as sentinel for the
-                # weight argument, since it is a valid value.
-                sentinel = object()
-                weights_arg = kwargs.get(weights_param, sentinel)
-                if (
-                    (weights_param not in kwargs and pretrained_param not in kwargs)
-                    or isinstance(weights_arg, WeightsEnum)
-                    or (isinstance(weights_arg, str) and weights_arg != "legacy")
-                    or weights_arg is None
-                ):
-                    continue
+        def inner_wrapper(**kwargs: Any) -> M:
+            process_kwargs(kwargs, "weights", *weights)
 
-                # If the pretrained parameter was passed as positional argument, it is now mapped to
-                # `kwargs[weights_param]`. This happens because the @kwonly_to_pos_or_kw decorator uses the current
-                # signature to infer the names of positionally passed arguments and thus has no knowledge that there
-                # used to be a pretrained parameter.
-                pretrained_positional = weights_arg is not sentinel
-                if pretrained_positional:
-                    # We put the pretrained argument under its legacy name in the keyword argument dictionary to have a
-                    # unified access to the value if the default value is a callable.
-                    kwargs[pretrained_param] = pretrained_arg = kwargs.pop(weights_param)
-                else:
-                    pretrained_arg = kwargs[pretrained_param]
+            if weights_backbone is not None:
+                pretrained_param, default = weights_backbone
+                process_kwargs(kwargs, "weights_backbone", pretrained_param, default)
 
-                if pretrained_arg:
-                    default_weights_arg = default(kwargs) if callable(default) else default
-                    if not isinstance(default_weights_arg, WeightsEnum):
-                        raise ValueError(f"No weights available for model {builder.__name__}")
-                else:
-                    default_weights_arg = None
-
-                if not pretrained_positional:
+                if "weights_backbone" not in kwargs:
+                    default = weights_backbone[1]
                     warnings.warn(
-                        f"The parameter '{pretrained_param}' is deprecated, please use '{weights_param}' instead."
+                        f"The default behavior of `weights_backbone` will change in the future. "
+                        f"The current behavior is equivalent to passing `weights_backbone={default}`, "
+                        f"but will change to `weights_backbone=None`. "
+                        f"Pass `weights_backbone` explicitly to supress this warning."
                     )
+                    kwargs["weights_backbone"] = default
 
-                msg = (
-                    f"Arguments other than a weight enum or `None` for '{weights_param}' are deprecated. "
-                    f"The current behavior is equivalent to passing `{weights_param}={default_weights_arg}`."
-                )
-                if pretrained_arg:
-                    msg = (
-                        f"{msg} You can also use `{weights_param}={type(default_weights_arg).__name__}.DEFAULT` "
-                        f"to get the most up-to-date weights."
-                    )
-                warnings.warn(msg)
-
-                del kwargs[pretrained_param]
-                kwargs[weights_param] = default_weights_arg
-
-            return builder(*args, **kwargs)
+            return builder(**kwargs)
 
         return inner_wrapper
 


### PR DESCRIPTION
Diff looks larger as it is. I refactored the loop into a local function and call it twice explicitly instead of looping over generic inputs. We should probably update the warnings to include a specific deprecation timeline.