### PR TITLE
Set MACOSX_DEPLOYMENT_TARGET=10.9 for binary jobs (#6298)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,6 +220,7 @@ binary_common: &binary_common
     PYTORCH_VERSION: << parameters.pytorch_version >>
     UNICODE_ABI: << parameters.unicode_abi >>
     CU_VERSION: << parameters.cu_version >>
+    MACOSX_DEPLOYMENT_TARGET: 10.9
 
 torchvision_ios_params: &torchvision_ios_params
   parameters:

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -220,6 +220,7 @@ binary_common: &binary_common
     PYTORCH_VERSION: << parameters.pytorch_version >>
     UNICODE_ABI: << parameters.unicode_abi >>
     CU_VERSION: << parameters.cu_version >>
+    MACOSX_DEPLOYMENT_TARGET: 10.9
 
 torchvision_ios_params: &torchvision_ios_params
   parameters:

--- a/packaging/torchvision/meta.yaml
+++ b/packaging/torchvision/meta.yaml
@@ -49,6 +49,7 @@ build:
     - FORCE_CUDA
     - BUILD_VERSION
     - TORCH_CUDA_ARCH_LIST
+    - MACOSX_DEPLOYMENT_TARGET
 
 test:
   imports:


### PR DESCRIPTION
Co-authored-by: Vasilis Vryniotis <datumbox@users.noreply.github.com>

<!-- Before submitting a PR, please make sure to check our contributing guidelines regarding code formatting, tests, and documentation: https://github.com/pytorch/vision/blob/main/CONTRIBUTING.md -->
