### PR TITLE
Fix M1 worklfow comments

### DIFF
--- a/.github/workflows/build-m1-binaries.yml
+++ b/.github/workflows/build-m1-binaries.yml
@@ -43,7 +43,7 @@ jobs:
           PY_VERS: ${{ matrix.py_vers }}
         run: |
           . ~/miniconda3/etc/profile.d/conda.sh
-          # Needed for JPEG library detection as setup.py detects conda presence by running `shlex.which('conda')`
+          # Needed for JPEG library detection as setup.py detects conda presence by running `shutil.which('conda')`
           export PATH=~/miniconda3/bin:$PATH
           set -ex
           . packaging/pkg_helpers.bash

--- a/.github/workflows/test-m1.yml
+++ b/.github/workflows/test-m1.yml
@@ -31,7 +31,7 @@ jobs:
           PY_VERS: ${{ matrix.py_vers }}
         run: |
           . ~/miniconda3/etc/profile.d/conda.sh
-          # Needed for JPEG library detection as setup.py detects conda presence by running `shlex.which('conda')`
+          # Needed for JPEG library detection as setup.py detects conda presence by running `shutil.which('conda')`
           export PATH=~/miniconda3/bin:$PATH
           set -ex
           conda create -yp ${ENV_NAME} python=${PY_VERS} numpy libpng jpeg scipy


### PR DESCRIPTION
I found this while getting familiar with the new workflows. `shlex` does not have a `which` function, but [`shutil` does](https://docs.python.org/3/library/shutil.html#shutil.which):

https://github.com/pytorch/vision/blob/6e535db255cee3ce878dd7a54dda01d4ec8932c1/setup.py#L105


