### PR TITLE
Fix Inception transform_input to use Float tensors

### DIFF
--- a/torchvision/models/inception.py
+++ b/torchvision/models/inception.py
@@ -94,9 +94,9 @@ class Inception3(nn.Module):
 
     def _transform_input(self, x: Tensor) -> Tensor:
         if self.transform_input:
-            x_ch0 = torch.unsqueeze(x[:, 0], 1) * (0.229 / 0.5) + (0.485 - 0.5) / 0.5
-            x_ch1 = torch.unsqueeze(x[:, 1], 1) * (0.224 / 0.5) + (0.456 - 0.5) / 0.5
-            x_ch2 = torch.unsqueeze(x[:, 2], 1) * (0.225 / 0.5) + (0.406 - 0.5) / 0.5
+            x_ch0 = torch.unsqueeze(x[:, 0], 1) * torch.tensor(0.229 / 0.5) + torch.tensor((0.485 - 0.5) / 0.5)
+            x_ch1 = torch.unsqueeze(x[:, 1], 1) * torch.tensor(0.224 / 0.5) + torch.tensor((0.456 - 0.5) / 0.5)
+            x_ch2 = torch.unsqueeze(x[:, 2], 1) * torch.tensor(0.225 / 0.5) + torch.tensor((0.406 - 0.5) / 0.5)
             x = torch.cat((x_ch0, x_ch1, x_ch2), 1)
         return x
 


### PR DESCRIPTION
This PR make inveption_v3 compatible with torch_tensorrt compilation.
Related issue: https://github.com/pytorch/TensorRT/issues/1096

Problem:
The following statements in `_transform_input` method
```
x_ch0 = torch.unsqueeze(x[:, 0], 1) * (0.229 / 0.5) + (0.485 - 0.5) / 0.5
```
is converted into Double tensor in the traced graph
```
%1512 : Double(requires_grad=0, device=cpu) = prim::Constant[value={0.458}]()
```
BUT Double is not supported by torch_tensorrt compiler - Error: `Unsupported ATen data type Double`

The fix changes Double to Float by wrapping constants with `torch.tensor()` (which is float32 by default)
```
x_ch0 = torch.unsqueeze(x[:, 0], 1) * torch.tensor(0.229 / 0.5) + torch.tensor((0.485 - 0.5) / 0.5)
```
As a result the traced graph has Float node now
```
%1502 : Float(requires_grad=0, device=cpu) = prim::Constant[value={0.458}]()
```

Now, traced inception_v3 model can be compiled by torch_tensorrt.