### PR TITLE
upgrade to next-gen CircleCI convenience images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -266,7 +266,7 @@ smoke_test_common: &smoke_test_common
 jobs:
   circleci_consistency:
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
     steps:
       - checkout
       - pip_install:
@@ -279,7 +279,7 @@ jobs:
 
   lint_python_and_config:
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
     steps:
       - checkout
       - pip_install:
@@ -298,7 +298,7 @@ jobs:
 
   lint_c:
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
     steps:
       - apt_install:
           args: libtinfo5
@@ -320,7 +320,7 @@ jobs:
 
   type_check_python:
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
     steps:
       - apt_install:
           args: libturbojpeg-dev
@@ -338,7 +338,7 @@ jobs:
 
   unittest_torchhub:
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
     steps:
       - checkout
       - install_torchvision
@@ -347,7 +347,7 @@ jobs:
 
   unittest_onnx:
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
     steps:
       - checkout
       - install_torchvision
@@ -359,7 +359,7 @@ jobs:
 
   unittest_prototype:
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
     resource_class: xlarge
     steps:
       - checkout
@@ -373,7 +373,7 @@ jobs:
 
   unittest_extended:
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
     resource_class: xlarge
     steps:
       - checkout
@@ -535,7 +535,7 @@ jobs:
   binary_android_build:
     <<: *torchvision_android_params
     docker:
-      - image: circleci/android:api-29-ndk
+      - image: cimg/android:api-29-ndk
     resource_class: xlarge
     steps:
     - attach_workspace:
@@ -554,7 +554,7 @@ jobs:
   binary_android_upload:
     <<: *torchvision_android_params
     docker:
-      - image: circleci/android:api-29-ndk
+      - image: cimg/android:api-29-ndk
     resource_class: xlarge
     steps:
     - attach_workspace:
@@ -613,7 +613,7 @@ jobs:
         description: "What whl subfolder to upload to, e.g., blank or cu100/ (trailing slash is important)"
         type: string
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
     steps:
       - attach_workspace:
           at: ~/workspace
@@ -1037,7 +1037,7 @@ jobs:
   build_docs:
     <<: *binary_common
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
     resource_class: 2xlarge+
     steps:
       - attach_workspace:

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -266,7 +266,7 @@ smoke_test_common: &smoke_test_common
 jobs:
   circleci_consistency:
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
     steps:
       - checkout
       - pip_install:
@@ -279,7 +279,7 @@ jobs:
 
   lint_python_and_config:
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
     steps:
       - checkout
       - pip_install:
@@ -298,7 +298,7 @@ jobs:
 
   lint_c:
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
     steps:
       - apt_install:
           args: libtinfo5
@@ -320,7 +320,7 @@ jobs:
 
   type_check_python:
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
     steps:
       - apt_install:
           args: libturbojpeg-dev
@@ -338,7 +338,7 @@ jobs:
 
   unittest_torchhub:
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
     steps:
       - checkout
       - install_torchvision
@@ -347,7 +347,7 @@ jobs:
 
   unittest_onnx:
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
     steps:
       - checkout
       - install_torchvision
@@ -359,7 +359,7 @@ jobs:
 
   unittest_prototype:
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
     resource_class: xlarge
     steps:
       - checkout
@@ -373,7 +373,7 @@ jobs:
 
   unittest_extended:
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
     resource_class: xlarge
     steps:
       - checkout
@@ -535,7 +535,7 @@ jobs:
   binary_android_build:
     <<: *torchvision_android_params
     docker:
-      - image: circleci/android:api-29-ndk
+      - image: cimg/android:api-29-ndk
     resource_class: xlarge
     steps:
     - attach_workspace:
@@ -554,7 +554,7 @@ jobs:
   binary_android_upload:
     <<: *torchvision_android_params
     docker:
-      - image: circleci/android:api-29-ndk
+      - image: cimg/android:api-29-ndk
     resource_class: xlarge
     steps:
     - attach_workspace:
@@ -613,7 +613,7 @@ jobs:
         description: "What whl subfolder to upload to, e.g., blank or cu100/ (trailing slash is important)"
         type: string
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
     steps:
       - attach_workspace:
           at: ~/workspace
@@ -1037,7 +1037,7 @@ jobs:
   build_docs:
     <<: *binary_common
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
     resource_class: 2xlarge+
     steps:
       - attach_workspace:


### PR DESCRIPTION
All workflows that currently run on a `circleci/*` docker image issue this warning:

![circleci_warning](https://user-images.githubusercontent.com/6849766/161001164-f3da871c-a102-46bd-8caa-4788cb740309.png)

[Example workflow](https://app.circleci.com/pipelines/github/pytorch/vision/16209/workflows/3cb5da6c-40b6-43bb-8d81-1aed43597927/jobs/1313281).

The warning points to [this thread](https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034/3). TL;DR: we should to migrate to `cimg/*` images as the `circleci/*` images will no longer receive support starting from 2023. Otherwise nothing should change :crossed_fingers: 
