### PR TITLE
Remove Python linking dependency if USE_PYTHON=OFF

### DIFF
--- a/cmake/TorchVisionConfig.cmake.in
+++ b/cmake/TorchVisionConfig.cmake.in
@@ -32,9 +32,12 @@ if (@USE_PYTHON@)
   if(NOT TARGET Python3::Python)
     find_package(Python3 COMPONENTS Development)
   endif()
+  set(${PN}_LINK_LIBRARIES "torch;Python3::Python")
+else()
+  set(${PN}_LINK_LIBRARIES "torch")
 endif()
 
-set_target_properties(TorchVision::TorchVision PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${${PN}_INCLUDE_DIR}" INTERFACE_LINK_LIBRARIES "torch;Python3::Python" )
+set_target_properties(TorchVision::TorchVision PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${${PN}_INCLUDE_DIR}" INTERFACE_LINK_LIBRARIES "${${PN}_LINK_LIBRARIES}")
 
 
 if(@WITH_CUDA@)

--- a/packaging/build_cmake.sh
+++ b/packaging/build_cmake.sh
@@ -48,7 +48,7 @@ TORCH_PATH=$(dirname $(python -c "import torch; print(torch.__file__)"))
 if [[ "$(uname)" == Darwin || "$OSTYPE" == "msys" ]]; then
     conda install -yq libpng jpeg
 else
-    yum install -y libpng-devel libjpeg-turbo-devel
+    yum install -y libpng libpng-devel libjpeg-turbo libjpeg-turbo-devel
 fi
 
 if [[ "$OSTYPE" == "msys" ]]; then


### PR DESCRIPTION
A similar fix proposed previously by #5602 failed the CI tests. I made some amendments, and it is compilable in my environment.

It should now correct the problem raised in #5863 as well.

Closes #5602.
Resolves #5863.