### PR TITLE
Add missing `resnext101_64x4d` to `hubconf.py`

### DIFF
--- a/hubconf.py
+++ b/hubconf.py
@@ -49,6 +49,7 @@ from torchvision.models.resnet import (
     resnet152,
     resnext50_32x4d,
     resnext101_32x8d,
+    resnext101_64x4d,
     wide_resnet50_2,
     wide_resnet101_2,
 )


### PR DESCRIPTION
Exposing `resnext101_64x4d` on hub. This was missed from #5935