### PR TITLE
Remove input checks for generalized_box_iou

### DIFF
--- a/torchvision/ops/boxes.py
+++ b/torchvision/ops/boxes.py
@@ -298,12 +298,6 @@ def generalized_box_iou(boxes1: Tensor, boxes2: Tensor) -> Tensor:
     """
     if not torch.jit.is_scripting() and not torch.jit.is_tracing():
         _log_api_usage_once(generalized_box_iou)
-    # degenerate boxes gives inf / nan results
-    # so do an early check
-    if (boxes1[:, 2:] < boxes1[:, :2]).any():
-        raise ValueError("Some of the input boxes1 are invalid.")
-    if not (boxes2[:, 2:] >= boxes2[:, :2]).all():
-        raise ValueError("Some of the input boxes2 are invalid.")
 
     inter, union = _box_inter_union(boxes1, boxes2)
     iou = inter / union


### PR DESCRIPTION
Similar to #5322 and as discussed at https://github.com/pytorch/vision/pull/5684#issuecomment-1079746782, we shouldn't put input checks in the box utility ops to avoid slow-downs due to GPU/CPU synchronisation.