### PR TITLE
docs: Added FCN to the new doc

### DIFF
--- a/docs/source/models/fcn.rst
+++ b/docs/source/models/fcn.rst
@@ -1,0 +1,26 @@
+FCN
+===
+
+.. currentmodule:: torchvision.models.segmentation
+
+The FCN model is based on the `Fully Convolutional Networks for Semantic
+Segmentation <https://arxiv.org/abs/1411.4038>`__
+paper.
+
+
+Model builders
+--------------
+
+The following model builders can be used to instantiate a FCN model, with or
+without pre-trained weights. All the model builders internally rely on the
+``torchvision.models.segmentation.fcn.FCN`` base class. Please refer to the `source
+code
+<https://github.com/pytorch/vision/blob/main/torchvision/models/segmentation/fcn.py>`_ for
+more details about this class.
+
+.. autosummary::
+    :toctree: generated/
+    :template: function.rst
+
+    fcn_resnet50
+    fcn_resnet101

--- a/docs/source/models/fcn.rst
+++ b/docs/source/models/fcn.rst
@@ -13,7 +13,7 @@ Model builders
 
 The following model builders can be used to instantiate a FCN model, with or
 without pre-trained weights. All the model builders internally rely on the
-``torchvision.models.segmentation.fcn.FCN`` base class. Please refer to the `source
+``torchvision.models.segmentation.FCN`` base class. Please refer to the `source
 code
 <https://github.com/pytorch/vision/blob/main/torchvision/models/segmentation/fcn.py>`_ for
 more details about this class.

--- a/docs/source/models_new.rst
+++ b/docs/source/models_new.rst
@@ -73,6 +73,7 @@ pre-trained weights:
    :maxdepth: 1
 
    models/deeplabv3
+   models/fcn
 
 
 Table of all available semantic segmentation weights

--- a/torchvision/models/segmentation/fcn.py
+++ b/torchvision/models/segmentation/fcn.py
@@ -126,6 +126,10 @@ def fcn_resnet50(
             weights are used.
         progress (bool, optional): If True, displays a progress bar of the
             download to stderr. Default is True.
+        num_classes (int, optional): number of output classes of the model (including the background).
+        aux_loss (bool, optional): If True, it uses an auxiliary loss.
+        weights_backbone (:class:`~torchvision.models.ResNet50_Weights, optional): The pretrained
+            weights for the backbone.
         **kwargs: parameters passed to the ``torchvision.models.segmentation.fcn.FCN``
             base class. Please refer to the `source code
             <https://github.com/pytorch/vision/blob/main/torchvision/models/segmentation/fcn.py>`_
@@ -178,6 +182,10 @@ def fcn_resnet101(
             weights are used.
         progress (bool, optional): If True, displays a progress bar of the
             download to stderr. Default is True.
+        num_classes (int, optional): number of output classes of the model (including the background).
+        aux_loss (bool, optional): If True, it uses an auxiliary loss.
+        weights_backbone (:class:`~torchvision.models.ResNet101_Weights, optional): The pretrained
+            weights for the backbone.
         **kwargs: parameters passed to the ``torchvision.models.segmentation.fcn.FCN``
             base class. Please refer to the `source code
             <https://github.com/pytorch/vision/blob/main/torchvision/models/segmentation/fcn.py>`_

--- a/torchvision/models/segmentation/fcn.py
+++ b/torchvision/models/segmentation/fcn.py
@@ -115,15 +115,26 @@ def fcn_resnet50(
     weights_backbone: Optional[ResNet50_Weights] = ResNet50_Weights.IMAGENET1K_V1,
     **kwargs: Any,
 ) -> FCN:
-    """Constructs a Fully-Convolutional Network model with a ResNet-50 backbone.
+    """Fully-Convolutional Network model with a ResNet-50 backbone from the `Fully Convolutional
+    Networks for Semantic Segmentation <https://arxiv.org/abs/1411.4038>`_ paper.
 
     Args:
-        weights (FCN_ResNet50_Weights, optional): The pretrained weights for the model
-        progress (bool): If True, displays a progress bar of the download to stderr
-        num_classes (int, optional): number of output classes of the model (including the background)
-        aux_loss (bool, optional): If True, it uses an auxiliary loss
-        weights_backbone (ResNet50_Weights, optional): The pretrained weights for the backbone
+        weights (:class:`~torchvision.models.segmentation.FCN_ResNet50_Weights`, optional): The
+            pretrained weights to use. See
+            :class:`~torchvision.models.segmentation.FCN_ResNet50_Weights` below for
+            more details, and possible values. By default, no pre-trained
+            weights are used.
+        progress (bool, optional): If True, displays a progress bar of the
+            download to stderr. Default is True.
+        **kwargs: parameters passed to the ``torchvision.models.segmentation.fcn.FCN``
+            base class. Please refer to the `source code
+            <https://github.com/pytorch/vision/blob/main/torchvision/models/segmentation/fcn.py>`_
+            for more details about this class.
+
+    .. autoclass:: torchvision.models.segmentation.FCN_ResNet50_Weights
+        :members:
     """
+
     weights = FCN_ResNet50_Weights.verify(weights)
     weights_backbone = ResNet50_Weights.verify(weights_backbone)
 
@@ -156,15 +167,26 @@ def fcn_resnet101(
     weights_backbone: Optional[ResNet101_Weights] = ResNet101_Weights.IMAGENET1K_V1,
     **kwargs: Any,
 ) -> FCN:
-    """Constructs a Fully-Convolutional Network model with a ResNet-101 backbone.
+    """Fully-Convolutional Network model with a ResNet-101 backbone from the `Fully Convolutional
+    Networks for Semantic Segmentation <https://arxiv.org/abs/1411.4038>`_ paper.
 
     Args:
-        weights (FCN_ResNet101_Weights, optional): The pretrained weights for the model
-        progress (bool): If True, displays a progress bar of the download to stderr
-        num_classes (int, optional): number of output classes of the model (including the background)
-        aux_loss (bool, optional): If True, it uses an auxiliary loss
-        weights_backbone (ResNet101_Weights, optional): The pretrained weights for the backbone
+        weights (:class:`~torchvision.models.segmentation.FCN_ResNet101_Weights`, optional): The
+            pretrained weights to use. See
+            :class:`~torchvision.models.segmentation.FCN_ResNet101_Weights` below for
+            more details, and possible values. By default, no pre-trained
+            weights are used.
+        progress (bool, optional): If True, displays a progress bar of the
+            download to stderr. Default is True.
+        **kwargs: parameters passed to the ``torchvision.models.segmentation.fcn.FCN``
+            base class. Please refer to the `source code
+            <https://github.com/pytorch/vision/blob/main/torchvision/models/segmentation/fcn.py>`_
+            for more details about this class.
+
+    .. autoclass:: torchvision.models.segmentation.FCN_ResNet101_Weights
+        :members:
     """
+
     weights = FCN_ResNet101_Weights.verify(weights)
     weights_backbone = ResNet101_Weights.verify(weights_backbone)
 

--- a/torchvision/models/segmentation/fcn.py
+++ b/torchvision/models/segmentation/fcn.py
@@ -128,7 +128,7 @@ def fcn_resnet50(
             download to stderr. Default is True.
         num_classes (int, optional): number of output classes of the model (including the background).
         aux_loss (bool, optional): If True, it uses an auxiliary loss.
-        weights_backbone (:class:`~torchvision.models.ResNet50_Weights, optional): The pretrained
+        weights_backbone (:class:`~torchvision.models.ResNet50_Weights`, optional): The pretrained
             weights for the backbone.
         **kwargs: parameters passed to the ``torchvision.models.segmentation.fcn.FCN``
             base class. Please refer to the `source code
@@ -184,7 +184,7 @@ def fcn_resnet101(
             download to stderr. Default is True.
         num_classes (int, optional): number of output classes of the model (including the background).
         aux_loss (bool, optional): If True, it uses an auxiliary loss.
-        weights_backbone (:class:`~torchvision.models.ResNet101_Weights, optional): The pretrained
+        weights_backbone (:class:`~torchvision.models.ResNet101_Weights`, optional): The pretrained
             weights for the backbone.
         **kwargs: parameters passed to the ``torchvision.models.segmentation.fcn.FCN``
             base class. Please refer to the `source code


### PR DESCRIPTION
Following up on https://github.com/pytorch/vision/issues/5897, this PR introduces the following modifications:

- creates the new rst doc file for FCN
- adds the reference on the new page
- updates the docstring accordingly

Any feedback is welcome!

cc @NicolasHug @datumbox