### PR TITLE
fix torchdata CI installation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,8 +155,14 @@ commands:
   install_prototype_dependencies:
     steps:
       - pip_install:
-          args: iopath git+https://github.com/pytorch/data
-          descr: Install prototype dependencies
+          args: iopath
+          descr: Install third-party dependencies
+      - pip_install:
+          args: -r https://raw.githubusercontent.com/pytorch/data/main/requirements.txt
+          descr: Install torchdata build dependencies
+      - pip_install:
+          args: --no-build-isolation git+https://github.com/pytorch/data
+          descr: Install torchdata from source
 
   # Most of the test suite is handled by the `unittest` jobs, with completely different workflow and setup.
   # This command can be used if only a selection of tests need to be run, for ad-hoc files.

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -155,8 +155,14 @@ commands:
   install_prototype_dependencies:
     steps:
       - pip_install:
-          args: iopath git+https://github.com/pytorch/data
-          descr: Install prototype dependencies
+          args: iopath
+          descr: Install third-party dependencies
+      - pip_install:
+          args: -r https://raw.githubusercontent.com/pytorch/data/main/requirements.txt
+          descr: Install torchdata build dependencies
+      - pip_install:
+          args: --no-build-isolation git+https://github.com/pytorch/data
+          descr: Install torchdata from source
 
   # Most of the test suite is handled by the `unittest` jobs, with completely different workflow and setup.
   # This command can be used if only a selection of tests need to be run, for ad-hoc files.


### PR DESCRIPTION
Addresses https://github.com/pytorch/data/pull/290#issuecomment-1074856241. See [this CI job](https://app.circleci.com/pipelines/github/pytorch/vision/15927/workflows/f4145728-c5a8-4513-b36c-80044325204d/jobs/1288641) for a failure that is happening without this patch.