### PR TITLE
Fix the typecheck error when loading weights

### DIFF
--- a/torchvision/models/_api.py
+++ b/torchvision/models/_api.py
@@ -1,9 +1,10 @@
 import importlib
 import inspect
 import sys
+import torch
 from dataclasses import dataclass, fields
 from inspect import signature
-from typing import Any, Callable, Dict, cast
+from typing import Any, Callable, Dict, cast, OrderedDict
 
 from torchvision._utils import StrEnum
 
@@ -59,7 +60,7 @@ class WeightsEnum(StrEnum):
                 )
         return obj
 
-    def get_state_dict(self, progress: bool) -> Dict[str, Any]:
+    def get_state_dict(self, progress: bool) -> OrderedDict[str, torch.Tensor]:
         return load_state_dict_from_url(self.url, progress=progress)
 
     def __repr__(self) -> str:

--- a/torchvision/models/_api.py
+++ b/torchvision/models/_api.py
@@ -61,7 +61,7 @@ class WeightsEnum(StrEnum):
         return obj
 
     def get_state_dict(self, progress: bool) -> OrderedDict[str, torch.Tensor]:
-        return load_state_dict_from_url(self.url, progress=progress)
+        return OrderedDict(load_state_dict_from_url(self.url, progress=progress))
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}.{self._name_}"

--- a/torchvision/models/_api.py
+++ b/torchvision/models/_api.py
@@ -1,11 +1,11 @@
 import importlib
 import inspect
 import sys
-import torch
 from dataclasses import dataclass, fields
 from inspect import signature
 from typing import Any, Callable, Dict, cast, OrderedDict
 
+import torch
 from torchvision._utils import StrEnum
 
 from .._internally_replaced_utils import load_state_dict_from_url


### PR DESCRIPTION
Currently the relase branch `release/0.13` have type check error : https://app.circleci.com/pipelines/github/pytorch/vision/17906/workflows/8f008f5a-13b2-4207-a378-51ae705b99b7/jobs/1450718

I am not too sure why it has error there but not on main, but I can reproduce the error on my local laptop. And this PR want to fix it.

However I may not have a full context why we use `Dict[str, Any]` for the return value of `get_state_dict`  function.  I saw that previously it use `OrderedDict` and changed on https://github.com/pytorch/vision/pull/5970/files.


