### PR TITLE
[DONT MERGE] PR to debug CI failures on windows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,7 +146,7 @@ commands:
         default: true
     steps:
       - pip_install:
-          args: --pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cpu
+          args: --pre torch==1.13.0.dev20220621 --extra-index-url https://download.pytorch.org/whl/nightly/cpu
           descr: Install PyTorch from nightly releases
       - pip_install:
           args: --no-build-isolation <<# parameters.editable >> --editable <</ parameters.editable >> .

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -146,7 +146,7 @@ commands:
         default: true
     steps:
       - pip_install:
-          args: --pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cpu
+          args: --pre torch==1.13.0.dev20220621 --extra-index-url https://download.pytorch.org/whl/nightly/cpu
           descr: Install PyTorch from nightly releases
       - pip_install:
           args: --no-build-isolation <<# parameters.editable >> --editable <</ parameters.editable >> .

--- a/.circleci/unittest/windows/scripts/install.sh
+++ b/.circleci/unittest/windows/scripts/install.sh
@@ -35,7 +35,7 @@ fi
 
 printf "Installing PyTorch with %s\n" "${cudatoolkit}"
 # conda install -y -c "pytorch-${UPLOAD_CHANNEL}" -c nvidia "pytorch-${UPLOAD_CHANNEL}"::pytorch[build="*${version}*"] "${cudatoolkit}"
-pip install --pre torch==1.13.0.dev20220621+cpu  --extra-index-url https://download.pytorch.org/whl/nightly/cpu
+pip install --pre torch==1.13.0.dev20220618+cpu  --extra-index-url https://download.pytorch.org/whl/nightly/cpu
 
 torch_cuda=$(python -c "import torch; print(torch.cuda.is_available())")
 echo torch.cuda.is_available is $torch_cuda

--- a/.circleci/unittest/windows/scripts/install.sh
+++ b/.circleci/unittest/windows/scripts/install.sh
@@ -34,7 +34,8 @@ else
 fi
 
 printf "Installing PyTorch with %s\n" "${cudatoolkit}"
-conda install -y -c "pytorch-${UPLOAD_CHANNEL}" -c nvidia "pytorch-${UPLOAD_CHANNEL}"::pytorch[build="*${version}*"] "${cudatoolkit}"
+# conda install -y -c "pytorch-${UPLOAD_CHANNEL}" -c nvidia "pytorch-${UPLOAD_CHANNEL}"::pytorch[build="*${version}*"] "${cudatoolkit}"
+pip install --pre torch==1.13.0.dev20220621+cpu  --extra-index-url https://download.pytorch.org/whl/nightly/cpu
 
 torch_cuda=$(python -c "import torch; print(torch.cuda.is_available())")
 echo torch.cuda.is_available is $torch_cuda

--- a/.circleci/unittest/windows/scripts/install.sh
+++ b/.circleci/unittest/windows/scripts/install.sh
@@ -35,7 +35,7 @@ fi
 
 printf "Installing PyTorch with %s\n" "${cudatoolkit}"
 # conda install -y -c "pytorch-${UPLOAD_CHANNEL}" -c nvidia "pytorch-${UPLOAD_CHANNEL}"::pytorch[build="*${version}*"] "${cudatoolkit}"
-pip install --pre torch==1.13.0.dev20220618+cpu  --extra-index-url https://download.pytorch.org/whl/nightly/cpu
+pip install --pre torch==1.13.0.dev20220621+cpu  --extra-index-url https://download.pytorch.org/whl/nightly/cpu
 
 torch_cuda=$(python -c "import torch; print(torch.cuda.is_available())")
 echo torch.cuda.is_available is $torch_cuda

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -603,7 +603,7 @@ def test_classification_model(model_fn, dev):
         "input_shape": (1, 3, 224, 224),
     }
     model_name = model_fn.__name__
-    if dev == "cuda" and SKIP_BIG_MODEL and model_name in skipped_big_models:
+    if SKIP_BIG_MODEL and model_name in skipped_big_models:
         pytest.skip("Skipped to reduce memory usage. Set env var SKIP_BIG_MODEL=0 to enable test for this model")
     kwargs = {**defaults, **_model_params.get(model_name, {})}
     num_classes = kwargs.get("num_classes")

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -618,6 +618,10 @@ def test_classification_model(model_fn, dev):
     _assert_expected(out.cpu(), model_name, prec=0.1)
     assert out.shape[-1] == num_classes
 
+    if SKIP_BIG_MODEL and model_name in skipped_big_models:
+        # Skip backprop test only
+        return
+
     _check_jit_scriptable(model, (x,), unwrapper=script_model_unwrapper.get(model_name, None), eager_out=out)
     _check_fx_compatible(model, x, eager_out=out)
 
@@ -628,10 +632,6 @@ def test_classification_model(model_fn, dev):
             if model_name not in autocast_flaky_numerics:
                 _assert_expected(out.cpu(), model_name, prec=0.1)
             assert out.shape[-1] == 50
-
-    if SKIP_BIG_MODEL and model_name in skipped_big_models:
-        # Skip backprop test only
-        return
 
     _check_input_backprop(model, x)
 

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -603,7 +603,7 @@ def test_classification_model(model_fn, dev):
         "input_shape": (1, 3, 224, 224),
     }
     model_name = model_fn.__name__
-    if SKIP_BIG_MODEL and model_name in skipped_big_models:
+    if dev == "cuda" and SKIP_BIG_MODEL and model_name in skipped_big_models:
         pytest.skip("Skipped to reduce memory usage. Set env var SKIP_BIG_MODEL=0 to enable test for this model")
     kwargs = {**defaults, **_model_params.get(model_name, {})}
     num_classes = kwargs.get("num_classes")


### PR DESCRIPTION
This PR is just meant to check on CI failures described on this issue: https://github.com/pytorch/vision/issues/6189

- First we try to skip the big models in CPU as well to make sure the problem is not caused by big model [confirmed GREEN for windows test]
- Second, we will test the big models with torch nightly 20220621 -> Still got issue
- @vfdev-5 try on torch nightly 20220618 and it is green (confirmed)
- using inference_mode and only skip jit, fx, and backprop doesn't work 

In summary, seems like there is a change on core since the nightly 20220618 works fine, but the later version is not. The main suspect of the problem is memory usage, and need double check if this is indeed the case with memory profiler. If yes, we should raise to core about this memory issue.