### PR TITLE
Update the dataset cache to factor input parameters

### DIFF
--- a/references/video_classification/train.py
+++ b/references/video_classification/train.py
@@ -98,10 +98,10 @@ def evaluate(model, criterion, data_loader, device):
     return metric_logger.acc1.global_avg
 
 
-def _get_cache_path(filepath):
+def _get_cache_path(filepath, args):
     import hashlib
-
-    h = hashlib.sha1(filepath.encode()).hexdigest()
+    value = f"{filepath}-{args.clip_len}-{args.kinetics_version}-{args.frame_rate}"
+    h = hashlib.sha1(value.encode()).hexdigest()
     cache_path = os.path.join("~", ".torch", "vision", "datasets", "kinetics", h[:10] + ".pt")
     cache_path = os.path.expanduser(cache_path)
     return cache_path
@@ -135,7 +135,7 @@ def main(args):
 
     print("Loading training data")
     st = time.time()
-    cache_path = _get_cache_path(traindir)
+    cache_path = _get_cache_path(traindir, args)
     transform_train = presets.VideoClassificationPresetTrain(crop_size=(112, 112), resize_size=(128, 171))
 
     if args.cache_dataset and os.path.exists(cache_path):
@@ -167,7 +167,7 @@ def main(args):
     print("Took", time.time() - st)
 
     print("Loading validation data")
-    cache_path = _get_cache_path(valdir)
+    cache_path = _get_cache_path(valdir, args)
 
     if args.weights and args.test_only:
         weights = torchvision.models.get_weight(args.weights)

--- a/references/video_classification/train.py
+++ b/references/video_classification/train.py
@@ -100,6 +100,7 @@ def evaluate(model, criterion, data_loader, device):
 
 def _get_cache_path(filepath, args):
     import hashlib
+
     value = f"{filepath}-{args.clip_len}-{args.kinetics_version}-{args.frame_rate}"
     h = hashlib.sha1(value.encode()).hexdigest()
     cache_path = os.path.join("~", ".torch", "vision", "datasets", "kinetics", h[:10] + ".pt")


### PR DESCRIPTION
The cache path currently used on video references doesn't factor in parameters that affect the stored data (such as clip length, kinetics version and frame rate). This means that every time we switch to a different model, we must invalidate the cache. This PR avoids this by adding the specific parameters in the `sha1` hash used for caching.

Proof this works:
```
Loading data
Loading training data
It is recommended to pre-compute the dataset cache on a single-gpu first, as it will be faster
100%|██████████| 1205/1205 [03:21<00:00,  5.97it/s]
./vision/torchvision/datasets/video_utils.py:223: UserWarning: There aren't enough frames in the current video to get a clip for the given clip length and frames between clips. The video (and potentially others) will be skipped.
  warnings.warn(
Saving dataset_train to ~/.torch/vision/datasets/kinetics/9ff8f5833e.pt
Took 203.63010907173157
Loading validation data
Loading dataset_test from ~/.torch/vision/datasets/kinetics/9ff8f5833e.pt
```