### PR TITLE
Swin transformer handle window size smaller than input size

### DIFF
--- a/torchvision/models/swin_transformer.py
+++ b/torchvision/models/swin_transformer.py
@@ -1,5 +1,5 @@
 from functools import partial
-from typing import Optional, Callable, List, Any
+from typing import Any, Callable, List, Optional, Tuple
 
 import torch
 import torch.nn.functional as F
@@ -9,7 +9,7 @@ from ..ops.misc import MLP, Permute
 from ..ops.stochastic_depth import StochasticDepth
 from ..transforms._presets import ImageClassification, InterpolationMode
 from ..utils import _log_api_usage_once
-from ._api import WeightsEnum, Weights
+from ._api import Weights, WeightsEnum
 from ._meta import _IMAGENET_CATEGORIES
 from ._utils import _ovewrite_named_param
 
@@ -374,7 +374,7 @@ class SwinTransformer(nn.Module):
         # build SwinTransformer blocks
         for i_stage in range(len(depths)):
             stage: List[nn.Module] = []
-            dim = embed_dim * 2 ** i_stage
+            dim = embed_dim * 2**i_stage
             for i_layer in range(depths[i_stage]):
                 # adjust stochastic depth probability based on the depth of the stage block
                 sd_prob = stochastic_depth_prob * float(stage_block_id) / (total_stage_blocks - 1)

--- a/torchvision/models/swin_transformer.py
+++ b/torchvision/models/swin_transformer.py
@@ -161,15 +161,17 @@ def shifted_window_attention(
 
 
 def _fix_window_and_shift_size(
-    input_hw: List[int], window_size: List[int], shift_size: List[int]
+    input_size: List[int], window_size: List[int], shift_size: List[int]
 ) -> Tuple[List[int], List[int]]:
     # Handle case where window_size is larger than input tensor
     # Reference on the original implementation: https://github.com/microsoft/Swin-Transformer/blob/main/models/swin_transformer.py#L192-L195
-    for i in range(2):
-        if input_hw[i] <= window_size[i]:
-            window_size[i] = input_hw[i]
-            shift_size[i] = 0
-    return window_size, shift_size
+    updated_window_size = window_size.copy()
+    updated_shift_size = shift_size.copy()
+    for i in range(len(input_size)):
+        if input_size[i] <= window_size[i]:
+            updated_window_size[i] = input_size[i]
+            updated_shift_size[i] = 0
+    return updated_window_size, updated_shift_size
 
 
 torch.fx.wrap("shifted_window_attention")
@@ -374,7 +376,7 @@ class SwinTransformer(nn.Module):
         # build SwinTransformer blocks
         for i_stage in range(len(depths)):
             stage: List[nn.Module] = []
-            dim = embed_dim * 2**i_stage
+            dim = embed_dim * 2 ** i_stage
             for i_layer in range(depths[i_stage]):
                 # adjust stochastic depth probability based on the depth of the stage block
                 sd_prob = stochastic_depth_prob * float(stage_block_id) / (total_stage_blocks - 1)


### PR DESCRIPTION
This PR introduce logic in swin transformer to update the window_size if it is bigger than the input size.
This behaviour follow the original implementation: https://github.com/microsoft/Swin-Transformer/blob/main/models/swin_transformer.py#L192-L195

We introduced this change on a commit in #6088, however since we want to cherrypick that PR and the main goal of #6088 is to adapt the components so it can be reused on the swin transformer 3d, we decide to revert back this change in order to lower the risk during the release. 

However since this change can be useful especially if we want to adapt the components to swin transformer v2 (as commented by @xiaohu2015 in https://github.com/pytorch/vision/pull/6088#issuecomment-1170819104), we introduce the change back in this PR.

We have tested this change by running the validation script:
```
python -u ~/script/run_with_submitit.py \
    --timeout 3000 --nodes 1 --ngpus 4 --batch-size=1 \
    --partition train --model <model_variant> \
    --data-path="/datasets01_ontap/imagenet_full_size/061417" \
    --weights="<weight_variant>_Weights.IMAGENET1K_V1" \
    --test-only \
```
where model_variant can be `swin_t, swin_s, swin_b` and weight_variant can be `Swin_T, Swin_S, Swin_B`.
Here are the validation resutl:

- swin_t, Swin_T : Acc@1 81.472 Acc@5 95.780
- swin_s, Swin_S: Acc@1 83.186 Acc@5 96.366
- swin_b, Swin_B: Acc@1 83.584 Acc@5 96.636

