### PR TITLE
[proto] Added few transforms tests, part 1

### DIFF
--- a/test/test_prototype_transforms.py
+++ b/test/test_prototype_transforms.py
@@ -453,7 +453,7 @@ class TestRandomRotation:
         fn.assert_called_once_with(inpt, **params, interpolation=interpolation, expand=expand, fill=fill, center=center)
 
 
-class TestRandomAffine(TestRandomRotation):
+class TestRandomAffine:
     def test_assertions(self):
         with pytest.raises(ValueError, match="is a single number, it must be positive"):
             transforms.RandomAffine(-0.7)

--- a/torchvision/prototype/transforms/_geometry.py
+++ b/torchvision/prototype/transforms/_geometry.py
@@ -236,15 +236,15 @@ class Pad(Transform):
         if not isinstance(padding, (numbers.Number, tuple, list)):
             raise TypeError("Got inappropriate padding arg")
 
+        if isinstance(padding, (tuple, list)) and len(padding) not in [1, 2, 4]:
+            raise ValueError(
+                f"Padding must be an int or a 1, 2, or 4 element tuple, not a {len(padding)} element tuple"
+            )
+
         _check_fill_arg(fill)
 
         if padding_mode not in ["constant", "edge", "reflect", "symmetric"]:
             raise ValueError("Padding mode should be either constant, edge, reflect or symmetric")
-
-        if isinstance(padding, Sequence) and len(padding) not in [1, 2, 4]:
-            raise ValueError(
-                f"Padding must be an int or a 1, 2, or 4 element tuple, not a {len(padding)} element tuple"
-            )
 
         self.padding = padding
         self.fill = fill
@@ -258,13 +258,15 @@ class RandomZoomOut(_RandomApplyTransform):
     def __init__(
         self,
         fill: Union[int, float, Sequence[int], Sequence[float]] = 0,
-        side_range: Tuple[float, float] = (1.0, 4.0),
+        side_range: Sequence[float] = (1.0, 4.0),
         p: float = 0.5,
     ) -> None:
         super().__init__(p=p)
 
         _check_fill_arg(fill)
         self.fill = fill
+
+        _check_sequence_input(side_range, "side_range", req_sizes=(2,))
 
         self.side_range = side_range
         if side_range[0] < 1.0 or side_range[0] > side_range[1]:

--- a/torchvision/transforms/transforms.py
+++ b/torchvision/transforms/transforms.py
@@ -1855,7 +1855,7 @@ def _check_sequence_input(x, name, req_sizes):
     if not isinstance(x, Sequence):
         raise TypeError(f"{name} should be a sequence of length {msg}.")
     if len(x) not in req_sizes:
-        raise ValueError(f"{name} should be sequence of length {msg}.")
+        raise ValueError(f"{name} should be a sequence of length {msg}.")
 
 
 def _setup_angle(x, name, req_sizes=(2,)):


### PR DESCRIPTION
Description:
- Updated `test_mixup_cutmix`
- Added tests for RandomRotation, RandomAffine, Pad, RandomZoomOut


Transforms `_transform` test checks if a transform calls correctly mid-level layer which is mocked. However, randomly generated parameters are hard to get access. A suggestion to store generated params as an attribute.

/!\ Merging branch is `proto-transforms-api` (not `main`)