### PR TITLE
[WIP] Add remove-able warnings for Beta modules or functions

### DIFF
--- a/test/test_backbone_utils.py
+++ b/test/test_backbone_utils.py
@@ -16,7 +16,11 @@ def get_available_models():
     return [
         k
         for k, v in models.__dict__.items()
-        if callable(v) and k[0].lower() == k[0] and k[0] != "_" and k != "get_weight"
+        if callable(v)
+        and k[0].lower() == k[0]
+        and k[0] != "_"
+        and k != "get_weight"
+        and not k.startswith("enable_beta")
     ]
 
 

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -26,7 +26,11 @@ def get_models_from_module(module):
     return [
         v
         for k, v in module.__dict__.items()
-        if callable(v) and k[0].lower() == k[0] and k[0] != "_" and k != "get_weight"
+        if callable(v)
+        and k[0].lower() == k[0]
+        and k[0] != "_"
+        and k != "get_weight"
+        and not k.startswith("enable_beta")
     ]
 
 

--- a/torchvision/io/__init__.py
+++ b/torchvision/io/__init__.py
@@ -40,6 +40,14 @@ from .video import (
 from .video_reader import VideoReader
 
 
+_BETA_VIDEO_API_IS_ENABLED = False
+
+
+def enable_beta_video_api():
+    global _BETA_VIDEO_API_IS_ENABLED
+    _BETA_VIDEO_API_IS_ENABLED = True
+
+
 __all__ = [
     "write_video",
     "read_video",

--- a/torchvision/io/video_reader.py
+++ b/torchvision/io/video_reader.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Any, Dict, Iterator
 
 import torch
@@ -92,6 +93,16 @@ class VideoReader:
 
     def __init__(self, path: str, stream: str = "video", num_threads: int = 0, device: str = "cpu") -> None:
         _log_api_usage_once(self)
+        from . import _BETA_VIDEO_API_IS_ENABLED  # import here to avoid circular import
+
+        if not _BETA_VIDEO_API_IS_ENABLED:
+            warnings.warn(
+                "The VideoReader class is still in Beta stage, which means "
+                "that backward compatibility isn't fully guaranteed. "
+                "Please visit <SOME_URL> to learn more about what we are planning to change in future versions. "
+                "To silence this warning, please call torchvision.io.enable_beta_video_api."
+            )
+
         self.is_cuda = False
         device = torch.device(device)
         if device.type == "cuda":

--- a/torchvision/models/__init__.py
+++ b/torchvision/models/__init__.py
@@ -1,3 +1,5 @@
+import importlib
+
 from .alexnet import *
 from .convnext import *
 from .densenet import *
@@ -18,6 +20,14 @@ from . import quantization
 from . import segmentation
 from . import video
 from ._api import get_weight
+
+
+def __getattr__(name):
+    if name == "detection":
+        return importlib.import_module("." + name, __name__)
+    else:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 _BETA_DETECTION_IS_ENABLED = False
 

--- a/torchvision/models/__init__.py
+++ b/torchvision/models/__init__.py
@@ -13,9 +13,15 @@ from .squeezenet import *
 from .vgg import *
 from .vision_transformer import *
 from .swin_transformer import *
-from . import detection
 from . import optical_flow
 from . import quantization
 from . import segmentation
 from . import video
 from ._api import get_weight
+
+_BETA_DETECTION_IS_ENABLED = False
+
+
+def enable_beta_detection():
+    global _BETA_DETECTION_IS_ENABLED
+    _BETA_DETECTION_IS_ENABLED = True

--- a/torchvision/models/detection/__init__.py
+++ b/torchvision/models/detection/__init__.py
@@ -5,3 +5,15 @@ from .mask_rcnn import *
 from .retinanet import *
 from .ssd import *
 from .ssdlite import *
+
+import warnings
+
+from .. import _BETA_DETECTION_IS_ENABLED
+
+if not _BETA_DETECTION_IS_ENABLED:
+    warnings.warn(
+        "The torchvision.models.detection module is still in Beta stage, which means "
+        "that backward compatibility isn't fully guaranteed. "
+        "Please visit <SOME_URL> to learn more about what we are planning to change in future versions. "
+        "To silence this warning, please call torchvision.models.enable_beta_detection."
+    )


### PR DESCRIPTION
Some POC for https://github.com/pytorch/pytorch/issues/72317

```py
#######################################################
# For entire module like torchvision.models.detection #
#######################################################

# No warning - anything before torchvision.models.detection
import torchvision
import torchvision.models
from torchvision import models
from torchvision.models import resnet50
from torchvision.models import segmentation

# Any of these will warn:
from torchvision.models import detection
from torchvision.models.detection import ssd
from torchvision.models.detection.ssd import ssd300_vgg16

torchvision.models.enable_beta_detection()  # Now all warnings are disabled
from torchvision.models import detection
from torchvision.models.detection import ssd
from torchvision.models.detection.ssd import ssd300_vgg16


####################
# For single class #
####################

from contextlib import suppress
from torchvision.io import VideoReader
with suppress(RuntimeError):  # VideoReader raises a RuntimeError, but that's unrelated
    VideoReader(path="path")  # raises warning

with suppress(RuntimeError):
    torchvision.io.enable_beta_video_api()
    VideoReader(path="path")  # no warning
```