### PR TITLE
Free avPacket on EAGAIN decoder error

### DIFF
--- a/torchvision/csrc/io/decoder/decoder.cpp
+++ b/torchvision/csrc/io/decoder/decoder.cpp
@@ -516,6 +516,8 @@ int Decoder::getFrame(size_t workingTimeInMs) {
       VLOG(4) << "Decoder is busy...";
       std::this_thread::yield();
       result = 0; // reset error, EAGAIN is not an error at all
+      // reset the packet to default settings
+      av_packet_unref(avPacket);
       continue;
     } else if (result == AVERROR_EOF) {
       flushStreams();


### PR DESCRIPTION
Summary:
According to the documentation the packet has to be freed after `av_read_frame()` call.
```
 If pkt->buf is NULL, then the packet is valid until the next
 av_read_frame() or until avformat_close_input(). Otherwise the packet
 is valid indefinitely. In both cases the packet must be freed with
 av_packet_unref when it is no longer needed.
```

Differential Revision: D38747612

