### PR TITLE
Respect `strict=False` when loading detection models

### DIFF
--- a/torchvision/models/detection/mask_rcnn.py
+++ b/torchvision/models/detection/mask_rcnn.py
@@ -317,7 +317,8 @@ class MaskRCNNHeads(nn.Sequential):
                 for type in ["weight", "bias"]:
                     old_key = f"{prefix}mask_fcn{i+1}.{type}"
                     new_key = f"{prefix}{i}.0.{type}"
-                    state_dict[new_key] = state_dict.pop(old_key)
+                    if old_key in state_dict:
+                        state_dict[new_key] = state_dict.pop(old_key)
 
         super()._load_from_state_dict(
             state_dict,

--- a/torchvision/models/detection/retinanet.py
+++ b/torchvision/models/detection/retinanet.py
@@ -45,7 +45,8 @@ def _v1_to_v2_weights(state_dict, prefix):
         for type in ["weight", "bias"]:
             old_key = f"{prefix}conv.{2*i}.{type}"
             new_key = f"{prefix}conv.{i}.0.{type}"
-            state_dict[new_key] = state_dict.pop(old_key)
+            if old_key in state_dict:
+                state_dict[new_key] = state_dict.pop(old_key)
 
 
 def _default_anchorgen():

--- a/torchvision/models/detection/rpn.py
+++ b/torchvision/models/detection/rpn.py
@@ -56,7 +56,8 @@ class RPNHead(nn.Module):
             for type in ["weight", "bias"]:
                 old_key = f"{prefix}conv.{type}"
                 new_key = f"{prefix}conv.0.0.{type}"
-                state_dict[new_key] = state_dict.pop(old_key)
+                if old_key in state_dict:
+                    state_dict[new_key] = state_dict.pop(old_key)
 
         super()._load_from_state_dict(
             state_dict,

--- a/torchvision/ops/feature_pyramid_network.py
+++ b/torchvision/ops/feature_pyramid_network.py
@@ -128,7 +128,8 @@ class FeaturePyramidNetwork(nn.Module):
                     for type in ["weight", "bias"]:
                         old_key = f"{prefix}{block}.{i}.{type}"
                         new_key = f"{prefix}{block}.{i}.0.{type}"
-                        state_dict[new_key] = state_dict.pop(old_key)
+                        if old_key in state_dict:
+                           state_dict[new_key] = state_dict.pop(old_key)
 
         super()._load_from_state_dict(
             state_dict,

--- a/torchvision/ops/feature_pyramid_network.py
+++ b/torchvision/ops/feature_pyramid_network.py
@@ -129,7 +129,7 @@ class FeaturePyramidNetwork(nn.Module):
                         old_key = f"{prefix}{block}.{i}.{type}"
                         new_key = f"{prefix}{block}.{i}.0.{type}"
                         if old_key in state_dict:
-                           state_dict[new_key] = state_dict.pop(old_key)
+                            state_dict[new_key] = state_dict.pop(old_key)
 
         super()._load_from_state_dict(
             state_dict,


### PR DESCRIPTION
Fixes #5835

Tested with:
```python
from torchvision.models import detection

fns = [v for k, v in detection.__dict__.items() if callable(v) and k[0].lower() == k[0] and k[0] != "_"]
for fn in fns:
    try:
        model = fn(weights_backbone=None)
        model.load_state_dict({}, strict=False)
        print(fn.__name__, "PASS")
    except:
        print(fn.__name__, "FAIL")
```

Output:
```
fasterrcnn_resnet50_fpn PASS
fasterrcnn_resnet50_fpn_v2 PASS
fasterrcnn_mobilenet_v3_large_fpn PASS
fasterrcnn_mobilenet_v3_large_320_fpn PASS
fcos_resnet50_fpn PASS
keypointrcnn_resnet50_fpn PASS
maskrcnn_resnet50_fpn PASS
maskrcnn_resnet50_fpn_v2 PASS
retinanet_resnet50_fpn PASS
retinanet_resnet50_fpn_v2 PASS
ssd300_vgg16 PASS
ssdlite320_mobilenet_v3_large PASS
```

I'm not adding the test in the unit-tests to avoid slowing them down further. This gap can be resolved properly once we redesign the testing strategy for models.