### PR TITLE
Indicate which weights correspond to pretrained=True in docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -330,8 +330,16 @@ def inject_weight_metadata(app, what, name, obj, options, lines):
 
         for field in obj:
             lines += [f"**{str(field)}**:", ""]
+
             if field == obj.DEFAULT:
-                lines += [f"This weight is also available as ``{obj.__name__}.DEFAULT``.", ""]
+                lines += [f"These weights are also available as ``{obj.__name__}.DEFAULT``."]
+            if field.name.endswith("V1"):
+                lines += [
+                    "These weights are the ones you get when using ``pretrained=True``, "
+                    "but note that ``pretrained`` is deprecated and will be removed in 0.15."
+                ]
+
+            lines.append("")
 
             table = []
 


### PR DESCRIPTION
As per @datumbox 's offline discussion, `pretrained=True` is equivalent to the V1 weights. This PR adds this information in the docs on all V1 weights.

![image](https://user-images.githubusercontent.com/1190450/167880589-e635431f-72bd-4b13-87d9-30c757552f3a.png)