### PR TITLE
Fixing CI job "cmake_linux_gpu" issue with setup_env.sh in docker

### DIFF
--- a/.circleci/unittest/linux/scripts/setup_env.sh
+++ b/.circleci/unittest/linux/scripts/setup_env.sh
@@ -8,6 +8,8 @@
 set -e
 
 this_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+# Avoid error: "fatal: unsafe repository"
+git config --global --add safe.directory '*'
 root_dir="$(git rev-parse --show-toplevel)"
 conda_dir="${root_dir}/conda"
 env_dir="${root_dir}/env"


### PR DESCRIPTION
New version of git checks folder owner and errors with 'fatal: unsafe repository' if owner is different.
Thus, `root_dir="$(git rev-parse --show-toplevel)"` is failing.

To fix the issue, just added all folders as safe directories

