### PR TITLE
fix caltech dataset downloads

### DIFF
--- a/torchvision/datasets/caltech.py
+++ b/torchvision/datasets/caltech.py
@@ -129,13 +129,15 @@ class Caltech101(VisionDataset):
             return
 
         download_and_extract_archive(
-            "http://www.vision.caltech.edu/Image_Datasets/Caltech101/101_ObjectCategories.tar.gz",
+            "https://drive.google.com/file/d/137RyRjvTBkBiIfeYBNZBtViDHQ6_Ewsp",
             self.root,
+            filename="101_ObjectCategories.tar.gz",
             md5="b224c7392d521a49829488ab0f1120d9",
         )
         download_and_extract_archive(
-            "http://www.vision.caltech.edu/Image_Datasets/Caltech101/Annotations.tar",
+            "https://drive.google.com/file/d/175kQy3UsZ0wUEHZjqkUDdNVssr7bgh_m",
             self.root,
+            filename="Annotations.tar",
             md5="6f83eeb1f24d99cab4eb377263132c91",
         )
 
@@ -228,7 +230,7 @@ class Caltech256(VisionDataset):
             return
 
         download_and_extract_archive(
-            "http://www.vision.caltech.edu/Image_Datasets/Caltech256/256_ObjectCategories.tar",
+            "https://drive.google.com/file/d/1r6o0pSROcV1_VwT4oSjA2FBUSCWGuxLK",
             self.root,
             filename="256_ObjectCategories.tar",
             md5="67b4f42ca05d46448c6bb8ecd2220f6d",

--- a/torchvision/prototype/datasets/_builtin/caltech.py
+++ b/torchvision/prototype/datasets/_builtin/caltech.py
@@ -9,7 +9,7 @@ from torchdata.datapipes.iter import (
     Filter,
     IterKeyZipper,
 )
-from torchvision.prototype.datasets.utils import Dataset, HttpResource, OnlineResource
+from torchvision.prototype.datasets.utils import Dataset, GDriveResource, OnlineResource
 from torchvision.prototype.datasets.utils._internal import (
     INFINITE_BUFFER_SIZE,
     read_mat,
@@ -49,13 +49,15 @@ class Caltech101(Dataset):
         )
 
     def _resources(self) -> List[OnlineResource]:
-        images = HttpResource(
-            "http://www.vision.caltech.edu/Image_Datasets/Caltech101/101_ObjectCategories.tar.gz",
+        images = GDriveResource(
+            "137RyRjvTBkBiIfeYBNZBtViDHQ6_Ewsp",
+            file_name="101_ObjectCategories.tar.gz",
             sha256="af6ece2f339791ca20f855943d8b55dd60892c0a25105fcd631ee3d6430f9926",
             preprocess="decompress",
         )
-        anns = HttpResource(
-            "http://www.vision.caltech.edu/Image_Datasets/Caltech101/Annotations.tar",
+        anns = GDriveResource(
+            "175kQy3UsZ0wUEHZjqkUDdNVssr7bgh_m",
+            file_name="Annotations.tar",
             sha256="1717f4e10aa837b05956e3f4c94456527b143eec0d95e935028b30aff40663d8",
         )
         return [images, anns]
@@ -171,8 +173,9 @@ class Caltech256(Dataset):
 
     def _resources(self) -> List[OnlineResource]:
         return [
-            HttpResource(
-                "http://www.vision.caltech.edu/Image_Datasets/Caltech256/256_ObjectCategories.tar",
+            GDriveResource(
+                "1r6o0pSROcV1_VwT4oSjA2FBUSCWGuxLK",
+                file_name="256_ObjectCategories.tar",
                 sha256="08ff01b03c65566014ae88eb0490dbe4419fc7ac4de726ee1163e39fd809543e",
             )
         ]

--- a/torchvision/prototype/datasets/_builtin/cub200.py
+++ b/torchvision/prototype/datasets/_builtin/cub200.py
@@ -13,11 +13,7 @@ from torchdata.datapipes.iter import (
     CSVParser,
     CSVDictParser,
 )
-from torchvision.prototype.datasets.utils import (
-    Dataset,
-    HttpResource,
-    OnlineResource,
-)
+from torchvision.prototype.datasets.utils import Dataset, GDriveResource, OnlineResource
 from torchvision.prototype.datasets.utils._internal import (
     INFINITE_BUFFER_SIZE,
     read_mat,
@@ -71,30 +67,35 @@ class CUB200(Dataset):
 
     def _resources(self) -> List[OnlineResource]:
         if self._year == "2011":
-            archive = HttpResource(
-                "http://www.vision.caltech.edu/visipedia-data/CUB-200-2011/CUB_200_2011.tgz",
+            archive = GDriveResource(
+                "1hbzc_P1FuxMkcabkgn9ZKinBwW683j45",
+                file_name="CUB_200_2011.tgz",
                 sha256="0c685df5597a8b24909f6a7c9db6d11e008733779a671760afef78feb49bf081",
                 preprocess="decompress",
             )
-            segmentations = HttpResource(
-                "http://www.vision.caltech.edu/visipedia-data/CUB-200-2011/segmentations.tgz",
+            segmentations = GDriveResource(
+                "1EamOKGLoTuZdtcVYbHMWNpkn3iAVj8TP",
+                file_name="segmentations.tgz",
                 sha256="dc77f6cffea0cbe2e41d4201115c8f29a6320ecb04fffd2444f51b8066e4b84f",
                 preprocess="decompress",
             )
             return [archive, segmentations]
         else:  # self._year == "2010"
-            split = HttpResource(
-                "http://www.vision.caltech.edu/visipedia-data/CUB-200/lists.tgz",
+            split = GDriveResource(
+                "1vZuZPqha0JjmwkdaS_XtYryE3Jf5Q1AC",
+                file_name="lists.tgz",
                 sha256="aeacbd5e3539ae84ea726e8a266a9a119c18f055cd80f3836d5eb4500b005428",
                 preprocess="decompress",
             )
-            images = HttpResource(
-                "http://www.vision.caltech.edu/visipedia-data/CUB-200/images.tgz",
+            images = GDriveResource(
+                "1GDr1OkoXdhaXWGA8S3MAq3a522Tak-nx",
+                file_name="images.tgz",
                 sha256="2a6d2246bbb9778ca03aa94e2e683ccb4f8821a36b7f235c0822e659d60a803e",
                 preprocess="decompress",
             )
-            anns = HttpResource(
-                "http://www.vision.caltech.edu/visipedia-data/CUB-200/annotations.tgz",
+            anns = GDriveResource(
+                "16NsbTpMs5L6hT4hUJAmpW2u7wH326WTR",
+                file_name="annotations.tgz",
                 sha256="c17b7841c21a66aa44ba8fe92369cc95dfc998946081828b1d7b8a4b716805c1",
                 preprocess="decompress",
             )


### PR DESCRIPTION
Fixes #5737. Their [website](http://www.vision.caltech.edu/datasets/) features this message:

![caltech](https://user-images.githubusercontent.com/6849766/162417847-80976b52-df31-47fa-bb71-a942f2551310.png)

The files are now hosted on [GDrive](https://drive.google.com/drive/folders/1cnQHqa8BkVx90-6-UojHnbMB0WhksSRc) linked under "Some of our datasets are available here.". The links at the bottom for Caltech 101 / 256 seem to feature the same data, but packaged in a different way. Thus, I've opted to just switch to GDrive as source.

I've confirmed that the download now works again and that the checksums indeed match the ones we have on record.