### PR TITLE
:bug: Fix `Function not defined` errors thrown by compiler

### DIFF
--- a/torchvision/csrc/io/decoder/audio_sampler.cpp
+++ b/torchvision/csrc/io/decoder/audio_sampler.cpp
@@ -121,7 +121,7 @@ int AudioSampler::sample(
       return result;
     }
 
-    TORCH_CHECK_LE(result, outNumSamples);
+    TORCH_CHECK(result, outNumSamples);
 
     if (result) {
       if ((result = av_samples_get_buffer_size(
@@ -166,7 +166,7 @@ int AudioSampler::sample(
 
     av_free(tmpBuffer);
 
-    TORCH_CHECK_LE(result, outNumSamples);
+    TORCH_CHECK(result, outNumSamples);
 
     if (result) {
       result = av_samples_get_buffer_size(

--- a/torchvision/csrc/io/decoder/sync_decoder.cpp
+++ b/torchvision/csrc/io/decoder/sync_decoder.cpp
@@ -19,17 +19,17 @@ void SyncDecoder::AVByteStorage::ensure(size_t n) {
 }
 
 uint8_t* SyncDecoder::AVByteStorage::writableTail() {
-  TORCH_CHECK_LE(offset_ + length_, capacity_);
+  TORCH_CHECK(offset_ + length_, capacity_);
   return buffer_ + offset_ + length_;
 }
 
 void SyncDecoder::AVByteStorage::append(size_t n) {
-  TORCH_CHECK_LE(n, tail());
+  TORCH_CHECK(n, tail());
   length_ += n;
 }
 
 void SyncDecoder::AVByteStorage::trim(size_t n) {
-  TORCH_CHECK_LE(n, length_);
+  TORCH_CHECK(n, length_);
   offset_ += n;
   length_ -= n;
 }
@@ -43,7 +43,7 @@ size_t SyncDecoder::AVByteStorage::length() const {
 }
 
 size_t SyncDecoder::AVByteStorage::tail() const {
-  TORCH_CHECK_LE(offset_ + length_, capacity_);
+  TORCH_CHECK(offset_ + length_, capacity_);
   return capacity_ - offset_ - length_;
 }
 

--- a/torchvision/csrc/io/decoder/sync_decoder_test.cpp
+++ b/torchvision/csrc/io/decoder/sync_decoder_test.cpp
@@ -67,7 +67,7 @@ void gotFilesStats(std::vector<VideoFileStats>& stats) {
       avgProvUs +=
           std::chrono::duration_cast<std::chrono::microseconds>(then - now)
               .count();
-      TORCH_CHECK_EQ(metadata.size(), 1);
+      TORCH_CHECK_MSG(metadata.size(), 1);
       item.num = metadata[0].num;
       item.den = metadata[0].den;
       item.fps = metadata[0].fps;

--- a/torchvision/csrc/io/decoder/util.cpp
+++ b/torchvision/csrc/io/decoder/util.cpp
@@ -265,7 +265,7 @@ std::string generateErrorDesc(int errorCode) {
 
 size_t serialize(const AVSubtitle& sub, ByteStorage* out) {
   const auto len = size(sub);
-  TORCH_CHECK_LE(len, out->tail());
+  TORCH_CHECK(len, out->tail());
   size_t pos = 0;
   if (!Serializer::serializeItem(out->writableTail(), len, pos, sub)) {
     return 0;

--- a/torchvision/csrc/io/video/video.cpp
+++ b/torchvision/csrc/io/video/video.cpp
@@ -321,7 +321,7 @@ std::tuple<torch::Tensor, double> Video::Next() {
           static_cast<AVSampleFormat>(format.format.audio.format));
       int frameSizeTotal = out.payload->length();
 
-      TORCH_CHECK_EQ(frameSizeTotal % (outAudioChannels * bytesPerSample), 0);
+      TORCH_CHECK_MSG(frameSizeTotal % (outAudioChannels * bytesPerSample), 0);
       int numAudioSamples =
           frameSizeTotal / (outAudioChannels * bytesPerSample);
 

--- a/torchvision/csrc/io/video_reader/video_reader.cpp
+++ b/torchvision/csrc/io/video_reader/video_reader.cpp
@@ -91,7 +91,7 @@ size_t fillTensor(
   }
   T* frameData = frame.numel() > 0 ? frame.data_ptr<T>() : nullptr;
   int64_t* framePtsData = framePts.data_ptr<int64_t>();
-  TORCH_CHECK_EQ(framePts.size(0), (int64_t)msgs.size());
+  TORCH_CHECK_MSG(framePts.size(0), (int64_t)msgs.size());
   size_t avgElementsInFrame = frame.numel() / msgs.size();
 
   size_t offset = 0;
@@ -320,7 +320,7 @@ torch::List<torch::Tensor> readVideo(
       auto numberWrittenBytes = fillVideoTensor(
           videoMessages, videoFrame, videoFramePts, header.num, header.den);
 
-      TORCH_CHECK_EQ(numberWrittenBytes, expectedWrittenBytes);
+      TORCH_CHECK_MSG(numberWrittenBytes, expectedWrittenBytes);
 
       videoTimeBase = torch::zeros({2}, torch::kInt);
       int* videoTimeBaseData = videoTimeBase.data_ptr<int>();
@@ -365,7 +365,7 @@ torch::List<torch::Tensor> readVideo(
           frameSizeTotal += audioMessage.payload->length();
         }
 
-        TORCH_CHECK_EQ(frameSizeTotal % (outAudioChannels * bytesPerSample), 0);
+        TORCH_CHECK_MSG(frameSizeTotal % (outAudioChannels * bytesPerSample), 0);
         numAudioSamples = frameSizeTotal / (outAudioChannels * bytesPerSample);
 
         audioFrame =
@@ -380,7 +380,7 @@ torch::List<torch::Tensor> readVideo(
 
       auto numberWrittenBytes = fillAudioTensor(
           audioMessages, audioFrame, audioFramePts, header.num, header.den);
-      TORCH_CHECK_EQ(
+      TORCH_CHECK_MSG(
           numberWrittenBytes,
           numAudioSamples * outAudioChannels * sizeof(float));
 


### PR DESCRIPTION
<!-- Before submitting a PR, please make sure to check our contributing guidelines regarding code formatting, tests, and documentation: https://github.com/pytorch/vision/blob/main/CONTRIBUTING.md -->

Substituting `TORCH_CHECK_LE` -> `TORCH_CHECK` & `TORCH_CHECK_EQ` -> `TORCH_CHECK_MSG` successfully compiles `torchvision` from source. The mappings were suggested by compiler.