### PR TITLE
Fixed rotate with expand inconsistency

### DIFF
--- a/test/test_functional_tensor.py
+++ b/test/test_functional_tensor.py
@@ -67,7 +67,7 @@ class TestRotate:
     IMG_W = 26
 
     @pytest.mark.parametrize("device", cpu_and_gpu())
-    @pytest.mark.parametrize("height, width", [(26, IMG_W), (32, IMG_W)])
+    @pytest.mark.parametrize("height, width", [(7, 33), (26, IMG_W), (32, IMG_W)])
     @pytest.mark.parametrize(
         "center",
         [
@@ -77,7 +77,7 @@ class TestRotate:
         ],
     )
     @pytest.mark.parametrize("dt", ALL_DTYPES)
-    @pytest.mark.parametrize("angle", range(-180, 180, 17))
+    @pytest.mark.parametrize("angle", range(-180, 180, 34))
     @pytest.mark.parametrize("expand", [True, False])
     @pytest.mark.parametrize(
         "fill",

--- a/torchvision/transforms/functional_tensor.py
+++ b/torchvision/transforms/functional_tensor.py
@@ -650,7 +650,7 @@ def _compute_output_size(matrix: List[float], w: int, h: int) -> Tuple[int, int]
     # https://github.com/python-pillow/Pillow/blob/11de3318867e4398057373ee9f12dcb33db7335c/src/PIL/Image.py#L2054
 
     # pts are Top-Left, Top-Right, Bottom-Left, Bottom-Right points.
-    # Points are defined are shifted due to affine matrix torch convention about
+    # Points are shifted due to affine matrix torch convention about
     # the center point. Center is (0, 0) for image center pivot point (w * 0.5, h * 0.5)
     pts = torch.tensor(
         [


### PR DESCRIPTION
Description:
- Fixed rotate with expand inconsistency between torch vs PIL on odd-sized images
- Updated tests
- Rewritten bmm -> matmul

This PR fixes output size inconsistency of odd-sized images.

Before:
```python
import torch
import torchvision
from torchvision.transforms.functional import rotate

print(torchvision.__version__)

img = torch.ones(3, 7, 33, dtype=torch.uint8)

out = rotate(img, angle=67, expand=True)
print(out.shape[1:][::-1])

from PIL import Image

pil_img = Image.new("RGB", (33, 7))
pil_out = rotate(pil_img, angle=67, expand=True)
print(pil_out.size)
> 
0.13.0a0+1af20e8
torch.Size([20, 34])
(21, 35)
```

Now:
```python
> 
0.13.0a0+050a5c9
torch.Size([21, 35])
(21, 35)
```
