### PR TITLE
Add RetinaNet improved weights

### DIFF
--- a/torchvision/models/detection/retinanet.py
+++ b/torchvision/models/detection/retinanet.py
@@ -672,17 +672,22 @@ class RetinaNet(nn.Module):
         return self.eager_outputs(losses, detections)
 
 
+_COMMON_META = {
+    "task": "image_object_detection",
+    "architecture": "RetinaNet",
+    "publication_year": 2017,
+    "categories": _COCO_CATEGORIES,
+    "interpolation": InterpolationMode.BILINEAR,
+}
+
+
 class RetinaNet_ResNet50_FPN_Weights(WeightsEnum):
     COCO_V1 = Weights(
         url="https://download.pytorch.org/models/retinanet_resnet50_fpn_coco-eeacb38b.pth",
         transforms=ObjectDetection,
         meta={
-            "task": "image_object_detection",
-            "architecture": "RetinaNet",
-            "publication_year": 2017,
+            **_COMMON_META,
             "num_params": 34014999,
-            "categories": _COCO_CATEGORIES,
-            "interpolation": InterpolationMode.BILINEAR,
             "recipe": "https://github.com/pytorch/vision/tree/main/references/detection#retinanet",
             "map": 36.4,
         },
@@ -691,7 +696,17 @@ class RetinaNet_ResNet50_FPN_Weights(WeightsEnum):
 
 
 class RetinaNet_ResNet50_FPN_V2_Weights(WeightsEnum):
-    pass
+    COCO_V1 = Weights(
+        url="",
+        transforms=ObjectDetection,
+        meta={
+            **_COMMON_META,
+            "num_params": 38198935,
+            "recipe": "",
+            "map": 41.5,
+        },
+    )
+    DEFAULT = COCO_V1
 
 
 @handle_legacy_interface(

--- a/torchvision/models/detection/retinanet.py
+++ b/torchvision/models/detection/retinanet.py
@@ -697,12 +697,12 @@ class RetinaNet_ResNet50_FPN_Weights(WeightsEnum):
 
 class RetinaNet_ResNet50_FPN_V2_Weights(WeightsEnum):
     COCO_V1 = Weights(
-        url="",
+        url="https://download.pytorch.org/models/retinanet_resnet50_fpn_v2_coco-5905b1c5.pth",
         transforms=ObjectDetection,
         meta={
             **_COMMON_META,
             "num_params": 38198935,
-            "recipe": "",
+            "recipe": "https://github.com/pytorch/vision/pull/5756",
             "map": 41.5,
         },
     )

--- a/torchvision/models/detection/retinanet.py
+++ b/torchvision/models/detection/retinanet.py
@@ -675,7 +675,6 @@ class RetinaNet(nn.Module):
 _COMMON_META = {
     "task": "image_object_detection",
     "architecture": "RetinaNet",
-    "publication_year": 2017,
     "categories": _COCO_CATEGORIES,
     "interpolation": InterpolationMode.BILINEAR,
 }
@@ -687,6 +686,7 @@ class RetinaNet_ResNet50_FPN_Weights(WeightsEnum):
         transforms=ObjectDetection,
         meta={
             **_COMMON_META,
+            "publication_year": 2017,
             "num_params": 34014999,
             "recipe": "https://github.com/pytorch/vision/tree/main/references/detection#retinanet",
             "map": 36.4,
@@ -701,6 +701,7 @@ class RetinaNet_ResNet50_FPN_V2_Weights(WeightsEnum):
         transforms=ObjectDetection,
         meta={
             **_COMMON_META,
+            "publication_year": 2019,
             "num_params": 38198935,
             "recipe": "https://github.com/pytorch/vision/pull/5756",
             "map": 41.5,


### PR DESCRIPTION
Fixes #5307

Adds new pre-trained weights for RetinaNet + ResNet50 + FPN for the v2 variant with post-paper optimizations (no FrozenBN + c5 instead of p5 input on extra layers + GN on Head + gIoU loss). It improves the previous baseline by +5.1 mAP.

Trained with:
```
python -u run_with_submitit.py --ngpus 8 --nodes 1 --weights-backbone ResNet50_Weights.IMAGENET1K_V2 \ 
--dataset coco --model retinanet_resnet50_fpn_v2 --opt adamw --lr 0.0001 --epochs 26 --lr-steps 16 22 \
--weight-decay 0.05 --norm-weight-decay 0.0 --data-augmentation multiscale --sync-bn
```

Verified with:
```
torchrun --nproc_per_node=1 train.py --test-only --weights RetinaNet_ResNet50_FPN_V2_Weights.COCO_V1 \
--model retinanet_resnet50_fpn_v2 -b 1

IoU metric: bbox
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.415
 Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.618
 Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.439
 Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.270
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.457
 Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.538
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.337
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.543
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.587
 Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.418
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.629
 Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.721
```