### PR TITLE
fix typo in 'swin_transformer.rst' docs

### DIFF
--- a/docs/source/models/swin_transformer.rst
+++ b/docs/source/models/swin_transformer.rst
@@ -11,7 +11,7 @@ paper.
 Model builders
 --------------
 
-The following model builders can be used to instanciate an SwinTransformer model. 
+The following model builders can be used to instantiate an SwinTransformer model. 
 `swin_t` can be instantiated with pre-trained weights and all others without. 
 All the model builders internally rely on the ``torchvision.models.swin_transformer.SwinTransformer`` 
 base class. Please refer to the `source code


### PR DESCRIPTION
changed 'instanciate' to 'instantiate'

<!-- Before submitting a PR, please make sure to check our contributing guidelines regarding code formatting, tests, and documentation: https://github.com/pytorch/vision/blob/main/CONTRIBUTING.md -->
