### PR TITLE
Remove jpeg dep for type-checking

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -322,9 +322,6 @@ jobs:
     docker:
       - image: cimg/python:3.7
     steps:
-      - apt_install:
-          args: libturbojpeg-dev
-          descr: Install additional system libraries
       - checkout
       - install_torchvision:
           editable: true

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -322,9 +322,6 @@ jobs:
     docker:
       - image: cimg/python:3.7
     steps:
-      - apt_install:
-          args: libturbojpeg-dev
-          descr: Install additional system libraries
       - checkout
       - install_torchvision:
           editable: true


### PR DESCRIPTION
Not sure why this was ever needed, let's see if CI goes red(er)