### PR TITLE
Remove duplicate doc args.

### DIFF
--- a/torchvision/models/regnet.py
+++ b/torchvision/models/regnet.py
@@ -1381,10 +1381,6 @@ def regnet_x_1_6gf(*, weights: Optional[RegNet_X_1_6GF_Weights] = None, progress
 
     .. autoclass:: torchvision.models.RegNet_X_1_6GF_Weights
         :members:
-
-    Args:
-        weights (RegNet_X_1_6GF_Weights, optional): The pretrained weights for the model
-        progress (bool): If True, displays a progress bar of the download to stderr
     """
     weights = RegNet_X_1_6GF_Weights.verify(weights)
 
@@ -1410,10 +1406,6 @@ def regnet_x_3_2gf(*, weights: Optional[RegNet_X_3_2GF_Weights] = None, progress
 
     .. autoclass:: torchvision.models.RegNet_X_3_2GF_Weights
         :members:
-
-    Args:
-        weights (RegNet_X_3_2GF_Weights, optional): The pretrained weights for the model
-        progress (bool): If True, displays a progress bar of the download to stderr
     """
     weights = RegNet_X_3_2GF_Weights.verify(weights)
 
@@ -1439,10 +1431,6 @@ def regnet_x_8gf(*, weights: Optional[RegNet_X_8GF_Weights] = None, progress: bo
 
     .. autoclass:: torchvision.models.RegNet_X_8GF_Weights
         :members:
-
-    Args:
-        weights (RegNet_X_8GF_Weights, optional): The pretrained weights for the model
-        progress (bool): If True, displays a progress bar of the download to stderr
     """
     weights = RegNet_X_8GF_Weights.verify(weights)
 
@@ -1468,10 +1456,6 @@ def regnet_x_16gf(*, weights: Optional[RegNet_X_16GF_Weights] = None, progress: 
 
     .. autoclass:: torchvision.models.RegNet_X_16GF_Weights
         :members:
-
-    Args:
-        weights (RegNet_X_16GF_Weights, optional): The pretrained weights for the model
-        progress (bool): If True, displays a progress bar of the download to stderr
     """
     weights = RegNet_X_16GF_Weights.verify(weights)
 
@@ -1497,10 +1481,6 @@ def regnet_x_32gf(*, weights: Optional[RegNet_X_32GF_Weights] = None, progress: 
 
     .. autoclass:: torchvision.models.RegNet_X_32GF_Weights
         :members:
-
-    Args:
-        weights (RegNet_X_32GF_Weights, optional): The pretrained weights for the model
-        progress (bool): If True, displays a progress bar of the download to stderr
     """
     weights = RegNet_X_32GF_Weights.verify(weights)
 


### PR DESCRIPTION
The developer of TorchStudio, @divideconcept, has sent me the following message offline:
```
...[Using] TorchStudio, I was able to spot some outliers that could need documentation fixing since 
the new weights were introduced:
regnet_x_16gf
regnet_x_1_6gf
regnet_x_32gf
regnet_x_3_2gf
regnet_x_8gf
```

This PR fixes the problem.