### PR TITLE
Enable openmp parallelization for nms kernel

### DIFF
--- a/torchvision/csrc/ops/autocast/nms_kernel.cpp
+++ b/torchvision/csrc/ops/autocast/nms_kernel.cpp
@@ -12,12 +12,14 @@ namespace {
 at::Tensor nms_autocast(
     const at::Tensor& dets,
     const at::Tensor& scores,
-    double iou_threshold) {
+    double iou_threshold,
+    double bias) {
   c10::impl::ExcludeDispatchKeyGuard no_autocast(c10::DispatchKey::Autocast);
   return nms(
       at::autocast::cached_cast(at::kFloat, dets),
       at::autocast::cached_cast(at::kFloat, scores),
-      iou_threshold);
+      iou_threshold,
+      bias);
 }
 
 } // namespace

--- a/torchvision/csrc/ops/cpu/nms_kernel.cpp
+++ b/torchvision/csrc/ops/cpu/nms_kernel.cpp
@@ -33,8 +33,10 @@ at::Tensor nms_kernel_impl(
 
   auto ndets = dets.size(0);
   at::Tensor suppressed_t = at::zeros({ndets}, dets.options().dtype(at::kByte));
+  at::Tensor keep_t = at::zeros({ndets}, dets.options().dtype(at::kLong));
 
   auto suppressed = suppressed_t.data_ptr<uint8_t>();
+  auto keep = keep_t.data_ptr<int64_t>();
   auto order = order_t.data_ptr<int64_t>();
   auto x1 = x1_t.data_ptr<scalar_t>();
   auto y1 = y1_t.data_ptr<scalar_t>();
@@ -42,10 +44,13 @@ at::Tensor nms_kernel_impl(
   auto y2 = y2_t.data_ptr<scalar_t>();
   auto areas = areas_t.data_ptr<scalar_t>();
 
+  int64_t num_to_keep = 0;
+
   for (int64_t _i = 0; _i < ndets; _i++) {
     auto i = order[_i];
     if (suppressed[i] == 1)
       continue;
+    keep[num_to_keep++] = i;
     auto ix1 = x1[i];
     auto iy1 = y1[i];
     auto ix2 = x2[i];
@@ -78,7 +83,7 @@ at::Tensor nms_kernel_impl(
         suppressed[j] = 1;
     }
   }
-  return at::nonzero(suppressed_t == 0).squeeze(1);
+  return keep_t.narrow(/*dim=*/0, /*start=*/0, /*length=*/num_to_keep);
 }
 
 at::Tensor nms_kernel(

--- a/torchvision/csrc/ops/cpu/nms_kernel.cpp
+++ b/torchvision/csrc/ops/cpu/nms_kernel.cpp
@@ -1,5 +1,6 @@
 #include <ATen/ATen.h>
 #include <torch/library.h>
+#include <ATen/Parallel.h>
 
 namespace vision {
 namespace ops {
@@ -57,31 +58,28 @@ at::Tensor nms_kernel_impl(
     auto iy2 = y2[i];
     auto iarea = areas[i];
 
-#ifdef _OPENMP
-#if (_OPENMP >= 201307)
-#pragma omp parallel for simd schedule( \
-    static) if (omp_get_max_threads() > 1 && !omp_in_parallel())
-#else
-#pragma omp parallel for schedule( \
-    static) if (omp_get_max_threads() > 1 && !omp_in_parallel())
-#endif
-#endif
-    for (int64_t _j = _i + 1; _j < ndets; _j++) {
-      auto j = order[_j];
-      if (suppressed[j] == 1)
-        continue;
-      auto xx1 = std::max(ix1, x1[j]);
-      auto yy1 = std::max(iy1, y1[j]);
-      auto xx2 = std::min(ix2, x2[j]);
-      auto yy2 = std::min(iy2, y2[j]);
+    at::parallel_for(
+      _i + 1,
+      ndets,
+      1,
+      [&](int64_t begin, int64_t end) {
+        for (int64_t _j = begin; _j < end; _j++) {
+          auto j = order[_j];
+          if (suppressed[j] == 1)
+            continue;
+          auto xx1 = std::max(ix1, x1[j]);
+          auto yy1 = std::max(iy1, y1[j]);
+          auto xx2 = std::min(ix2, x2[j]);
+          auto yy2 = std::min(iy2, y2[j]);
 
-      auto w = std::max(static_cast<scalar_t>(0), xx2 - xx1 + static_cast<scalar_t>(bias));
-      auto h = std::max(static_cast<scalar_t>(0), yy2 - yy1 + static_cast<scalar_t>(bias));
-      auto inter = w * h;
-      auto ovr = inter / (iarea + areas[j] - inter);
-      if (ovr > iou_threshold)
-        suppressed[j] = 1;
-    }
+          auto w = std::max(static_cast<scalar_t>(0), xx2 - xx1 + static_cast<scalar_t>(bias));
+          auto h = std::max(static_cast<scalar_t>(0), yy2 - yy1 + static_cast<scalar_t>(bias));
+          auto inter = w * h;
+          auto ovr = inter / (iarea + areas[j] - inter);
+          if (ovr > iou_threshold)
+            suppressed[j] = 1;
+        }
+      });
   }
   return keep_t.narrow(/*dim=*/0, /*start=*/0, /*length=*/num_to_keep);
 }

--- a/torchvision/csrc/ops/cpu/nms_kernel.cpp
+++ b/torchvision/csrc/ops/cpu/nms_kernel.cpp
@@ -10,7 +10,8 @@ template <typename scalar_t>
 at::Tensor nms_kernel_impl(
     const at::Tensor& dets,
     const at::Tensor& scores,
-    double iou_threshold) {
+    double iou_threshold,
+    double bias) {
   TORCH_CHECK(!dets.is_cuda(), "dets must be a CPU tensor");
   TORCH_CHECK(!scores.is_cuda(), "scores must be a CPU tensor");
   TORCH_CHECK(
@@ -25,7 +26,7 @@ at::Tensor nms_kernel_impl(
   auto x2_t = dets.select(1, 2).contiguous();
   auto y2_t = dets.select(1, 3).contiguous();
 
-  at::Tensor areas_t = (x2_t - x1_t) * (y2_t - y1_t);
+  at::Tensor areas_t = (x2_t - x1_t + static_cast<scalar_t>(bias)) * (y2_t - y1_t + static_cast<scalar_t>(bias));
 
   auto order_t = std::get<1>(
       scores.sort(/*stable=*/true, /*dim=*/0, /* descending=*/true));
@@ -69,8 +70,8 @@ at::Tensor nms_kernel_impl(
       auto xx2 = std::min(ix2, x2[j]);
       auto yy2 = std::min(iy2, y2[j]);
 
-      auto w = std::max(static_cast<scalar_t>(0), xx2 - xx1);
-      auto h = std::max(static_cast<scalar_t>(0), yy2 - yy1);
+      auto w = std::max(static_cast<scalar_t>(0), xx2 - xx1 + static_cast<scalar_t>(bias));
+      auto h = std::max(static_cast<scalar_t>(0), yy2 - yy1 + static_cast<scalar_t>(bias));
       auto inter = w * h;
       auto ovr = inter / (iarea + areas[j] - inter);
       if (ovr > iou_threshold)
@@ -83,7 +84,8 @@ at::Tensor nms_kernel_impl(
 at::Tensor nms_kernel(
     const at::Tensor& dets,
     const at::Tensor& scores,
-    double iou_threshold) {
+    double iou_threshold,
+    double bias) {
   TORCH_CHECK(
       dets.dim() == 2, "boxes should be a 2d tensor, got ", dets.dim(), "D");
   TORCH_CHECK(
@@ -106,7 +108,7 @@ at::Tensor nms_kernel(
   auto result = at::empty({0}, dets.options());
 
   AT_DISPATCH_FLOATING_TYPES(dets.scalar_type(), "nms_kernel", [&] {
-    result = nms_kernel_impl<scalar_t>(dets, scores, iou_threshold);
+    result = nms_kernel_impl<scalar_t>(dets, scores, iou_threshold, bias);
   });
   return result;
 }

--- a/torchvision/csrc/ops/cuda/nms_kernel.cu
+++ b/torchvision/csrc/ops/cuda/nms_kernel.cu
@@ -80,9 +80,11 @@ __global__ void nms_kernel_impl(
 at::Tensor nms_kernel(
     const at::Tensor& dets,
     const at::Tensor& scores,
-    double iou_threshold) {
+    double iou_threshold,
+    double bias) {
   TORCH_CHECK(dets.is_cuda(), "dets must be a CUDA tensor");
   TORCH_CHECK(scores.is_cuda(), "scores must be a CUDA tensor");
+  TORCH_CHECK(bias == 0.0, "CUDA nms kernel bias parameter must be zero");
 
   TORCH_CHECK(
       dets.dim() == 2, "boxes should be a 2d tensor, got ", dets.dim(), "D");

--- a/torchvision/csrc/ops/nms.cpp
+++ b/torchvision/csrc/ops/nms.cpp
@@ -10,17 +10,18 @@ namespace ops {
 at::Tensor nms(
     const at::Tensor& dets,
     const at::Tensor& scores,
-    double iou_threshold) {
+    double iou_threshold,
+    const double bias) {
   C10_LOG_API_USAGE_ONCE("torchvision.csrc.ops.nms.nms");
   static auto op = c10::Dispatcher::singleton()
                        .findSchemaOrThrow("torchvision::nms", "")
                        .typed<decltype(nms)>();
-  return op.call(dets, scores, iou_threshold);
+  return op.call(dets, scores, iou_threshold, bias);
 }
 
 TORCH_LIBRARY_FRAGMENT(torchvision, m) {
   m.def(TORCH_SELECTIVE_SCHEMA(
-      "torchvision::nms(Tensor dets, Tensor scores, float iou_threshold) -> Tensor"));
+      "torchvision::nms(Tensor dets, Tensor scores, float iou_threshold, float bias) -> Tensor"));
 }
 
 } // namespace ops

--- a/torchvision/csrc/ops/nms.h
+++ b/torchvision/csrc/ops/nms.h
@@ -9,7 +9,8 @@ namespace ops {
 VISION_API at::Tensor nms(
     const at::Tensor& dets,
     const at::Tensor& scores,
-    double iou_threshold);
+    double iou_threshold,
+    const double bias = 0.0);
 
 } // namespace ops
 } // namespace vision

--- a/torchvision/ops/boxes.py
+++ b/torchvision/ops/boxes.py
@@ -9,7 +9,7 @@ from ..utils import _log_api_usage_once
 from ._box_convert import _box_cxcywh_to_xyxy, _box_xyxy_to_cxcywh, _box_xywh_to_xyxy, _box_xyxy_to_xywh
 
 
-def nms(boxes: Tensor, scores: Tensor, iou_threshold: float) -> Tensor:
+def nms(boxes: Tensor, scores: Tensor, iou_threshold: float, bias: float = 0.0) -> Tensor:
     """
     Performs non-maximum suppression (NMS) on the boxes according
     to their intersection-over-union (IoU).
@@ -37,7 +37,7 @@ def nms(boxes: Tensor, scores: Tensor, iou_threshold: float) -> Tensor:
     if not torch.jit.is_scripting() and not torch.jit.is_tracing():
         _log_api_usage_once(nms)
     _assert_has_ops()
-    return torch.ops.torchvision.nms(boxes, scores, iou_threshold)
+    return torch.ops.torchvision.nms(boxes, scores, iou_threshold, bias)
 
 
 def batched_nms(


### PR DESCRIPTION
In this PR:
- Add the OpenMP support to NMS CPU Kernel to enable the parallel calculation. 

- The MaskRCNN NMS kernel(https://github.com/facebookresearch/maskrcnn-benchmark/blob/main/maskrcnn_benchmark/csrc/cpu/nms_cpu.cpp#L5-L65) has offset of 1 when doing the calculation. Add the offset parameter(by default zero) to torch vision NMS kernel, then the MaskRCNN NMS kernel can share the implementation of Torchvision NMS Kernel.
