### PR TITLE
Fix `if` condition for s3/conda uploads 

### DIFF
--- a/.github/workflows/build-m1-binaries.yml
+++ b/.github/workflows/build-m1-binaries.yml
@@ -79,7 +79,7 @@ jobs:
           name: torchvision-py${{ matrix.py_vers }}-macos11-m1
           path: dist/
       - name: Upload wheel to S3
-        if: ${{ github.event_name == 'push' && (steps.extract_branch.outputs.branch == 'nightly' || startsWith(github.event.ref, 'refs/tags/')) }}
+        if: ${{ github.event_name == 'push' && (github.event.ref == 'ref/heads/nightly' || startsWith(github.event.ref, 'refs/tags/')) }}
         shell: arch -arch arm64 bash {0}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_PYTORCH_UPLOADER_ACCESS_KEY_ID }}
@@ -139,7 +139,7 @@ jobs:
           name: torchvision-py${{ matrix.py_vers }}-macos11-m1-conda
           path: dist/
       - name: Upload package to conda
-        if: ${{ github.event_name == 'push' && steps.extract_branch.outputs.branch == 'nightly' }}
+        if: ${{ github.event_name == 'push' && (github.event.ref == 'ref/heads/nightly' || startsWith(github.event.ref, 'refs/tags/')) }}
         shell: arch -arch arm64 bash {0}
         env:
           CONDA_PYTORCHBOT_TOKEN: ${{ secrets.CONDA_PYTORCHBOT_TOKEN }}


### PR DESCRIPTION
Replace `steps.extract_branch.outputs.branch` (which were probably taken from
    https://stackoverflow.com/questions/58033366/how-to-get-the-current-branch-within-github-actions
    ) with straightforward `github.event.ref`

Before this change nightly M1 builds were not actually uploaded as once can observe from https://github.com/pytorch/vision/runs/6811614195?check_suite_focus=true
Tested in  https://github.com/malfet/deleteme/runs/6822647720?check_suite_focus=true and https://github.com/malfet/deleteme/runs/6822691158?check_suite_focus=true