### PR TITLE
remove redundant hipify from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -147,15 +147,6 @@ def get_extensions():
         is_rocm_pytorch = (torch.version.hip is not None) and (ROCM_HOME is not None)
 
     if is_rocm_pytorch:
-        from torch.utils.hipify import hipify_python
-
-        hipify_python.hipify(
-            project_directory=this_dir,
-            output_directory=this_dir,
-            includes="torchvision/csrc/ops/cuda/*",
-            show_detailed=True,
-            is_pytorch_extension=True,
-        )
         source_cuda = glob.glob(os.path.join(extensions_dir, "ops", "hip", "*.hip"))
         # Copy over additional files
         for file in glob.glob(r"torchvision/csrc/ops/cuda/*.h"):


### PR DESCRIPTION
<!-- Before submitting a PR, please make sure to check our contributing guidelines regarding code formatting, tests, and documentation: https://github.com/pytorch/vision/blob/main/CONTRIBUTING.md -->

Remove the redundant call for hipify from setup.py 
- build -passes 
- pytest test/test_transforms.py -- 
```
SKIPPED [1] test/test_transforms.py:156: accimage not available
SKIPPED [1] test/test_transforms.py:164: accimage not available
SKIPPED [1] test/test_transforms.py:173: accimage not available
SKIPPED [1] test/test_transforms.py:194: accimage not available
SKIPPED [1] test/test_transforms.py:933: Temporarily disabled
XFAIL test/test_transforms.py::test_max_value_iinfo
  torch.iinfo() is not supported by torchscript. See https://github.com/pytorch/pytorch/issues/41492.
============================================================================== 1306 passed, 5 skipped, 1 xfailed, 361 warnings in 449.93s (0:07:29) ==============================================================================
```
