### PR TITLE
Pin setuptools to 58.0.4 on Widnows

### DIFF
--- a/.circleci/unittest/windows/scripts/environment.yml
+++ b/.circleci/unittest/windows/scripts/environment.yml
@@ -10,6 +10,7 @@ dependencies:
   - jpeg
   - ca-certificates
   - hdf5
+  - setuptools == 58.0.4
   - pip:
     - future
     - pillow >=5.3.0, !=8.3.*


### PR DESCRIPTION
`setuptools` were update on anaconda to [61.2.0](https://anaconda.org/anaconda/setuptools/files?version=61.2.0) 10 days ago, but CircleCI environment caching occluded the issue for a while, but when update happened Win+Python-3.7 build started to fail, which suggests that it might have been caused by https://github.com/pypa/setuptools/issues/3219

Fixes https://github.com/pytorch/vision/issues/5830