### PR TITLE
Extend `_log_api_usage_once` to work for overwritten classes

### DIFF
--- a/torchvision/utils.py
+++ b/torchvision/utils.py
@@ -564,7 +564,7 @@ def _log_api_usage_once(obj: Any) -> None:
     """
     module = obj.__module__
     if not module.startswith("torchvision"):
-        module = f"torchvision.fb.{module}"
+        module = f"torchvision.internal.{module}"
     name = obj.__class__.__name__
     if isinstance(obj, FunctionType):
         name = obj.__name__

--- a/torchvision/utils.py
+++ b/torchvision/utils.py
@@ -562,9 +562,10 @@ def _log_api_usage_once(obj: Any) -> None:
     Args:
         obj (class instance or method): an object to extract info from.
     """
-    if not obj.__module__.startswith("torchvision"):
-        return
+    module = obj.__module__
+    if not module.startswith("torchvision"):
+        module = f"torchvision.fb.{module}"
     name = obj.__class__.__name__
     if isinstance(obj, FunctionType):
         name = obj.__name__
-    torch._C._log_api_usage_once(f"{obj.__module__}.{name}")
+    torch._C._log_api_usage_once(f"{module}.{name}")


### PR DESCRIPTION
The current implementation skips the method calls when a class is subclassed:
```python
import torchvision


class ResNet50(torchvision.models.ResNet):
    pass

m = ResNet50(torchvision.models.resnet.Bottleneck, [3, 4, 23, 3])
```

With this patch, the call will happen using the `torchvision.internal` prefix.