### PR TITLE
More robust check in tests for 16 bits images

### DIFF
--- a/test/test_image.py
+++ b/test/test_image.py
@@ -158,7 +158,7 @@ def test_decode_png(img_path, pil_mode, mode):
 
     img_pil = normalize_dimensions(img_pil)
 
-    if "16" in img_path:
+    if img_path.endswith("16.png"):
         # 16 bits image decoding is supported, but only as a private API
         # FIXME: see https://github.com/pytorch/vision/issues/4731 for potential solutions to making it public
         with pytest.raises(RuntimeError, match="At most 8-bit PNG images are supported"):


### PR DESCRIPTION
Addresses https://github.com/pytorch/vision/issues/4731#issuecomment-1073787964

To determine whether an image is a 16 bits png, our tests just do `if "16" in img_path: ...` but that can break in some CIs where `16` is part of the path; this PR introduces a more robust check.

~It might be worth including in the bugfix release for package managers. @jdsgomes Do you know if/when the bugfix release is planned?~