### PR TITLE
Disable `test_encode|write_jpeg_reference` tests

### DIFF
--- a/test/test_image.py
+++ b/test/test_image.py
@@ -421,7 +421,7 @@ def _collect_if(cond):
     return _inner
 
 
-@_collect_if(cond=IS_WINDOWS)
+@_collect_if(cond=False)
 @pytest.mark.parametrize(
     "img_path",
     [pytest.param(jpeg_path, id=_get_safe_image_name(jpeg_path)) for jpeg_path in get_images(ENCODE_JPEG, ".jpg")],
@@ -452,7 +452,7 @@ def test_encode_jpeg_reference(img_path):
         assert_equal(jpeg_bytes, pil_bytes)
 
 
-@_collect_if(cond=IS_WINDOWS)
+@_collect_if(cond=False)
 @pytest.mark.parametrize(
     "img_path",
     [pytest.param(jpeg_path, id=_get_safe_image_name(jpeg_path)) for jpeg_path in get_images(ENCODE_JPEG, ".jpg")],


### PR DESCRIPTION
<!-- Before submitting a PR, please make sure to check our contributing guidelines regarding code formatting, tests, and documentation: https://github.com/pytorch/vision/blob/main/CONTRIBUTING.md -->

Temporarily disable [flaky tests](https://app.circleci.com/pipelines/github/pytorch/vision/17079/workflows/55573a3d-f1cd-4523-8f9d-783b6f452059/jobs/1384154/tests) on windows that cause the CI failure.

cc @NicolasHug 