### PR TITLE
indicate md5 checksum is not used for security

### DIFF
--- a/torchvision/datasets/utils.py
+++ b/torchvision/datasets/utils.py
@@ -53,6 +53,9 @@ def gen_bar_updater() -> Callable[[int, int, int], None]:
 
 
 def calculate_md5(fpath: str, chunk_size: int = 1024 * 1024) -> str:
+    # Setting the `usedforsecurity` flag does not change anything about the functionality, but indicates that we are
+    # not using the MD5 checksum for cryptography. This enables its usage in restricted environments like FIPS. Without
+    # it torchvision.datasets is unusable in these environments since we perform a MD5 check everywhere.
     md5 = hashlib.md5(**dict(usedforsecurity=False) if sys.version_info >= (3, 9) else dict())
     with open(fpath, "rb") as f:
         for chunk in iter(lambda: f.read(chunk_size), b""):

--- a/torchvision/datasets/utils.py
+++ b/torchvision/datasets/utils.py
@@ -7,6 +7,7 @@ import os
 import os.path
 import pathlib
 import re
+import sys
 import tarfile
 import urllib
 import urllib.error
@@ -52,7 +53,7 @@ def gen_bar_updater() -> Callable[[int, int, int], None]:
 
 
 def calculate_md5(fpath: str, chunk_size: int = 1024 * 1024) -> str:
-    md5 = hashlib.md5()
+    md5 = hashlib.md5(**dict(usedforsecurity=False) if sys.version_info >= (3, 9) else dict())
     with open(fpath, "rb") as f:
         for chunk in iter(lambda: f.read(chunk_size), b""):
             md5.update(chunk)


### PR DESCRIPTION
Fixes https://github.com/pytorch/vision/pull/4102#issuecomment-1085108412. 

This does not change the functionality in any way, but allows the use of our datasets on [FIPS compliant systems](https://en.wikipedia.org/wiki/FIPS_140-2) that use Python >= 3.9.