### PR TITLE
fix MixUp and CutMix

### DIFF
--- a/torchvision/prototype/transforms/_augment.py
+++ b/torchvision/prototype/transforms/_augment.py
@@ -106,7 +106,7 @@ class _BaseMixupCutmix(_RandomApplyTransform):
     def forward(self, *inpts: Any) -> Any:
         sample = inpts if len(inpts) > 1 else inpts[0]
         if not (has_any(sample, features.Image, is_simple_tensor) and has_any(sample, features.OneHotLabel)):
-            raise TypeError(f"{type(self).__name__}() is only defined for Image's *and* OneHotLabel's.")
+            raise TypeError(f"{type(self).__name__}() is only defined for tensor images and one-hot labels.")
         if has_any(sample, features.BoundingBox, features.SegmentationMask, features.Label):
             raise TypeError(
                 f"{type(self).__name__}() does not support bounding boxes, segmentation masks and plain labels."

--- a/torchvision/prototype/transforms/_augment.py
+++ b/torchvision/prototype/transforms/_augment.py
@@ -105,9 +105,7 @@ class _BaseMixupCutmix(_RandomApplyTransform):
 
     def forward(self, *inpts: Any) -> Any:
         sample = inpts if len(inpts) > 1 else inpts[0]
-        if not (
-            has_any(sample, features.Image, PIL.Image.Image, is_simple_tensor) and has_any(sample, features.OneHotLabel)
-        ):
+        if not (has_any(sample, features.Image, is_simple_tensor) and has_any(sample, features.OneHotLabel)):
             raise TypeError(f"{type(self).__name__}() is only defined for Image's *and* OneHotLabel's.")
         if has_any(sample, features.BoundingBox, features.SegmentationMask, features.Label):
             raise TypeError(
@@ -129,12 +127,16 @@ class RandomMixup(_BaseMixupCutmix):
 
     def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
         lam = params["lam"]
-        if isinstance(inpt, features.Image):
+        if isinstance(inpt, features.Image) or is_simple_tensor(inpt):
             if inpt.ndim < 4:
                 raise ValueError("Need a batch of images")
             output = inpt.clone()
             output = output.roll(1, -4).mul_(1 - lam).add_(output.mul_(lam))
-            return features.Image.new_like(inpt, output)
+
+            if isinstance(inpt, features.Image):
+                output = features.Image.new_like(inpt, output)
+
+            return output
         elif isinstance(inpt, features.OneHotLabel):
             return self._mixup_onehotlabel(inpt, lam)
         else:
@@ -166,7 +168,7 @@ class RandomCutmix(_BaseMixupCutmix):
         return dict(box=box, lam_adjusted=lam_adjusted)
 
     def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
-        if isinstance(inpt, features.Image):
+        if isinstance(inpt, features.Image) or is_simple_tensor(inpt):
             box = params["box"]
             if inpt.ndim < 4:
                 raise ValueError("Need a batch of images")
@@ -174,7 +176,11 @@ class RandomCutmix(_BaseMixupCutmix):
             image_rolled = inpt.roll(1, -4)
             output = inpt.clone()
             output[..., y1:y2, x1:x2] = image_rolled[..., y1:y2, x1:x2]
-            return features.Image.new_like(inpt, output)
+
+            if isinstance(inpt, features.Image):
+                output = features.Image.new_like(inpt, output)
+
+            return output
         elif isinstance(inpt, features.OneHotLabel):
             lam_adjusted = params["lam_adjusted"]
             return self._mixup_onehotlabel(inpt, lam_adjusted)


### PR DESCRIPTION
I dropped the ball for two separate things in #6447:

- PIL is not supported by `MixUp` and `CutMix` since we need a batch of images (read batched and collated). 
- Just adding plain tensors to the allowed types is not sufficient and `_transforms` has to be adapted.