### PR TITLE
remove custom __repr__ from prototype features

### DIFF
--- a/torchvision/prototype/features/_feature.py
+++ b/torchvision/prototype/features/_feature.py
@@ -83,6 +83,3 @@ class _Feature(torch.Tensor):
             return cls.new_like(args[0], output, dtype=output.dtype, device=output.device)
         else:
             return output
-
-    def __repr__(self) -> str:
-        return cast(str, torch.Tensor.__repr__(self)).replace("tensor", type(self).__name__)


### PR DESCRIPTION
Amongst other things, pytorch/pytorch#73459 added support for automatically [include the name of the tensor subclass in the `__repr__`](https://github.com/pytorch/pytorch/blob/7422ccea8b564132b50227b35a9bfbf06730d71a/torch/_tensor_str.py#L307). Thus, we no longer need to do this ourselves.

The same PR also changed the signature of `Tensor.__repr__` which lead to [`mypy` errors](https://app.circleci.com/pipelines/github/pytorch/vision/17152/workflows/0580fe16-3f0c-4da5-9464-3e61d1c6c95d/jobs/1389825).