### PR TITLE
Handle empty weights in doc generation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -316,6 +316,11 @@ def inject_weight_metadata(app, what, name, obj, options, lines):
     """
 
     if obj.__name__.endswith(("_Weights", "_QuantizedWeights")):
+
+        if len(obj) == 0:
+            lines[:] = ["There are no available pre-trained weights."]
+            return
+
         lines[:] = [
             "The model builder above accepts the following values as the ``weights`` parameter.",
             f"``{obj.__name__}.DEFAULT`` is equivalent to ``{obj.DEFAULT}``.",

--- a/torchvision/models/mnasnet.py
+++ b/torchvision/models/mnasnet.py
@@ -316,6 +316,8 @@ def mnasnet0_75(*, weights: Optional[MNASNet0_75_Weights] = None, progress: bool
             <https://github.com/pytorch/vision/blob/main/torchvision/models/mnasnet.py>`_
             for more details about this class.
 
+    .. autoclass:: torchvision.models.MNASNet0_75_Weights
+        :members:
     """
     weights = MNASNet0_75_Weights.verify(weights)
 
@@ -366,6 +368,8 @@ def mnasnet1_3(*, weights: Optional[MNASNet1_3_Weights] = None, progress: bool =
             <https://github.com/pytorch/vision/blob/main/torchvision/models/mnasnet.py>`_
             for more details about this class.
 
+    .. autoclass:: torchvision.models.MNASNet1_3_Weights
+        :members:
     """
     weights = MNASNet1_3_Weights.verify(weights)
 


### PR DESCRIPTION
This PR allows to document weights enums that don't have pre-trained weights.

![image](https://user-images.githubusercontent.com/1190450/168116333-ce4664cd-958c-47fb-b535-f423e4f4c558.png)