### PR TITLE
[Cherrypick 0.13] Fixing issue with setup_env.sh in docker (#6106)

### DIFF
--- a/.circleci/unittest/linux/scripts/setup_env.sh
+++ b/.circleci/unittest/linux/scripts/setup_env.sh
@@ -8,6 +8,8 @@
 set -e
 
 this_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+# Avoid error: "fatal: unsafe repository"
+git config --global --add safe.directory '*'
 root_dir="$(git rev-parse --show-toplevel)"
 conda_dir="${root_dir}/conda"
 env_dir="${root_dir}/env"


### PR DESCRIPTION
Cherrypick #6106 

This PR is a fix to the CI that trigger error:
```
fatal: unsafe repository ('/home/circleci/project' is owned by someone else)
To add an exception for this directory, call:

	git config --global --add safe.directory /home/circleci/project

```