### PR TITLE
expand prototype test matrix to different Python versions

### DIFF
--- a/.github/workflows/prototype-tests.yml
+++ b/.github/workflows/prototype-tests.yml
@@ -7,10 +7,18 @@ jobs:
   prototype:
     strategy:
       matrix:
+        python-version:
+          - "3.7"
+          - "3.8"
+          - "3.9"
+          - "3.10"
         os:
           - ubuntu-latest
-          - windows-latest
-          - macos-latest
+        include:
+          - python-version: "3.7"
+            os: windows-latest
+          - python-version: "3.7"
+            os: macos-latest
       fail-fast: false
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
This expands the prototype test matrix to test all Python versions on Linux. This should give us some extra safety to catch stuff like #5801 and https://github.com/pytorch/data/runs/6500848588#step:9:1977, which are not visible on Python 3.7.

Since GitHub actions is free for OSS projects, this does not add any costs.