### PR TITLE
Adding `_log_api_usage_once` to Swin's reusable components

### DIFF
--- a/torchvision/models/swin_transformer.py
+++ b/torchvision/models/swin_transformer.py
@@ -34,6 +34,7 @@ class PatchMerging(nn.Module):
 
     def __init__(self, dim: int, norm_layer: Callable[..., nn.Module] = nn.LayerNorm):
         super().__init__()
+        _log_api_usage_once(self)
         self.dim = dim
         self.reduction = nn.Linear(4 * dim, 2 * dim, bias=False)
         self.norm = norm_layer(4 * dim)
@@ -268,6 +269,7 @@ class SwinTransformerBlock(nn.Module):
         attn_layer: Callable[..., nn.Module] = ShiftedWindowAttention,
     ):
         super().__init__()
+        _log_api_usage_once(self)
 
         self.norm1 = norm_layer(dim)
         self.attn = attn_layer(


### PR DESCRIPTION
We forgot to add the logger on the reusable components of Swin Transformer. @YosuaMichael's refactoring at #6088 enabled us to reuse this implementation at https://github.com/facebookresearch/multimodal/pull/43. The logger, which is no-op for any user outside Meta, will allow us to trace better internal usages at Meta and keep an eye on modifications we need to do in these components to make them reusable.