### PR TITLE
Change weights return type to Mapping

### DIFF
--- a/torchvision/models/_api.py
+++ b/torchvision/models/_api.py
@@ -3,7 +3,7 @@ import inspect
 import sys
 from dataclasses import dataclass, fields
 from inspect import signature
-from typing import Any, Callable, Dict, cast
+from typing import Any, Callable, Dict, Mapping, cast
 
 from torchvision._utils import StrEnum
 
@@ -59,7 +59,7 @@ class WeightsEnum(StrEnum):
                 )
         return obj
 
-    def get_state_dict(self, progress: bool) -> Dict[str, Any]:
+    def get_state_dict(self, progress: bool) -> Mapping[str, Any]:
         return load_state_dict_from_url(self.url, progress=progress)
 
     def __repr__(self) -> str:


### PR DESCRIPTION
<!-- Before submitting a PR, please make sure to check our contributing guidelines regarding code formatting, tests, and documentation: https://github.com/pytorch/vision/blob/main/CONTRIBUTING.md -->
As of recently, PyTorch Core's [switched](https://github.com/pytorch/pytorch/blob/master/torch/nn/modules/module.py#L1534) its types to the following signature:
```python
    def load_state_dict(self, state_dict: Mapping[str, Any],
                        strict: bool = True):
```

This PR aligns with it.