### PR TITLE
port `ScaleJitter` from detection reference to prototype transforms

### DIFF
--- a/test/test_prototype_transforms.py
+++ b/test/test_prototype_transforms.py
@@ -1148,17 +1148,17 @@ class TestScaleJitter:
         assert int(target_size[1] * scale_range[0]) <= width <= int(target_size[1] * scale_range[1])
 
     def test__transform(self, mocker):
-        interpolation_sentinel = object()
+        interpolation_sentinel = mocker.MagicMock()
 
         transform = transforms.ScaleJitter(target_size=(16, 12), interpolation=interpolation_sentinel)
-        transform._transformed_types = (object,)
+        transform._transformed_types = (mocker.MagicMock,)
 
-        size_sentinel = object()
+        size_sentinel = mocker.MagicMock()
         mocker.patch(
             "torchvision.prototype.transforms._geometry.ScaleJitter._get_params", return_value=dict(size=size_sentinel)
         )
 
-        inpt_sentinel = object()
+        inpt_sentinel = mocker.MagicMock()
 
         mock = mocker.patch("torchvision.prototype.transforms._geometry.F.resize")
         transform(inpt_sentinel)

--- a/test/test_prototype_transforms.py
+++ b/test/test_prototype_transforms.py
@@ -1102,3 +1102,42 @@ class TestCompose:
         inpt = torch.rand(1, 3, 32, 32)
         output = c(inpt)
         assert isinstance(output, torch.Tensor)
+
+
+class TestScaleJitter:
+    def test__get_params(self, mocker):
+        image_size = (24, 32)
+        target_size = (16, 12)
+        scale_range = (0.5, 1.5)
+
+        transform = transforms.ScaleJitter(target_size=target_size, scale_range=scale_range)
+
+        sample = mocker.MagicMock(spec=features.Image, num_channels=3, image_size=image_size)
+        params = transform._get_params(sample)
+
+        assert "size" in params
+        size = params["size"]
+
+        assert isinstance(size, tuple) and len(size) == 2
+        height, width = size
+
+        assert int(target_size[0] * scale_range[0]) <= height <= int(target_size[0] * scale_range[1])
+        assert int(target_size[1] * scale_range[0]) <= width <= int(target_size[1] * scale_range[1])
+
+    def test__transform(self, mocker):
+        interpolation_sentinel = object()
+
+        transform = transforms.ScaleJitter(target_size=(16, 12), interpolation=interpolation_sentinel)
+        transform._transformed_types = (object,)
+
+        size_sentinel = object()
+        mocker.patch(
+            "torchvision.prototype.transforms._geometry.ScaleJitter._get_params", return_value=dict(size=size_sentinel)
+        )
+
+        inpt_sentinel = object()
+
+        mock = mocker.patch("torchvision.prototype.transforms._geometry.F.resize")
+        transform(inpt_sentinel)
+
+        mock.assert_called_once_with(inpt_sentinel, size=size_sentinel, interpolation=interpolation_sentinel)

--- a/torchvision/prototype/transforms/__init__.py
+++ b/torchvision/prototype/transforms/__init__.py
@@ -30,6 +30,7 @@ from ._geometry import (
     RandomVerticalFlip,
     RandomZoomOut,
     Resize,
+    ScaleJitter,
     TenCrop,
 )
 from ._meta import ConvertBoundingBoxFormat, ConvertImageColorSpace, ConvertImageDtype

--- a/torchvision/prototype/transforms/_geometry.py
+++ b/torchvision/prototype/transforms/_geometry.py
@@ -611,3 +611,29 @@ class ElasticTransform(Transform):
             fill=self.fill,
             interpolation=self.interpolation,
         )
+
+
+class ScaleJitter(Transform):
+    def __init__(
+        self,
+        target_size: Tuple[int, int],
+        scale_range: Tuple[float, float] = (0.1, 2.0),
+        interpolation: InterpolationMode = InterpolationMode.BILINEAR,
+    ):
+        super().__init__()
+        self.target_size = target_size
+        self.scale_range = scale_range
+        self.interpolation = interpolation
+
+    def _get_params(self, sample: Any) -> Dict[str, Any]:
+        image = query_image(sample)
+        _, orig_height, orig_width = get_image_dimensions(image)
+
+        r = self.scale_range[0] + torch.rand(1) * (self.scale_range[1] - self.scale_range[0])
+        new_width = int(self.target_size[1] * r)
+        new_height = int(self.target_size[0] * r)
+
+        return dict(size=(new_height, new_width))
+
+    def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
+        return F.resize(inpt, size=params["size"], interpolation=self.interpolation)


### PR DESCRIPTION
```py
import torch
from torchvision.prototype import features, transforms


image = features.EncodedImage.from_path(
    "test/assets/fakedata/logos/rgb_pytorch.png"
).decode()

bounding_boxes = features.BoundingBox(
    [[60, 30, 15, 15]],
    format=features.BoundingBoxFormat.CXCYWH,
    image_size=(100, 100),
    dtype=torch.float,
)

segmentation_masks = torch.zeros((1, 100, 100), dtype=torch.bool)
segmentation_masks[..., 24:36, 55:66] = True
segmentation_masks = features.SegmentationMask(segmentation_masks)

target = dict(
    boxes=bounding_boxes,
    masks=segmentation_masks,
)
sample = image, target

transform = transforms.ScaleJitter(target_size=(100, 100))

torch.manual_seed(0)

for i in range(5):
    transformed_image, transformed_target = transform(sample)
    transformed_bounding_boxes = transformed_target["boxes"]
    transformed_segmentation_masks = transformed_target["masks"]
```

![0](https://user-images.githubusercontent.com/6849766/184363948-62c19ea7-c10a-49fa-a025-123e198d7742.png) ![1](https://user-images.githubusercontent.com/6849766/184363966-0f11fe71-b4e2-4a1e-9162-41860709656e.png) ![2](https://user-images.githubusercontent.com/6849766/184363978-da5330e8-0571-4129-8573-f05c0f90a79f.png) ![3](https://user-images.githubusercontent.com/6849766/184364083-db61c131-b6c7-4569-95a0-9dea63bc76b8.png) ![4](https://user-images.githubusercontent.com/6849766/184364088-3d197054-a42e-4c11-9102-8a23fd854a47.png)

I've verified that plugging `image` and `target` in the current reference transform yields the same results. 

