### PR TITLE
[RFC] Registration mechanism for models 

### DIFF
--- a/torchvision/models/__init__.py
+++ b/torchvision/models/__init__.py
@@ -14,4 +14,4 @@ from .vgg import *
 from .vision_transformer import *
 from .swin_transformer import *
 from . import detection, optical_flow, quantization, segmentation, video
-from ._api import get_model, get_model_weight, get_weight, list_models
+from ._api import get_model, get_model_weights, get_weight, list_models

--- a/torchvision/models/__init__.py
+++ b/torchvision/models/__init__.py
@@ -14,4 +14,4 @@ from .vgg import *
 from .vision_transformer import *
 from .swin_transformer import *
 from . import detection, optical_flow, quantization, segmentation, video
-from ._api import get_weight
+from ._api import get_weight, list_models, load

--- a/torchvision/models/__init__.py
+++ b/torchvision/models/__init__.py
@@ -14,4 +14,4 @@ from .vgg import *
 from .vision_transformer import *
 from .swin_transformer import *
 from . import detection, optical_flow, quantization, segmentation, video
-from ._api import get_weight, list_models, load_model
+from ._api import get_weight, list_models, get_model, get_model_weight

--- a/torchvision/models/__init__.py
+++ b/torchvision/models/__init__.py
@@ -14,4 +14,4 @@ from .vgg import *
 from .vision_transformer import *
 from .swin_transformer import *
 from . import detection, optical_flow, quantization, segmentation, video
-from ._api import get_weight, list_models, get_model, get_model_weight
+from ._api import get_model, get_model_weight, get_weight, list_models

--- a/torchvision/models/__init__.py
+++ b/torchvision/models/__init__.py
@@ -14,4 +14,4 @@ from .vgg import *
 from .vision_transformer import *
 from .swin_transformer import *
 from . import detection, optical_flow, quantization, segmentation, video
-from ._api import get_weight, list_models, load
+from ._api import get_weight, list_models, load_model

--- a/torchvision/models/_api.py
+++ b/torchvision/models/_api.py
@@ -162,7 +162,7 @@ def register_model(name: str, overwrite: bool = False) -> Callable[[Callable[...
 
 def list_models(module: Optional[ModuleType] = None) -> List[str]:
     """
-    Returns a list with the names of registred models.
+    Returns a list with the names of registered models.
 
     Args:
         module (ModuleType, optional): The module from which we want to extract the available models.

--- a/torchvision/models/_api.py
+++ b/torchvision/models/_api.py
@@ -125,10 +125,10 @@ def get_model_weight(model: Union[Callable, str]) -> W:
     """
     if isinstance(model, str):
         model = find_model(model)
-    return _get_enum_from_fn(model)
+    return cast(W, _get_enum_from_fn(model))
 
 
-def _get_enum_from_fn(fn: Callable) -> W:
+def _get_enum_from_fn(fn: Callable) -> WeightsEnum:
     """
     Internal method that gets the weight enum of a specific model builder method.
 
@@ -159,7 +159,7 @@ def _get_enum_from_fn(fn: Callable) -> W:
             "The WeightsEnum class for the specific method couldn't be retrieved. Make sure the typing info is correct."
         )
 
-    return cast(W, weights_enum)
+    return cast(WeightsEnum, weights_enum)
 
 
 M = TypeVar("M", bound=Type[nn.Module])

--- a/torchvision/models/_api.py
+++ b/torchvision/models/_api.py
@@ -3,9 +3,10 @@ import inspect
 import sys
 from dataclasses import dataclass, fields
 from inspect import signature
-from torch import nn
 from types import ModuleType
 from typing import Any, Callable, cast, Dict, List, Mapping, Optional, Type, TypeVar
+
+from torch import nn
 
 from torchvision._utils import StrEnum
 
@@ -155,6 +156,7 @@ def register_model(name: str, overwrite: bool = False) -> Callable[[Callable[...
             raise ValueError(f"An entry is already registered under the name '{name}'.")
         BUILTIN_MODELS[name] = fn
         return fn
+
     return wrapper
 
 

--- a/torchvision/models/_api.py
+++ b/torchvision/models/_api.py
@@ -4,7 +4,7 @@ import sys
 from dataclasses import dataclass, fields
 from inspect import signature
 from types import ModuleType
-from typing import Any, Callable, cast, Dict, List, Mapping, Optional, Type, TypeVar
+from typing import Any, Callable, cast, Dict, List, Mapping, Optional, Type, TypeVar, Union
 
 from torch import nn
 
@@ -113,18 +113,19 @@ def get_weight(name: str) -> WeightsEnum:
 W = TypeVar("W", bound=Type[WeightsEnum])
 
 
-def get_model_weight(name: str) -> W:
+def get_model_weight(model: Union[Callable, str]) -> W:
     """
-    Retuns the Weights Enum from the model name.
+    Retuns the Weights Enum of a model.
 
     Args:
-        name (str): The name under which the model is registered.
+        name (callable or str): The model builder function or the name under which it is registered.
 
     Returns:
         weights_enum (W): The weights enum class associated with the model.
     """
-    fn = _find_model(name)
-    return _get_enum_from_fn(fn)
+    if isinstance(model, str):
+        model = _find_model(model)
+    return _get_enum_from_fn(model)
 
 
 def _get_enum_from_fn(fn: Callable) -> W:

--- a/torchvision/models/_api.py
+++ b/torchvision/models/_api.py
@@ -168,7 +168,9 @@ def list_models(module: Optional[ModuleType] = None) -> List[str]:
     Returns:
         models (list): A list with the names of available models.
     """
-    models = [k for k, v in BUILTIN_MODELS.items() if module is None or v.__module__ == module]
+    models = [
+        k for k, v in BUILTIN_MODELS.items() if module is None or v.__module__.rsplit(".", 1)[0] == module.__name__
+    ]
     return sorted(models)
 
 

--- a/torchvision/models/_api.py
+++ b/torchvision/models/_api.py
@@ -13,7 +13,7 @@ from torchvision._utils import StrEnum
 from .._internally_replaced_utils import load_state_dict_from_url
 
 
-__all__ = ["WeightsEnum", "Weights", "get_model", "get_model_weight", "get_weight", "list_models"]
+__all__ = ["WeightsEnum", "Weights", "get_model", "get_model_weights", "get_weight", "list_models"]
 
 
 @dataclass
@@ -78,7 +78,7 @@ class WeightsEnum(StrEnum):
 
 def get_weight(name: str) -> WeightsEnum:
     """
-    Gets the weight enum value by its full name. Example: "ResNet50_Weights.IMAGENET1K_V1"
+    Gets the weights enum value by its full name. Example: "ResNet50_Weights.IMAGENET1K_V1"
 
     Args:
         name (str): The name of the weight enum entry.
@@ -113,9 +113,9 @@ def get_weight(name: str) -> WeightsEnum:
 W = TypeVar("W", bound=Type[WeightsEnum])
 
 
-def get_model_weight(model: Union[Callable, str]) -> W:
+def get_model_weights(model: Union[Callable, str]) -> W:
     """
-    Retuns the Weights Enum of a model.
+    Retuns the weights enum class associated to the given model.
 
     Args:
         name (callable or str): The model builder function or the name under which it is registered.

--- a/torchvision/models/_api.py
+++ b/torchvision/models/_api.py
@@ -150,10 +150,10 @@ M = TypeVar("M", bound=Type[nn.Module])
 BUILTIN_MODELS = {}
 
 
-def register_model(name: Optional[str] = None, overwrite: bool = False) -> Callable[[Callable[..., M]], Callable[..., M]]:
+def register_model(name: Optional[str] = None) -> Callable[[Callable[..., M]], Callable[..., M]]:
     def wrapper(fn: Callable[..., M]) -> Callable[..., M]:
         key = name if name is not None else fn.__name__
-        if key in BUILTIN_MODELS and not overwrite:
+        if key in BUILTIN_MODELS:
             raise ValueError(f"An entry is already registered under the name '{key}'.")
         BUILTIN_MODELS[key] = fn
         return fn
@@ -177,7 +177,7 @@ def list_models(module: Optional[ModuleType] = None) -> List[str]:
     return sorted(models)
 
 
-def load(name: str, **config: Any) -> M:
+def load_model(name: str, **config: Any) -> M:
     """
     Gets the model name and configuration and returns an instantiated model.
 

--- a/torchvision/models/_api.py
+++ b/torchvision/models/_api.py
@@ -152,7 +152,7 @@ BUILTIN_MODELS = {}
 def register_model(name: str, overwrite: bool = False) -> Callable[[Callable[..., M]], Callable[..., M]]:
     def wrapper(fn: Callable[..., M]) -> Callable[..., M]:
         if name in BUILTIN_MODELS and not overwrite:
-            raise ValueError(f"A model is already registered under tha name '{name}'.")
+            raise ValueError(f"An entry is already registered under the name '{name}'.")
         BUILTIN_MODELS[name] = fn
         return fn
     return wrapper

--- a/torchvision/models/_api.py
+++ b/torchvision/models/_api.py
@@ -150,11 +150,12 @@ M = TypeVar("M", bound=Type[nn.Module])
 BUILTIN_MODELS = {}
 
 
-def register_model(name: str, overwrite: bool = False) -> Callable[[Callable[..., M]], Callable[..., M]]:
+def register_model(name: Optional[str] = None, overwrite: bool = False) -> Callable[[Callable[..., M]], Callable[..., M]]:
     def wrapper(fn: Callable[..., M]) -> Callable[..., M]:
-        if name in BUILTIN_MODELS and not overwrite:
-            raise ValueError(f"An entry is already registered under the name '{name}'.")
-        BUILTIN_MODELS[name] = fn
+        key = name if name is not None else fn.__name__
+        if key in BUILTIN_MODELS and not overwrite:
+            raise ValueError(f"An entry is already registered under the name '{key}'.")
+        BUILTIN_MODELS[key] = fn
         return fn
 
     return wrapper

--- a/torchvision/models/_api.py
+++ b/torchvision/models/_api.py
@@ -13,7 +13,7 @@ from torchvision._utils import StrEnum
 from .._internally_replaced_utils import load_state_dict_from_url
 
 
-__all__ = ["WeightsEnum", "Weights", "get_weight", "list_models", "get_model", "get_model_weight"]
+__all__ = ["WeightsEnum", "Weights", "get_model", "get_model_weight", "get_weight", "list_models"]
 
 
 @dataclass
@@ -124,7 +124,7 @@ def get_model_weight(model: Union[Callable, str]) -> W:
         weights_enum (W): The weights enum class associated with the model.
     """
     if isinstance(model, str):
-        model = _find_model(model)
+        model = find_model(model)
     return _get_enum_from_fn(model)
 
 
@@ -194,7 +194,7 @@ def list_models(module: Optional[ModuleType] = None) -> List[str]:
     return sorted(models)
 
 
-def _find_model(name: str) -> Callable[..., M]:
+def find_model(name: str) -> Callable[..., M]:
     name = name.lower()
     try:
         fn = BUILTIN_MODELS[name]
@@ -214,5 +214,5 @@ def get_model(name: str, **config: Any) -> M:
     Returns:
         model (nn.Module): The initialized model.
     """
-    fn = _find_model(name)
+    fn = find_model(name)
     return fn(**config)

--- a/torchvision/models/alexnet.py
+++ b/torchvision/models/alexnet.py
@@ -6,7 +6,7 @@ import torch.nn as nn
 
 from ..transforms._presets import ImageClassification
 from ..utils import _log_api_usage_once
-from ._api import Weights, WeightsEnum
+from ._api import Weights, WeightsEnum, register_model
 from ._meta import _IMAGENET_CATEGORIES
 from ._utils import _ovewrite_named_param, handle_legacy_interface
 
@@ -75,6 +75,7 @@ class AlexNet_Weights(WeightsEnum):
     DEFAULT = IMAGENET1K_V1
 
 
+@register_model("alexnet")
 @handle_legacy_interface(weights=("pretrained", AlexNet_Weights.IMAGENET1K_V1))
 def alexnet(*, weights: Optional[AlexNet_Weights] = None, progress: bool = True, **kwargs: Any) -> AlexNet:
     """AlexNet model architecture from `One weird trick for parallelizing convolutional neural networks <https://arxiv.org/abs/1404.5997>`__.

--- a/torchvision/models/alexnet.py
+++ b/torchvision/models/alexnet.py
@@ -6,7 +6,7 @@ import torch.nn as nn
 
 from ..transforms._presets import ImageClassification
 from ..utils import _log_api_usage_once
-from ._api import Weights, WeightsEnum, register_model
+from ._api import register_model, Weights, WeightsEnum
 from ._meta import _IMAGENET_CATEGORIES
 from ._utils import _ovewrite_named_param, handle_legacy_interface
 

--- a/torchvision/models/alexnet.py
+++ b/torchvision/models/alexnet.py
@@ -75,7 +75,7 @@ class AlexNet_Weights(WeightsEnum):
     DEFAULT = IMAGENET1K_V1
 
 
-@register_model("alexnet")
+@register_model()
 @handle_legacy_interface(weights=("pretrained", AlexNet_Weights.IMAGENET1K_V1))
 def alexnet(*, weights: Optional[AlexNet_Weights] = None, progress: bool = True, **kwargs: Any) -> AlexNet:
     """AlexNet model architecture from `One weird trick for parallelizing convolutional neural networks <https://arxiv.org/abs/1404.5997>`__.

--- a/torchvision/models/mobilenetv3.py
+++ b/torchvision/models/mobilenetv3.py
@@ -8,7 +8,7 @@ from torch import nn, Tensor
 from ..ops.misc import Conv2dNormActivation, SqueezeExcitation as SElayer
 from ..transforms._presets import ImageClassification
 from ..utils import _log_api_usage_once
-from ._api import Weights, WeightsEnum
+from ._api import Weights, WeightsEnum, register_model
 from ._meta import _IMAGENET_CATEGORIES
 from ._utils import _make_divisible, _ovewrite_named_param, handle_legacy_interface
 
@@ -371,6 +371,7 @@ class MobileNet_V3_Small_Weights(WeightsEnum):
     DEFAULT = IMAGENET1K_V1
 
 
+@register_model("mobilenet_v3_large")
 @handle_legacy_interface(weights=("pretrained", MobileNet_V3_Large_Weights.IMAGENET1K_V1))
 def mobilenet_v3_large(
     *, weights: Optional[MobileNet_V3_Large_Weights] = None, progress: bool = True, **kwargs: Any
@@ -401,6 +402,7 @@ def mobilenet_v3_large(
     return _mobilenet_v3(inverted_residual_setting, last_channel, weights, progress, **kwargs)
 
 
+@register_model("mobilenet_v3_small")
 @handle_legacy_interface(weights=("pretrained", MobileNet_V3_Small_Weights.IMAGENET1K_V1))
 def mobilenet_v3_small(
     *, weights: Optional[MobileNet_V3_Small_Weights] = None, progress: bool = True, **kwargs: Any

--- a/torchvision/models/mobilenetv3.py
+++ b/torchvision/models/mobilenetv3.py
@@ -371,7 +371,7 @@ class MobileNet_V3_Small_Weights(WeightsEnum):
     DEFAULT = IMAGENET1K_V1
 
 
-@register_model("mobilenet_v3_large")
+@register_model()
 @handle_legacy_interface(weights=("pretrained", MobileNet_V3_Large_Weights.IMAGENET1K_V1))
 def mobilenet_v3_large(
     *, weights: Optional[MobileNet_V3_Large_Weights] = None, progress: bool = True, **kwargs: Any
@@ -402,7 +402,7 @@ def mobilenet_v3_large(
     return _mobilenet_v3(inverted_residual_setting, last_channel, weights, progress, **kwargs)
 
 
-@register_model("mobilenet_v3_small")
+@register_model()
 @handle_legacy_interface(weights=("pretrained", MobileNet_V3_Small_Weights.IMAGENET1K_V1))
 def mobilenet_v3_small(
     *, weights: Optional[MobileNet_V3_Small_Weights] = None, progress: bool = True, **kwargs: Any

--- a/torchvision/models/mobilenetv3.py
+++ b/torchvision/models/mobilenetv3.py
@@ -8,7 +8,7 @@ from torch import nn, Tensor
 from ..ops.misc import Conv2dNormActivation, SqueezeExcitation as SElayer
 from ..transforms._presets import ImageClassification
 from ..utils import _log_api_usage_once
-from ._api import Weights, WeightsEnum, register_model
+from ._api import register_model, Weights, WeightsEnum
 from ._meta import _IMAGENET_CATEGORIES
 from ._utils import _make_divisible, _ovewrite_named_param, handle_legacy_interface
 

--- a/torchvision/models/quantization/mobilenetv3.py
+++ b/torchvision/models/quantization/mobilenetv3.py
@@ -184,7 +184,7 @@ class MobileNet_V3_Large_QuantizedWeights(WeightsEnum):
     DEFAULT = IMAGENET1K_QNNPACK_V1
 
 
-@register_model("quantized_mobilenet_v3_large")
+@register_model(name="quantized_mobilenet_v3_large")
 @handle_legacy_interface(
     weights=(
         "pretrained",

--- a/torchvision/models/quantization/mobilenetv3.py
+++ b/torchvision/models/quantization/mobilenetv3.py
@@ -7,7 +7,7 @@ from torch.ao.quantization import DeQuantStub, QuantStub
 
 from ...ops.misc import Conv2dNormActivation, SqueezeExcitation
 from ...transforms._presets import ImageClassification
-from .._api import Weights, WeightsEnum
+from .._api import Weights, WeightsEnum, register_model
 from .._meta import _IMAGENET_CATEGORIES
 from .._utils import _ovewrite_named_param, handle_legacy_interface
 from ..mobilenetv3 import (
@@ -184,6 +184,7 @@ class MobileNet_V3_Large_QuantizedWeights(WeightsEnum):
     DEFAULT = IMAGENET1K_QNNPACK_V1
 
 
+@register_model("quantized_mobilenet_v3_large")
 @handle_legacy_interface(
     weights=(
         "pretrained",

--- a/torchvision/models/quantization/mobilenetv3.py
+++ b/torchvision/models/quantization/mobilenetv3.py
@@ -7,7 +7,7 @@ from torch.ao.quantization import DeQuantStub, QuantStub
 
 from ...ops.misc import Conv2dNormActivation, SqueezeExcitation
 from ...transforms._presets import ImageClassification
-from .._api import Weights, WeightsEnum, register_model
+from .._api import register_model, Weights, WeightsEnum
 from .._meta import _IMAGENET_CATEGORIES
 from .._utils import _ovewrite_named_param, handle_legacy_interface
 from ..mobilenetv3 import (

--- a/torchvision/prototype/datasets/_api.py
+++ b/torchvision/prototype/datasets/_api.py
@@ -12,8 +12,10 @@ D = TypeVar("D", bound=Type[Dataset])
 BUILTIN_INFOS: Dict[str, Dict[str, Any]] = {}
 
 
-def register_info(name: str) -> Callable[[Callable[[], Dict[str, Any]]], Callable[[], Dict[str, Any]]]:
+def register_info(name: str, overwrite: bool = False) -> Callable[[Callable[[], Dict[str, Any]]], Callable[[], Dict[str, Any]]]:
     def wrapper(fn: Callable[[], Dict[str, Any]]) -> Callable[[], Dict[str, Any]]:
+        if name in BUILTIN_INFOS and not overwrite:
+            raise ValueError(f"An entry is already registered under the name '{name}'.")
         BUILTIN_INFOS[name] = fn()
         return fn
 
@@ -23,8 +25,10 @@ def register_info(name: str) -> Callable[[Callable[[], Dict[str, Any]]], Callabl
 BUILTIN_DATASETS = {}
 
 
-def register_dataset(name: str) -> Callable[[D], D]:
+def register_dataset(name: str, overwrite: bool = False) -> Callable[[D], D]:
     def wrapper(dataset_cls: D) -> D:
+        if name in BUILTIN_DATASETS and not overwrite:
+            raise ValueError(f"An entry is already registered under the name '{name}'.")
         BUILTIN_DATASETS[name] = dataset_cls
         return dataset_cls
 

--- a/torchvision/prototype/datasets/_api.py
+++ b/torchvision/prototype/datasets/_api.py
@@ -12,12 +12,8 @@ D = TypeVar("D", bound=Type[Dataset])
 BUILTIN_INFOS: Dict[str, Dict[str, Any]] = {}
 
 
-def register_info(
-    name: str, overwrite: bool = False
-) -> Callable[[Callable[[], Dict[str, Any]]], Callable[[], Dict[str, Any]]]:
+def register_info(name: str) -> Callable[[Callable[[], Dict[str, Any]]], Callable[[], Dict[str, Any]]]:
     def wrapper(fn: Callable[[], Dict[str, Any]]) -> Callable[[], Dict[str, Any]]:
-        if name in BUILTIN_INFOS and not overwrite:
-            raise ValueError(f"An entry is already registered under the name '{name}'.")
         BUILTIN_INFOS[name] = fn()
         return fn
 
@@ -27,10 +23,8 @@ def register_info(
 BUILTIN_DATASETS = {}
 
 
-def register_dataset(name: str, overwrite: bool = False) -> Callable[[D], D]:
+def register_dataset(name: str) -> Callable[[D], D]:
     def wrapper(dataset_cls: D) -> D:
-        if name in BUILTIN_DATASETS and not overwrite:
-            raise ValueError(f"An entry is already registered under the name '{name}'.")
         BUILTIN_DATASETS[name] = dataset_cls
         return dataset_cls
 

--- a/torchvision/prototype/datasets/_api.py
+++ b/torchvision/prototype/datasets/_api.py
@@ -12,7 +12,9 @@ D = TypeVar("D", bound=Type[Dataset])
 BUILTIN_INFOS: Dict[str, Dict[str, Any]] = {}
 
 
-def register_info(name: str, overwrite: bool = False) -> Callable[[Callable[[], Dict[str, Any]]], Callable[[], Dict[str, Any]]]:
+def register_info(
+    name: str, overwrite: bool = False
+) -> Callable[[Callable[[], Dict[str, Any]]], Callable[[], Dict[str, Any]]]:
     def wrapper(fn: Callable[[], Dict[str, Any]]) -> Callable[[], Dict[str, Any]]:
         if name in BUILTIN_INFOS and not overwrite:
             raise ValueError(f"An entry is already registered under the name '{name}'.")


### PR DESCRIPTION
Fixes #1143

**Note:** This PR is meant to document the RFC with code examples and it's not mean to be merged. Some tests are failing because they are not compatible with the mechanism. This will be resolved on the follow up PRs that will actually introduce the mechanism to TorchVision.

## Objective

Create a model registration mechanism responsible for:
- Listing the names of all available models under a specific module
- Getting a model (initializing) from its name
- Getting the weight enum of the model from its name or model builder
- Registering models under a specific name

## Background

As discussed at #5088, a model registration mechanism is needed to be able to quickly list the available modules.

Currently we use hacky workarounds in order to list our models:
https://github.com/pytorch/vision/blob/6ca9c76adb6daf2695d603ad623a9cf1c4f4806f/test/test_models.py#L24-L30

The same applies for initializing models from their names:
https://github.com/pytorch/vision/blob/e288f6ca01a5009ab32f1db010b31f14756e0303/references/classification/train.py#L223-L225

https://github.com/pytorch/vision/blob/6ca9c76adb6daf2695d603ad623a9cf1c4f4806f/torchvision/models/detection/backbone_utils.py#L112



## Overview

Offer a mechanism that stores all models on a single private global dictionary along with public getter/listing methods located under `torchvision.models` that will allow users to interact with the mechanism. This proposal aligns closely with the registration mechanism proposed at the Datasets V2 API, offering a similar user experience.

### List models

Listing all available models:
```python
>>> torchvision.models.list_models()
['alexnet', 'mobilenet_v3_large', 'mobilenet_v3_small', 'quantized_mobilenet_v3_large', ...]
```

Listing available models from a specific module:
```python
>>> torchvision.models.list_models(module=torchvision.models)
['alexnet', 'mobilenet_v3_large', 'mobilenet_v3_small', ...]
>>> torchvision.models.list_models(module=torchvision.models.quantization)
['quantized_mobilenet_v3_large', ...]

```

### Get models

Getting an initialized model with pre-trained weights from its name:
```python
>>> torchvision.models.get_model("quantized_mobilenet_v3_large", weights="DEFAULT")
QuantizableMobileNetV3(
  (features): Sequential(
   ....
   )
)
```

### Get weights

Getting the Weight Enum class of a model from its name:
```python
>>> torchvision.models.get_model_weights("quantized_mobilenet_v3_large")
<enum 'MobileNet_V3_Large_QuantizedWeights'>
```

Getting the Weight Enum class of a model from its callable (model builder):
```python
>>> torchvision.models.get_model_weights(torchvision.models.quantization.mobilenet_v3_large)
<enum 'MobileNet_V3_Large_QuantizedWeights'>
```

### Register models

To register a model we use a special decorator and provide an arbitrary name:
```python
@register_model(name="mobilenet_v3_large")
def mobilenet_v3_large(
    *, weights: Optional[MobileNet_V3_Large_Weights] = None, progress: bool = True, **kwargs: Any
) -> MobileNetV3:
    pass

@register_model(name="quantized_mobilenet_v3_large")
def mobilenet_v3_large(
    *,
    weights: Optional[Union[MobileNet_V3_Large_QuantizedWeights, MobileNet_V3_Large_Weights]] = None,
    progress: bool = True,
    quantize: bool = False,
    **kwargs: Any,
) -> QuantizableMobileNetV3:
    pass
```

If you are registering a method under the same as its method name, you can omit passing the name. The following call will register the method under the name `"some_model"`:
```python
@register_model()
def some_model():
    pass
```

Registering a model under an existing name throws an error.

### Other details
- We will keep the registration mechanism private. Perhaps on the future we can consider allowing users to use it to register custom models but that's not part of this RFC.
- Unfortunately the names of the methods under `torchvision.models.quantization` conflict with those under `torchvision.models`. As a result we need to offer the ability to register them under arbitrary names that resolve the conflicts.
- The current registration mechanism will throw an error if one tries to register a model under an existing name. It's possible to extend the mechanism to allow overwrites (similar to ClassyVision) but given that the mechanism is private we don't have an immediate need of this feature.

## Alternatives Considered

We considered offering separate registration APIs per submodule (aka one for `torchvision.models`, one for `torchvision.models.detection` etc). This would resolve the issue of name conflicts across submodules but would lead to having separate public methods per package. Moreover this would lead to an awkward design since methods like `torchvision.models.get_weight()` already support all model subpackages.