### PR TITLE
Add weight for mnasnet0_75 and mnasnet1_3

### DIFF
--- a/torchvision/models/mnasnet.py
+++ b/torchvision/models/mnasnet.py
@@ -235,8 +235,21 @@ class MNASNet0_5_Weights(WeightsEnum):
 
 
 class MNASNet0_75_Weights(WeightsEnum):
-    # If a default model is added here the corresponding changes need to be done in mnasnet0_75
-    pass
+    IMAGENET1K_V1 = Weights(
+        url="https://download.pytorch.org/models/mnasnet0_75-7090bc5f.pth",
+        transforms=partial(ImageClassification, crop_size=224, resize_size=232),
+        meta={
+            **_COMMON_META,
+            "recipe": "MOCK"
+            "num_params": 3170208,
+            "metrics": {
+                # TODO: still mock need to update!
+                "acc@1": 71.180,
+                "acc@5": 90.494,
+            },
+        },
+    )
+    DEFAULT = IMAGENET1K_V1
 
 
 class MNASNet1_0_Weights(WeightsEnum):
@@ -256,8 +269,21 @@ class MNASNet1_0_Weights(WeightsEnum):
 
 
 class MNASNet1_3_Weights(WeightsEnum):
-    # If a default model is added here the corresponding changes need to be done in mnasnet1_3
-    pass
+    IMAGENET1K_V1 = Weights(
+        url="https://download.pytorch.org/models/mnasnet1_3-a4c69d6f.pth",
+        transforms=partial(ImageClassification, crop_size=224, resize_size=232),
+        meta={
+            **_COMMON_META,
+            "recipe": "MOCK"
+            "num_params": 6282256,
+            "metrics": {
+                # TODO: still mock need to update!
+                "acc@1": 76.506,
+                "acc@5": 93.522,
+            },
+        },
+    )
+    DEFAULT = IMAGENET1K_V1
 
 
 def _mnasnet(alpha: float, weights: Optional[WeightsEnum], progress: bool, **kwargs: Any) -> MNASNet:


### PR DESCRIPTION
Adding mnasnet0_75 and mnasnet1_3 weights.

Training commands:
```
# Training mnas0_75
python -u ~/script/run_with_submitit.py \
    --timeout 6000 --ngpus 8 --nodes 1 --batch-size=128 \
    --partition train --model mnasnet0_75 \
    --data-path="/datasets01_ontap/imagenet_full_size/061417" \
    --lr=0.5 --lr-scheduler=cosineannealinglr --lr-warmup-epochs=5 --lr-warmup-method=linear \
    --auto-augment=ta_wide --epochs=600 --random-erase=0.1 --weight-decay=0.00002 \
    --norm-weight-decay=0.0 --label-smoothing=0.1 --mixup-alpha=0.2 --cutmix-alpha=1.0 \
    --train-crop-size=176 --model-ema --val-resize-size=232 --ra-sampler --ra-reps=4

# Training mnas1_3
python -u ~/script/run_with_submitit.py \
    --timeout 6000 --ngpus 8 --nodes 1 --batch-size=128 \
    --partition train --model mnasnet1_3 \
    --data-path="/datasets01_ontap/imagenet_full_size/061417" \
    --lr=0.5 --lr-scheduler=cosineannealinglr --lr-warmup-epochs=5 --lr-warmup-method=linear \
    --auto-augment=ta_wide --epochs=600 --random-erase=0.1 --weight-decay=0.00002 \
    --norm-weight-decay=0.0 --label-smoothing=0.1 --mixup-alpha=0.2 --cutmix-alpha=1.0 \
    --train-crop-size=176 --model-ema --val-resize-size=232 --ra-sampler --ra-reps=4
```

TODO: Give validation command and result