### PR TITLE
use enum class method for integer interpolation modes

### DIFF
--- a/torchvision/prototype/transforms/_geometry.py
+++ b/torchvision/prototype/transforms/_geometry.py
@@ -9,7 +9,7 @@ import torch
 from torchvision.prototype import features
 from torchvision.prototype.transforms import Transform, functional as F
 from torchvision.transforms.functional import pil_to_tensor, InterpolationMode
-from torchvision.transforms.transforms import _setup_size, _interpolation_modes_from_int
+from torchvision.transforms.transforms import _setup_size
 from typing_extensions import Literal
 
 from ._transform import _RandomApplyTransform
@@ -131,7 +131,7 @@ class RandomResizedCrop(Transform):
                 "Argument interpolation should be of type InterpolationMode instead of int. "
                 "Please, use InterpolationMode enum."
             )
-            interpolation = _interpolation_modes_from_int(interpolation)
+            interpolation = InterpolationMode.from_legacy_int(interpolation)
 
         self.size = size
         self.scale = scale

--- a/torchvision/transforms/functional.py
+++ b/torchvision/transforms/functional.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import math
 import numbers
 import warnings
@@ -32,19 +34,16 @@ class InterpolationMode(Enum):
     HAMMING = "hamming"
     LANCZOS = "lanczos"
 
-
-# TODO: Once torchscript supports Enums with staticmethod
-# this can be put into InterpolationMode as staticmethod
-def _interpolation_modes_from_int(i: int) -> InterpolationMode:
-    inverse_modes_mapping = {
-        0: InterpolationMode.NEAREST,
-        2: InterpolationMode.BILINEAR,
-        3: InterpolationMode.BICUBIC,
-        4: InterpolationMode.BOX,
-        5: InterpolationMode.HAMMING,
-        1: InterpolationMode.LANCZOS,
-    }
-    return inverse_modes_mapping[i]
+    @classmethod
+    def from_legacy_int(cls, legacy_int: int) -> InterpolationMode:
+        return {
+            0: InterpolationMode.NEAREST,
+            2: InterpolationMode.BILINEAR,
+            3: InterpolationMode.BICUBIC,
+            4: InterpolationMode.BOX,
+            5: InterpolationMode.HAMMING,
+            1: InterpolationMode.LANCZOS,
+        }[legacy_int]
 
 
 pil_modes_mapping = {
@@ -417,7 +416,7 @@ def resize(
             "Argument interpolation should be of type InterpolationMode instead of int. "
             "Please, use InterpolationMode enum."
         )
-        interpolation = _interpolation_modes_from_int(interpolation)
+        interpolation = InterpolationMode.from_legacy_int(interpolation)
 
     if not isinstance(interpolation, InterpolationMode):
         raise TypeError("Argument interpolation should be a InterpolationMode")
@@ -674,7 +673,7 @@ def perspective(
             "Argument interpolation should be of type InterpolationMode instead of int. "
             "Please, use InterpolationMode enum."
         )
-        interpolation = _interpolation_modes_from_int(interpolation)
+        interpolation = InterpolationMode.from_legacy_int(interpolation)
 
     if not isinstance(interpolation, InterpolationMode):
         raise TypeError("Argument interpolation should be a InterpolationMode")
@@ -1040,7 +1039,7 @@ def rotate(
             "The parameter 'resample' is deprecated since 0.12 and will be removed 0.14. "
             "Please use 'interpolation' instead."
         )
-        interpolation = _interpolation_modes_from_int(resample)
+        interpolation = InterpolationMode.from_legacy_int(resample)
 
     # Backward compatibility with integer value
     if isinstance(interpolation, int):
@@ -1048,7 +1047,7 @@ def rotate(
             "Argument interpolation should be of type InterpolationMode instead of int. "
             "Please, use InterpolationMode enum."
         )
-        interpolation = _interpolation_modes_from_int(interpolation)
+        interpolation = InterpolationMode.from_legacy_int(interpolation)
 
     if not isinstance(angle, (int, float)):
         raise TypeError("Argument angle should be int or float")
@@ -1129,7 +1128,7 @@ def affine(
             "The parameter 'resample' is deprecated since 0.12 and will be removed in 0.14. "
             "Please use 'interpolation' instead."
         )
-        interpolation = _interpolation_modes_from_int(resample)
+        interpolation = InterpolationMode.from_legacy_int(resample)
 
     # Backward compatibility with integer value
     if isinstance(interpolation, int):
@@ -1137,7 +1136,7 @@ def affine(
             "Argument interpolation should be of type InterpolationMode instead of int. "
             "Please, use InterpolationMode enum."
         )
-        interpolation = _interpolation_modes_from_int(interpolation)
+        interpolation = InterpolationMode.from_legacy_int(interpolation)
 
     if fillcolor is not None:
         warnings.warn(

--- a/torchvision/transforms/transforms.py
+++ b/torchvision/transforms/transforms.py
@@ -15,7 +15,7 @@ except ImportError:
 
 from ..utils import _log_api_usage_once
 from . import functional as F
-from .functional import InterpolationMode, _interpolation_modes_from_int
+from .functional import InterpolationMode
 
 
 __all__ = [
@@ -333,7 +333,7 @@ class Resize(torch.nn.Module):
                 "Argument interpolation should be of type InterpolationMode instead of int. "
                 "Please, use InterpolationMode enum."
             )
-            interpolation = _interpolation_modes_from_int(interpolation)
+            interpolation = InterpolationMode.from_legacy_int(interpolation)
 
         self.interpolation = interpolation
         self.antialias = antialias
@@ -771,7 +771,7 @@ class RandomPerspective(torch.nn.Module):
                 "Argument interpolation should be of type InterpolationMode instead of int. "
                 "Please, use InterpolationMode enum."
             )
-            interpolation = _interpolation_modes_from_int(interpolation)
+            interpolation = InterpolationMode.from_legacy_int(interpolation)
 
         self.interpolation = interpolation
         self.distortion_scale = distortion_scale
@@ -891,7 +891,7 @@ class RandomResizedCrop(torch.nn.Module):
                 "Argument interpolation should be of type InterpolationMode instead of int. "
                 "Please, use InterpolationMode enum."
             )
-            interpolation = _interpolation_modes_from_int(interpolation)
+            interpolation = InterpolationMode.from_legacy_int(interpolation)
 
         self.interpolation = interpolation
         self.scale = scale
@@ -1293,7 +1293,7 @@ class RandomRotation(torch.nn.Module):
                 "The parameter 'resample' is deprecated since 0.12 and will be removed 0.14. "
                 "Please use 'interpolation' instead."
             )
-            interpolation = _interpolation_modes_from_int(resample)
+            interpolation = InterpolationMode.from_legacy_int(resample)
 
         # Backward compatibility with integer value
         if isinstance(interpolation, int):
@@ -1301,7 +1301,7 @@ class RandomRotation(torch.nn.Module):
                 "Argument interpolation should be of type InterpolationMode instead of int. "
                 "Please, use InterpolationMode enum."
             )
-            interpolation = _interpolation_modes_from_int(interpolation)
+            interpolation = InterpolationMode.from_legacy_int(interpolation)
 
         self.degrees = _setup_angle(degrees, name="degrees", req_sizes=(2,))
 
@@ -1422,7 +1422,7 @@ class RandomAffine(torch.nn.Module):
                 "The parameter 'resample' is deprecated since 0.12 and will be removed in 0.14. "
                 "Please use 'interpolation' instead."
             )
-            interpolation = _interpolation_modes_from_int(resample)
+            interpolation = InterpolationMode.from_legacy_int(resample)
 
         # Backward compatibility with integer value
         if isinstance(interpolation, int):
@@ -1430,7 +1430,7 @@ class RandomAffine(torch.nn.Module):
                 "Argument interpolation should be of type InterpolationMode instead of int. "
                 "Please, use InterpolationMode enum."
             )
-            interpolation = _interpolation_modes_from_int(interpolation)
+            interpolation = InterpolationMode.from_legacy_int(interpolation)
 
         if fillcolor is not None:
             warnings.warn(


### PR DESCRIPTION
https://github.com/pytorch/vision/blob/96aecd2d65c892a2c17ab2be2f1deae774380606/torchvision/transforms/functional.py#L36-L37

Seems to work now:

```py
import torch


from torchvision.transforms import functional as F, InterpolationMode


eager = F.resize
scripted = torch.jit.script(eager)

args = (torch.rand(3, 256, 256), [512, 128])
interpolation = 2

torch.testing.assert_close(
    eager(*args, interpolation=interpolation),
    scripted(*args, interpolation=InterpolationMode.from_legacy_int(interpolation)),
)
```

Note that we already cannot call the scripted function with an `int`, since we annotated `interpolation: InterpolationMode`:


```py
@torch.jit.script
def foo(bar: InterpolationMode):
    if isinstance(bar, int):
        baz = F._interpolation_modes_from_int(bar)
    else:
        baz = bar
    return baz


foo(1)
```

```
RuntimeError: foo() Expected a value of type 'Enum<__torch__.torchvision.transforms.functional.InterpolationMode>' for argument 'bar' but instead found type 'int'.
```