### PR TITLE
Fix minor bug on `PolynomialLR` invocation

### DIFF
--- a/references/segmentation/train.py
+++ b/references/segmentation/train.py
@@ -186,7 +186,7 @@ def main(args):
 
     iters_per_epoch = len(data_loader)
     main_lr_scheduler = PolynomialLR(
-        optimizer, total_steps=iters_per_epoch * (args.epochs - args.lr_warmup_epochs), power=0.9
+        optimizer, total_iters=iters_per_epoch * (args.epochs - args.lr_warmup_epochs), power=0.9
     )
 
     if args.lr_warmup_epochs > 0:


### PR DESCRIPTION
Resolves issue reported at https://github.com/pytorch/vision/commit/6e535db255cee3ce878dd7a54dda01d4ec8932c1#commitcomment-81409388

There seems to be a misspelling on the name of the parameter. This PR updates `total_steps` to `total_iters` which is the [correct argument](https://github.com/pytorch/pytorch/blob/4618371da56c887195e2e1d16dad2b9686302800/torch/optim/lr_scheduler.py#L734).

<!-- Before submitting a PR, please make sure to check our contributing guidelines regarding code formatting, tests, and documentation: https://github.com/pytorch/vision/blob/main/CONTRIBUTING.md -->
