### PR TITLE
call _upcast to consider overflow for computing giou loss

### DIFF
--- a/torchvision/ops/giou_loss.py
+++ b/torchvision/ops/giou_loss.py
@@ -4,7 +4,7 @@ from torch import Tensor
 
 def _upcast(t: Tensor) -> Tensor:
     # Protects from numerical overflows in multiplications by upcasting to the equivalent higher type
-    if not t.dtype in (torch.float32, torch.float64):
+    if t.dtype not in (torch.float32, torch.float64):
         return t.float()
     return t
 

--- a/torchvision/ops/giou_loss.py
+++ b/torchvision/ops/giou_loss.py
@@ -4,10 +4,9 @@ from torch import Tensor
 
 def _upcast(t: Tensor) -> Tensor:
     # Protects from numerical overflows in multiplications by upcasting to the equivalent higher type
-    if t.is_floating_point():
-        return t if t.dtype in (torch.float32, torch.float64) else t.float()
-    else:
-        return t if t.dtype in (torch.int32, torch.int64) else t.int()
+    if not t.dtype in (torch.float32, torch.float64)
+        return t.float()
+    return t
 
 
 def generalized_box_iou_loss(

--- a/torchvision/ops/giou_loss.py
+++ b/torchvision/ops/giou_loss.py
@@ -1,4 +1,13 @@
 import torch
+from torch import Tensor
+
+
+def _upcast(t: Tensor) -> Tensor:
+    # Protects from numerical overflows in multiplications by upcasting to the equivalent higher type
+    if t.is_floating_point():
+        return t if t.dtype in (torch.float32, torch.float64) else t.float()
+    else:
+        return t if t.dtype in (torch.int32, torch.int64) else t.int()
 
 
 def generalized_box_iou_loss(
@@ -34,6 +43,8 @@ def generalized_box_iou_loss(
         https://arxiv.org/abs/1902.09630
     """
 
+    boxes1 = _upcast(boxes1)
+    boxes2 = _upcast(boxes2)
     x1, y1, x2, y2 = boxes1.unbind(dim=-1)
     x1g, y1g, x2g, y2g = boxes2.unbind(dim=-1)
 

--- a/torchvision/ops/giou_loss.py
+++ b/torchvision/ops/giou_loss.py
@@ -4,7 +4,7 @@ from torch import Tensor
 
 def _upcast(t: Tensor) -> Tensor:
     # Protects from numerical overflows in multiplications by upcasting to the equivalent higher type
-    if not t.dtype in (torch.float32, torch.float64)
+    if not t.dtype in (torch.float32, torch.float64):
         return t.float()
     return t
 


### PR DESCRIPTION
giou loss is weak at overflow problem because it computes area of box.

https://github.com/pytorch/vision/blob/main/torchvision/ops/boxes.py#L226-L242

<!-- Before submitting a PR, please make sure to check our contributing guidelines regarding code formatting, tests, and documentation: https://github.com/pytorch/vision/blob/main/CONTRIBUTING.md -->
