### PR TITLE
Fix Accuracy meta-data on shufflenetv2

### DIFF
--- a/torchvision/models/shufflenetv2.py
+++ b/torchvision/models/shufflenetv2.py
@@ -198,8 +198,8 @@ class ShuffleNet_V2_X0_5_Weights(WeightsEnum):
             **_COMMON_META,
             "num_params": 1366792,
             "metrics": {
-                "acc@1": 69.362,
-                "acc@5": 88.316,
+                "acc@1": 60.552,
+                "acc@5": 81.746,
             },
         },
     )
@@ -214,8 +214,8 @@ class ShuffleNet_V2_X1_0_Weights(WeightsEnum):
             **_COMMON_META,
             "num_params": 2278604,
             "metrics": {
-                "acc@1": 60.552,
-                "acc@5": 81.746,
+                "acc@1": 69.362,
+                "acc@5": 88.316,
             },
         },
     )


### PR DESCRIPTION
Fixing the reverted numbers of `shufflenet_v2_x0_5` and `shufflenet_v2_x1_0`.