### PR TITLE
remove unnecessary pytest install

### DIFF
--- a/.circleci/unittest/linux/scripts/install.sh
+++ b/.circleci/unittest/linux/scripts/install.sh
@@ -31,9 +31,9 @@ esac
 
 printf "Installing PyTorch with %s\n" "${cudatoolkit}"
 if [ "${os}" == "MacOSX" ]; then
-    conda install -y -c "pytorch-${UPLOAD_CHANNEL}" "pytorch-${UPLOAD_CHANNEL}"::pytorch "${cudatoolkit}" pytest
+    conda install -y -c "pytorch-${UPLOAD_CHANNEL}" "pytorch-${UPLOAD_CHANNEL}"::pytorch "${cudatoolkit}"
 else
-    conda install -y -c "pytorch-${UPLOAD_CHANNEL}" -c nvidia "pytorch-${UPLOAD_CHANNEL}"::pytorch[build="*${version}*"] "${cudatoolkit}" pytest
+    conda install -y -c "pytorch-${UPLOAD_CHANNEL}" -c nvidia "pytorch-${UPLOAD_CHANNEL}"::pytorch[build="*${version}*"] "${cudatoolkit}"
 fi
 
 printf "* Installing torchvision\n"

--- a/.circleci/unittest/windows/scripts/install.sh
+++ b/.circleci/unittest/windows/scripts/install.sh
@@ -28,7 +28,7 @@ else
 fi
 
 printf "Installing PyTorch with %s\n" "${cudatoolkit}"
-conda install -y -c "pytorch-${UPLOAD_CHANNEL}" -c nvidia "pytorch-${UPLOAD_CHANNEL}"::pytorch[build="*${version}*"] "${cudatoolkit}" pytest
+conda install -y -c "pytorch-${UPLOAD_CHANNEL}" -c nvidia "pytorch-${UPLOAD_CHANNEL}"::pytorch[build="*${version}*"] "${cudatoolkit}"
 
 torch_cuda=$(python -c "import torch; print(torch.cuda.is_available())")
 echo torch.cuda.is_available is $torch_cuda


### PR DESCRIPTION
`pytest` is already installed during the environment setup:

https://github.com/pytorch/vision/blob/095cabb76cdcd4763bad629481d189b91e3df42c/.circleci/unittest/linux/scripts/environment.yml#L5

https://github.com/pytorch/vision/blob/095cabb76cdcd4763bad629481d189b91e3df42c/.circleci/unittest/windows/scripts/environment.yml#L5

Thus, passing it again does nothing. For example [this CI run](https://app.circleci.com/pipelines/github/pytorch/vision/16384/workflows/1f8c1f18-9e5a-4fd3-9bb9-5c169829a8f4/jobs/1328471).

```
The following NEW packages will be INSTALLED:

cpuonly            pytorch-nightly/noarch::cpuonly-2.0-0
libuv              pkgs/main/linux-64::libuv-1.40.0-h7b6447c_0
pytorch            pytorch-nightly/linux-64::pytorch-1.12.0.dev20220404-py3.7_cpu_0
pytorch-mutex      pytorch-nightly/noarch::pytorch-mutex-1.0-cpu
```


