### PR TITLE
Add SWAG model weight that only the linear head is finetuned to ImageNet1K

### DIFF
--- a/torchvision/models/regnet.py
+++ b/torchvision/models/regnet.py
@@ -588,6 +588,9 @@ class RegNet_Y_16GF_Weights(WeightsEnum):
         },
     )
     IMAGENET1K_SWAG_LINEAR_V1 = Weights(
+        # This model has trunk weight from weakly supervised learning described in https://arxiv.org/pdf/2201.08371.pdf
+        # with only linear head finetuned to IMAGENET1K dataset
+        # This model is suitable for users that want to fine tune the pretrained trunk on other downstream datasets
         url="https://download.pytorch.org/models/regnet_y_16gf_lc_swag-f3ec0043.pth",
         transforms=partial(
             ImageClassification, crop_size=224, resize_size=224, interpolation=InterpolationMode.BICUBIC
@@ -638,6 +641,9 @@ class RegNet_Y_32GF_Weights(WeightsEnum):
         },
     )
     IMAGENET1K_SWAG_LINEAR_V1 = Weights(
+        # This model has trunk weight from weakly supervised learning described in https://arxiv.org/pdf/2201.08371.pdf
+        # with only linear head finetuned to IMAGENET1K dataset
+        # This model is suitable for users that want to fine tune the pretrained trunk on other downstream datasets
         url="https://download.pytorch.org/models/regnet_y_32gf_lc_swag-e1583746.pth",
         transforms=partial(
             ImageClassification, crop_size=224, resize_size=224, interpolation=InterpolationMode.BICUBIC
@@ -666,6 +672,9 @@ class RegNet_Y_128GF_Weights(WeightsEnum):
         },
     )
     IMAGENET1K_SWAG_LINEAR_V1 = Weights(
+        # This model has trunk weight from weakly supervised learning described in https://arxiv.org/pdf/2201.08371.pdf
+        # with only linear head finetuned to IMAGENET1K dataset
+        # This model is suitable for users that want to fine tune the pretrained trunk on other downstream datasets
         url="https://download.pytorch.org/models/regnet_y_128gf_lc_swag-cbe8ce12.pth",
         transforms=partial(
             ImageClassification, crop_size=224, resize_size=224, interpolation=InterpolationMode.BICUBIC

--- a/torchvision/models/regnet.py
+++ b/torchvision/models/regnet.py
@@ -587,6 +587,19 @@ class RegNet_Y_16GF_Weights(WeightsEnum):
             "acc@5": 98.054,
         },
     )
+    IMAGENET1K_SWAG_LC_V1 = Weights(
+        url="https://download.pytorch.org/models/regnet_y_16gf_lc_swag-f3ec0043.pth",
+        transforms=partial(
+            ImageClassification, crop_size=224, resize_size=224, interpolation=InterpolationMode.BICUBIC
+        ),
+        meta={
+            **_COMMON_SWAG_META,
+            "num_params": 83590140,
+            # Still mocks
+            "acc@1": 86.012,
+            "acc@5": 98.054,
+        },
+    )
     DEFAULT = IMAGENET1K_V2
 
 
@@ -625,6 +638,19 @@ class RegNet_Y_32GF_Weights(WeightsEnum):
             "acc@5": 98.362,
         },
     )
+    IMAGENET1K_SWAG_LC_V1 = Weights(
+        url="https://download.pytorch.org/models/regnet_y_32gf_lc_swag-e1583746.pth",
+        transforms=partial(
+            ImageClassification, crop_size=224, resize_size=224, interpolation=InterpolationMode.BICUBIC
+        ),
+        meta={
+            **_COMMON_SWAG_META,
+            "num_params": 145046770,
+            # Still mocks
+            "acc@1": 86.838,
+            "acc@5": 98.362,
+        },
+    )
     DEFAULT = IMAGENET1K_V2
 
 
@@ -637,6 +663,19 @@ class RegNet_Y_128GF_Weights(WeightsEnum):
         meta={
             **_COMMON_SWAG_META,
             "num_params": 644812894,
+            "acc@1": 88.228,
+            "acc@5": 98.682,
+        },
+    )
+    IMAGENET1K_SWAG_LC_V1 = Weights(
+        url="https://download.pytorch.org/models/regnet_y_128gf_lc_swag-cbe8ce12.pth",
+        transforms=partial(
+            ImageClassification, crop_size=224, resize_size=224, interpolation=InterpolationMode.BICUBIC
+        ),
+        meta={
+            **_COMMON_SWAG_META,
+            "num_params": 644812894,
+            # Still mocks
             "acc@1": 88.228,
             "acc@5": 98.682,
         },

--- a/torchvision/models/regnet.py
+++ b/torchvision/models/regnet.py
@@ -575,7 +575,7 @@ class RegNet_Y_16GF_Weights(WeightsEnum):
             "acc@5": 96.328,
         },
     )
-    IMAGENET1K_SWAG_V1 = Weights(
+    IMAGENET1K_SWAG_E2E_V1 = Weights(
         url="https://download.pytorch.org/models/regnet_y_16gf_swag-43afe44d.pth",
         transforms=partial(
             ImageClassification, crop_size=384, resize_size=384, interpolation=InterpolationMode.BICUBIC
@@ -588,15 +588,13 @@ class RegNet_Y_16GF_Weights(WeightsEnum):
         },
     )
     IMAGENET1K_SWAG_LINEAR_V1 = Weights(
-        # This model has trunk weight from weakly supervised learning described in https://arxiv.org/pdf/2201.08371.pdf
-        # with only linear head finetuned to IMAGENET1K dataset
-        # This model is suitable for users that want to fine tune the pretrained trunk on other downstream datasets
         url="https://download.pytorch.org/models/regnet_y_16gf_lc_swag-f3ec0043.pth",
         transforms=partial(
             ImageClassification, crop_size=224, resize_size=224, interpolation=InterpolationMode.BICUBIC
         ),
         meta={
             **_COMMON_SWAG_META,
+            "recipe": "https://github.com/pytorch/vision/pull/5793",
             "num_params": 83590140,
             "acc@1": 83.976,
             "acc@5": 97.244,
@@ -628,7 +626,7 @@ class RegNet_Y_32GF_Weights(WeightsEnum):
             "acc@5": 96.498,
         },
     )
-    IMAGENET1K_SWAG_V1 = Weights(
+    IMAGENET1K_SWAG_E2E_V1 = Weights(
         url="https://download.pytorch.org/models/regnet_y_32gf_swag-04fdfa75.pth",
         transforms=partial(
             ImageClassification, crop_size=384, resize_size=384, interpolation=InterpolationMode.BICUBIC
@@ -641,15 +639,13 @@ class RegNet_Y_32GF_Weights(WeightsEnum):
         },
     )
     IMAGENET1K_SWAG_LINEAR_V1 = Weights(
-        # This model has trunk weight from weakly supervised learning described in https://arxiv.org/pdf/2201.08371.pdf
-        # with only linear head finetuned to IMAGENET1K dataset
-        # This model is suitable for users that want to fine tune the pretrained trunk on other downstream datasets
         url="https://download.pytorch.org/models/regnet_y_32gf_lc_swag-e1583746.pth",
         transforms=partial(
             ImageClassification, crop_size=224, resize_size=224, interpolation=InterpolationMode.BICUBIC
         ),
         meta={
             **_COMMON_SWAG_META,
+            "recipe": "https://github.com/pytorch/vision/pull/5793",
             "num_params": 145046770,
             "acc@1": 84.622,
             "acc@5": 97.480,
@@ -659,7 +655,7 @@ class RegNet_Y_32GF_Weights(WeightsEnum):
 
 
 class RegNet_Y_128GF_Weights(WeightsEnum):
-    IMAGENET1K_SWAG_V1 = Weights(
+    IMAGENET1K_SWAG_E2E_V1 = Weights(
         url="https://download.pytorch.org/models/regnet_y_128gf_swag-c8ce3e52.pth",
         transforms=partial(
             ImageClassification, crop_size=384, resize_size=384, interpolation=InterpolationMode.BICUBIC
@@ -672,21 +668,19 @@ class RegNet_Y_128GF_Weights(WeightsEnum):
         },
     )
     IMAGENET1K_SWAG_LINEAR_V1 = Weights(
-        # This model has trunk weight from weakly supervised learning described in https://arxiv.org/pdf/2201.08371.pdf
-        # with only linear head finetuned to IMAGENET1K dataset
-        # This model is suitable for users that want to fine tune the pretrained trunk on other downstream datasets
         url="https://download.pytorch.org/models/regnet_y_128gf_lc_swag-cbe8ce12.pth",
         transforms=partial(
             ImageClassification, crop_size=224, resize_size=224, interpolation=InterpolationMode.BICUBIC
         ),
         meta={
             **_COMMON_SWAG_META,
+            "recipe": "https://github.com/pytorch/vision/pull/5793",
             "num_params": 644812894,
             "acc@1": 86.068,
             "acc@5": 97.844,
         },
     )
-    DEFAULT = IMAGENET1K_SWAG_V1
+    DEFAULT = IMAGENET1K_SWAG_E2E_V1
 
 
 class RegNet_X_400MF_Weights(WeightsEnum):

--- a/torchvision/models/regnet.py
+++ b/torchvision/models/regnet.py
@@ -595,9 +595,8 @@ class RegNet_Y_16GF_Weights(WeightsEnum):
         meta={
             **_COMMON_SWAG_META,
             "num_params": 83590140,
-            # Still mocks
-            "acc@1": 86.012,
-            "acc@5": 98.054,
+            "acc@1": 83.976,
+            "acc@5": 97.244,
         },
     )
     DEFAULT = IMAGENET1K_V2
@@ -646,9 +645,8 @@ class RegNet_Y_32GF_Weights(WeightsEnum):
         meta={
             **_COMMON_SWAG_META,
             "num_params": 145046770,
-            # Still mocks
-            "acc@1": 86.838,
-            "acc@5": 98.362,
+            "acc@1": 84.622,
+            "acc@5": 97.480,
         },
     )
     DEFAULT = IMAGENET1K_V2
@@ -675,9 +673,8 @@ class RegNet_Y_128GF_Weights(WeightsEnum):
         meta={
             **_COMMON_SWAG_META,
             "num_params": 644812894,
-            # Still mocks
-            "acc@1": 88.228,
-            "acc@5": 98.682,
+            "acc@1": 86.068,
+            "acc@5": 97.844,
         },
     )
     DEFAULT = IMAGENET1K_SWAG_V1

--- a/torchvision/models/regnet.py
+++ b/torchvision/models/regnet.py
@@ -587,7 +587,7 @@ class RegNet_Y_16GF_Weights(WeightsEnum):
             "acc@5": 98.054,
         },
     )
-    IMAGENET1K_SWAG_LC_V1 = Weights(
+    IMAGENET1K_SWAG_LINEAR_V1 = Weights(
         url="https://download.pytorch.org/models/regnet_y_16gf_lc_swag-f3ec0043.pth",
         transforms=partial(
             ImageClassification, crop_size=224, resize_size=224, interpolation=InterpolationMode.BICUBIC
@@ -637,7 +637,7 @@ class RegNet_Y_32GF_Weights(WeightsEnum):
             "acc@5": 98.362,
         },
     )
-    IMAGENET1K_SWAG_LC_V1 = Weights(
+    IMAGENET1K_SWAG_LINEAR_V1 = Weights(
         url="https://download.pytorch.org/models/regnet_y_32gf_lc_swag-e1583746.pth",
         transforms=partial(
             ImageClassification, crop_size=224, resize_size=224, interpolation=InterpolationMode.BICUBIC
@@ -665,7 +665,7 @@ class RegNet_Y_128GF_Weights(WeightsEnum):
             "acc@5": 98.682,
         },
     )
-    IMAGENET1K_SWAG_LC_V1 = Weights(
+    IMAGENET1K_SWAG_LINEAR_V1 = Weights(
         url="https://download.pytorch.org/models/regnet_y_128gf_lc_swag-cbe8ce12.pth",
         transforms=partial(
             ImageClassification, crop_size=224, resize_size=224, interpolation=InterpolationMode.BICUBIC

--- a/torchvision/models/vision_transformer.py
+++ b/torchvision/models/vision_transformer.py
@@ -366,6 +366,24 @@ class ViT_B_16_Weights(WeightsEnum):
             "acc@5": 97.650,
         },
     )
+    IMAGENET1K_SWAG_LC_V1 = Weights(
+        url="https://download.pytorch.org/models/vit_b_16_lc_swag-4e70ced5.pth",
+        transforms=partial(
+            ImageClassification,
+            crop_size=224,
+            resize_size=224,
+            interpolation=InterpolationMode.BICUBIC,
+        ),
+        meta={
+            **_COMMON_SWAG_META,
+            "num_params": 86567656,
+            "size": (224, 224),
+            "min_size": (224, 224),
+            # Still mocks
+            "acc@1": 85.304,
+            "acc@5": 97.650,
+        },
+    )
     DEFAULT = IMAGENET1K_V1
 
 
@@ -417,6 +435,24 @@ class ViT_L_16_Weights(WeightsEnum):
             "acc@5": 98.512,
         },
     )
+    IMAGENET1K_SWAG_LC_V1 = Weights(
+        url="https://download.pytorch.org/models/vit_l_16_lc_swag-4d563306.pth",
+        transforms=partial(
+            ImageClassification,
+            crop_size=224,
+            resize_size=224,
+            interpolation=InterpolationMode.BICUBIC,
+        ),
+        meta={
+            **_COMMON_SWAG_META,
+            "num_params": 304326632,
+            "size": (224, 224),
+            "min_size": (224, 224),
+            # Still mocks
+            "acc@1": 88.064,
+            "acc@5": 98.512,
+        },
+    )
     DEFAULT = IMAGENET1K_V1
 
 
@@ -451,6 +487,24 @@ class ViT_H_14_Weights(WeightsEnum):
             "num_params": 633470440,
             "size": (518, 518),
             "min_size": (518, 518),
+            "acc@1": 88.552,
+            "acc@5": 98.694,
+        },
+    )
+    IMAGENET1K_SWAG_LC_V1 = Weights(
+        url="https://download.pytorch.org/models/vit_h_14_lc_swag-c1eb923e.pth",
+        transforms=partial(
+            ImageClassification,
+            crop_size=224,
+            resize_size=224,
+            interpolation=InterpolationMode.BICUBIC,
+        ),
+        meta={
+            **_COMMON_SWAG_META,
+            "num_params": 632045800,
+            "size": (224, 224),
+            "min_size": (224, 224),
+            # Still mocks
             "acc@1": 88.552,
             "acc@5": 98.694,
         },

--- a/torchvision/models/vision_transformer.py
+++ b/torchvision/models/vision_transformer.py
@@ -366,7 +366,7 @@ class ViT_B_16_Weights(WeightsEnum):
             "acc@5": 97.650,
         },
     )
-    IMAGENET1K_SWAG_LC_V1 = Weights(
+    IMAGENET1K_SWAG_LINEAR_V1 = Weights(
         url="https://download.pytorch.org/models/vit_b_16_lc_swag-4e70ced5.pth",
         transforms=partial(
             ImageClassification,
@@ -434,7 +434,7 @@ class ViT_L_16_Weights(WeightsEnum):
             "acc@5": 98.512,
         },
     )
-    IMAGENET1K_SWAG_LC_V1 = Weights(
+    IMAGENET1K_SWAG_LINEAR_V1 = Weights(
         url="https://download.pytorch.org/models/vit_l_16_lc_swag-4d563306.pth",
         transforms=partial(
             ImageClassification,
@@ -489,7 +489,7 @@ class ViT_H_14_Weights(WeightsEnum):
             "acc@5": 98.694,
         },
     )
-    IMAGENET1K_SWAG_LC_V1 = Weights(
+    IMAGENET1K_SWAG_LINEAR_V1 = Weights(
         url="https://download.pytorch.org/models/vit_h_14_lc_swag-c1eb923e.pth",
         transforms=partial(
             ImageClassification,

--- a/torchvision/models/vision_transformer.py
+++ b/torchvision/models/vision_transformer.py
@@ -349,7 +349,7 @@ class ViT_B_16_Weights(WeightsEnum):
             "acc@5": 95.318,
         },
     )
-    IMAGENET1K_SWAG_V1 = Weights(
+    IMAGENET1K_SWAG_E2E_V1 = Weights(
         url="https://download.pytorch.org/models/vit_b_16_swag-9ac1b537.pth",
         transforms=partial(
             ImageClassification,
@@ -367,9 +367,6 @@ class ViT_B_16_Weights(WeightsEnum):
         },
     )
     IMAGENET1K_SWAG_LINEAR_V1 = Weights(
-        # This model has trunk weight from weakly supervised learning described in https://arxiv.org/pdf/2201.08371.pdf
-        # with only linear head finetuned to IMAGENET1K dataset
-        # This model is suitable for users that want to fine tune the pretrained trunk on other downstream datasets
         url="https://download.pytorch.org/models/vit_b_16_lc_swag-4e70ced5.pth",
         transforms=partial(
             ImageClassification,
@@ -379,6 +376,7 @@ class ViT_B_16_Weights(WeightsEnum):
         ),
         meta={
             **_COMMON_SWAG_META,
+            "recipe": "https://github.com/pytorch/vision/pull/5793",
             "num_params": 86567656,
             "size": (224, 224),
             "min_size": (224, 224),
@@ -420,7 +418,7 @@ class ViT_L_16_Weights(WeightsEnum):
             "acc@5": 94.638,
         },
     )
-    IMAGENET1K_SWAG_V1 = Weights(
+    IMAGENET1K_SWAG_E2E_V1 = Weights(
         url="https://download.pytorch.org/models/vit_l_16_swag-4f3808c9.pth",
         transforms=partial(
             ImageClassification,
@@ -438,9 +436,6 @@ class ViT_L_16_Weights(WeightsEnum):
         },
     )
     IMAGENET1K_SWAG_LINEAR_V1 = Weights(
-        # This model has trunk weight from weakly supervised learning described in https://arxiv.org/pdf/2201.08371.pdf
-        # with only linear head finetuned to IMAGENET1K dataset
-        # This model is suitable for users that want to fine tune the pretrained trunk on other downstream datasets
         url="https://download.pytorch.org/models/vit_l_16_lc_swag-4d563306.pth",
         transforms=partial(
             ImageClassification,
@@ -450,6 +445,7 @@ class ViT_L_16_Weights(WeightsEnum):
         ),
         meta={
             **_COMMON_SWAG_META,
+            "recipe": "https://github.com/pytorch/vision/pull/5793",
             "num_params": 304326632,
             "size": (224, 224),
             "min_size": (224, 224),
@@ -478,7 +474,7 @@ class ViT_L_32_Weights(WeightsEnum):
 
 
 class ViT_H_14_Weights(WeightsEnum):
-    IMAGENET1K_SWAG_V1 = Weights(
+    IMAGENET1K_SWAG_E2E_V1 = Weights(
         url="https://download.pytorch.org/models/vit_h_14_swag-80465313.pth",
         transforms=partial(
             ImageClassification,
@@ -496,9 +492,6 @@ class ViT_H_14_Weights(WeightsEnum):
         },
     )
     IMAGENET1K_SWAG_LINEAR_V1 = Weights(
-        # This model has trunk weight from weakly supervised learning described in https://arxiv.org/pdf/2201.08371.pdf
-        # with only linear head finetuned to IMAGENET1K dataset
-        # This model is suitable for users that want to fine tune the pretrained trunk on other downstream datasets
         url="https://download.pytorch.org/models/vit_h_14_lc_swag-c1eb923e.pth",
         transforms=partial(
             ImageClassification,
@@ -508,6 +501,7 @@ class ViT_H_14_Weights(WeightsEnum):
         ),
         meta={
             **_COMMON_SWAG_META,
+            "recipe": "https://github.com/pytorch/vision/pull/5793",
             "num_params": 632045800,
             "size": (224, 224),
             "min_size": (224, 224),
@@ -515,7 +509,7 @@ class ViT_H_14_Weights(WeightsEnum):
             "acc@5": 97.730,
         },
     )
-    DEFAULT = IMAGENET1K_SWAG_V1
+    DEFAULT = IMAGENET1K_SWAG_E2E_V1
 
 
 @handle_legacy_interface(weights=("pretrained", ViT_B_16_Weights.IMAGENET1K_V1))

--- a/torchvision/models/vision_transformer.py
+++ b/torchvision/models/vision_transformer.py
@@ -367,6 +367,9 @@ class ViT_B_16_Weights(WeightsEnum):
         },
     )
     IMAGENET1K_SWAG_LINEAR_V1 = Weights(
+        # This model has trunk weight from weakly supervised learning described in https://arxiv.org/pdf/2201.08371.pdf
+        # with only linear head finetuned to IMAGENET1K dataset
+        # This model is suitable for users that want to fine tune the pretrained trunk on other downstream datasets
         url="https://download.pytorch.org/models/vit_b_16_lc_swag-4e70ced5.pth",
         transforms=partial(
             ImageClassification,
@@ -435,6 +438,9 @@ class ViT_L_16_Weights(WeightsEnum):
         },
     )
     IMAGENET1K_SWAG_LINEAR_V1 = Weights(
+        # This model has trunk weight from weakly supervised learning described in https://arxiv.org/pdf/2201.08371.pdf
+        # with only linear head finetuned to IMAGENET1K dataset
+        # This model is suitable for users that want to fine tune the pretrained trunk on other downstream datasets
         url="https://download.pytorch.org/models/vit_l_16_lc_swag-4d563306.pth",
         transforms=partial(
             ImageClassification,
@@ -490,6 +496,9 @@ class ViT_H_14_Weights(WeightsEnum):
         },
     )
     IMAGENET1K_SWAG_LINEAR_V1 = Weights(
+        # This model has trunk weight from weakly supervised learning described in https://arxiv.org/pdf/2201.08371.pdf
+        # with only linear head finetuned to IMAGENET1K dataset
+        # This model is suitable for users that want to fine tune the pretrained trunk on other downstream datasets
         url="https://download.pytorch.org/models/vit_h_14_lc_swag-c1eb923e.pth",
         transforms=partial(
             ImageClassification,

--- a/torchvision/models/vision_transformer.py
+++ b/torchvision/models/vision_transformer.py
@@ -379,9 +379,8 @@ class ViT_B_16_Weights(WeightsEnum):
             "num_params": 86567656,
             "size": (224, 224),
             "min_size": (224, 224),
-            # Still mocks
-            "acc@1": 85.304,
-            "acc@5": 97.650,
+            "acc@1": 81.886,
+            "acc@5": 96.180,
         },
     )
     DEFAULT = IMAGENET1K_V1
@@ -448,9 +447,8 @@ class ViT_L_16_Weights(WeightsEnum):
             "num_params": 304326632,
             "size": (224, 224),
             "min_size": (224, 224),
-            # Still mocks
-            "acc@1": 88.064,
-            "acc@5": 98.512,
+            "acc@1": 85.146,
+            "acc@5": 97.422,
         },
     )
     DEFAULT = IMAGENET1K_V1
@@ -504,9 +502,8 @@ class ViT_H_14_Weights(WeightsEnum):
             "num_params": 632045800,
             "size": (224, 224),
             "min_size": (224, 224),
-            # Still mocks
-            "acc@1": 88.552,
-            "acc@5": 98.694,
+            "acc@1": 85.708,
+            "acc@5": 97.730,
         },
     )
     DEFAULT = IMAGENET1K_SWAG_V1


### PR DESCRIPTION
subtask of https://github.com/pytorch/vision/issues/5708

### Model Description

This model has trunk weight from weakly supervised learning described in https://arxiv.org/pdf/2201.08371.pdf. The linear head is fine-tuned to IMAGENET1K dataset while the pre-trained trunk weights are frozen. 

_**This model is suitable for users that want to fine tune the pre-trained trunk on other downstream datasets**_

### Linear head Fine-tuning parameters on IMAGENET1K:

**Regnet model (for all size 16gf, 32gf, 128gf):**

- Num epochs: 28
- Trained on 1 nodes with 8 voltas GPU (32Gb) each
- Batch size per GPU: 32
- image size: 224
- SGD Optimizer with params:
  * weight decay: 0.001
  * momentum: 0.9
  * use Nesterov: True
- Learning Rate param:
  * scheduler: CosineAnnealingLR
  * Start value: 0.001 
- ImageAugmentation transforms:
  * RandomResizeCrop of size 224 with interpolation 3
  * RandomHorizontalFlip
  * Normalize
- Note: Trained with pytorch mixed precision

**VIsion Transformer (for all size b/16, l/16, h/14):**

- Num epochs: 28
- Trained on 4 nodes with 8 voltas GPU (32Gb) each
- Batch size per GPU: 32
- image size: 224
- SGD Optimizer with params:
  * weight decay: 1.00 E-09
  * momentum: 0.9
  * use Nesterov: True
- Learning Rate param:
  * scheduler: CosineAnnealingLR
  * Start value: 0.04
- ImageAugmentation transforms:
  * RandomResizeCrop of size 224 with interpolation 3
  * RandomHorizontalFlip
  * Normalize
- Note: Trained with pytorch mixed precision

### Validation script and result

```
## RegNet_Y_16GF
python -u ~/script/run_with_submitit.py --timeout 3000 --ngpus 1 --nodes 1 --partition train --model regnet_y_16gf --data-path="/datasets01_ontap/imagenet_full_size/061417" --test-only --batch-size=1 --weights="RegNet_Y_16GF_Weights.IMAGENET1K_SWAG_LINEAR_V1"
# Acc@1 83.976 Acc@5 97.244

## RegNet_Y_32GF
python -u ~/script/run_with_submitit.py --timeout 3000 --ngpus 1 --nodes 1 --partition train --model regnet_y_32gf --data-path="/datasets01_ontap/imagenet_full_size/061417" --test-only --batch-size=1 --weights="RegNet_Y_32GF_Weights.IMAGENET1K_SWAG_LINEAR_V1"
# Acc@1 84.622 Acc@5 97.480

## RegNet_Y_128GF
python -u ~/script/run_with_submitit.py --timeout 3000 --ngpus 1 --nodes 1 --partition train --model regnet_y_128gf --data-path="/datasets01_ontap/imagenet_full_size/061417" --test-only --batch-size=1 --weights="RegNet_Y_128GF_Weights.IMAGENET1K_SWAG_LINEAR_V1"
# Acc@1 86.068 Acc@5 97.844

## ViT_B_16
python -u ~/script/run_with_submitit.py --timeout 3000 --ngpus 1 --nodes 1 --partition train --model vit_b_16 --data-path="/datasets01_ontap/imagenet_full_size/061417" --test-only --batch-size=1 --weights="ViT_B_16_Weights.IMAGENET1K_SWAG_LINEAR_V1"
# Acc@1 81.886 Acc@5 96.180

## ViT_L_16
python -u ~/script/run_with_submitit.py --timeout 3000 --ngpus 1 --nodes 1 --partition train --model vit_l_16 --data-path="/datasets01_ontap/imagenet_full_size/061417" --test-only --batch-size=1 --weights="ViT_L_16_Weights.IMAGENET1K_SWAG_LINEAR_V1"
# Acc@1 85.146 Acc@5 97.422

## ViT_H_14
python -u ~/script/run_with_submitit.py --timeout 3000 --ngpus 1 --nodes 1 --partition train --model vit_h_14 --data-path="/datasets01_ontap/imagenet_full_size/061417" --test-only --batch-size=1 --weights="ViT_H_14_Weights.IMAGENET1K_SWAG_LINEAR_V1"
# Acc@1 85.708 Acc@5 97.730
```
