### PR TITLE
Fix anaconda upload step

### DIFF
--- a/.github/workflows/build-m1-binaries.yml
+++ b/.github/workflows/build-m1-binaries.yml
@@ -42,9 +42,7 @@ jobs:
           ENV_NAME: conda-env-${{ github.run_id }}
           PY_VERS: ${{ matrix.py_vers }}
         run: |
-          . ~/miniconda3/etc/profile.d/conda.sh
           # Needed for JPEG library detection as setup.py detects conda presence by running `shutil.which('conda')`
-          export PATH=~/miniconda3/bin:$PATH
           set -ex
           . packaging/pkg_helpers.bash
           # if we are uploading to test channell, our version consist only of the base: 0.x.x - no date string or suffix added
@@ -67,7 +65,6 @@ jobs:
           ENV_NAME: conda-test-env-${{ github.run_id }}
           PY_VERS: ${{ matrix.py_vers }}
         run: |
-          . ~/miniconda3/etc/profile.d/conda.sh
           set -ex
           conda create -yp ${ENV_NAME} python=${PY_VERS} numpy
           conda run -p ${ENV_NAME} python3 -mpip install torch --pre --extra-index-url=https://download.pytorch.org/whl/${CHANNEL}
@@ -115,7 +112,6 @@ jobs:
       - name: Install conda-build and purge previous artifacts
         shell: arch -arch arm64 bash {0}
         run: |
-          . ~/miniconda3/etc/profile.d/conda.sh
           conda install -yq conda-build
           conda build purge-all
 
@@ -126,7 +122,6 @@ jobs:
           PYTHON_VERSION: ${{ matrix.py_vers }}
           CU_VERSION: cpu
         run: |
-          . ~/miniconda3/etc/profile.d/conda.sh
           set -ex
           . packaging/pkg_helpers.bash
 
@@ -156,7 +151,7 @@ jobs:
         env:
           CONDA_PYTORCHBOT_TOKEN: ${{ secrets.CONDA_PYTORCHBOT_TOKEN }}
         run: |
-          . ~/miniconda3/etc/profile.d/conda.sh
           conda install -yq anaconda-client
           set -x
-          ~/miniconda3/bin/anaconda  -t "${CONDA_PYTORCHBOT_TOKEN}" upload ~/miniconda3/conda-bld/osx-arm64/*.tar.bz2 -u "pytorch-${CHANNEL}" --label main --no-progress --force
+          export ANACONDA_PATH=$(conda info --base)/bin
+          $ANACONDA_PATH/anaconda  -t "${CONDA_PYTORCHBOT_TOKEN}" upload ~/miniconda3/conda-bld/osx-arm64/*.tar.bz2 -u "pytorch-${CHANNEL}" --label main --no-progress --force


### PR DESCRIPTION
Testing:
```
export ANACONDA_PATH=$(conda info --base)/bin
echo $ANACONDA_PATH
/opt/homebrew/Caskroom/miniconda/base/bin
$ANACONDA_PATH/anaconda -V
anaconda Command line client (version 1.10.0)
```

