### PR TITLE
Fix broken linter on main branch

### DIFF
--- a/torchvision/csrc/io/decoder/video_sampler.cpp
+++ b/torchvision/csrc/io/decoder/video_sampler.cpp
@@ -68,23 +68,25 @@ int transformImage(
   if (context) {
     // NOTE: srcY stride always 0: this is a parameter of YUV format
     if ((result = sws_scale(
-            context, srcSlice, srcStride, 0, inFormat.height, planes, lines)) <
+             context, srcSlice, srcStride, 0, inFormat.height, planes, lines)) <
         0) {
-      LOG(ERROR) << "sws_scale failed, err: " << Util::generateErrorDesc(result);
+      LOG(ERROR) << "sws_scale failed, err: "
+                 << Util::generateErrorDesc(result);
       return result;
     }
-  } else if (inFormat.width == outFormat.width &&
-    inFormat.height == outFormat.height &&
-    inFormat.format == outFormat.format) {
+  } else if (
+      inFormat.width == outFormat.width &&
+      inFormat.height == outFormat.height &&
+      inFormat.format == outFormat.format) {
     // Copy planes without using sws_scale if sws_getContext failed.
     av_image_copy(
-      planes,
-      lines,
-      (const uint8_t**)srcSlice,
-      srcStride,
-      (AVPixelFormat)inFormat.format,
-      inFormat.width,
-      inFormat.height);
+        planes,
+        lines,
+        (const uint8_t**)srcSlice,
+        srcStride,
+        (AVPixelFormat)inFormat.format,
+        inFormat.width,
+        inFormat.height);
   } else {
     LOG(ERROR) << "Invalid scale context format " << inFormat.format;
     return AVERROR(EINVAL);


### PR DESCRIPTION
The FBsync cherrypick on #6359 broke the linter. 

To make syncing on FBcode easier, we decided to merge and fix immediately on a follow up PR.