### PR TITLE
update IterKeyZipper usages to accept multiple datapipes

### DIFF
--- a/torchvision/prototype/datasets/_builtin/caltech.py
+++ b/torchvision/prototype/datasets/_builtin/caltech.py
@@ -115,8 +115,7 @@ class Caltech101(Dataset):
         dp = IterKeyZipper(
             images_dp,
             anns_dp,
-            key_fn=self._images_key_fn,
-            ref_key_fn=self._anns_key_fn,
+            key_fn=[self._images_key_fn, self._anns_key_fn],
             buffer_size=INFINITE_BUFFER_SIZE,
             keep_key=True,
         )

--- a/torchvision/prototype/datasets/_builtin/celeba.py
+++ b/torchvision/prototype/datasets/_builtin/celeba.py
@@ -113,7 +113,8 @@ class CelebA(Dataset):
     def _prepare_sample(
         self,
         data: Tuple[
-            Tuple[str, Tuple[Tuple[str, List[str]], Tuple[str, BinaryIO]]],
+            Tuple[str, Dict[str, str]],
+            Tuple[str, BinaryIO],
             Tuple[
                 Tuple[str, Dict[str, str]],
                 Tuple[str, Dict[str, str]],
@@ -122,12 +123,9 @@ class CelebA(Dataset):
             ],
         ],
     ) -> Dict[str, Any]:
-        split_and_image_data, ann_data = data
-        _, (_, image_data) = split_and_image_data
-        path, buffer = image_data
+        _, (path, buffer), ((_, identity), (_, attributes), (_, bounding_box), (_, landmarks)) = data
 
         image = EncodedImage.from_file(buffer)
-        (_, identity), (_, attributes), (_, bounding_box), (_, landmarks) = ann_data
 
         return dict(
             path=path,
@@ -173,16 +171,8 @@ class CelebA(Dataset):
         dp = IterKeyZipper(
             splits_dp,
             images_dp,
-            key_fn=getitem(0),
-            ref_key_fn=path_accessor("name"),
-            buffer_size=INFINITE_BUFFER_SIZE,
-            keep_key=True,
-        )
-        dp = IterKeyZipper(
-            dp,
             anns_dp,
-            key_fn=getitem(0),
-            ref_key_fn=getitem(0, 0),
+            key_fn=[getitem(0), path_accessor("name"), getitem(0, 0)],
             buffer_size=INFINITE_BUFFER_SIZE,
         )
         return Mapper(dp, self._prepare_sample)

--- a/torchvision/prototype/datasets/_builtin/clevr.py
+++ b/torchvision/prototype/datasets/_builtin/clevr.py
@@ -89,8 +89,7 @@ class CLEVR(Dataset):
             dp = IterKeyZipper(
                 images_dp,
                 scenes_dp,
-                key_fn=path_accessor("name"),
-                ref_key_fn=getitem("image_filename"),
+                key_fn=[path_accessor("name"), getitem("image_filename")],
                 buffer_size=INFINITE_BUFFER_SIZE,
             )
         else:

--- a/torchvision/prototype/datasets/_builtin/coco.py
+++ b/torchvision/prototype/datasets/_builtin/coco.py
@@ -212,16 +212,14 @@ class Coco(Dataset):
         anns_dp = IterKeyZipper(
             anns_meta_dp,
             images_meta_dp,
-            key_fn=getitem(0, "image_id"),
-            ref_key_fn=getitem("id"),
+            key_fn=[getitem(0, "image_id"), getitem("id")],
             buffer_size=INFINITE_BUFFER_SIZE,
         )
 
         dp = IterKeyZipper(
             anns_dp,
             images_dp,
-            key_fn=getitem(1, "file_name"),
-            ref_key_fn=path_accessor("name"),
+            key_fn=[getitem(1, "file_name"), path_accessor("name")],
             buffer_size=INFINITE_BUFFER_SIZE,
         )
 

--- a/torchvision/prototype/datasets/_builtin/dtd.py
+++ b/torchvision/prototype/datasets/_builtin/dtd.py
@@ -70,13 +70,9 @@ class DTD(Dataset):
         # The split files contain hardcoded posix paths for the images, e.g. banded/banded_0001.jpg
         return str(path.relative_to(path.parents[1]).as_posix())
 
-    def _prepare_sample(self, data: Tuple[Tuple[str, List[str]], Tuple[str, BinaryIO]]) -> Dict[str, Any]:
-        (_, joint_categories_data), image_data = data
-        _, *joint_categories = joint_categories_data
-        path, buffer = image_data
-
-        category = pathlib.Path(path).parent.name
-
+    def _prepare_sample(self, data: Tuple[str, List[str], Tuple[str, BinaryIO]]) -> Dict[str, Any]:
+        id, (_, *joint_categories), (path, buffer) = data
+        category = id.split("/", 1)[0]
         return dict(
             joint_categories={category for category in joint_categories if category},
             label=Label.from_category(category, categories=self.categories),
@@ -106,15 +102,8 @@ class DTD(Dataset):
         dp = IterKeyZipper(
             splits_dp,
             joint_categories_dp,
-            key_fn=getitem(),
-            ref_key_fn=getitem(0),
-            buffer_size=INFINITE_BUFFER_SIZE,
-        )
-        dp = IterKeyZipper(
-            dp,
             images_dp,
-            key_fn=getitem(0),
-            ref_key_fn=self._image_key_fn,
+            key_fn=[getitem(), getitem(0), self._image_key_fn],
             buffer_size=INFINITE_BUFFER_SIZE,
         )
         return Mapper(dp, self._prepare_sample)

--- a/torchvision/prototype/datasets/_builtin/imagenet.py
+++ b/torchvision/prototype/datasets/_builtin/imagenet.py
@@ -182,8 +182,7 @@ class ImageNet(Dataset):
             dp = IterKeyZipper(
                 label_dp,
                 images_dp,
-                key_fn=getitem(0),
-                ref_key_fn=self._val_test_image_key,
+                key_fn=[getitem(0), self._val_test_image_key],
                 buffer_size=INFINITE_BUFFER_SIZE,
             )
             dp = Mapper(dp, self._prepare_val_data)

--- a/torchvision/prototype/datasets/_builtin/voc.py
+++ b/torchvision/prototype/datasets/_builtin/voc.py
@@ -120,14 +120,11 @@ class VOC(Dataset):
 
     def _prepare_sample(
         self,
-        data: Tuple[Tuple[Tuple[str, str], Tuple[str, BinaryIO]], Tuple[str, BinaryIO]],
+        data: Tuple[str, Tuple[str, BinaryIO], Tuple[str, BinaryIO]],
         *,
         prepare_ann_fn: Callable[[BinaryIO], Dict[str, Any]],
     ) -> Dict[str, Any]:
-        split_and_image_data, ann_data = data
-        _, image_data = split_and_image_data
-        image_path, image_buffer = image_data
-        ann_path, ann_buffer = ann_data
+        _, (image_path, image_buffer), (ann_path, ann_buffer) = data
 
         return dict(
             prepare_ann_fn(ann_buffer),
@@ -153,19 +150,17 @@ class VOC(Dataset):
 
         split_dp = Filter(split_dp, functools.partial(self._is_in_folder, name=self._SPLIT_FOLDER[config.task]))
         split_dp = Filter(split_dp, path_comparator("name", f"{config.split}.txt"))
-        split_dp = LineReader(split_dp, decode=True)
+        split_dp = LineReader(split_dp, decode=True, return_path=False)
         split_dp = hint_sharding(split_dp)
         split_dp = hint_shuffling(split_dp)
 
-        dp = split_dp
-        for level, data_dp in enumerate((images_dp, anns_dp)):
-            dp = IterKeyZipper(
-                dp,
-                data_dp,
-                key_fn=getitem(*[0] * level, 1),
-                ref_key_fn=path_accessor("stem"),
-                buffer_size=INFINITE_BUFFER_SIZE,
-            )
+        dp = IterKeyZipper(
+            split_dp,
+            images_dp,
+            anns_dp,
+            key_fn=[getitem(), path_accessor("stem"), path_accessor("stem")],
+            buffer_size=INFINITE_BUFFER_SIZE,
+        )
         return Mapper(
             dp,
             functools.partial(


### PR DESCRIPTION
This updates our builtin datasets after pytorch/data#336. In total, I consider this change a win, since we are able to remove a lot of nested structures that come into place by "stacking" multiple `IterKeyZipper`'s.
