### PR TITLE
[FBcode->GH] Add an option to skip packets with empty data

### DIFF
--- a/torchvision/csrc/io/decoder/decoder.cpp
+++ b/torchvision/csrc/io/decoder/decoder.cpp
@@ -522,6 +522,13 @@ int Decoder::getFrame(size_t workingTimeInMs) {
       VLOG(1) << "End of stream";
       result = ENODATA;
       break;
+    } else if (
+        result == AVERROR(EPERM) && params_.skipOperationNotPermittedPackets) {
+      // reset error, lets skip packets with EPERM
+      result = 0;
+      // reset the packet to default settings
+      av_packet_unref(avPacket);
+      continue;
     } else if (result < 0) {
       flushStreams();
       LOG(ERROR) << "uuid=" << params_.loggingUuid
@@ -588,7 +595,7 @@ int Decoder::getFrame(size_t workingTimeInMs) {
           << result;
 
   // loop can be terminated, either by:
-  // 1. explcitly iterrupted
+  // 1. explicitly interrupted
   // 3. unrecoverable error or ENODATA (end of stream) or ETIMEDOUT (timeout)
   // 4. decoded frames pts are out of the specified range
   // 5. success decoded frame

--- a/torchvision/csrc/io/decoder/defs.h
+++ b/torchvision/csrc/io/decoder/defs.h
@@ -210,6 +210,9 @@ struct DecoderParameters {
 
   std::string tlsCertFile;
   std::string tlsKeyFile;
+
+  // Skip packets that fail with EPERM errors and continue decoding.
+  bool skipOperationNotPermittedPackets{false};
 };
 
 struct DecoderHeader {


### PR DESCRIPTION
Cherypick of a671bfff97770e15a98a16fdd194d906c9531a0a

Summary:
This diff adds **`skipOperationNotPermittedPackets`** to `DecoderParameters`.

Once that is set to `True`, it allows decoder to skip through those packets, that are causing `EPERM` errors and result into stoppage of consuming a stream.

Reviewed By: jdsgomes

Differential Revision: D38732706

fbshipit-source-id: a5cb64e14edda376e6ba240089ebee2e3a9865d0

<!-- Before submitting a PR, please make sure to check our contributing guidelines regarding code formatting, tests, and documentation: https://github.com/pytorch/vision/blob/main/CONTRIBUTING.md -->
