### PR TITLE
docs: Added quantized ResNext to the new doc

### DIFF
--- a/docs/source/models/resnext_quant.rst
+++ b/docs/source/models/resnext_quant.rst
@@ -1,0 +1,25 @@
+Quantized ResNeXt
+=================
+
+.. currentmodule:: torchvision.models.quantization
+
+The quantized ResNext model is based on the `Aggregated Residual Transformations for Deep Neural Networks <https://arxiv.org/abs/1611.05431v2>`__
+paper.
+
+
+Model builders
+--------------
+
+The following model builders can be used to instantiate a quantized ResNeXt
+model, with or without pre-trained weights. All the model builders internally
+rely on the ``torchvision.models.quantization.resnet.QuantizableResNet``
+base class. Please refer to the `source code
+<https://github.com/pytorch/vision/blob/main/torchvision/models/quantization/resnet.py>`_
+for more details about this class.
+
+.. autosummary::
+    :toctree: generated/
+    :template: function.rst
+
+    resnext101_32x8d
+    resnext101_64x4d

--- a/docs/source/models_new.rst
+++ b/docs/source/models_new.rst
@@ -206,6 +206,7 @@ pre-trained weights:
    models/mobilenetv2_quant
    models/mobilenetv3_quant
    models/resnet_quant
+   models/resnext_quant
    models/shufflenetv2_quant
 
 |

--- a/torchvision/models/quantization/resnet.py
+++ b/torchvision/models/quantization/resnet.py
@@ -366,7 +366,7 @@ def resnext101_32x8d(
     **kwargs: Any,
 ) -> QuantizableResNet:
     """ResNeXt-101 32x8d model from
-    `Aggregated Residual Transformation for Deep Neural Networks <https://arxiv.org/abs/1611.05431.pdf>`_
+    `Aggregated Residual Transformation for Deep Neural Networks <https://arxiv.org/abs/1611.05431>`_
 
     .. note::
         Note that ``quantize = True`` returns a quantized model with 8 bit
@@ -409,7 +409,7 @@ def resnext101_64x4d(
     **kwargs: Any,
 ) -> QuantizableResNet:
     """ResNeXt-101 64x4d model from
-    `Aggregated Residual Transformation for Deep Neural Networks <https://arxiv.org/abs/1611.05431.pdf>`_
+    `Aggregated Residual Transformation for Deep Neural Networks <https://arxiv.org/abs/1611.05431>`_
 
     .. note::
         Note that ``quantize = True`` returns a quantized model with 8 bit


### PR DESCRIPTION
Following up on https://github.com/pytorch/vision/issues/5987, this PR introduces the following modifications:

- creates the new rst doc file for quantized resnext
- adds the reference on the new page
- updates the docstring accordingly

Any feedback is welcome!

cc @NicolasHug @datumbox