### PR TITLE
Fix weight doc generation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -326,7 +326,15 @@ def inject_weight_metadata(app, what, name, obj, options, lines):
                 lines += [f"This weight is also available as ``{obj.__name__}.DEFAULT``.", ""]
 
             table = []
-            for k, v in field.meta.items():
+
+            # the `meta` dict contains another embedded `metrics` dict. To
+            # simplify the table generation below, we create the
+            # `meta_with_metrics` dict, where the metrics dict has been "flattened"
+            meta = field.meta
+            metrics = meta.pop("metrics", {})
+            meta_with_metrics = dict(meta, **metrics)
+
+            for k, v in meta_with_metrics.items():
                 if k == "categories":
                     continue
                 elif k == "recipe":


### PR DESCRIPTION
Fixes https://github.com/pytorch/vision/pull/5859#pullrequestreview-950197056

Rendered docs: https://output.circle-artifacts.com/output/job/910114e1-8910-4ee4-a997-f50b5e4cbb5b/artifacts/0/docs/models/generated/torchvision.models.regnet_y_400mf.html#torchvision.models.regnet_y_400mf

The doc looks like it used to: individual metrics appear just like any other field in the `meta` dict: 

![image](https://user-images.githubusercontent.com/1190450/165055301-2fe47437-f214-4b57-b2cf-ee4bfa6bd644.png)


We could also have a separate table for metrics, for each weight. No strong opinion.