### PR TITLE
Use libjpeg-turbo in CI instead of libjpeg

### DIFF
--- a/.circleci/unittest/linux/scripts/environment.yml
+++ b/.circleci/unittest/linux/scripts/environment.yml
@@ -1,6 +1,7 @@
 channels:
   - pytorch
   - defaults
+  - conda-forge
 dependencies:
   - pytest
   - pytest-cov

--- a/.circleci/unittest/linux/scripts/environment.yml
+++ b/.circleci/unittest/linux/scripts/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - pytest-mock
   - pip
   - libpng
-  - jpeg-turbo
+  - libjpeg-turbo
   - ca-certificates
   - h5py
   - pip:

--- a/.circleci/unittest/linux/scripts/environment.yml
+++ b/.circleci/unittest/linux/scripts/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - pytest-mock
   - pip
   - libpng
-  - jpeg
+  - jpeg-turbo
   - ca-certificates
   - h5py
   - pip:

--- a/.circleci/unittest/windows/scripts/environment.yml
+++ b/.circleci/unittest/windows/scripts/environment.yml
@@ -1,13 +1,14 @@
 channels:
   - pytorch
   - defaults
+  - conda-forge
 dependencies:
   - pytest
   - pytest-cov
   - pytest-mock
   - pip
   - libpng
-  - jpeg
+  - libjpeg-turbo
   - ca-certificates
   - hdf5
   - setuptools == 58.0.4

--- a/test/test_image.py
+++ b/test/test_image.py
@@ -409,32 +409,6 @@ def test_encode_jpeg_errors():
         encode_jpeg(torch.empty((100, 100), dtype=torch.uint8))
 
 
-@_collect_if(cond=False)
-@pytest.mark.parametrize(
-    "img_path",
-    [pytest.param(jpeg_path, id=_get_safe_image_name(jpeg_path)) for jpeg_path in get_images(ENCODE_JPEG, ".jpg")],
-)
-def test_write_jpeg_reference(img_path, tmpdir):
-    # FIXME: Remove this eventually, see test_encode_jpeg_reference
-    data = read_file(img_path)
-    img = decode_jpeg(data)
-
-    basedir = os.path.dirname(img_path)
-    filename, _ = os.path.splitext(os.path.basename(img_path))
-    torch_jpeg = os.path.join(tmpdir, f"{filename}_torch.jpg")
-    pil_jpeg = os.path.join(basedir, "jpeg_write", f"{filename}_pil.jpg")
-
-    write_jpeg(img, torch_jpeg, quality=75)
-
-    with open(torch_jpeg, "rb") as f:
-        torch_bytes = f.read()
-
-    with open(pil_jpeg, "rb") as f:
-        pil_bytes = f.read()
-
-    assert_equal(torch_bytes, pil_bytes)
-
-
 @pytest.mark.parametrize(
     "img_path",
     [pytest.param(jpeg_path, id=_get_safe_image_name(jpeg_path)) for jpeg_path in get_images(ENCODE_JPEG, ".jpg")],

--- a/test/test_image.py
+++ b/test/test_image.py
@@ -478,8 +478,6 @@ def test_write_jpeg_reference(img_path, tmpdir):
     assert_equal(torch_bytes, pil_bytes)
 
 
-# TODO: Remove the skip. See https://github.com/pytorch/vision/issues/5162.
-@pytest.mark.skip("this test fails because PIL uses libjpeg-turbo")
 @pytest.mark.parametrize(
     "img_path",
     [pytest.param(jpeg_path, id=_get_safe_image_name(jpeg_path)) for jpeg_path in get_images(ENCODE_JPEG, ".jpg")],
@@ -498,8 +496,6 @@ def test_encode_jpeg(img_path):
         assert_equal(encoded_jpeg_torch, encoded_jpeg_pil)
 
 
-# TODO: Remove the skip. See https://github.com/pytorch/vision/issues/5162.
-@pytest.mark.skip("this test fails because PIL uses libjpeg-turbo")
 @pytest.mark.parametrize(
     "img_path",
     [pytest.param(jpeg_path, id=_get_safe_image_name(jpeg_path)) for jpeg_path in get_images(ENCODE_JPEG, ".jpg")],

--- a/test/test_image.py
+++ b/test/test_image.py
@@ -94,10 +94,14 @@ def test_decode_jpeg(img_path, pil_mode, mode):
     data = read_file(img_path)
     img_ljpeg = decode_image(data, mode=mode)
 
-    # Permit a small variation on pixel values to account for differences
-    # between Pillow's libjpeg and ours.
-    abs_mean_diff = (img_ljpeg.type(torch.float32) - img_pil).abs().mean().item()
-    assert abs_mean_diff < 1
+    # In theory PIL and torchvision rely on the same libjpeg-turbo, so decoding
+    # should be exactly the same. There seem to be small differences with some
+    # GRAY mode images though. Might be worth investigating why.
+    if mode == ImageReadMode.GRAY:
+        abs_mean_diff = (img_ljpeg.type(torch.float32) - img_pil).abs().mean().item()
+        assert abs_mean_diff < 1
+    else:
+        assert_equal(img_ljpeg, img_pil)
 
 
 def test_decode_jpeg_errors():

--- a/test/test_image.py
+++ b/test/test_image.py
@@ -94,10 +94,10 @@ def test_decode_jpeg(img_path, pil_mode, mode):
     data = read_file(img_path)
     img_ljpeg = decode_image(data, mode=mode)
 
-    # Permit a small variation on pixel values to account for implementation
-    # differences between Pillow and LibJPEG.
+    # Permit a small variation on pixel values to account for differences
+    # between Pillow's libjpeg and ours.
     abs_mean_diff = (img_ljpeg.type(torch.float32) - img_pil).abs().mean().item()
-    assert abs_mean_diff < 2
+    assert abs_mean_diff < 1
 
 
 def test_decode_jpeg_errors():
@@ -407,49 +407,6 @@ def test_encode_jpeg_errors():
 
     with pytest.raises(RuntimeError, match="Input data should be a 3-dimensional tensor"):
         encode_jpeg(torch.empty((100, 100), dtype=torch.uint8))
-
-
-def _collect_if(cond):
-    # TODO: remove this once test_encode_jpeg_reference and test_write_jpeg_reference
-    # are removed
-    def _inner(test_func):
-        if cond:
-            return test_func
-        else:
-            return pytest.mark.dont_collect(test_func)
-
-    return _inner
-
-
-@_collect_if(cond=False)
-@pytest.mark.parametrize(
-    "img_path",
-    [pytest.param(jpeg_path, id=_get_safe_image_name(jpeg_path)) for jpeg_path in get_images(ENCODE_JPEG, ".jpg")],
-)
-def test_encode_jpeg_reference(img_path):
-    # This test is *wrong*.
-    # It compares a torchvision-encoded jpeg with a PIL-encoded jpeg (the reference), but it
-    # starts encoding the torchvision version from an image that comes from
-    # decode_jpeg, which can yield different results from pil.decode (see
-    # test_decode... which uses a high tolerance).
-    # Instead, we should start encoding from the exact same decoded image, for a
-    # valid comparison. This is done in test_encode_jpeg, but unfortunately
-    # these more correct tests fail on windows (probably because of a difference
-    # in libjpeg) between torchvision and PIL.
-    # FIXME: make the correct tests pass on windows and remove this.
-    dirname = os.path.dirname(img_path)
-    filename, _ = os.path.splitext(os.path.basename(img_path))
-    write_folder = os.path.join(dirname, "jpeg_write")
-    expected_file = os.path.join(write_folder, f"{filename}_pil.jpg")
-    img = decode_jpeg(read_file(img_path))
-
-    with open(expected_file, "rb") as f:
-        pil_bytes = f.read()
-        pil_bytes = torch.as_tensor(list(pil_bytes), dtype=torch.uint8)
-    for src_img in [img, img.contiguous()]:
-        # PIL sets jpeg quality to 75 by default
-        jpeg_bytes = encode_jpeg(src_img, quality=75)
-        assert_equal(jpeg_bytes, pil_bytes)
 
 
 @_collect_if(cond=False)


### PR DESCRIPTION
This PR makes our CI rely on libjpeg-turbo insteaf of libjpeg. The main benefit of libjpeg-turbo is decoding speed, but this will also allow us to clean up our tests and make them more robust.

**Note**: This PR only concerns the CI tests, not the packaging for conda or PyPI. I'll look into that in a separate PR.

We had numerous issues and headaches in the past because of differences between PIL and torchvision and their underlying implementation (libjpeg vs libjpeg-turbo), e.g. https://github.com/pytorch/vision/issues/3913, https://github.com/pytorch/vision/pull/5910 or https://github.com/pytorch/vision/issues/5162. 

PIL has been shipped on libjpeg-turbo for a while **on Windows** https://github.com/python-pillow/Pillow/issues/3833#issuecomment-585211263, and since PIL 9, the linux and MacOS wheels are [now also linked against turbo](https://pillow.readthedocs.io/en/stable/releasenotes/9.0.0.html#switched-to-libjpeg-turbo-in-macos-and-linux-wheels).

Shipping with libjpeg-turbo instead of libjpeg will allow us to be fully aligned with PIL, and greatly simplify / cleanup our tests, which had become a bit messy (see the amount of removed code in this PR). Note that [internally](https://www.internalfb.com/code/fbsource/[ddae37f0f1bdc93133485334e1beaa5ebab51899]/fbcode/pytorch/vision/TARGETS?lines=280), we already rely on turbo.


Closes https://github.com/pytorch/vision/pull/5184
Closes https://github.com/pytorch/vision/issues/5162
Closes https://github.com/pytorch/vision/issues/3913
Fixes https://github.com/pytorch/vision/pull/5910