### PR TITLE
[bugfix] Check if norm_layer has not-None weight before init

### DIFF
--- a/torchvision/models/resnet.py
+++ b/torchvision/models/resnet.py
@@ -217,9 +217,9 @@ class ResNet(nn.Module):
         # This improves the model by 0.2~0.3% according to https://arxiv.org/abs/1706.02677
         if zero_init_residual:
             for m in self.modules():
-                if isinstance(m, Bottleneck):
+                if isinstance(m, Bottleneck) and m.bn3.weight is not None:
                     nn.init.constant_(m.bn3.weight, 0)  # type: ignore[arg-type]
-                elif isinstance(m, BasicBlock):
+                elif isinstance(m, BasicBlock) and m.bn2.weight is not None:
                     nn.init.constant_(m.bn2.weight, 0)  # type: ignore[arg-type]
 
     def _make_layer(


### PR DESCRIPTION
I tried to resolve bug reported on https://github.com/pytorch/vision/issues/6074.

@datumbox I may not have a full context here, let me know what you think.