### PR TITLE
Adding ciou and diou support in `_box_loss()`

### DIFF
--- a/torchvision/models/detection/_utils.py
+++ b/torchvision/models/detection/_utils.py
@@ -534,5 +534,5 @@ def _box_loss(
             return complete_box_iou_loss(bbox_per_image, matched_gt_boxes_per_image, reduction="sum", eps=eps)
         elif type == "diou":
             return distance_box_iou_loss(bbox_per_image, matched_gt_boxes_per_image, reduction="sum", eps=eps)
-        else: # giou
+        else:  # giou
             return generalized_box_iou_loss(bbox_per_image, matched_gt_boxes_per_image, reduction="sum", eps=eps)

--- a/torchvision/models/detection/_utils.py
+++ b/torchvision/models/detection/_utils.py
@@ -5,7 +5,7 @@ from typing import Dict, List, Optional, Tuple
 import torch
 from torch import Tensor, nn
 from torch.nn import functional as F
-from torchvision.ops import FrozenBatchNorm2d, generalized_box_iou_loss
+from torchvision.ops import FrozenBatchNorm2d, complete_box_iou_loss, distance_box_iou_loss, generalized_box_iou_loss
 
 
 class BalancedPositiveNegativeSampler:
@@ -518,7 +518,7 @@ def _box_loss(
     bbox_regression_per_image: Tensor,
     cnf: Optional[Dict[str, float]] = None,
 ) -> Tensor:
-    torch._assert(type in ["l1", "smooth_l1", "giou"], f"Unsupported loss: {type}")
+    torch._assert(type in ["l1", "smooth_l1", "ciou", "diou", "giou"], f"Unsupported loss: {type}")
 
     if type == "l1":
         target_regression = box_coder.encode_single(matched_gt_boxes_per_image, anchors_per_image)
@@ -527,7 +527,12 @@ def _box_loss(
         target_regression = box_coder.encode_single(matched_gt_boxes_per_image, anchors_per_image)
         beta = cnf["beta"] if cnf is not None and "beta" in cnf else 1.0
         return F.smooth_l1_loss(bbox_regression_per_image, target_regression, reduction="sum", beta=beta)
-    else:  # giou
+    else:
         bbox_per_image = box_coder.decode_single(bbox_regression_per_image, anchors_per_image)
         eps = cnf["eps"] if cnf is not None and "eps" in cnf else 1e-7
-        return generalized_box_iou_loss(bbox_per_image, matched_gt_boxes_per_image, reduction="sum", eps=eps)
+        if type == "ciou":
+            return complete_box_iou_loss(bbox_per_image, matched_gt_boxes_per_image, reduction="sum", eps=eps)
+        elif type == "diou":
+            return distance_box_iou_loss(bbox_per_image, matched_gt_boxes_per_image, reduction="sum", eps=eps)
+        else: # giou
+            return generalized_box_iou_loss(bbox_per_image, matched_gt_boxes_per_image, reduction="sum", eps=eps)

--- a/torchvision/models/detection/_utils.py
+++ b/torchvision/models/detection/_utils.py
@@ -532,7 +532,7 @@ def _box_loss(
         eps = cnf["eps"] if cnf is not None and "eps" in cnf else 1e-7
         if type == "ciou":
             return complete_box_iou_loss(bbox_per_image, matched_gt_boxes_per_image, reduction="sum", eps=eps)
-        elif type == "diou":
+        if type == "diou":
             return distance_box_iou_loss(bbox_per_image, matched_gt_boxes_per_image, reduction="sum", eps=eps)
-        else:  # giou
-            return generalized_box_iou_loss(bbox_per_image, matched_gt_boxes_per_image, reduction="sum", eps=eps)
+        # otherwise giou
+        return generalized_box_iou_loss(bbox_per_image, matched_gt_boxes_per_image, reduction="sum", eps=eps)


### PR DESCRIPTION
Related to #5983

Adding support of cIoU and dIoU loss on the private `_box_loss()` used for regression. Currently this is an internal API used only by RetinaNet. I've done limited runs and seems that neither of the two losses improve performance:
- gIoU (baseline): 41.5 mAP
- cIoU: 41.1 mAP
- dIoU: 41.3 mAP

Hence I wont be making any changes on the `retinanet_resnet50_fpn_v2` pretrained weights.