### PR TITLE
Add flag to ignore ffmpeg in python build.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -356,6 +356,8 @@ def get_extensions():
             print("Error fetching ffmpeg version, ignoring ffmpeg.")
             has_ffmpeg = False
 
+    use_ffmpeg = os.getenv("USE_FFMPEG", "1") == "1"
+    has_ffmpeg = has_ffmpeg and use_ffmpeg
     print(f"FFmpeg found: {has_ffmpeg}")
 
     if has_ffmpeg:

--- a/setup.py
+++ b/setup.py
@@ -356,7 +356,7 @@ def get_extensions():
             print("Error fetching ffmpeg version, ignoring ffmpeg.")
             has_ffmpeg = False
 
-    use_ffmpeg = os.getenv("USE_FFMPEG", "1") == "1"
+    use_ffmpeg = os.getenv("TORCHVISION_USE_FFMPEG", "1") == "1"
     has_ffmpeg = has_ffmpeg and use_ffmpeg
     print(f"FFmpeg found: {has_ffmpeg}")
 


### PR DESCRIPTION
This PR adds a flag to disable building the parts of the code that depend on ffmpeg in the python build