### PR TITLE
Allow ffmpeg on Linux Python 3.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -342,11 +342,7 @@ def get_extensions():
 
     ffmpeg_exe = shutil.which("ffmpeg")
     has_ffmpeg = ffmpeg_exe is not None
-    # FIXME: Building torchvision with ffmpeg on MacOS or with Python 3.9
-    # FIXME: causes crash. See the following GitHub issues for more details.
-    # FIXME: https://github.com/pytorch/pytorch/issues/65000
-    # FIXME: https://github.com/pytorch/vision/issues/3367
-    if sys.platform != "linux" or (sys.version_info.major == 3 and sys.version_info.minor == 9):
+    if sys.platform != "linux":
         has_ffmpeg = False
     if has_ffmpeg:
         try:


### PR DESCRIPTION
Fixes #4430

It seems that the latest main on Python 3.9 no longer seg faults:
```
pytest -v test/test_video*

==================================================================================================================== test session starts =====================================================================================================================
platform linux -- Python 3.9.5, pytest-6.2.4, py-1.10.0, pluggy-0.13.1 -- ~/conda/envs/slowfast/bin/python
cachedir: .pytest_cache
rootdir: ~/repos/vision, configfile: pytest.ini
plugins: mock-3.6.1, hydra-core-1.2.0
collected 394 items                                                                                                                                                                                                                                          

....
test/test_video_reader.py::TestVideoReader::test_stress_test_read_video_from_file[RATRACE_wave_f_nm_np1_fr_goo_37.avi] SKIPPED (This stress test will iteratively decode the same set of videos.It helps to detect memory leak but it takes lots o...) [  6%]
test/test_video_reader.py::TestVideoReader::test_stress_test_read_video_from_file[SchoolRulesHowTheyHelpUs_wave_f_nm_np1_ba_med_0.avi] SKIPPED (This stress test will iteratively decode the same set of videos.It helps to detect memory leak but...) [  6%]
test/test_video_reader.py::TestVideoReader::test_stress_test_read_video_from_file[TrumanShow_wave_f_nm_np1_fr_med_26.avi] SKIPPED (This stress test will iteratively decode the same set of videos.It helps to detect memory leak but it takes lot...) [  6%]
test/test_video_reader.py::TestVideoReader::test_stress_test_read_video_from_file[v_SoccerJuggling_g23_c01.avi] SKIPPED (This stress test will iteratively decode the same set of videos.It helps to detect memory leak but it takes lots of time ...) [  7%]
test/test_video_reader.py::TestVideoReader::test_stress_test_read_video_from_file[v_SoccerJuggling_g24_c01.avi] SKIPPED (This stress test will iteratively decode the same set of videos.It helps to detect memory leak but it takes lots of time ...) [  7%]
test/test_video_reader.py::TestVideoReader::test_stress_test_read_video_from_file[R6llTwEh07w.mp4] SKIPPED (This stress test will iteratively decode the same set of videos.It helps to detect memory leak but it takes lots of time to run.By def...) [  7%]
test/test_video_reader.py::TestVideoReader::test_stress_test_read_video_from_file[SOX5yA1l24A.mp4] SKIPPED (This stress test will iteratively decode the same set of videos.It helps to detect memory leak but it takes lots of time to run.By def...) [  7%]
test/test_video_reader.py::TestVideoReader::test_stress_test_read_video_from_file[WUzgd7C1pWA.mp4] SKIPPED (This stress test will iteratively decode the same set of videos.It helps to detect memory leak but it takes lots of time to run.By def...) [  8%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file[RATRACE_wave_f_nm_np1_fr_goo_37.avi-config0] PASSED                                                                                                                              [  8%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file[SchoolRulesHowTheyHelpUs_wave_f_nm_np1_ba_med_0.avi-config1] PASSED                                                                                                              [  8%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file[TrumanShow_wave_f_nm_np1_fr_med_26.avi-config2] PASSED                                                                                                                           [  8%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file[v_SoccerJuggling_g23_c01.avi-config3] PASSED                                                                                                                                     [  9%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file[v_SoccerJuggling_g24_c01.avi-config4] PASSED                                                                                                                                     [  9%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file[R6llTwEh07w.mp4-config5] PASSED                                                                                                                                                  [  9%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file[SOX5yA1l24A.mp4-config6] PASSED                                                                                                                                                  [  9%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file[WUzgd7C1pWA.mp4-config7] PASSED                                                                                                                                                  [ 10%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_read_single_stream_only[1-0-RATRACE_wave_f_nm_np1_fr_goo_37.avi-config0] PASSED                                                                                                  [ 10%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_read_single_stream_only[1-0-SchoolRulesHowTheyHelpUs_wave_f_nm_np1_ba_med_0.avi-config1] PASSED                                                                                  [ 10%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_read_single_stream_only[1-0-TrumanShow_wave_f_nm_np1_fr_med_26.avi-config2] PASSED                                                                                               [ 10%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_read_single_stream_only[1-0-v_SoccerJuggling_g23_c01.avi-config3] PASSED                                                                                                         [ 11%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_read_single_stream_only[1-0-v_SoccerJuggling_g24_c01.avi-config4] PASSED                                                                                                         [ 11%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_read_single_stream_only[1-0-R6llTwEh07w.mp4-config5] PASSED                                                                                                                      [ 11%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_read_single_stream_only[1-0-SOX5yA1l24A.mp4-config6] PASSED                                                                                                                      [ 11%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_read_single_stream_only[1-0-WUzgd7C1pWA.mp4-config7] PASSED                                                                                                                      [ 12%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_read_single_stream_only[0-1-RATRACE_wave_f_nm_np1_fr_goo_37.avi-config0] PASSED                                                                                                  [ 12%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_read_single_stream_only[0-1-SchoolRulesHowTheyHelpUs_wave_f_nm_np1_ba_med_0.avi-config1] PASSED                                                                                  [ 12%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_read_single_stream_only[0-1-TrumanShow_wave_f_nm_np1_fr_med_26.avi-config2] PASSED                                                                                               [ 12%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_read_single_stream_only[0-1-v_SoccerJuggling_g23_c01.avi-config3] PASSED                                                                                                         [ 13%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_read_single_stream_only[0-1-v_SoccerJuggling_g24_c01.avi-config4] PASSED                                                                                                         [ 13%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_read_single_stream_only[0-1-R6llTwEh07w.mp4-config5] PASSED                                                                                                                      [ 13%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_read_single_stream_only[0-1-SOX5yA1l24A.mp4-config6] PASSED                                                                                                                      [ 13%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_read_single_stream_only[0-1-WUzgd7C1pWA.mp4-config7] PASSED                                                                                                                      [ 14%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_rescale_min_dimension[RATRACE_wave_f_nm_np1_fr_goo_37.avi] PASSED                                                                                                                [ 14%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_rescale_min_dimension[SchoolRulesHowTheyHelpUs_wave_f_nm_np1_ba_med_0.avi] PASSED                                                                                                [ 14%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_rescale_min_dimension[TrumanShow_wave_f_nm_np1_fr_med_26.avi] PASSED                                                                                                             [ 14%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_rescale_min_dimension[v_SoccerJuggling_g23_c01.avi] PASSED                                                                                                                       [ 15%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_rescale_min_dimension[v_SoccerJuggling_g24_c01.avi] PASSED                                                                                                                       [ 15%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_rescale_min_dimension[R6llTwEh07w.mp4] PASSED                                                                                                                                    [ 15%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_rescale_min_dimension[SOX5yA1l24A.mp4] PASSED                                                                                                                                    [ 15%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_rescale_min_dimension[WUzgd7C1pWA.mp4] PASSED                                                                                                                                    [ 16%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_rescale_max_dimension[RATRACE_wave_f_nm_np1_fr_goo_37.avi] PASSED                                                                                                                [ 16%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_rescale_max_dimension[SchoolRulesHowTheyHelpUs_wave_f_nm_np1_ba_med_0.avi] PASSED                                                                                                [ 16%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_rescale_max_dimension[TrumanShow_wave_f_nm_np1_fr_med_26.avi] PASSED                                                                                                             [ 17%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_rescale_max_dimension[v_SoccerJuggling_g23_c01.avi] PASSED                                                                                                                       [ 17%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_rescale_max_dimension[v_SoccerJuggling_g24_c01.avi] PASSED                                                                                                                       [ 17%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_rescale_max_dimension[R6llTwEh07w.mp4] PASSED                                                                                                                                    [ 17%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_rescale_max_dimension[SOX5yA1l24A.mp4] PASSED                                                                                                                                    [ 18%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_rescale_max_dimension[WUzgd7C1pWA.mp4] PASSED                                                                                                                                    [ 18%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_rescale_both_min_max_dimension[RATRACE_wave_f_nm_np1_fr_goo_37.avi] PASSED                                                                                                       [ 18%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_rescale_both_min_max_dimension[SchoolRulesHowTheyHelpUs_wave_f_nm_np1_ba_med_0.avi] PASSED                                                                                       [ 18%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_rescale_both_min_max_dimension[TrumanShow_wave_f_nm_np1_fr_med_26.avi] PASSED                                                                                                    [ 19%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_rescale_both_min_max_dimension[v_SoccerJuggling_g23_c01.avi] PASSED                                                                                                              [ 19%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_rescale_both_min_max_dimension[v_SoccerJuggling_g24_c01.avi] PASSED                                                                                                              [ 19%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_rescale_both_min_max_dimension[R6llTwEh07w.mp4] PASSED                                                                                                                           [ 19%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_rescale_both_min_max_dimension[SOX5yA1l24A.mp4] PASSED                                                                                                                           [ 20%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_rescale_both_min_max_dimension[WUzgd7C1pWA.mp4] PASSED                                                                                                                           [ 20%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_rescale_width[RATRACE_wave_f_nm_np1_fr_goo_37.avi] PASSED                                                                                                                        [ 20%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_rescale_width[SchoolRulesHowTheyHelpUs_wave_f_nm_np1_ba_med_0.avi] PASSED                                                                                                        [ 20%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_rescale_width[TrumanShow_wave_f_nm_np1_fr_med_26.avi] PASSED                                                                                                                     [ 21%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_rescale_width[v_SoccerJuggling_g23_c01.avi] PASSED                                                                                                                               [ 21%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_rescale_width[v_SoccerJuggling_g24_c01.avi] PASSED                                                                                                                               [ 21%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_rescale_width[R6llTwEh07w.mp4] PASSED                                                                                                                                            [ 21%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_rescale_width[SOX5yA1l24A.mp4] PASSED                                                                                                                                            [ 22%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_rescale_width[WUzgd7C1pWA.mp4] PASSED                                                                                                                                            [ 22%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_rescale_height[RATRACE_wave_f_nm_np1_fr_goo_37.avi] PASSED                                                                                                                       [ 22%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_rescale_height[SchoolRulesHowTheyHelpUs_wave_f_nm_np1_ba_med_0.avi] PASSED                                                                                                       [ 22%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_rescale_height[TrumanShow_wave_f_nm_np1_fr_med_26.avi] PASSED                                                                                                                    [ 23%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_rescale_height[v_SoccerJuggling_g23_c01.avi] PASSED                                                                                                                              [ 23%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_rescale_height[v_SoccerJuggling_g24_c01.avi] PASSED                                                                                                                              [ 23%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_rescale_height[R6llTwEh07w.mp4] PASSED                                                                                                                                           [ 23%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_rescale_height[SOX5yA1l24A.mp4] PASSED                                                                                                                                           [ 24%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_rescale_height[WUzgd7C1pWA.mp4] PASSED                                                                                                                                           [ 24%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_rescale_width_and_height[RATRACE_wave_f_nm_np1_fr_goo_37.avi] PASSED                                                                                                             [ 24%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_rescale_width_and_height[SchoolRulesHowTheyHelpUs_wave_f_nm_np1_ba_med_0.avi] PASSED                                                                                             [ 24%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_rescale_width_and_height[TrumanShow_wave_f_nm_np1_fr_med_26.avi] PASSED                                                                                                          [ 25%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_rescale_width_and_height[v_SoccerJuggling_g23_c01.avi] PASSED                                                                                                                    [ 25%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_rescale_width_and_height[v_SoccerJuggling_g24_c01.avi] PASSED                                                                                                                    [ 25%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_rescale_width_and_height[R6llTwEh07w.mp4] PASSED                                                                                                                                 [ 25%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_rescale_width_and_height[SOX5yA1l24A.mp4] PASSED                                                                                                                                 [ 26%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_rescale_width_and_height[WUzgd7C1pWA.mp4] PASSED                                                                                                                                 [ 26%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_audio_resampling[9600-RATRACE_wave_f_nm_np1_fr_goo_37.avi] PASSED                                                                                                                [ 26%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_audio_resampling[9600-SchoolRulesHowTheyHelpUs_wave_f_nm_np1_ba_med_0.avi] PASSED                                                                                                [ 26%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_audio_resampling[9600-TrumanShow_wave_f_nm_np1_fr_med_26.avi] PASSED                                                                                                             [ 27%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_audio_resampling[9600-v_SoccerJuggling_g23_c01.avi] PASSED                                                                                                                       [ 27%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_audio_resampling[9600-v_SoccerJuggling_g24_c01.avi] PASSED                                                                                                                       [ 27%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_audio_resampling[9600-R6llTwEh07w.mp4] PASSED                                                                                                                                    [ 27%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_audio_resampling[9600-SOX5yA1l24A.mp4] PASSED                                                                                                                                    [ 28%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_audio_resampling[9600-WUzgd7C1pWA.mp4] PASSED                                                                                                                                    [ 28%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_audio_resampling[96000-RATRACE_wave_f_nm_np1_fr_goo_37.avi] PASSED                                                                                                               [ 28%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_audio_resampling[96000-SchoolRulesHowTheyHelpUs_wave_f_nm_np1_ba_med_0.avi] PASSED                                                                                               [ 28%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_audio_resampling[96000-TrumanShow_wave_f_nm_np1_fr_med_26.avi] PASSED                                                                                                            [ 29%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_audio_resampling[96000-v_SoccerJuggling_g23_c01.avi] PASSED                                                                                                                      [ 29%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_audio_resampling[96000-v_SoccerJuggling_g24_c01.avi] PASSED                                                                                                                      [ 29%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_audio_resampling[96000-R6llTwEh07w.mp4] PASSED                                                                                                                                   [ 29%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_audio_resampling[96000-SOX5yA1l24A.mp4] PASSED                                                                                                                                   [ 30%]
test/test_video_reader.py::TestVideoReader::test_read_video_from_file_audio_resampling[96000-WUzgd7C1pWA.mp4] PASSED                                                                                                                                   [ 30%]
...

====================================================================================================================== warnings summary ======================================================================================================================
test/test_video_reader.py::TestVideoReader::test_compare_read_video_from_memory_and_file[RATRACE_wave_f_nm_np1_fr_goo_37.avi-config0]
  ~/repos/vision/test/test_video_reader.py:260: UserWarning: The given buffer is not writable, and PyTorch does not support non-writable tensors. This means you can write to the underlying (supposedly non-writable) buffer using the tensor. You may want to copy the buffer to protect its data or make it writable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at  /opt/conda/conda-bld/pytorch_1645603849401/work/torch/csrc/utils/tensor_new.cpp:1008.)
    video_tensor = torch.frombuffer(fp.read(), dtype=torch.uint8)

test/test_video_reader.py: 12 warnings
  ~/repos/vision/torchvision/io/_video_opt.py:436: UserWarning: The pts_unit 'pts' gives wrong results and will be removed in a follow-up version. Please use pts_unit 'sec'.
    warnings.warn(

test/test_video_reader.py: 12 warnings
  ~/repos/vision/torchvision/io/video.py:162: UserWarning: The pts_unit 'pts' gives wrong results. Please use pts_unit 'sec'.
    warnings.warn("The pts_unit 'pts' gives wrong results. Please use pts_unit 'sec'.")

-- Docs: https://docs.pytest.org/en/stable/warnings.html
================================================================================================================== short test summary info ===================================================================================================================
SKIPPED [7] test/test_video_gpu_decoder.py:18: Didn't compile with support for gpu decoder
SKIPPED [10] test/test_video_gpu_decoder.py:41: Didn't compile with support for gpu decoder
SKIPPED [7] test/test_video_gpu_decoder.py:68: Didn't compile with support for gpu decoder
SKIPPED [8] test/test_video_reader.py:373: This stress test will iteratively decode the same set of videos.It helps to detect memory leak but it takes lots of time to run.By default, it is disabled
======================================================================================================= 362 passed, 32 skipped, 25 warnings in 56.49s ========================================================================================================
```