### PR TITLE
Make nvjpeg handle creation once_flag static

### DIFF
--- a/torchvision/csrc/io/image/cuda/decode_jpeg_cuda.cpp
+++ b/torchvision/csrc/io/image/cuda/decode_jpeg_cuda.cpp
@@ -71,7 +71,7 @@ torch::Tensor decode_jpeg_cuda(
   at::cuda::CUDAGuard device_guard(device);
 
   // Create global nvJPEG handle
-  std::once_flag nvjpeg_handle_creation_flag;
+  static std::once_flag nvjpeg_handle_creation_flag;
   std::call_once(nvjpeg_handle_creation_flag, []() {
     if (nvjpeg_handle == nullptr) {
       nvjpegStatus_t create_status = nvjpegCreateSimple(&nvjpeg_handle);


### PR DESCRIPTION
As properly pointed by  @ShiyangZhang, the `once_flag` var should global (or static), not local https://github.com/pytorch/vision/issues/4378#issuecomment-1084018984

For ref, this doesn't change anything to the more global leak issue https://github.com/pytorch/vision/issues/4378