### PR TITLE
Add more info on new models.srt

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -347,10 +347,6 @@ def inject_weight_metadata(app, what, name, obj, options, lines):
             metrics = meta.pop("metrics", {})
             meta_with_metrics = dict(meta, **metrics)
 
-            # We don't want to document these, they can be too long
-            for k in ["categories", "keypoint_names"]:
-                meta_with_metrics.pop(k, None)
-
             custom_docs = meta_with_metrics.pop("_docs", None)  # Custom per-Weights docs
             if custom_docs is not None:
                 lines += [custom_docs, ""]
@@ -360,6 +356,10 @@ def inject_weight_metadata(app, what, name, obj, options, lines):
                     v = f"`link <{v}>`__"
                 elif k == "min_size":
                     v = f"height={v[0]}, width={v[1]}"
+                elif k in {"categories", "keypoint_names"} and isinstance(v, list):
+                    max_visible = 3
+                    v_sample = ", ".join(v[:max_visible])
+                    v = f"{v_sample}, ... ({len(v)-max_visible} omitted)" if len(v) > max_visible else v_sample
                 table.append((str(k), str(v)))
             table = tabulate(table, tablefmt="rst")
             lines += [".. rst-class:: table-weights"]  # Custom CSS class, see custom_torchvision.css

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -367,7 +367,7 @@ def inject_weight_metadata(app, what, name, obj, options, lines):
             lines += textwrap.indent(table, " " * 4).split("\n")
             lines.append("")
             lines.append(
-                f"The inference transforms are available at ``{str(field)}.transforms`` and "
+                f"The preprocessing/inference transforms are available at ``{str(field)}.transforms`` and "
                 f"perform the following operations: {field.transforms().describe()}"
             )
             lines.append("")

--- a/docs/source/models_new.rst
+++ b/docs/source/models_new.rst
@@ -90,7 +90,12 @@ Most pre-trained models can be accessed directly via PyTorch Hub without having 
 
     import torch
 
+    # Option 1: passing weights param as string
     model = torch.hub.load("pytorch/vision", "resnet50", weights="DEFAULT")
+
+    # Option 2: passing weights param as enum
+    weights = torch.hub.load("pytorch/vision", "get_weight", weights="ResNet50_Weights.IMAGENET1K_V2")
+    model = torch.hub.load("pytorch/vision", "resnet50", weights=weights)
 
 The only exception to the above are the detection models included on
 :mod:`torchvision.models.detection`. These models require TorchVision
@@ -250,7 +255,7 @@ Here is an example of how to use the pre-trained quantized image classification 
 Table of all available quantized classification weights
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Accuracies are reported on ImageNet
+Accuracies are reported on ImageNet-1K using single crops:
 
 .. include:: generated/classification_quant_table.rst
 

--- a/docs/source/models_new.rst
+++ b/docs/source/models_new.rst
@@ -33,7 +33,7 @@ environment variable. See :func:`torch.hub.load_state_dict_from_url` for details
     <https://pytorch.org/docs/stable/notes/serialization.html#id6>`_
 
 
-Initializing Pre-trained models
+Initializing pre-trained models
 -------------------------------
 
 As of v0.13, TorchVision offers a new `Multi-weight support API
@@ -80,26 +80,6 @@ Migrating to the new API is very straightforward. The following method calls bet
     resnet50(False)  # deprecated
 
 Note that the ``pretrained`` parameter is now deprecated, using it will emit warnings and will be removed on v0.15.
-
-Loading models from Hub
------------------------
-
-Most pre-trained models can be accessed directly via PyTorch Hub without having TorchVision installed:
-
-.. code:: python
-
-    import torch
-
-    # Option 1: passing weights param as string
-    model = torch.hub.load("pytorch/vision", "resnet50", weights="IMAGENET1K_V2")
-
-    # Option 2: passing weights param as enum
-    weights = torch.hub.load("pytorch/vision", "get_weight", weights="ResNet50_Weights.IMAGENET1K_V2")
-    model = torch.hub.load("pytorch/vision", "resnet50", weights=weights)
-
-The only exception to the above are the detection models included on
-:mod:`torchvision.models.detection`. These models require TorchVision
-to be installed because they depend on custom C++ operators.
 
 Using the pre-trained models
 ----------------------------
@@ -498,3 +478,23 @@ Table of all available video classification weights
 Accuracies are reported on Kinetics-400 using single crops for clip length 16:
 
 .. include:: generated/video_table.rst
+
+Using models from Hub
+=====================
+
+Most pre-trained models can be accessed directly via PyTorch Hub without having TorchVision installed:
+
+.. code:: python
+
+    import torch
+
+    # Option 1: passing weights param as string
+    model = torch.hub.load("pytorch/vision", "resnet50", weights="IMAGENET1K_V2")
+
+    # Option 2: passing weights param as enum
+    weights = torch.hub.load("pytorch/vision", "get_weight", weights="ResNet50_Weights.IMAGENET1K_V2")
+    model = torch.hub.load("pytorch/vision", "resnet50", weights=weights)
+
+The only exception to the above are the detection models included on
+:mod:`torchvision.models.detection`. These models require TorchVision
+to be installed because they depend on custom C++ operators.

--- a/docs/source/models_new.rst
+++ b/docs/source/models_new.rst
@@ -201,6 +201,9 @@ Here is an example of how to use the pre-trained image classification models:
     category_name = weights.meta["categories"][class_id]
     print(f"{category_name}: {100 * score:.1f}%")
 
+The classes that the pre-trained model outputs are the following can be
+found on `weights.meta["categories"]`.
+
 Table of all available classification weights
 ---------------------------------------------
 
@@ -253,6 +256,9 @@ Here is an example of how to use the pre-trained quantized image classification 
     score = prediction[class_id].item()
     category_name = weights.meta["categories"][class_id]
     print(f"{category_name}: {100 * score}%")
+
+The classes that the pre-trained model outputs are the following can be
+found on `weights.meta["categories"]`.
 
 
 Table of all available quantized classification weights
@@ -307,11 +313,15 @@ Here is an example of how to use the pre-trained semantic segmentation models:
     mask = normalized_masks[0, class_to_idx["dog"]]
     to_pil_image(mask).show()
 
+The classes that the pre-trained model outputs are the following can be
+found on `weights.meta["categories"]`. The output format of the models
+is illustrated in :ref:`_semantic_seg_output`.
+
 
 Table of all available semantic segmentation weights
 ----------------------------------------------------
 
-All models are evaluated on COCO val2017:
+All models are evaluated a subset of COCO val2017, on the 20 categories that are present in the Pascal VOC dataset:
 
 .. include:: generated/segmentation_table.rst
 
@@ -319,6 +329,13 @@ All models are evaluated on COCO val2017:
 
 Object Detection, Instance Segmentation and Person Keypoint Detection
 =====================================================================
+
+The pre-trained models for detection, instance segmentation and
+keypoint detection are initialized with the classification models
+in torchvision.
+
+The models expect a list of ``Tensor[C, H, W]``. Check the constructor
+of the models for more information.
 
 Object Detection
 ----------------
@@ -372,10 +389,14 @@ Here is an example of how to use the pre-trained object detection models:
     im = to_pil_image(box.detach())
     im.show()
 
+The classes that the pre-trained model outputs are the following can be
+found on `weights.meta["categories"]`. For details on how to plot the
+bounding boxes of the models, you may refer to :ref:`instance_seg_output`.
+
 Table of all available Object detection weights
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Box MAPs are reported on COCO
+Box MAPs are reported on COCO val2017:
 
 .. include:: generated/detection_table.rst
 
@@ -393,12 +414,12 @@ weights:
    models/mask_rcnn
 
 
-For details on how to plot the masks of such models, you may refer to :ref:`semantic_seg_output`.
+For details on how to plot the masks of the models, you may refer to :ref:`instance_seg_output`.
 
 Table of all available Instance segmentation weights
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Box and Mask MAPs are reported on COCO
+Box and Mask MAPs are reported on COCO val2017:
 
 .. include:: generated/instance_segmentation_table.rst
 
@@ -407,7 +428,7 @@ Keypoint Detection
 
 .. currentmodule:: torchvision.models.detection
 
-The following keypoint detection models are available, with or without
+The following person keypoint detection models are available, with or without
 pre-trained weights:
 
 .. toctree::
@@ -415,10 +436,14 @@ pre-trained weights:
 
    models/keypoint_rcnn
 
+The classes that the pre-trained model outputs are the following can be
+found on `weights.meta["keypoint_names"]`. For details on how to plot the
+bounding boxes of the models, you may refer to :ref:`_keypoint_output`.
+
 Table of all available Keypoint detection weights
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Box and Keypoint MAPs are reported on COCO:
+Box and Keypoint MAPs are reported on COCO val2017:
 
 .. include:: generated/detection_keypoint_table.rst
 
@@ -471,6 +496,6 @@ Here is an example of how to use the pre-trained video classification models:
 Table of all available video classification weights
 ---------------------------------------------------
 
-Accuracies are reported on Kinetics-400
+Accuracies are reported on Kinetics-400 using single crops for clip length 16:
 
 .. include:: generated/video_table.rst

--- a/docs/source/models_new.rst
+++ b/docs/source/models_new.rst
@@ -24,6 +24,49 @@ keypoint detection, video classification, and optical flow.
     `documentation 
     <https://pytorch.org/docs/stable/notes/serialization.html#id6>`_   
 
+As of v0.13, TorchVision offers a new `Multi-weight support API
+<https://pytorch.org/blog/introducing-torchvision-new-multi-weight-support-api/>`_ for loading different weights to the
+existing model builder methods:
+
+.. code:: python
+
+    from torchvision.models import resnet50, ResNet50_Weights
+
+    # Old weights with accuracy 76.130%
+    resnet50(weights=ResNet50_Weights.IMAGENET1K_V1)
+
+    # New weights with accuracy 80.858%
+    resnet50(weights=ResNet50_Weights.IMAGENET1K_V2)
+
+    # Best available weights (currently alias for IMAGENET1K_V2)
+    # Note that these weights may change across versions
+    resnet50(weights=ResNet50_Weights.DEFAULT)
+
+    # Strings are also supported
+    resnet50(weights="IMAGENET1K_V2")
+
+    # No weights - random initialization
+    resnet50(weights=None)  # or resnet50()
+
+
+Migrating to the new API is very straightforward. The following method calls between the 2 APIs are all equivalent:
+
+.. code:: python
+
+    from torchvision.models import resnet50, ResNet50_Weights
+
+    # Using pretrained weights:
+    resnet50(weights=ResNet50_Weights.IMAGENET1K_V1)
+    resnet50(pretrained=True)  # deprecated
+    resnet50(True)  # deprecated
+
+    # Using no weights:
+    resnet50(weights=None)
+    resnet50(pretrained=False)  # deprecated
+    resnet50(False)  # deprecated
+
+Note that the ``pretrained`` parameter is now deprecated, using it will emit warnings and will be removed on v0.15.
+
 
 Classification
 ==============
@@ -56,6 +99,34 @@ weights:
    models/vision_transformer
    models/wide_resnet
 
+|
+
+Here is an example of how to use the pre-trained image classification models:
+
+.. code:: python
+
+    from torchvision.io import read_image
+    from torchvision.models import resnet50, ResNet50_Weights
+
+    img = read_image("test/assets/encode_jpeg/grace_hopper_517x606.jpg")
+
+    # Step 1: Initialize model with the best available weights
+    weights = ResNet50_Weights.DEFAULT
+    model = resnet50(weights=weights)
+    model.eval()
+
+    # Step 2: Initialize the inference transforms
+    preprocess = weights.transforms()
+
+    # Step 3: Apply inference preprocessing transforms
+    batch = preprocess(img).unsqueeze(0)
+
+    # Step 4: Use the model and print the predicted category
+    prediction = model(batch).squeeze(0).softmax(0)
+    class_id = prediction.argmax().item()
+    score = prediction[class_id].item()
+    category_name = weights.meta["categories"][class_id]
+    print(f"{category_name}: {100 * score:.1f}%")
 
 Table of all available classification weights
 ---------------------------------------------
@@ -77,6 +148,35 @@ pre-trained weights:
 
    models/googlenet_quant
    models/mobilenetv2_quant
+
+|
+
+Here is an example of how to use the pre-trained quantized image classification models:
+
+.. code:: python
+
+    from torchvision.io import read_image
+    from torchvision.models.quantization import resnet50, ResNet50_QuantizedWeights
+
+    img = read_image("test/assets/encode_jpeg/grace_hopper_517x606.jpg")
+
+    # Step 1: Initialize model with the best available weights
+    weights = ResNet50_QuantizedWeights.DEFAULT
+    model = resnet50(weights=weights, quantize=True)
+    model.eval()
+
+    # Step 2: Initialize the inference transforms
+    preprocess = weights.transforms()
+
+    # Step 3: Apply inference preprocessing transforms
+    batch = preprocess(img).unsqueeze(0)
+
+    # Step 4: Use the model and print the predicted category
+    prediction = model(batch).squeeze(0).softmax(0)
+    class_id = prediction.argmax().item()
+    score = prediction[class_id].item()
+    category_name = weights.meta["categories"][class_id]
+    print(f"{category_name}: {100 * score}%")
 
 
 Table of all available quantized classification weights
@@ -100,6 +200,37 @@ pre-trained weights:
    models/deeplabv3
    models/fcn
    models/lraspp
+
+|
+
+Here is an example of how to use the pre-trained semantic segmentation models:
+
+.. code:: python
+
+    from torchvision.io.image import read_image
+    from torchvision.models.segmentation import fcn_resnet50, FCN_ResNet50_Weights
+    from torchvision.transforms.functional import to_pil_image
+
+    img = read_image("gallery/assets/dog1.jpg")
+
+    # Step 1: Initialize model with the best available weights
+    weights = FCN_ResNet50_Weights.DEFAULT
+    model = fcn_resnet50(weights=weights)
+    model.eval()
+
+    # Step 2: Initialize the inference transforms
+    preprocess = weights.transforms()
+
+    # Step 3: Apply inference preprocessing transforms
+    batch = preprocess(img).unsqueeze(0)
+
+    # Step 4: Use the model and visualize the prediction
+    prediction = model(batch)["out"]
+    normalized_masks = prediction.softmax(dim=1)
+    class_to_idx = {cls: idx for (idx, cls) in enumerate(weights.meta["categories"])}
+    mask = normalized_masks[0, class_to_idx["dog"]]
+    to_pil_image(mask).show()
+
 
 Table of all available semantic segmentation weights
 ----------------------------------------------------
@@ -129,6 +260,41 @@ weights:
    models/retinanet
    models/ssd
    models/ssdlite
+
+|
+
+Here is an example of how to use the pre-trained object detection models:
+
+.. code:: python
+
+
+    from torchvision.io.image import read_image
+    from torchvision.models.detection import fasterrcnn_resnet50_fpn_v2, FasterRCNN_ResNet50_FPN_V2_Weights
+    from torchvision.utils import draw_bounding_boxes
+    from torchvision.transforms.functional import to_pil_image
+
+    img = read_image("test/assets/encode_jpeg/grace_hopper_517x606.jpg")
+
+    # Step 1: Initialize model with the best available weights
+    weights = FasterRCNN_ResNet50_FPN_V2_Weights.DEFAULT
+    model = fasterrcnn_resnet50_fpn_v2(weights=weights, box_score_thresh=0.9)
+    model.eval()
+
+    # Step 2: Initialize the inference transforms
+    preprocess = weights.transforms()
+
+    # Step 3: Apply inference preprocessing transforms
+    batch = [preprocess(img)]
+
+    # Step 4: Use the model and visualize the prediction
+    prediction = model(batch)[0]
+    labels = [weights.meta["categories"][i] for i in prediction["labels"]]
+    box = draw_bounding_boxes(img, boxes=prediction["boxes"],
+                              labels=labels,
+                              colors="red",
+                              width=4, font_size=30)
+    im = to_pil_image(box.detach())
+    im.show()
 
 Table of all available Object detection weights
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -190,6 +356,38 @@ pre-trained weights:
    :maxdepth: 1
 
    models/video_resnet
+
+|
+
+Here is an example of how to use the pre-trained video classification models:
+
+.. code:: python
+
+
+    from torchvision.io.video import read_video
+    from torchvision.models.video import r3d_18, R3D_18_Weights
+
+    vid, _, _ = read_video("test/assets/videos/v_SoccerJuggling_g23_c01.avi")
+    vid = vid[:32]  # optionally shorten duration
+
+    # Step 1: Initialize model with the best available weights
+    weights = R3D_18_Weights.DEFAULT
+    model = r3d_18(weights=weights)
+    model.eval()
+
+    # Step 2: Initialize the inference transforms
+    preprocess = weights.transforms()
+
+    # Step 3: Apply inference preprocessing transforms
+    batch = preprocess(vid).unsqueeze(0)
+
+    # Step 4: Use the model and print the predicted category
+    prediction = model(batch).squeeze(0).softmax(0)
+    label = prediction.argmax().item()
+    score = prediction[label].item()
+    category_name = weights.meta["categories"][label]
+    print(f"{category_name}: {100 * score}%")
+
 
 Table of all available video classification weights
 ---------------------------------------------------

--- a/docs/source/models_new.rst
+++ b/docs/source/models_new.rst
@@ -27,7 +27,7 @@ environment variable. See :func:`torch.hub.load_state_dict_from_url` for details
     Backward compatibility is guaranteed for loading a serialized
     ``state_dict`` to the model created using old PyTorch version.
     On the contrary, loading entire saved models or serialized
-    ``ScriptModules`` (seralized using older versions of PyTorch)
+    ``ScriptModules`` (serialized using older versions of PyTorch)
     may not preserve the historic behaviour. Refer to the following
     `documentation
     <https://pytorch.org/docs/stable/notes/serialization.html#id6>`_

--- a/docs/source/models_new.rst
+++ b/docs/source/models_new.rst
@@ -46,7 +46,7 @@ existing model builder methods:
     resnet50(weights="IMAGENET1K_V2")
 
     # No weights - random initialization
-    resnet50(weights=None)  # or resnet50()
+    resnet50(weights=None)
 
 
 Migrating to the new API is very straightforward. The following method calls between the 2 APIs are all equivalent:
@@ -57,11 +57,13 @@ Migrating to the new API is very straightforward. The following method calls bet
 
     # Using pretrained weights:
     resnet50(weights=ResNet50_Weights.IMAGENET1K_V1)
+    resnet50(weights="IMAGENET1K_V1")
     resnet50(pretrained=True)  # deprecated
     resnet50(True)  # deprecated
 
     # Using no weights:
     resnet50(weights=None)
+    resnet50()
     resnet50(pretrained=False)  # deprecated
     resnet50(False)  # deprecated
 

--- a/docs/source/models_new.rst
+++ b/docs/source/models_new.rst
@@ -201,8 +201,7 @@ Here is an example of how to use the pre-trained image classification models:
     category_name = weights.meta["categories"][class_id]
     print(f"{category_name}: {100 * score:.1f}%")
 
-The classes that the pre-trained model outputs are the following can be
-found on `weights.meta["categories"]`.
+The classes of the pre-trained model outputs can be found at ``weights.meta["categories"]``.
 
 Table of all available classification weights
 ---------------------------------------------
@@ -257,8 +256,7 @@ Here is an example of how to use the pre-trained quantized image classification 
     category_name = weights.meta["categories"][class_id]
     print(f"{category_name}: {100 * score}%")
 
-The classes that the pre-trained model outputs are the following can be
-found on `weights.meta["categories"]`.
+The classes of the pre-trained model outputs can be found at ``weights.meta["categories"]``.
 
 
 Table of all available quantized classification weights
@@ -313,9 +311,8 @@ Here is an example of how to use the pre-trained semantic segmentation models:
     mask = normalized_masks[0, class_to_idx["dog"]]
     to_pil_image(mask).show()
 
-The classes that the pre-trained model outputs are the following can be
-found on `weights.meta["categories"]`. The output format of the models
-is illustrated in :ref:`_semantic_seg_output`.
+The classes of the pre-trained model outputs can be found at ``weights.meta["categories"]``.
+The output format of the models is illustrated in :ref:`semantic_seg_output`.
 
 
 Table of all available semantic segmentation weights
@@ -332,10 +329,8 @@ Object Detection, Instance Segmentation and Person Keypoint Detection
 
 The pre-trained models for detection, instance segmentation and
 keypoint detection are initialized with the classification models
-in torchvision.
-
-The models expect a list of ``Tensor[C, H, W]``. Check the constructor
-of the models for more information.
+in torchvision. The models expect a list of ``Tensor[C, H, W]``.
+Check the constructor of the models for more information.
 
 Object Detection
 ----------------
@@ -389,9 +384,8 @@ Here is an example of how to use the pre-trained object detection models:
     im = to_pil_image(box.detach())
     im.show()
 
-The classes that the pre-trained model outputs are the following can be
-found on `weights.meta["categories"]`. For details on how to plot the
-bounding boxes of the models, you may refer to :ref:`instance_seg_output`.
+The classes of the pre-trained model outputs can be found at ``weights.meta["categories"]``.
+For details on how to plot the bounding boxes of the models, you may refer to :ref:`instance_seg_output`.
 
 Table of all available Object detection weights
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -412,6 +406,8 @@ weights:
    :maxdepth: 1
 
    models/mask_rcnn
+
+|
 
 
 For details on how to plot the masks of the models, you may refer to :ref:`instance_seg_output`.
@@ -436,9 +432,10 @@ pre-trained weights:
 
    models/keypoint_rcnn
 
-The classes that the pre-trained model outputs are the following can be
-found on `weights.meta["keypoint_names"]`. For details on how to plot the
-bounding boxes of the models, you may refer to :ref:`_keypoint_output`.
+|
+
+The classes of the pre-trained model outputs can be found at ``weights.meta["keypoint_names"]``.
+For details on how to plot the bounding boxes of the models, you may refer to :ref:`keypoint_output`.
 
 Table of all available Keypoint detection weights
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -491,6 +488,8 @@ Here is an example of how to use the pre-trained video classification models:
     score = prediction[label].item()
     category_name = weights.meta["categories"][label]
     print(f"{category_name}: {100 * score}%")
+
+The classes of the pre-trained model outputs can be found at ``weights.meta["categories"]``.
 
 
 Table of all available video classification weights

--- a/docs/source/models_new.rst
+++ b/docs/source/models_new.rst
@@ -3,30 +3,42 @@
 Models and pre-trained weights - New
 ####################################
 
-.. note::
-
-    These are the new models docs, documenting the new multi-weight API.
-    TODO: Once all is done, remove the "- New" part in the title above, and
-    rename this file as models.rst
-
-
 The ``torchvision.models`` subpackage contains definitions of models for addressing
 different tasks, including: image classification, pixelwise semantic
 segmentation, object detection, instance segmentation, person
 keypoint detection, video classification, and optical flow.
 
+General information on pre-trained weights
+==========================================
+
+TorchVision offers pre-trained weights for every provided architecture, using
+the PyTorch :mod:`torch.hub`. Instancing a pre-trained model will download its
+weights to a cache directory. This directory can be set using the `TORCH_HOME`
+environment variable. See :func:`torch.hub.load_state_dict_from_url` for details.
+
+.. note::
+
+    The pre-trained models provided in this library may have their own licenses or
+    terms and conditions derived from the dataset used for training. It is your
+    responsibility to determine whether you have permission to use the models for
+    your use case.
+
 .. note ::
-    Backward compatibility is guaranteed for loading a serialized 
-    ``state_dict`` to the model created using old PyTorch version. 
-    On the contrary, loading entire saved models or serialized 
-    ``ScriptModules`` (seralized using older versions of PyTorch) 
-    may not preserve the historic behaviour. Refer to the following 
-    `documentation 
-    <https://pytorch.org/docs/stable/notes/serialization.html#id6>`_   
+    Backward compatibility is guaranteed for loading a serialized
+    ``state_dict`` to the model created using old PyTorch version.
+    On the contrary, loading entire saved models or serialized
+    ``ScriptModules`` (seralized using older versions of PyTorch)
+    may not preserve the historic behaviour. Refer to the following
+    `documentation
+    <https://pytorch.org/docs/stable/notes/serialization.html#id6>`_
+
+
+Initializing Pre-trained models
+-------------------------------
 
 As of v0.13, TorchVision offers a new `Multi-weight support API
-<https://pytorch.org/blog/introducing-torchvision-new-multi-weight-support-api/>`_ for loading different weights to the
-existing model builder methods:
+<https://pytorch.org/blog/introducing-torchvision-new-multi-weight-support-api/>`_
+for loading different weights to the existing model builder methods:
 
 .. code:: python
 
@@ -68,6 +80,60 @@ Migrating to the new API is very straightforward. The following method calls bet
     resnet50(False)  # deprecated
 
 Note that the ``pretrained`` parameter is now deprecated, using it will emit warnings and will be removed on v0.15.
+
+Loading models from Hub
+-----------------------
+
+Most pre-trained models can be accessed directly via PyTorch Hub without having TorchVision installed:
+
+.. code:: python
+
+    import torch
+
+    model = torch.hub.load("pytorch/vision", "resnet50", weights="DEFAULT")
+
+The only exception to the above are the detection models included on
+:mod:`torchvision.models.detection`. These models require TorchVision
+to be installed because they depend on custom C++ operators.
+
+Using the pre-trained models
+----------------------------
+
+Before using the pre-trained models, one must preprocess the image
+(resize with right resolution/interpolation, apply inference transforms,
+rescale the values etc). There is no standard way to do this as it depends on
+how a given model was trained. It can vary across model families, variants or
+even weight versions. Using the correct preprocessing method is critical and
+failing to do so may lead to decreased accuracy or incorrect outputs.
+
+All the necessary information for the inference transforms of each pre-trained
+model is provided on its weights documentation. To simplify inference, TorchVision
+bundles the necessary preprocessing transforms into each model weight. These are
+accessible via the ``weight.transforms`` attribute:
+
+.. code:: python
+
+    # Initialize the Weight Transforms
+    weights = ResNet50_Weights.DEFAULT
+    preprocess = weights.transforms()
+
+    # Apply it to the input image
+    img_transformed = preprocess(img)
+
+
+Some models use modules which have different training and evaluation
+behavior, such as batch normalization. To switch between these modes, use
+``model.train()`` or ``model.eval()`` as appropriate. See
+:meth:`~torch.nn.Module.train` or :meth:`~torch.nn.Module.eval` for details.
+
+.. code:: python
+
+    # Initialize model
+    weights = ResNet50_Weights.DEFAULT
+    model = resnet50(weights=weights)
+
+    # Set model to eval mode
+    model.eval()
 
 
 Classification
@@ -133,7 +199,7 @@ Here is an example of how to use the pre-trained image classification models:
 Table of all available classification weights
 ---------------------------------------------
 
-Accuracies are reported on ImageNet
+Accuracies are reported on ImageNet-1K using single crops:
 
 .. include:: generated/classification_table.rst
 
@@ -142,7 +208,7 @@ Quantized models
 
 .. currentmodule:: torchvision.models.quantization
 
-The following quantized classification models are available, with or without
+The following architectures provide support for INT8 quantized models, with or without
 pre-trained weights:
 
 .. toctree::

--- a/docs/source/models_new.rst
+++ b/docs/source/models_new.rst
@@ -91,7 +91,7 @@ Most pre-trained models can be accessed directly via PyTorch Hub without having 
     import torch
 
     # Option 1: passing weights param as string
-    model = torch.hub.load("pytorch/vision", "resnet50", weights="DEFAULT")
+    model = torch.hub.load("pytorch/vision", "resnet50", weights="IMAGENET1K_V2")
 
     # Option 2: passing weights param as enum
     weights = torch.hub.load("pytorch/vision", "get_weight", weights="ResNet50_Weights.IMAGENET1K_V2")
@@ -388,6 +388,9 @@ weights:
    :maxdepth: 1
 
    models/mask_rcnn
+
+
+For details on how to plot the masks of such models, you may refer to :ref:`semantic_seg_output`.
 
 Table of all available Instance segmentation weights
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/gallery/plot_visualization_utils.py
+++ b/gallery/plot_visualization_utils.py
@@ -379,6 +379,8 @@ show(dogs_with_masks)
 # instance with class 15 (which corresponds to 'bench') was not selected.
 
 #####################################
+# .. _keypoint_output:
+#
 # Visualizing keypoints
 # ------------------------------
 # The :func:`~torchvision.utils.draw_keypoints` function can be used to

--- a/torchvision/transforms/_presets.py
+++ b/torchvision/transforms/_presets.py
@@ -71,8 +71,8 @@ class ImageClassification(nn.Module):
     def describe(self) -> str:
         return (
             f"The images are resized to ``resize_size={self.resize_size}`` using ``interpolation={self.interpolation}``, "
-            f"followed by a central crop of ``crop_size={self.crop_size}``. Then the values are rescaled to "
-            f"``[0.0, 1.0]`` and normalized using ``mean={self.mean}`` and ``std={self.std}``."
+            f"followed by a central crop of ``crop_size={self.crop_size}``. Finally the values are first rescaled to "
+            f"``[0.0, 1.0]`` and then normalized using ``mean={self.mean}`` and ``std={self.std}``."
         )
 
 
@@ -127,8 +127,8 @@ class VideoClassification(nn.Module):
     def describe(self) -> str:
         return (
             f"The video frames are resized to ``resize_size={self.resize_size}`` using ``interpolation={self.interpolation}``, "
-            f"followed by a central crop of ``crop_size={self.crop_size}``. Then the values are rescaled to "
-            f"``[0.0, 1.0]`` and normalized using ``mean={self.mean}`` and ``std={self.std}``."
+            f"followed by a central crop of ``crop_size={self.crop_size}``. Finally the values are first rescaled to "
+            f"``[0.0, 1.0]`` and then normalized using ``mean={self.mean}`` and ``std={self.std}``."
         )
 
 
@@ -168,7 +168,8 @@ class SemanticSegmentation(nn.Module):
     def describe(self) -> str:
         return (
             f"The images are resized to ``resize_size={self.resize_size}`` using ``interpolation={self.interpolation}``. "
-            f"Then the values are rescaled to ``[0.0, 1.0]`` and normalized using ``mean={self.mean}`` and ``std={self.std}``."
+            f"Finally the values are first rescaled to ``[0.0, 1.0]`` and then normalized using ``mean={self.mean}`` and "
+            f"``std={self.std}``."
         )
 
 


### PR DESCRIPTION
Addresses partially #6014

Demo: https://output.circle-artifacts.com/output/job/a9a5210b-ed03-4165-9e8f-24a5071eeb82/artifacts/0/docs/models_new.html

This PR:

- Transfers all the missing information from the old docs (Torch Hub, validation dataset info) and adds references to galleries when available
- Adds additional new info for models (licensing, code examples for meta-data, preprocessing usage)
- Performs small updates on the code examples and docs.
- Makes partially visible the category meta. See screenshots below:

<img width="777" alt="image" src="https://user-images.githubusercontent.com/5347466/168629215-1b0741dd-fc61-43b1-ad6b-2d5dda885fbb.png">


<img width="777" alt="image" src="https://user-images.githubusercontent.com/5347466/168629323-6a657f72-106b-4a55-ac28-02d65b05d4aa.png">
