### PR TITLE
docs: Added MobileNetV2 to the new doc

### DIFF
--- a/docs/source/models/mobilenetv2.rst
+++ b/docs/source/models/mobilenetv2.rst
@@ -1,0 +1,24 @@
+MobileNet V2
+============
+
+.. currentmodule:: torchvision.models
+
+The MobileNet V2 model is based on the `MobileNetV2: Inverted Residuals and Linear
+Bottlenecks <https://arxiv.org/abs/1801.04381>`__ paper.
+
+
+Model builders
+--------------
+
+The following model builders can be used to instantiate a MobileNetV2 model, with or
+without pre-trained weights. All the model builders internally rely on the
+``torchvision.models.mobilenetv2.MobileNetV2`` base class. Please refer to the `source
+code
+<https://github.com/pytorch/vision/blob/main/torchvision/models/mobilenetv2.py>`_ for
+more details about this class.
+
+.. autosummary::
+    :toctree: generated/
+    :template: function.rst
+
+    mobilenet_v2

--- a/docs/source/models_new.rst
+++ b/docs/source/models_new.rst
@@ -42,6 +42,7 @@ weights:
    models/efficientnet
    models/efficientnetv2
    models/googlenet
+   models/mobilenetv2
    models/regnet
    models/resnet
    models/resnext

--- a/torchvision/models/mobilenetv2.py
+++ b/torchvision/models/mobilenetv2.py
@@ -233,13 +233,23 @@ class MobileNet_V2_Weights(WeightsEnum):
 def mobilenet_v2(
     *, weights: Optional[MobileNet_V2_Weights] = None, progress: bool = True, **kwargs: Any
 ) -> MobileNetV2:
-    """
-    Constructs a MobileNetV2 architecture from
-    `"MobileNetV2: Inverted Residuals and Linear Bottlenecks" <https://arxiv.org/abs/1801.04381>`_.
+    """MobileNetV2 architecture from the `MobileNetV2: Inverted Residuals and Linear
+    Bottlenecks <https://arxiv.org/abs/1801.04381>`_ paper.
 
     Args:
-        weights (MobileNet_V2_Weights, optional): The pretrained weights for the model
-        progress (bool): If True, displays a progress bar of the download to stderr
+        weights (:class:`~torchvision.models.MobileNet_V2_Weights`, optional): The
+            pretrained weights to use. See
+            :class:`~torchvision.models.MobileNet_V2_Weights` below for
+            more details, and possible values. By default, no pre-trained
+            weights are used.
+        progress (bool, optional): If True, displays a progress bar of the
+            download to stderr. Default is True.
+        **kwargs: parameters passed to the ``torchvision.models.mobilenetv2.MobileNetV2``
+            base class. Please refer to the `source code
+            <https://github.com/pytorch/vision/blob/main/torchvision/models/mobilenetv2.py>`_
+            for more details about this class.
+    .. autoclass:: torchvision.models.MobileNet_V2_Weights
+        :members:
     """
     weights = MobileNet_V2_Weights.verify(weights)
 

--- a/torchvision/models/mobilenetv2.py
+++ b/torchvision/models/mobilenetv2.py
@@ -248,6 +248,7 @@ def mobilenet_v2(
             base class. Please refer to the `source code
             <https://github.com/pytorch/vision/blob/main/torchvision/models/mobilenetv2.py>`_
             for more details about this class.
+
     .. autoclass:: torchvision.models.MobileNet_V2_Weights
         :members:
     """


### PR DESCRIPTION
Following up on #5833, this PR introduces the following modifications:
- creates the new rst doc file for MobileNetV2
- adds the reference on the new page
- updates the docstring accordingly

Any feedback is welcome!

cc @NicolasHug @datumbox 