### PR TITLE
[DO NOT MERGE] LibTorchvision 0.13 binary push

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1609,6 +1609,12 @@ workflows:
           ios_arch: arm64
           ios_platform: OS
           name: binary_libtorchvision_ops_ios_12.0.0_arm64
+      - binary_ios_upload:
+          build_environment: binary-libtorchvision_ops-ios-12.0.0-upload
+          context: org-member
+          requires:
+          - binary_libtorchvision_ops_ios_12.0.0_x86_64
+          - binary_libtorchvision_ops_ios_12.0.0_arm64
       - binary_android_build:
           build_environment: binary-libtorchvision_ops-android
           name: binary_libtorchvision_ops_android
@@ -1755,34 +1761,6 @@ workflows:
 
   nightly:
     jobs:
-      - binary_ios_build:
-          build_environment: nightly-binary-libtorchvision_ops-ios-12.0.0-x86_64
-          filters:
-            branches:
-              only:
-              - nightly
-          ios_arch: x86_64
-          ios_platform: SIMULATOR
-          name: nightly_binary_libtorchvision_ops_ios_12.0.0_x86_64
-      - binary_ios_build:
-          build_environment: nightly-binary-libtorchvision_ops-ios-12.0.0-arm64
-          filters:
-            branches:
-              only:
-              - nightly
-          ios_arch: arm64
-          ios_platform: OS
-          name: nightly_binary_libtorchvision_ops_ios_12.0.0_arm64
-      - binary_ios_upload:
-          build_environment: nightly-binary-libtorchvision_ops-ios-12.0.0-upload
-          context: org-member
-          filters:
-            branches:
-              only:
-              - nightly
-          requires:
-          - nightly_binary_libtorchvision_ops_ios_12.0.0_x86_64
-          - nightly_binary_libtorchvision_ops_ios_12.0.0_arm64
       - binary_android_upload:
           build_environment: nightly-binary-libtorchvision_ops-android-upload
           context: org-member

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -1112,7 +1112,6 @@ workflows:
 
   nightly:
     jobs:
-      {{ ios_workflows(nightly=True) }}
       {{ android_workflows(nightly=True) }}
       {{ build_workflows(prefix="nightly_", filter_branch="nightly", upload=True) }}
   docker_build:

--- a/.circleci/regenerate.py
+++ b/.circleci/regenerate.py
@@ -290,14 +290,21 @@ def ios_workflows(indentation=6, nightly=False):
             build_job["filters"] = gen_filter_branch_tree("nightly")
         jobs.append({"binary_ios_build": build_job})
 
-    if nightly:
-        upload_job = {
-            "build_environment": f"{env_prefix}binary-libtorchvision_ops-ios-12.0.0-upload",
-            "context": "org-member",
-            "filters": gen_filter_branch_tree("nightly"),
-            "requires": build_job_names,
-        }
-        jobs.append({"binary_ios_upload": upload_job})
+    # if nightly:
+    #     upload_job = {
+    #         "build_environment": f"{env_prefix}binary-libtorchvision_ops-ios-12.0.0-upload",
+    #         "context": "org-member",
+    #         "filters": gen_filter_branch_tree("nightly"),
+    #         "requires": build_job_names,
+    #     }
+    #     jobs.append({"binary_ios_upload": upload_job})
+    upload_job = {
+        "build_environment": f"{env_prefix}binary-libtorchvision_ops-ios-12.0.0-upload",
+        "context": "org-member",
+        "requires": build_job_names,
+    }
+    jobs.append({"binary_ios_upload": upload_job})
+
     return indent(indentation, jobs)
 
 

--- a/.circleci/unittest/ios/scripts/binary_ios_build.sh
+++ b/.circleci/unittest/ios/scripts/binary_ios_build.sh
@@ -5,7 +5,7 @@ echo ""
 echo "DIR: $(pwd)"
 WORKSPACE=/Users/distiller/workspace
 PROJ_ROOT_IOS=/Users/distiller/project/ios
-PYTORCH_IOS_NIGHTLY_NAME=libtorch_ios_nightly_build.zip
+PYTORCH_IOS_NIGHTLY_NAME=libtorch_ios_1.12.0.zip
 export TCLLIBPATH="/usr/local/lib"
 
 # install conda
@@ -22,6 +22,8 @@ export CMAKE_PREFIX_PATH=${CONDA_PREFIX:-"$(dirname $(which conda))/../"}
 
 # sync submodules
 cd ${PROJ_ROOT_IOS}
+git fetch
+git checkout release/0.13
 git submodule sync
 git submodule update --init --recursive
 
@@ -32,7 +34,7 @@ mkdir -p ${PROJ_ROOT_IOS}/pytorch
 TORCH_ROOT="${PROJ_ROOT_IOS}/pytorch"
 
 cd ${TORCH_ROOT}
-wget https://ossci-ios-build.s3.amazonaws.com/${PYTORCH_IOS_NIGHTLY_NAME}
+wget https://ossci-ios.s3.amazonaws.com/${PYTORCH_IOS_NIGHTLY_NAME}
 mkdir -p ./build_ios
 unzip -d ./build_ios ./${PYTORCH_IOS_NIGHTLY_NAME}
 

--- a/.circleci/unittest/ios/scripts/binary_ios_upload.sh
+++ b/.circleci/unittest/ios/scripts/binary_ios_upload.sh
@@ -20,7 +20,7 @@ lipo -i ${ZIP_DIR}/install/lib/*.a
 # copy the license
 cp ${PROJ_ROOT}/LICENSE ${ZIP_DIR}/
 # zip the library
-ZIPFILE=libtorchvision_ops_ios_nightly_build.zip
+ZIPFILE=libtorchvision_ops_ios_0.13.zip
 cd ${ZIP_DIR}
 #for testing
 touch version.txt
@@ -39,4 +39,4 @@ set +x
 export AWS_ACCESS_KEY_ID=${AWS_S3_ACCESS_KEY_FOR_PYTORCH_BINARY_UPLOAD}
 export AWS_SECRET_ACCESS_KEY=${AWS_S3_ACCESS_SECRET_FOR_PYTORCH_BINARY_UPLOAD}
 set -x
-aws s3 cp ${ZIPFILE} s3://ossci-ios-build/ --acl public-read
+aws s3 cp ${ZIPFILE} s3://ossci-ios/ --acl public-read


### PR DESCRIPTION
This is a duplicate of https://github.com/pytorch/vision/pull/6383

It's intended to generate and upload the 0.13 cocoapod binary, do not merge this PR.

CircleCI doesn't want to authorize the ios_binary_upload step on the first PR. Attempting creating a new PR after creating a CircleCI acct to see if that will appease it.
