### PR TITLE
Use --no-implicit-optional for type checking

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -4,8 +4,8 @@ files = torchvision
 show_error_codes = True
 pretty = True
 allow_redefinition = True
-warn_redundant_casts = True
 no_implicit_optional = True
+warn_redundant_casts = True
 
 [mypy-torchvision.prototype.features.*]
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -5,6 +5,7 @@ show_error_codes = True
 pretty = True
 allow_redefinition = True
 warn_redundant_casts = True
+no_implicit_optional = True
 
 [mypy-torchvision.prototype.features.*]
 

--- a/torchvision/datasets/utils.py
+++ b/torchvision/datasets/utils.py
@@ -458,7 +458,7 @@ T = TypeVar("T", str, bytes)
 def verify_str_arg(
     value: T,
     arg: Optional[str] = None,
-    valid_values: Iterable[T] = None,
+    valid_values: Optional[Iterable[T]] = None,
     custom_msg: Optional[str] = None,
 ) -> T:
     if not isinstance(value, torch._six.string_classes):


### PR DESCRIPTION
This makes type checking PEP 484 compliant (as of 2018).
mypy will change its defaults soon.

See:
https://github.com/python/mypy/issues/9091
https://github.com/python/mypy/pull/13401