### PR TITLE
Add unit-tests for M1

### DIFF
--- a/.github/workflows/build-m1-binaries.yml
+++ b/.github/workflows/build-m1-binaries.yml
@@ -49,6 +49,7 @@ jobs:
           name: torchvision-py${{ matrix.py_vers }}-macos11-m1
           path: dist/
       - name: Upload wheel to S3
+        if: ${{ github.event_name == 'push' && steps.extract_branch.outputs.branch == 'nightly' }}
         shell: arch -arch arm64 bash {0}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_PYTORCH_UPLOADER_ACCESS_KEY_ID }}

--- a/.github/workflows/build-m1-binaries.yml
+++ b/.github/workflows/build-m1-binaries.yml
@@ -1,7 +1,13 @@
 name: Build on M1
 on:
   pull_request:
-
+    paths:
+      - .github/workflows/build-m1-binaries.yml
+  push:
+    branches:
+      - nightly
+      - main
+  workflow_dispatch:
 jobs:
   build_wheels:
     name: "Build TorchVision M1 wheels"

--- a/.github/workflows/build-m1-binaries.yml
+++ b/.github/workflows/build-m1-binaries.yml
@@ -28,7 +28,7 @@ jobs:
           set -ex
           export BUILD_VERSION=0.14.0.dev$(date "+%Y%m%d")
           WHL_NAME=torchvision-${BUILD_VERSION}-cp${PY_VERS/.}-cp${PY_VERS/.}-macosx_11_0_arm64.whl
-          conda create -yp ${ENV_NAME} python=${PY_VERS} numpy libpng openjpeg wheel pkg-config
+          conda create -yp ${ENV_NAME} python=${PY_VERS} numpy libpng libjpeg wheel pkg-config
           conda run -p ${ENV_NAME} python3 -mpip install torch --extra-index-url=https://download.pytorch.org/whl/nightly
           conda run -p ${ENV_NAME} python3 -mpip install delocate
           conda run -p ${ENV_NAME} python3 setup.py bdist_wheel

--- a/.github/workflows/build-m1-binaries.yml
+++ b/.github/workflows/build-m1-binaries.yml
@@ -50,6 +50,7 @@ jobs:
           conda run --cwd /tmp -p ${ENV_NAME} python3 -c "import torch;import torchvision;print('Is torchvision useable?', all(x is not None for x in [torch.ops.image.decode_png, torch.ops.torchvision.roi_align]))"
           conda env remove -p ${ENV_NAME}
       - name: Upload wheel to GitHub
+        if: ${{ github.event_name == 'push' && steps.extract_branch.outputs.branch == 'nightly' }}
         uses: actions/upload-artifact@v3
         with:
           name: torchvision-py${{ matrix.py_vers }}-macos11-m1

--- a/.github/workflows/build-m1-binaries.yml
+++ b/.github/workflows/build-m1-binaries.yml
@@ -1,12 +1,7 @@
 name: Build on M1
 on:
   pull_request:
-    paths:
-      - .github/workflows/build-m1-binaries.yml
-  push:
-    branches:
-      - nightly
-  workflow_dispatch:
+
 jobs:
   build_wheels:
     name: "Build TorchVision M1 wheels"

--- a/.github/workflows/test-m1.yml
+++ b/.github/workflows/test-m1.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 jobs:
   tests:
-    name: "Build TorchVision M1 wheels"
+    name: "Unit-tests on M1"
     runs-on: macos-m1
     strategy:
       matrix:

--- a/.github/workflows/test-m1.yml
+++ b/.github/workflows/test-m1.yml
@@ -25,6 +25,6 @@ jobs:
           conda create -yp ${ENV_NAME} python=${PY_VERS} numpy libpng openjpeg wheel pkg-config
           conda run -p ${ENV_NAME} python3 -mpip install torch --extra-index-url=https://download.pytorch.org/whl/nightly
           conda run -p ${ENV_NAME} python3 setup.py develop
-          conda run -p ${ENV_NAME} python3 -mpip install scipy pytest pytest-mock
+          conda run -p ${ENV_NAME} python3 -mpip install pytest pytest-mock
           pytest -v --durations 20
           conda env remove -p ${ENV_NAME}

--- a/.github/workflows/test-m1.yml
+++ b/.github/workflows/test-m1.yml
@@ -25,5 +25,6 @@ jobs:
           conda create -yp ${ENV_NAME} python=${PY_VERS} numpy libpng openjpeg wheel pkg-config
           conda run -p ${ENV_NAME} python3 -mpip install torch --extra-index-url=https://download.pytorch.org/whl/nightly
           conda run -p ${ENV_NAME} python3 setup.py develop
+          conda run -p ${ENV_NAME} python3 -mpip install scipy pytest pytest-mock
           pytest -v --durations 20
           conda env remove -p ${ENV_NAME}

--- a/.github/workflows/test-m1.yml
+++ b/.github/workflows/test-m1.yml
@@ -39,5 +39,5 @@ jobs:
         run: |
           . ~/miniconda3/etc/profile.d/conda.sh
           set -ex
-          conda run -p ${ENV_NAME} --no-capture-output python3 -u -mpytest --tb=long --durations 20
+          conda run -p ${ENV_NAME} --no-capture-output python3 -u -mpytest -vv --tb=long --durations 20
           conda env remove -p ${ENV_NAME}

--- a/.github/workflows/test-m1.yml
+++ b/.github/workflows/test-m1.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-      - name: Run tests
+      - name: Install TorchVision
         shell: arch -arch arm64 bash {0}
         env:
           ENV_NAME: conda-env-${{ github.run_id }}
@@ -26,5 +26,11 @@ jobs:
           conda run -p ${ENV_NAME} python3 -mpip install torch --extra-index-url=https://download.pytorch.org/whl/nightly
           conda run -p ${ENV_NAME} python3 setup.py develop
           conda run -p ${ENV_NAME} python3 -mpip install pytest pytest-mock
-          conda run -p ${ENV_NAME} python3 -mpytest -v --durations 20
+      - name: Run tests
+        shell: arch -arch arm64 bash {0}
+        env:
+          ENV_NAME: conda-env-${{ github.run_id }}
+          PY_VERS: ${{ matrix.py_vers }}
+        run: |
+          conda run -p ${ENV_NAME} --no-capture-output python3 -u -mpytest -v --durations 20
           conda env remove -p ${ENV_NAME}

--- a/.github/workflows/test-m1.yml
+++ b/.github/workflows/test-m1.yml
@@ -21,7 +21,6 @@ jobs:
         run: |
           . ~/miniconda3/etc/profile.d/conda.sh
           set -ex
-          export BUILD_VERSION=0.14.0.dev$(date "+%Y%m%d")
           conda create -yp ${ENV_NAME} python=${PY_VERS} numpy libpng openjpeg wheel pkg-config
           conda run -p ${ENV_NAME} python3 -mpip install torch --extra-index-url=https://download.pytorch.org/whl/nightly
           conda run -p ${ENV_NAME} python3 setup.py develop

--- a/.github/workflows/test-m1.yml
+++ b/.github/workflows/test-m1.yml
@@ -1,7 +1,13 @@
 name: Unit-tests on M1
 on:
   pull_request:
-
+    paths:
+      - .github/workflows/test-m1.yml
+  push:
+    branches:
+      - nightly
+      - main
+  workflow_dispatch:
 jobs:
   tests:
     name: "Build TorchVision M1 wheels"

--- a/.github/workflows/test-m1.yml
+++ b/.github/workflows/test-m1.yml
@@ -1,7 +1,9 @@
 name: Unit-tests on M1
 on:
-  pull_request:
-
+  workflow_run:
+    workflows: ["Build on M1"]
+    types:
+      - completed
 jobs:
   tests:
     name: "Build TorchVision M1 wheels"
@@ -19,21 +21,23 @@ jobs:
       - name: Upgrade system packages
         run: python -m pip install --upgrade pip setuptools wheel
 
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: torchvision-py3.8-macos11-m1
+
       - name: Checkout repository
-        uses: actions/checkout@v3
-
-      - name: Install PyTorch nightly builds
-        run: pip install --progress-bar=off --pre torch torchdata --extra-index-url https://download.pytorch.org/whl/nightly/cpu/
-
-      - name: Install torchvision
-        run: pip install --progress-bar=off --no-build-isolation --editable .
-
-      - name: Install other prototype dependencies
-        run: pip install --progress-bar=off scipy pycocotools h5py iopath
-
-      - name: Install test requirements
-        run: pip install --progress-bar=off pytest pytest-mock
+        uses: actions/checkout@v2
 
       - name: Run prototype tests
-        shell: bash
-        run: pytest -v --durations 20
+        shell: arch -arch arm64 bash {0}
+        env:
+          ENV_NAME: conda-test-env-${{ github.run_id }}
+        run: |
+          . ~/miniconda3/etc/profile.d/conda.sh
+          set -ex
+          conda create -yp ${ENV_NAME} python=3.8 numpy
+          conda run -p ${ENV_NAME} python3 -mpip install torch --extra-index-url=https://download.pytorch.org/whl/nightly
+          conda run -p ${ENV_NAME} python3 -mpip install *.whl
+          pytest -v --durations 20
+          conda env remove -p ${ENV_NAME}

--- a/.github/workflows/test-m1.yml
+++ b/.github/workflows/test-m1.yml
@@ -27,10 +27,10 @@ jobs:
         run: |
           . ~/miniconda3/etc/profile.d/conda.sh
           set -ex
-          conda create -yp ${ENV_NAME} python=${PY_VERS} numpy libpng openjpeg wheel pkg-config
+          conda create -yp ${ENV_NAME} python=${PY_VERS} numpy libpng openjpeg scipy
           conda run -p ${ENV_NAME} python3 -mpip install torch --extra-index-url=https://download.pytorch.org/whl/nightly
           conda run -p ${ENV_NAME} python3 setup.py develop
-          conda run -p ${ENV_NAME} python3 -mpip install pytest pytest-mock
+          conda run -p ${ENV_NAME} python3 -mpip install pytest pytest-mock av
       - name: Run tests
         shell: arch -arch arm64 bash {0}
         env:
@@ -39,5 +39,5 @@ jobs:
         run: |
           . ~/miniconda3/etc/profile.d/conda.sh
           set -ex
-          conda run -p ${ENV_NAME} --no-capture-output python3 -u -mpytest -vv --tb=long --durations 20
+          conda run -p ${ENV_NAME} --no-capture-output python3 -u -mpytest -v --tb=long --durations 20
           conda env remove -p ${ENV_NAME}

--- a/.github/workflows/test-m1.yml
+++ b/.github/workflows/test-m1.yml
@@ -39,5 +39,5 @@ jobs:
         run: |
           . ~/miniconda3/etc/profile.d/conda.sh
           set -ex
-          conda run -p ${ENV_NAME} --no-capture-output python3 -u -mpytest -v --durations 20
+          conda run -p ${ENV_NAME} --no-capture-output python3 -u -mpytest --tb=long --durations 20
           conda env remove -p ${ENV_NAME}

--- a/.github/workflows/test-m1.yml
+++ b/.github/workflows/test-m1.yml
@@ -1,9 +1,7 @@
 name: Unit-tests on M1
 on:
-  workflow_run:
-    workflows: ["Build on M1"]
-    types:
-      - completed
+  pull_request:
+
 jobs:
   tests:
     name: "Build TorchVision M1 wheels"
@@ -13,31 +11,19 @@ jobs:
         py_vers: [ "3.8"]
 
     steps:
-      - name: Set up python
-        uses: actions/setup-python@v3
-        with:
-          python-version: 3.8
-
-      - name: Upgrade system packages
-        run: python -m pip install --upgrade pip setuptools wheel
-
-      - name: Download artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: torchvision-py3.8-macos11-m1
-
       - name: Checkout repository
         uses: actions/checkout@v2
-
-      - name: Run prototype tests
+      - name: Run tests
         shell: arch -arch arm64 bash {0}
         env:
-          ENV_NAME: conda-test-env-${{ github.run_id }}
+          ENV_NAME: conda-env-${{ github.run_id }}
+          PY_VERS: ${{ matrix.py_vers }}
         run: |
           . ~/miniconda3/etc/profile.d/conda.sh
           set -ex
-          conda create -yp ${ENV_NAME} python=3.8 numpy
+          export BUILD_VERSION=0.14.0.dev$(date "+%Y%m%d")
+          conda create -yp ${ENV_NAME} python=${PY_VERS} numpy libpng openjpeg wheel pkg-config
           conda run -p ${ENV_NAME} python3 -mpip install torch --extra-index-url=https://download.pytorch.org/whl/nightly
-          conda run -p ${ENV_NAME} python3 -mpip install *.whl
+          conda run -p ${ENV_NAME} python3 setup.py develop
           pytest -v --durations 20
           conda env remove -p ${ENV_NAME}

--- a/.github/workflows/test-m1.yml
+++ b/.github/workflows/test-m1.yml
@@ -26,5 +26,5 @@ jobs:
           conda run -p ${ENV_NAME} python3 -mpip install torch --extra-index-url=https://download.pytorch.org/whl/nightly
           conda run -p ${ENV_NAME} python3 setup.py develop
           conda run -p ${ENV_NAME} python3 -mpip install pytest pytest-mock
-          pytest -v --durations 20
+          conda run -p ${ENV_NAME} python3 -mpytest -v --durations 20
           conda env remove -p ${ENV_NAME}

--- a/.github/workflows/test-m1.yml
+++ b/.github/workflows/test-m1.yml
@@ -1,0 +1,39 @@
+name: Unit-tests on M1
+on:
+  pull_request:
+
+jobs:
+  tests:
+    name: "Build TorchVision M1 wheels"
+    runs-on: macos-m1
+    strategy:
+      matrix:
+        py_vers: [ "3.8"]
+
+    steps:
+      - name: Set up python
+        uses: actions/setup-python@v3
+        with:
+          python-version: 3.8
+
+      - name: Upgrade system packages
+        run: python -m pip install --upgrade pip setuptools wheel
+
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install PyTorch nightly builds
+        run: pip install --progress-bar=off --pre torch torchdata --extra-index-url https://download.pytorch.org/whl/nightly/cpu/
+
+      - name: Install torchvision
+        run: pip install --progress-bar=off --no-build-isolation --editable .
+
+      - name: Install other prototype dependencies
+        run: pip install --progress-bar=off scipy pycocotools h5py iopath
+
+      - name: Install test requirements
+        run: pip install --progress-bar=off pytest pytest-mock
+
+      - name: Run prototype tests
+        shell: bash
+        run: pytest -v --durations 20

--- a/.github/workflows/test-m1.yml
+++ b/.github/workflows/test-m1.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           . ~/miniconda3/etc/profile.d/conda.sh
           set -ex
-          conda create -yp ${ENV_NAME} python=${PY_VERS} numpy libpng openjpeg scipy
+          conda create -yp ${ENV_NAME} python=${PY_VERS} numpy libpng libjpeg scipy
           conda run -p ${ENV_NAME} python3 -mpip install torch --extra-index-url=https://download.pytorch.org/whl/nightly
           conda run -p ${ENV_NAME} python3 setup.py develop
           conda run -p ${ENV_NAME} python3 -mpip install pytest pytest-mock av

--- a/.github/workflows/test-m1.yml
+++ b/.github/workflows/test-m1.yml
@@ -37,5 +37,7 @@ jobs:
           ENV_NAME: conda-env-${{ github.run_id }}
           PY_VERS: ${{ matrix.py_vers }}
         run: |
+          . ~/miniconda3/etc/profile.d/conda.sh
+          set -ex
           conda run -p ${ENV_NAME} --no-capture-output python3 -u -mpytest -v --durations 20
           conda env remove -p ${ENV_NAME}


### PR DESCRIPTION
Addressing https://github.com/pytorch/vision/pull/5948#issuecomment-1141854832

This PR:
- Adds binary build execution runs for M1 on main branch
- Adds unit-test execution for M1 on main and nightly branches