### PR TITLE
[proto] Compose transform keeps BC

### DIFF
--- a/test/test_prototype_transforms.py
+++ b/test/test_prototype_transforms.py
@@ -1083,3 +1083,22 @@ class TestToTensor:
             fn.call_count == 0
         else:
             fn.assert_called_once_with(inpt)
+
+
+class TestCompose:
+    def test_assertions(self):
+        with pytest.raises(TypeError, match="Argument transforms should be a sequence of callables"):
+            transforms.Compose(123)
+
+    @pytest.mark.parametrize(
+        "trfms",
+        [
+            [transforms.Pad(2), transforms.RandomCrop(28)],
+            [lambda x: 2.0 * x],
+        ],
+    )
+    def test_ctor(self, trfms):
+        c = transforms.Compose(trfms)
+        inpt = torch.rand(1, 3, 32, 32)
+        output = c(inpt)
+        assert isinstance(output, torch.Tensor)

--- a/torchvision/prototype/transforms/_container.py
+++ b/torchvision/prototype/transforms/_container.py
@@ -2,19 +2,18 @@ from typing import Any, Callable, Dict, List, Optional, Sequence
 
 import torch
 from torchvision.prototype.transforms import Transform
-from torchvision.utils import _log_api_usage_once
 
 from ._transform import _RandomApplyTransform
 
 
-class Compose:
+class Compose(Transform):
     def __init__(self, transforms: Sequence[Callable]) -> None:
-        _log_api_usage_once(self)
+        super().__init__()
         if not isinstance(transforms, Sequence):
             raise TypeError("Argument transforms should be a sequence of callables")
         self.transforms = transforms
 
-    def __call__(self, *inputs: Any) -> Any:
+    def forward(self, *inputs: Any) -> Any:
         sample = inputs if len(inputs) > 1 else inputs[0]
         for transform in self.transforms:
             sample = transform(sample)

--- a/torchvision/prototype/transforms/_container.py
+++ b/torchvision/prototype/transforms/_container.py
@@ -1,19 +1,20 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, Sequence
 
 import torch
 from torchvision.prototype.transforms import Transform
+from torchvision.utils import _log_api_usage_once
 
 from ._transform import _RandomApplyTransform
 
 
-class Compose(Transform):
-    def __init__(self, *transforms: Transform) -> None:
-        super().__init__()
+class Compose:
+    def __init__(self, transforms: Sequence[Callable]) -> None:
+        _log_api_usage_once(self)
+        if not isinstance(transforms, Sequence):
+            raise TypeError("Argument transforms should be a sequence of callables")
         self.transforms = transforms
-        for idx, transform in enumerate(transforms):
-            self.add_module(str(idx), transform)
 
-    def forward(self, *inputs: Any) -> Any:
+    def __call__(self, *inputs: Any) -> Any:
         sample = inputs if len(inputs) > 1 else inputs[0]
         for transform in self.transforms:
             sample = transform(sample)


### PR DESCRIPTION
- input transforms should be an iterable to keep BC
- Removed subclassing from `Transform` such that transforms could be any non-nn-Module functions