### PR TITLE
add test to enforce __len__ is working on prototype datasets

### DIFF
--- a/test/test_prototype_builtin_datasets.py
+++ b/test/test_prototype_builtin_datasets.py
@@ -154,6 +154,13 @@ class TestCommon:
                 #  resolved
                 assert dp.buffer_size == INFINITE_BUFFER_SIZE
 
+    @parametrize_dataset_mocks(DATASET_MOCKS)
+    def test_has_length(self, test_home, dataset_mock, config):
+        dataset_mock.prepare(test_home, config)
+        dataset = datasets.load(dataset_mock.name, **config)
+
+        assert len(dataset) > 0
+
 
 # FIXME: DATASET_MOCKS["qmnist"]
 @parametrize_dataset_mocks({})


### PR DESCRIPTION
Note that this test only checks if the `__len__` method returns a plausible result. It cannot check the actual value, since the mock data only contains a few examples. Thus, `len(dataset)` diverges from the actual number of samples. The latter is tested in  

https://github.com/pytorch/vision/blob/b5149557f0a7113860836faf71514c4238c7a2cc/test/test_prototype_builtin_datasets.py#L85
