### PR TITLE
explain version tagging procedure

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -94,6 +94,26 @@ By default, GPU support is built if CUDA is found and ``torch.cuda.is_available(
 It's possible to force building GPU support by setting ``FORCE_CUDA=1`` environment variable,
 which is useful when building a docker image.
 
+Building custom wheels
+======================
+
+When running on custom hardware (eg. Jetson), you may want to build your own wheels.  If so,
+you should make sure that your torchvision wheel has a dependency on the correct custom torch
+version.  
+For eg. the `Poetry dependency resolver <https://python-poetry.org/>`_ this seems to be a 
+requirement to make torch installations work.  
+
+Proper version tagging can be achieved with the following procedure (example here for +cu113 tag)
+
+.. code:: bash
+    
+    pip install torch==1.11.0+cu113
+    export PYTORCH_VERSION=1.11.0+cu113 # Used to derive Pytorch dependency
+    export BUILD_VERSION==0.12.0+cu113 # Used to generate Torchvision tag
+    python setup.py bdist_wheel-
+
+The resulting wheel will have a dependency on torch==1.11.0+cu113
+
 Image Backend
 =============
 Torchvision currently supports the following image backends:


### PR DESCRIPTION
I've had to build custom wheels of both torch and torchvision for Jetson.   Since we use the Poetry dependency resolver (rather than requirements.txt of setup.py) I had to ensure that torchvision is linked to the correct pre-compiled version of torch.  

After some digging, I found that there are environment variables to do this, but the process is not well-documented.  I would propose to add this to the README.  Initial proposal below.