### PR TITLE
Update git-blame-ignore-revs following new ufmt version

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -5,3 +5,5 @@
 5f0edb97b46e5bff71dc19dedef05c5396eeaea2
 # update python syntax >=3.6 (#4585)
 d367a01a18a3ae6bee13d8be3b63fd6a581ea46f
+# Upgrade usort to 1.0.2 and black to 22.3.0 (#5106) 
+6ca9c76adb6daf2695d603ad623a9cf1c4f4806f

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,7 @@ Instead of relying directly on `black` however, we rely on
 [ufmt](https://github.com/omnilib/ufmt), for compatibility reasons with Facebook
 internal infrastructure.
 
-To format your code, install `ufmt` with `pip install ufmt==1.3.2 black==21.9b0 usort==0.6.4` and use e.g.:
+To format your code, install `ufmt` with `pip install ufmt==3.9.2 black==22.3.0 usort==1.0.2` and use e.g.:
 
 ```bash
 ufmt format torchvision

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,7 @@ Instead of relying directly on `black` however, we rely on
 [ufmt](https://github.com/omnilib/ufmt), for compatibility reasons with Facebook
 internal infrastructure.
 
-To format your code, install `ufmt` with `pip install ufmt==3.9.2 black==22.3.0 usort==1.0.2` and use e.g.:
+To format your code, install `ufmt` with `pip install ufmt==1.3.2 black==22.3.0 usort==1.0.2` and use e.g.:
 
 ```bash
 ufmt format torchvision


### PR DESCRIPTION
This will help ignoring https://github.com/pytorch/vision/pull/5106 in `git blame`.

I also updated our CONTRIBUTING guide instruction regarding the required version of `black`, etc.