### PR TITLE
simplify boundingbox kernels with jit compatible ellipsis

### DIFF
--- a/torchvision/prototype/transforms/functional/_geometry.py
+++ b/torchvision/prototype/transforms/functional/_geometry.py
@@ -401,18 +401,16 @@ def pad_bounding_box(
 ) -> torch.Tensor:
     left, _, top, _ = _FT._parse_pad_padding(padding)
 
-    shape = bounding_box.shape
-
     bounding_box = convert_bounding_box_format(
         bounding_box, old_format=format, new_format=features.BoundingBoxFormat.XYXY
-    ).view(-1, 4)
+    )
 
-    bounding_box[:, 0::2] += left
-    bounding_box[:, 1::2] += top
+    bounding_box[..., 0::2] += left
+    bounding_box[..., 1::2] += top
 
     return convert_bounding_box_format(
         bounding_box, old_format=features.BoundingBoxFormat.XYXY, new_format=format, copy=False
-    ).view(shape)
+    )
 
 
 crop_image_tensor = _FT.crop
@@ -425,19 +423,17 @@ def crop_bounding_box(
     top: int,
     left: int,
 ) -> torch.Tensor:
-    shape = bounding_box.shape
-
     bounding_box = convert_bounding_box_format(
         bounding_box, old_format=format, new_format=features.BoundingBoxFormat.XYXY
-    ).view(-1, 4)
+    )
 
     # Crop or implicit pad if left and/or top have negative values:
-    bounding_box[:, 0::2] -= left
-    bounding_box[:, 1::2] -= top
+    bounding_box[..., 0::2] -= left
+    bounding_box[..., 1::2] -= top
 
     return convert_bounding_box_format(
         bounding_box, old_format=features.BoundingBoxFormat.XYXY, new_format=format, copy=False
-    ).view(shape)
+    )
 
 
 def perspective_image_tensor(


### PR DESCRIPTION
Addresses https://github.com/pytorch/vision/pull/5781#discussion_r855411284. Cross posting my answer there:

*Good catch. I was under the impression `...` was not supported by `torch.jit.script` in general, but this seems fine:*

```py
@torch.jit.script
def foo(x: torch.Tensor) -> torch.Tensor:
    y = x.clone()
    y[..., 0::2] += 1
    return y
```

*It seems, only the explicit indices are not supported:*

```py
@torch.jit.script
def bar(x: torch.Tensor) -> torch.Tensor:
    y = x.clone()
    y[..., [0, 2]] += 1
    return y
```

```
RuntimeError: 
Ellipses followed by tensor indexing is currently not supported:
[...]
def bar(x: torch.Tensor) -> torch.Tensor:
    y = x.clone()
    y[..., [0, 2]] += 1
    ~~~~~~~~~~~~~ <--- HERE
    return y
```
