### PR TITLE
[EXPERIMENTAL] Add support for dynamic frames per clip

### DIFF
--- a/references/video_classification/train.py
+++ b/references/video_classification/train.py
@@ -155,6 +155,8 @@ def main(args):
     train_crop_size = tuple(args.train_crop_size)
 
     if args.clip_len == 0:
+        if args.batch_size != 1:
+            raise ValueError("Dynamic clip length is supported only for batch-size 1.")
         args.clip_len = None
 
     traindir = os.path.join(args.data_path, "train")

--- a/references/video_classification/train.py
+++ b/references/video_classification/train.py
@@ -154,6 +154,9 @@ def main(args):
     train_resize_size = tuple(args.train_resize_size)
     train_crop_size = tuple(args.train_crop_size)
 
+    if args.clip_len == 0:
+        args.clip_len = None
+
     traindir = os.path.join(args.data_path, "train")
     valdir = os.path.join(args.data_path, "val")
 
@@ -346,7 +349,13 @@ def get_args_parser(add_help=True):
     )
     parser.add_argument("--model", default="r2plus1d_18", type=str, help="model name")
     parser.add_argument("--device", default="cuda", type=str, help="device (Use cuda or cpu Default: cuda)")
-    parser.add_argument("--clip-len", default=16, type=int, metavar="N", help="number of frames per clip")
+    parser.add_argument(
+        "--clip-len",
+        default=16,
+        type=int,
+        metavar="N",
+        help="number of frames per clip. If 0, all video frames will be used.",
+    )
     parser.add_argument("--frame-rate", default=15, type=int, metavar="N", help="the frame rate")
     parser.add_argument(
         "--clips-per-video", default=5, type=int, metavar="N", help="maximum number of clips per video to consider"

--- a/torchvision/datasets/kinetics.py
+++ b/torchvision/datasets/kinetics.py
@@ -52,7 +52,7 @@ class Kinetics(VisionDataset):
                 │   │    └── ...
 
             Note: split is appended automatically using the split argument.
-        frames_per_clip (int): number of frames in a clip
+        frames_per_clip (int, optional): number of frames in a clip. If `None`, all frames will be returned.
         num_classes (int): select between Kinetics-400 (default), Kinetics-600, and Kinetics-700
         split (str): split of the dataset to consider; supports ``"train"`` (default) ``"val"`` ``"test"``
         frame_rate (float): If omitted, interpolate different frame rate for each clip.
@@ -92,7 +92,7 @@ class Kinetics(VisionDataset):
     def __init__(
         self,
         root: str,
-        frames_per_clip: int,
+        frames_per_clip: Optional[int],
         num_classes: str = "400",
         split: str = "train",
         frame_rate: Optional[int] = None,
@@ -285,7 +285,7 @@ class Kinetics400(Kinetics):
                     ├── clipx.avi
                     └── ...
 
-        frames_per_clip (int): number of frames in a clip
+        frames_per_clip (int, optional): number of frames in a clip. If `None`, all frames will be returned.
         step_between_clips (int): number of frames between each clip
         transform (callable, optional): A function/transform that  takes in a TxHxWxC video
             and returns a transformed version.
@@ -302,7 +302,7 @@ class Kinetics400(Kinetics):
     def __init__(
         self,
         root: str,
-        frames_per_clip: int,
+        frames_per_clip: Optional[int],
         num_classes: Any = None,
         split: Any = None,
         download: Any = None,

--- a/torchvision/datasets/video_utils.py
+++ b/torchvision/datasets/video_utils.py
@@ -215,7 +215,7 @@ class VideoClips:
         _idxs = VideoClips._resample_video_idx(int(math.floor(total_frames)), fps, frame_rate)
         video_pts = video_pts[_idxs]
         if num_frames is None:
-            num_frames = total_frames
+            num_frames = int(total_frames)
         clips = unfold(video_pts, num_frames, step)
         if not clips.numel():
             warnings.warn(


### PR DESCRIPTION
The [S3D](https://arxiv.org/pdf/1712.04851.pdf) model (see #6412) uses a less common validation protocol which requires passing all the available frames during inference. Currently this is not possible.

This PR attempts to change this (untested) by making the specific option optional. The "solution" is quite messy, not sure we should merge or if we should leave as a reference patch for people who want to reproduce the accuracy of the model.