### PR TITLE
Minor fix antialias arg

### DIFF
--- a/torchvision/prototype/transforms/functional/_geometry.py
+++ b/torchvision/prototype/transforms/functional/_geometry.py
@@ -45,7 +45,7 @@ def resize_image_tensor(
     size: List[int],
     interpolation: InterpolationMode = InterpolationMode.BILINEAR,
     max_size: Optional[int] = None,
-    antialias: Optional[bool] = None,
+    antialias: bool = False,
 ) -> torch.Tensor:
     num_channels, old_height, old_width = get_dimensions_image_tensor(image)
     new_height, new_width = _compute_output_size((old_height, old_width), size=size, max_size=max_size)

--- a/torchvision/transforms/functional.py
+++ b/torchvision/transforms/functional.py
@@ -471,6 +471,9 @@ def resize(
         pil_interpolation = pil_modes_mapping[interpolation]
         return F_pil.resize(img, size=output_size, interpolation=pil_interpolation)
 
+    if antialias is None:
+        antialias = False
+
     return F_t.resize(img, size=output_size, interpolation=interpolation.value, antialias=antialias)
 
 

--- a/torchvision/transforms/functional_tensor.py
+++ b/torchvision/transforms/functional_tensor.py
@@ -430,15 +430,12 @@ def resize(
     img: Tensor,
     size: List[int],
     interpolation: str = "bilinear",
-    antialias: Optional[bool] = None,
+    antialias: bool = False,
 ) -> Tensor:
     _assert_image_tensor(img)
 
     if isinstance(size, tuple):
         size = list(size)
-
-    if antialias is None:
-        antialias = False
 
     if antialias and interpolation not in ["bilinear", "bicubic"]:
         raise ValueError("Antialias option is supported for bilinear and bicubic interpolation modes only")


### PR DESCRIPTION
Description:

Antialias was defined as None in the public API as we deal with Pillow and Tensor backend. Pillow applies unconditionally the anti-aliasing and there is no way to disable it. Thus for Pillow we keep `antialias=None`. For Tensors, we can do antialias=True or False, None->False. 

The purpose of this PR is to make `antialias` argument's default value and type hint more explcit in proto's `resize_image_tensor` signature and in private `resize` methods. Mainly, for tensors `antialias=None` does not make much sense.
