### PR TITLE
[proto] OneHotLabel subclass Label and implements `from_category` and `to_categories`

### DIFF
--- a/torchvision/prototype/features/_label.py
+++ b/torchvision/prototype/features/_label.py
@@ -49,7 +49,7 @@ class Label(_Feature):
         return tree_map(lambda idx: self.categories[idx], self.tolist())
 
 
-class OneHotLabel(_Feature):
+class OneHotLabel(Label):
     categories: Optional[Sequence[str]]
 
     def __new__(
@@ -77,3 +77,21 @@ class OneHotLabel(_Feature):
         return super().new_like(
             other, data, categories=categories if categories is not None else other.categories, **kwargs
         )
+
+    @classmethod
+    def from_category(
+        cls,
+        category: str,
+        *,
+        categories: Sequence[str],
+        **kwargs: Any,
+    ) -> Label:
+        ohe_tensor = torch.zeros(len(categories), dtype=torch.long)
+        ohe_tensor[categories.index(category)] = 1
+        return cls(ohe_tensor, categories=categories, **kwargs)
+
+    def to_categories(self) -> Any:
+        if self.categories is None:
+            raise RuntimeError("OneHotLabel does not have categories")
+        label = self.argmax(dim=-1)
+        return tree_map(lambda idx: self.categories[idx], label.tolist())

--- a/torchvision/prototype/features/_label.py
+++ b/torchvision/prototype/features/_label.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, cast, Optional, Sequence, Union
+from typing import Any, Optional, Sequence, Union
 
 import torch
 from torch.utils._pytree import tree_map

--- a/torchvision/prototype/features/_label.py
+++ b/torchvision/prototype/features/_label.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Any, cast, Optional, Sequence, Union
 
 import torch
-from torchvision.prototype.utils._internal import apply_recursively
+from torch.utils._pytree import tree_map
 
 from ._feature import _Feature
 
@@ -43,10 +43,10 @@ class Label(_Feature):
         return cls(categories.index(category), categories=categories, **kwargs)
 
     def to_categories(self) -> Any:
-        if not self.categories:
-            raise RuntimeError()
+        if self.categories is None:
+            raise RuntimeError("Label does not have categories")
 
-        return apply_recursively(lambda idx: cast(Sequence[str], self.categories)[idx], self.tolist())
+        return tree_map(lambda idx: self.categories[idx], self.tolist())
 
 
 class OneHotLabel(_Feature):


### PR DESCRIPTION
Description:

- OneHotLabel subclass Label
- Implemented `OneHotLabel.from_category` and `OneHotLabel.to_categories`


```python
import torch
from torchvision.prototype.features import Label, OneHotLabel

Label.from_category("dog", categories=["dog", "cat", "boat"])

l = Label(torch.tensor([[[0, 0, 2], [0, 1, 2]], [[0, 0, 1], [1, 1, 2]]]), categories=["dog", "cat", "boat"])
print(l.to_categories())

l = OneHotLabel(torch.eye(3, 3, dtype=torch.long)[None, None, ...].expand(1, 2, 3, 3), categories=["dog", "cat", "boat"])
print(l.to_categories())

print(OneHotLabel.from_category("cat", categories=["dog", "cat", "boat"]))
```
Output:
```
[[['dog', 'dog', 'boat'], ['dog', 'cat', 'boat']], [['dog', 'dog', 'cat'], ['cat', 'cat', 'boat']]]
[[['dog', 'cat', 'boat'], ['dog', 'cat', 'boat']]]
OneHotLabel([0, 1, 0])
```

Note: This PR is based upon https://github.com/pytorch/vision/pull/6419
