### PR TITLE
Add unit-tests for M1

### DIFF
--- a/.github/workflows/build-m1-binaries.yml
+++ b/.github/workflows/build-m1-binaries.yml
@@ -31,7 +31,7 @@ jobs:
           . packaging/pkg_helpers.bash
           setup_build_version
           WHL_NAME=torchvision-${BUILD_VERSION}-cp${PY_VERS/.}-cp${PY_VERS/.}-macosx_11_0_arm64.whl
-          conda create -yp ${ENV_NAME} python=${PY_VERS} numpy libpng "jpeg<=9b" wheel pkg-config
+          conda create -yp ${ENV_NAME} python=${PY_VERS} numpy libpng jpeg wheel pkg-config
           conda run -p ${ENV_NAME} python3 -mpip install torch --pre --extra-index-url=https://download.pytorch.org/whl/nightly
           conda run -p ${ENV_NAME} python3 -mpip install delocate
           conda run -p ${ENV_NAME} python3 setup.py bdist_wheel

--- a/.github/workflows/build-m1-binaries.yml
+++ b/.github/workflows/build-m1-binaries.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - nightly
+      - main
   workflow_dispatch:
 jobs:
   build_wheels:
@@ -54,11 +55,13 @@ jobs:
           conda run --cwd /tmp -p ${ENV_NAME} python3 -c "import torchvision;print(torchvision.io.read_image('${PWD}/gallery/assets/dog1.jpg').shape)"
           conda env remove -p ${ENV_NAME}
       - name: Upload wheel to GitHub
+        if: ${{ github.event_name == 'push' && steps.extract_branch.outputs.branch == 'nightly' }}
         uses: actions/upload-artifact@v3
         with:
           name: torchvision-py${{ matrix.py_vers }}-macos11-m1
           path: dist/
       - name: Upload wheel to S3
+        if: ${{ github.event_name == 'push' && steps.extract_branch.outputs.branch == 'nightly' }}
         shell: arch -arch arm64 bash {0}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_PYTORCH_UPLOADER_ACCESS_KEY_ID }}

--- a/.github/workflows/test-m1.yml
+++ b/.github/workflows/test-m1.yml
@@ -1,0 +1,43 @@
+name: Unit-tests on M1
+on:
+  pull_request:
+    paths:
+      - .github/workflows/test-m1.yml
+  push:
+    branches:
+      - nightly
+      - main
+  workflow_dispatch:
+jobs:
+  tests:
+    name: "Unit-tests on M1"
+    runs-on: macos-m1
+    strategy:
+      matrix:
+        py_vers: [ "3.8"]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Install TorchVision
+        shell: arch -arch arm64 bash {0}
+        env:
+          ENV_NAME: conda-env-${{ github.run_id }}
+          PY_VERS: ${{ matrix.py_vers }}
+        run: |
+          . ~/miniconda3/etc/profile.d/conda.sh
+          set -ex
+          conda create -yp ${ENV_NAME} python=${PY_VERS} numpy libpng libjpeg scipy
+          conda run -p ${ENV_NAME} python3 -mpip install torch --extra-index-url=https://download.pytorch.org/whl/nightly
+          conda run -p ${ENV_NAME} python3 setup.py develop
+          conda run -p ${ENV_NAME} python3 -mpip install pytest pytest-mock av
+      - name: Run tests
+        shell: arch -arch arm64 bash {0}
+        env:
+          ENV_NAME: conda-env-${{ github.run_id }}
+          PY_VERS: ${{ matrix.py_vers }}
+        run: |
+          . ~/miniconda3/etc/profile.d/conda.sh
+          set -ex
+          conda run -p ${ENV_NAME} --no-capture-output python3 -u -mpytest -v --tb=long --durations 20
+          conda env remove -p ${ENV_NAME}

--- a/.github/workflows/test-m1.yml
+++ b/.github/workflows/test-m1.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           . ~/miniconda3/etc/profile.d/conda.sh
           set -ex
-          conda create -yp ${ENV_NAME} python=${PY_VERS} numpy libpng libjpeg scipy
+          conda create -yp ${ENV_NAME} python=${PY_VERS} numpy libpng "jpeg<=9b" scipy
           conda run -p ${ENV_NAME} python3 -mpip install torch --extra-index-url=https://download.pytorch.org/whl/nightly
           conda run -p ${ENV_NAME} python3 setup.py develop
           conda run -p ${ENV_NAME} python3 -mpip install pytest pytest-mock av

--- a/.github/workflows/test-m1.yml
+++ b/.github/workflows/test-m1.yml
@@ -29,7 +29,7 @@ jobs:
           # Needed for JPEG library detection as setup.py detects conda presence by running `shlex.which('conda')`
           export PATH=~/miniconda3/bin:$PATH
           set -ex
-          conda create -yp ${ENV_NAME} python=${PY_VERS} numpy libpng "jpeg<=9b" scipy
+          conda create -yp ${ENV_NAME} python=${PY_VERS} numpy libpng jpeg scipy
           conda run -p ${ENV_NAME} python3 -mpip install torch --extra-index-url=https://download.pytorch.org/whl/nightly
           conda run -p ${ENV_NAME} python3 setup.py develop
           conda run -p ${ENV_NAME} python3 -mpip install pytest pytest-mock av

--- a/.github/workflows/test-m1.yml
+++ b/.github/workflows/test-m1.yml
@@ -26,6 +26,8 @@ jobs:
           PY_VERS: ${{ matrix.py_vers }}
         run: |
           . ~/miniconda3/etc/profile.d/conda.sh
+          # Needed for JPEG library detection as setup.py detects conda presence by running `shlex.which('conda')`
+          export PATH=~/miniconda3/bin:$PATH
           set -ex
           conda create -yp ${ENV_NAME} python=${PY_VERS} numpy libpng "jpeg<=9b" scipy
           conda run -p ${ENV_NAME} python3 -mpip install torch --extra-index-url=https://download.pytorch.org/whl/nightly


### PR DESCRIPTION
Exactly the same as https://github.com/pytorch/vision/pull/6111 from @datumbox . I have to open a new PR instead of re-opening https://github.com/pytorch/vision/pull/6111, because its corresponding branch was deleted.d

We're opening this one to see if our tests pass on M1 after the recent https://github.com/pytorch/vision/pull/6122 from @malfet.

If they do not pass, considering the very pressing release deadline, we will have to revert all M1-related PRs from the release branch, as previously indicated in https://github.com/pytorch/vision/pull/6111#issuecomment-1143318848.