### PR TITLE
add some feature attributes to repr

### DIFF
--- a/torchvision/prototype/features/_bounding_box.py
+++ b/torchvision/prototype/features/_bounding_box.py
@@ -41,6 +41,9 @@ class BoundingBox(_Feature):
 
         return bounding_box
 
+    def __repr__(self, *, tensor_contents: Any = None) -> str:  # type: ignore[override]
+        return self._make_repr(format=self.format, image_size=self.image_size)
+
     @classmethod
     def new_like(
         cls,

--- a/torchvision/prototype/features/_feature.py
+++ b/torchvision/prototype/features/_feature.py
@@ -86,6 +86,12 @@ class _Feature(torch.Tensor):
         else:
             return output
 
+    def _make_repr(self, **kwargs: Any) -> str:
+        # This is a poor man's implementation of the proposal in https://github.com/pytorch/pytorch/issues/76532.
+        # If that ever gets implemented, remove this in favor of the solution on the `torch.Tensor` class.
+        extra_repr = ", ".join(f"{key}={value}" for key, value in kwargs.items())
+        return f"{super().__repr__()[:-1]}, {extra_repr})"
+
     def horizontal_flip(self) -> _Feature:
         return self
 

--- a/torchvision/prototype/features/_image.py
+++ b/torchvision/prototype/features/_image.py
@@ -64,6 +64,9 @@ class Image(_Feature):
 
         return image
 
+    def __repr__(self, *, tensor_contents: Any = None) -> str:  # type: ignore[override]
+        return self._make_repr(color_space=self.color_space)
+
     @classmethod
     def new_like(
         cls, other: Image, data: Any, *, color_space: Optional[Union[ColorSpace, str]] = None, **kwargs: Any


### PR DESCRIPTION
```py
>>> features.Image(torch.zeros(1, 2, 2))
Image([[[0., 0.],
        [0., 0.]]], color_space=ColorSpace.GRAY)
>>> features.Image(torch.zeros(3, 2, 2))
Image([[[0., 0.],
        [0., 0.]],
       [[0., 0.],
        [0., 0.]],
       [[0., 0.],
        [0., 0.]]], color_space=ColorSpace.RGB)
>>> box = features.BoundingBox([0, 0, 2, 2], format=features.BoundingBoxFormat.XYXY, image_size=(2, 2))
>>> box
BoundingBox([0, 0, 2, 2], format=BoundingBoxFormat.XYXY, image_size=(2, 2))
>>> box.to_format(features.BoundingBoxFormat.CXCYWH)
BoundingBox([1, 1, 2, 2], format=BoundingBoxFormat.CXCYWH, image_size=(2, 2))
```

I intentionally did not add `Label.categories` here, since we need some way to shorten the list in case it is long. For example, that will be 1000 entries for ImageNet with each entry roughly 20-30 characters long.