### PR TITLE
disable pyav==9.1.1 on windows

### DIFF
--- a/.circleci/unittest/windows/scripts/environment.yml
+++ b/.circleci/unittest/windows/scripts/environment.yml
@@ -14,6 +14,6 @@ dependencies:
     - future
     - pillow >=5.3.0, !=8.3.*
     - scipy
-    - av
+    - av != 9.1.1
     - dataclasses
     - h5py


### PR DESCRIPTION
`pyav==9.1.1` was released a couple of hours ago and leads to failures on Windows. See for example [this CI run](https://app.circleci.com/pipelines/github/pytorch/vision/16294/workflows/436fdf0e-38bf-453a-aef3-574d5a0cac5c/jobs/1320724):

```
Successfully installed av-9.1.1 pillow-9.1.0
```

```
ImportError: DLL load failed while importing _core: The specified module could not be found.
```