### PR TITLE
add test to enforce infinite buffer size for all applicable datapipes

### DIFF
--- a/test/test_prototype_builtin_datasets.py
+++ b/test/test_prototype_builtin_datasets.py
@@ -8,6 +8,7 @@ import torch
 from builtin_dataset_mocks import parametrize_dataset_mocks, DATASET_MOCKS
 from torch.testing._comparison import assert_equal, TensorLikePair, ObjectPair
 from torch.utils.data.graph import traverse
+from torch.utils.data.graph_settings import get_all_graph_pipes
 from torchdata.datapipes.iter import (
     IterDataPipe,
     Shuffler,
@@ -29,6 +30,10 @@ assert_samples_equal = functools.partial(
 )
 
 
+def extract_datapipes(dp):
+    return get_all_graph_pipes(traverse(dp, only_datapipe=True))
+
+
 @pytest.fixture
 def test_home(mocker, tmp_path):
     mocker.patch("torchvision.prototype.datasets._api.home", return_value=str(tmp_path))
@@ -43,15 +48,6 @@ def test_coverage():
             f"are exposed through `torchvision.prototype.datasets.load()`, but are not tested. "
             f"Please add mock data to `test/builtin_dataset_mocks.py`."
         )
-
-
-def extract_datapipes(dp):
-    def scan(graph):
-        for node, sub_graph in graph.items():
-            yield node
-            yield from scan(sub_graph)
-
-    yield from scan(traverse(dp))
 
 
 @pytest.mark.filterwarnings("error")

--- a/test/test_prototype_builtin_datasets.py
+++ b/test/test_prototype_builtin_datasets.py
@@ -9,17 +9,7 @@ from builtin_dataset_mocks import parametrize_dataset_mocks, DATASET_MOCKS
 from torch.testing._comparison import assert_equal, TensorLikePair, ObjectPair
 from torch.utils.data.graph import traverse
 from torch.utils.data.graph_settings import get_all_graph_pipes
-from torchdata.datapipes.iter import (
-    IterDataPipe,
-    Shuffler,
-    ShardingFilter,
-    Demultiplexer,
-    Forker,
-    Grouper,
-    MaxTokenBucketizer,
-    UnZipper,
-    IterKeyZipper,
-)
+from torchdata.datapipes.iter import IterDataPipe, Shuffler, ShardingFilter
 from torchvision._utils import sequence_to_str
 from torchvision.prototype import transforms, datasets
 from torchvision.prototype.datasets.utils._internal import INFINITE_BUFFER_SIZE
@@ -165,21 +155,14 @@ class TestCommon:
         dataset = datasets.load(dataset_mock.name, **config)
 
         for dp in extract_datapipes(dataset):
-            if isinstance(
-                dp,
-                (
-                    Shuffler,
-                    Demultiplexer,
-                    Forker,
-                    Grouper,
-                    MaxTokenBucketizer,
-                    UnZipper,
-                    IterKeyZipper,
-                ),
-            ):
-                # TODO: replace this with the proper sentinel as soon as https://github.com/pytorch/data/issues/335 is
-                #  resolved
-                assert dp.buffer_size == INFINITE_BUFFER_SIZE
+            try:
+                buffer_size = getattr(dp, "buffer_size")
+            except AttributeError:
+                continue
+
+            # TODO: replace this with the proper sentinel as soon as https://github.com/pytorch/data/issues/335 is
+            #  resolved
+            assert buffer_size == INFINITE_BUFFER_SIZE
 
 
 @parametrize_dataset_mocks(DATASET_MOCKS["qmnist"])

--- a/test/test_prototype_builtin_datasets.py
+++ b/test/test_prototype_builtin_datasets.py
@@ -155,14 +155,10 @@ class TestCommon:
         dataset = datasets.load(dataset_mock.name, **config)
 
         for dp in extract_datapipes(dataset):
-            try:
-                buffer_size = getattr(dp, "buffer_size")
-            except AttributeError:
-                continue
-
-            # TODO: replace this with the proper sentinel as soon as https://github.com/pytorch/data/issues/335 is
-            #  resolved
-            assert buffer_size == INFINITE_BUFFER_SIZE
+            if hasattr(dp, "buffer_size"):
+                # TODO: replace this with the proper sentinel as soon as https://github.com/pytorch/data/issues/335 is
+                #  resolved
+                assert dp.buffer_size == INFINITE_BUFFER_SIZE
 
 
 @parametrize_dataset_mocks(DATASET_MOCKS["qmnist"])


### PR DESCRIPTION
Given that is not acceptable for our datasets to drop any sample, we need to use an infinite buffer size in all datapipes that have a variable sized buffer. This PR adds a test that enforces this.

Currently we use 

https://github.com/pytorch/vision/blob/1db8795733b91cd6dd62a0baa7ecbae6790542bc/torchvision/prototype/datasets/utils/_internal.py#L42-L43

but that hopefully changes after pytorch/data#335 is resolved. 