### PR TITLE
Update meta-data documentation 

### DIFF
--- a/torchvision/models/_api.py
+++ b/torchvision/models/_api.py
@@ -28,7 +28,9 @@ class Weights:
         meta (Dict[str, Any]): Stores meta-data related to the weights of the model and its configuration. These can be
             informative attributes (for example the number of parameters/flops, recipe link/methods used in training
             etc), configuration parameters (for example the `num_classes`) needed to construct the model or important
-            meta-data (for example the `classes` of a classification model) needed to use the model.
+            meta-data (for example the `classes` of a classification model) needed to use the model. These meta-data
+            are considered part of the documentation and as a result there are no BC guarnatees (fields can be added,
+            removed and modified on future releases).
     """
 
     url: str


### PR DESCRIPTION
It's quite likely that on future versions of TorchVision, we will have to modify the meta-data stored along with the weights. I believe that those meta-data are documentation and not code and as a result we should be able to modify them (add, delete, edit fields) on the future.

This PR adds a note on the documentation to clarify that there are no BC guarantees on meta-data.