### PR TITLE
Skip big models on cpu

### DIFF
--- a/test/test_models.py
+++ b/test/test_models.py
@@ -603,7 +603,7 @@ def test_classification_model(model_fn, dev):
         "input_shape": (1, 3, 224, 224),
     }
     model_name = model_fn.__name__
-    if dev == "cuda" and SKIP_BIG_MODEL and model_name in skipped_big_models:
+    if SKIP_BIG_MODEL and model_name in skipped_big_models:
         pytest.skip("Skipped to reduce memory usage. Set env var SKIP_BIG_MODEL=0 to enable test for this model")
     kwargs = {**defaults, **_model_params.get(model_name, {})}
     num_classes = kwargs.get("num_classes")


### PR DESCRIPTION
Addressing issue https://github.com/pytorch/vision/issues/6189

It seems like the CI is broken in windows machine cpu due to the big model.
I have sorted all weights base on the number of parameters and here is what I got:
<img width="791" alt="image" src="https://user-images.githubusercontent.com/3679860/175311790-ca72ba12-fe4c-4607-af70-de84b36eb357.png">

In this PR we will use the existing list of `skipped_big_models` but we also skip in cpu instead of just cuda.