### PR TITLE
[v0.13.0] .circleci: Bump version for pytorch 1.12.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,11 +190,11 @@ binary_common: &binary_common
     build_version:
       description: "version number of release binary; by default, build a nightly"
       type: string
-      default: ""
+      default: "0.13.0"
     pytorch_version:
       description: "PyTorch version to build against; by default, use a nightly"
       type: string
-      default: ""
+      default: "1.12.0"
     # Don't edit these
     python_version:
       description: "Python version to build against (e.g., 3.7)"

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -190,11 +190,11 @@ binary_common: &binary_common
     build_version:
       description: "version number of release binary; by default, build a nightly"
       type: string
-      default: ""
+      default: "0.13.0"
     pytorch_version:
       description: "PyTorch version to build against; by default, use a nightly"
       type: string
-      default: ""
+      default: "1.12.0"
     # Don't edit these
     python_version:
       description: "Python version to build against (e.g., 3.7)"


### PR DESCRIPTION
[v0.13.0] .circleci: Bump version for pytorch 1.12.0
