### PR TITLE
Allow custom docs for Weight enums and Weights fields

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -320,7 +320,14 @@ def inject_weight_metadata(app, what, name, obj, options, lines):
             "The model builder above accepts the following values as the ``weights`` parameter.",
             f"``{obj.__name__}.DEFAULT`` is equivalent to ``{obj.DEFAULT}``.",
         ]
+
+        if obj.__doc__ != "An enumeration.":
+            # We only show the custom enum doc if it was overriden. The default one from Python is "An enumeration"
+            lines.append("")
+            lines.append(obj.__doc__)
+
         lines.append("")
+
         for field in obj:
             lines += [f"**{str(field)}**:", ""]
             if field == obj.DEFAULT:
@@ -335,10 +342,14 @@ def inject_weight_metadata(app, what, name, obj, options, lines):
             metrics = meta.pop("metrics", {})
             meta_with_metrics = dict(meta, **metrics)
 
+            meta_with_metrics.pop("categories", None)  # We don't want to document these, they can be too long
+
+            custom_docs = meta_with_metrics.pop("_docs", None)  # Custom per-Weights docs
+            if custom_docs is not None:
+                lines += [custom_docs, ""]
+
             for k, v in meta_with_metrics.items():
-                if k == "categories":
-                    continue
-                elif k == "recipe":
+                if k == "recipe":
                     v = f"`link <{v}>`__"
                 table.append((str(k), str(v)))
             table = tabulate(table, tablefmt="rst")

--- a/test/test_extended_models.py
+++ b/test/test_extended_models.py
@@ -90,6 +90,7 @@ def test_schema_meta_validation(model_fn):
         "num_params",
         "recipe",
         "unquantized",
+        "_docs",
     }
     # mandatory fields for each computer vision task
     classification_fields = {"categories", ("metrics", "acc@1"), ("metrics", "acc@5")}

--- a/torchvision/models/resnet.py
+++ b/torchvision/models/resnet.py
@@ -345,6 +345,7 @@ class ResNet34_Weights(WeightsEnum):
 
 class ResNet50_Weights(WeightsEnum):
     """Below you can find the available pre-trained weights for ResNet50:"""
+
     IMAGENET1K_V1 = Weights(
         url="https://download.pytorch.org/models/resnet50-0676ba61.pth",
         transforms=partial(ImageClassification, crop_size=224),
@@ -358,7 +359,7 @@ class ResNet50_Weights(WeightsEnum):
             },
             "_docs": """
             These are standard weights using the basic recipe of the paper.
-            """
+            """,
         },
     )
     IMAGENET1K_V2 = Weights(
@@ -375,7 +376,7 @@ class ResNet50_Weights(WeightsEnum):
             "_docs": """
             These are improved weights, using TorchVision's `new recipe
             <https://pytorch.org/blog/how-to-train-state-of-the-art-models-using-torchvision-latest-primitives/>`_.
-            """
+            """,
         },
     )
     DEFAULT = IMAGENET1K_V2

--- a/torchvision/models/resnet.py
+++ b/torchvision/models/resnet.py
@@ -344,8 +344,6 @@ class ResNet34_Weights(WeightsEnum):
 
 
 class ResNet50_Weights(WeightsEnum):
-    """Below you can find the available pre-trained weights for ResNet50:"""
-
     IMAGENET1K_V1 = Weights(
         url="https://download.pytorch.org/models/resnet50-0676ba61.pth",
         transforms=partial(ImageClassification, crop_size=224),

--- a/torchvision/models/resnet.py
+++ b/torchvision/models/resnet.py
@@ -356,9 +356,8 @@ class ResNet50_Weights(WeightsEnum):
                 "acc@1": 76.130,
                 "acc@5": 92.862,
             },
-            # Putting this here but the _docs key could also just be a field of the Weights dataclass
             "_docs": """
-            Standard weights using the basic recipe of the paper:
+            These are standard weights using the basic recipe of the paper.
             """
         },
     )
@@ -374,7 +373,8 @@ class ResNet50_Weights(WeightsEnum):
                 "acc@5": 95.434,
             },
             "_docs": """
-            Improved weights using TorchVision's `new recipe <https://pytorch.org/blog/how-to-train-state-of-the-art-models-using-torchvision-latest-primitives/>`_:
+            These are improved weights, using TorchVision's `new recipe
+            <https://pytorch.org/blog/how-to-train-state-of-the-art-models-using-torchvision-latest-primitives/>`_.
             """
         },
     )

--- a/torchvision/models/resnet.py
+++ b/torchvision/models/resnet.py
@@ -358,7 +358,7 @@ class ResNet50_Weights(WeightsEnum):
             },
             # Putting this here but the _docs key could also just be a field of the Weights dataclass
             "_docs": """
-            <Some doc specific to ResNet50_Weights.IMAGENET1K_V2>
+            Standard weights using the basic recipe of the paper:
             """
         },
     )
@@ -374,7 +374,7 @@ class ResNet50_Weights(WeightsEnum):
                 "acc@5": 95.434,
             },
             "_docs": """
-            <Some doc specific to ResNet50_Weights.IMAGENET1K_V2>
+            Improved weights using TorchVision's `new recipe <https://pytorch.org/blog/how-to-train-state-of-the-art-models-using-torchvision-latest-primitives/>`_:
             """
         },
     )

--- a/torchvision/models/resnet.py
+++ b/torchvision/models/resnet.py
@@ -344,6 +344,7 @@ class ResNet34_Weights(WeightsEnum):
 
 
 class ResNet50_Weights(WeightsEnum):
+    """<Some doc specific to ResNet50_Weights>"""
     IMAGENET1K_V1 = Weights(
         url="https://download.pytorch.org/models/resnet50-0676ba61.pth",
         transforms=partial(ImageClassification, crop_size=224),
@@ -355,6 +356,10 @@ class ResNet50_Weights(WeightsEnum):
                 "acc@1": 76.130,
                 "acc@5": 92.862,
             },
+            # Putting this here but the _docs key could also just be a field of the Weights dataclass
+            "_docs": """
+            <Some doc specific to ResNet50_Weights.IMAGENET1K_V2>
+            """
         },
     )
     IMAGENET1K_V2 = Weights(
@@ -368,6 +373,9 @@ class ResNet50_Weights(WeightsEnum):
                 "acc@1": 80.858,
                 "acc@5": 95.434,
             },
+            "_docs": """
+            <Some doc specific to ResNet50_Weights.IMAGENET1K_V2>
+            """
         },
     )
     DEFAULT = IMAGENET1K_V2

--- a/torchvision/models/resnet.py
+++ b/torchvision/models/resnet.py
@@ -344,7 +344,7 @@ class ResNet34_Weights(WeightsEnum):
 
 
 class ResNet50_Weights(WeightsEnum):
-    """<Some doc specific to ResNet50_Weights>"""
+    """Below you can find the available pre-trained weights for ResNet50:"""
     IMAGENET1K_V1 = Weights(
         url="https://download.pytorch.org/models/resnet50-0676ba61.pth",
         transforms=partial(ImageClassification, crop_size=224),


### PR DESCRIPTION
This PR makes it possible to document a weight enum, or a single `Weights` class.


rendered docs: https://output.circle-artifacts.com/output/job/cc788413-d4e6-4e1b-be75-453a8b5fb736/artifacts/0/docs/models/generated/torchvision.models.resnet50.html#torchvision.models.ResNet50_Weights