### PR TITLE
Clarify TypeError message

### DIFF
--- a/torchvision/utils.py
+++ b/torchvision/utils.py
@@ -60,7 +60,7 @@ def make_grid(
         if isinstance(tensor, list):
             typ = "a list not containing only tensors"
         else:
-            typ = type(tensor)
+            typ = repr(type(tensor))
         raise TypeError(f"tensor or list of tensors expected, got {typ}")
 
     if "range" in kwargs.keys():

--- a/torchvision/utils.py
+++ b/torchvision/utils.py
@@ -58,7 +58,7 @@ def make_grid(
         _log_api_usage_once(make_grid)
     if not (torch.is_tensor(tensor) or (isinstance(tensor, list) and all(torch.is_tensor(t) for t in tensor))):
         if isinstance(tensor, list):
-            typ += "a list not containing only tensors"
+            typ = "a list not containing only tensors"
         else:
             typ = type(tensor)
         raise TypeError(f"tensor or list of tensors expected, got {typ}")

--- a/torchvision/utils.py
+++ b/torchvision/utils.py
@@ -57,7 +57,11 @@ def make_grid(
     if not torch.jit.is_scripting() and not torch.jit.is_tracing():
         _log_api_usage_once(make_grid)
     if not (torch.is_tensor(tensor) or (isinstance(tensor, list) and all(torch.is_tensor(t) for t in tensor))):
-        raise TypeError(f"tensor or list of tensors expected, got {type(tensor)}")
+        if isinstance(tensor, list):
+            typ += "a list not containing only tensors"
+        else:
+            typ = type(tensor)
+        raise TypeError(f"tensor or list of tensors expected, got {typ}")
 
     if "range" in kwargs.keys():
         warnings.warn(


### PR DESCRIPTION
To have a more clearer message than `TypeError: tensor or list of tensors expected, got <class 'list'>`, when having (for example) a list of numpy arrays.
Even better would be to parse the list and return the type of the first non-tensor. If you don't mind the code difference, I'll program that.