### PR TITLE
Add FasterRCNN improved weights

### DIFF
--- a/torchvision/models/detection/faster_rcnn.py
+++ b/torchvision/models/detection/faster_rcnn.py
@@ -393,7 +393,17 @@ class FasterRCNN_ResNet50_FPN_Weights(WeightsEnum):
 
 
 class FasterRCNN_ResNet50_FPN_V2_Weights(WeightsEnum):
-    pass
+    COCO_V1 = Weights(
+        url="https://download.pytorch.org/models/fasterrcnn_resnet50_fpn_v2_coco-dd69338a.pth",
+        transforms=ObjectDetection,
+        meta={
+            **_COMMON_META,
+            "num_params": 43712278,
+            "recipe": "",
+            "map": 46.7,
+        },
+    )
+    DEFAULT = COCO_V1
 
 
 class FasterRCNN_MobileNet_V3_Large_FPN_Weights(WeightsEnum):

--- a/torchvision/models/detection/faster_rcnn.py
+++ b/torchvision/models/detection/faster_rcnn.py
@@ -398,6 +398,7 @@ class FasterRCNN_ResNet50_FPN_V2_Weights(WeightsEnum):
         transforms=ObjectDetection,
         meta={
             **_COMMON_META,
+            "publication_year": 2021,
             "num_params": 43712278,
             "recipe": "https://github.com/pytorch/vision/pull/5763",
             "map": 46.7,

--- a/torchvision/models/detection/faster_rcnn.py
+++ b/torchvision/models/detection/faster_rcnn.py
@@ -399,7 +399,7 @@ class FasterRCNN_ResNet50_FPN_V2_Weights(WeightsEnum):
         meta={
             **_COMMON_META,
             "num_params": 43712278,
-            "recipe": "",
+            "recipe": "https://github.com/pytorch/vision/pull/5763",
             "map": 46.7,
         },
     )


### PR DESCRIPTION
Fixes #5307

Adds new pre-trained weights for FasterRCNN + ResNet50 + FPN for the v2 variant with post-paper optimizations (no FrozenBN + c5 instead of p5 input on extra layers + heavier RPN/Box Heads with BNs). It improves the previous baseline by +9.7 mAP.

Trained with:
```
python -u run_with_submitit.py --ngpus 8 --nodes 4 --dataset coco --model fasterrcnn_resnet50_fpn_v2 \
--epochs 400 --lr-steps 352 384 --lr 0.1 --batch-size 2 --weight-decay 0.00004 --sync-bn \
--data-augmentation lsj 
```

Verified with:
```
torchrun --nproc_per_node=1 train.py --test-only --weights FasterRCNN_ResNet50_FPN_V2_Weights.COCO_V1 \
--model fasterrcnn_resnet50_fpn_v2 -b 1

IoU metric: bbox
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.467
 Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.673
 Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.511
 Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.303
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.506
 Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.602
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.366
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.579
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.609
 Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.441
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.645
 Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.754
```