### PR TITLE
Fix push on release reference name

### DIFF
--- a/.github/workflows/build-m1-binaries.yml
+++ b/.github/workflows/build-m1-binaries.yml
@@ -33,7 +33,7 @@ jobs:
             echo "CHANNEL=test" >> "$GITHUB_ENV"
           fi
       - name: Set Release CHANNEL (for release)
-        if: ${{ (github.event_name == 'pull_request' && startsWith(github.base_ref, 'release')) || startsWith(github.ref, 'release') }}
+        if: ${{ (github.event_name == 'pull_request' && startsWith(github.base_ref, 'release')) || startsWith(github.ref, 'refs/heads/release') }}
         run: |
           echo "CHANNEL=test" >> "$GITHUB_ENV"
       - name: Build TorchVision M1 wheel
@@ -110,7 +110,7 @@ jobs:
             echo "CHANNEL=test" >> "$GITHUB_ENV"
           fi
       - name: Set CHANNEL Release (for release)
-        if: ${{ (github.event_name == 'pull_request' && startsWith(github.base_ref, 'release')) || startsWith(github.ref, 'release') }}
+        if: ${{ (github.event_name == 'pull_request' && startsWith(github.base_ref, 'release')) || startsWith(github.ref, 'refs/heads/release') }}
         run: |
           echo "CHANNEL=test" >> "$GITHUB_ENV"
       - name: Install conda-build and purge previous artifacts

--- a/.github/workflows/test-m1.yml
+++ b/.github/workflows/test-m1.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Set Release CHANNEL (for release)
-        if: ${{ (github.event_name == 'pull_request' && startsWith(github.base_ref, 'release')) || startsWith(github.ref, 'release') }}
+        if: ${{ (github.event_name == 'pull_request' && startsWith(github.base_ref, 'release')) || startsWith(github.ref, 'refs/heads/release') }}
         run: |
           echo "CHANNEL=test" >> "$GITHUB_ENV"
       - name: Install TorchVision


### PR DESCRIPTION
Fix push on release reference name:
We want to compare it against ```refs/heads/release``` rather then ```release```
Tests: https://github.com/atalman/vision/commit/af17cd95d2d43ca13354fb700e2da42108dd5a87
Sets correctly release chanell (wheels): https://github.com/atalman/vision/runs/6901327010?check_suite_focus=true
