### PR TITLE
Add needs_cuda to GPU decoder tests

### DIFF
--- a/test/test_video_gpu_decoder.py
+++ b/test/test_video_gpu_decoder.py
@@ -3,7 +3,7 @@ import os
 
 import pytest
 import torch
-from test.common_utils import needs_cuda
+from common_utils import needs_cuda
 from torchvision.io import _HAS_GPU_VIDEO_DECODER, VideoReader
 
 try:

--- a/test/test_video_gpu_decoder.py
+++ b/test/test_video_gpu_decoder.py
@@ -3,6 +3,7 @@ import os
 
 import pytest
 import torch
+from test.common_utils import needs_cuda
 from torchvision.io import _HAS_GPU_VIDEO_DECODER, VideoReader
 
 try:
@@ -13,6 +14,7 @@ except ImportError:
 VIDEO_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "assets", "videos")
 
 
+@needs_cuda
 @pytest.mark.skipif(_HAS_GPU_VIDEO_DECODER is False, reason="Didn't compile with support for gpu decoder")
 class TestVideoGPUDecoder:
     @pytest.mark.skipif(av is None, reason="PyAV unavailable")


### PR DESCRIPTION
Following up on https://github.com/pytorch/vision/issues/5702#issuecomment-1087555783

Tests won't be run on a GPU without the `@needs_cuda` decorator.