### PR TITLE
check full sample in query_bounding_box

### DIFF
--- a/test/test_prototype_transforms.py
+++ b/test/test_prototype_transforms.py
@@ -1478,6 +1478,7 @@ class TestFixedSizeCrop:
         left_sentinel = mocker.MagicMock()
         height_sentinel = mocker.MagicMock()
         width_sentinel = mocker.MagicMock()
+        is_valid = mocker.MagicMock() if needs_crop else None
         padding_sentinel = mocker.MagicMock()
         mocker.patch(
             "torchvision.prototype.transforms._geometry.FixedSizeCrop._get_params",
@@ -1487,6 +1488,7 @@ class TestFixedSizeCrop:
                 left=left_sentinel,
                 height=height_sentinel,
                 width=width_sentinel,
+                is_valid=is_valid,
                 padding=padding_sentinel,
                 needs_pad=needs_pad,
             ),

--- a/torchvision/prototype/transforms/_geometry.py
+++ b/torchvision/prototype/transforms/_geometry.py
@@ -788,8 +788,12 @@ class FixedSizeCrop(Transform):
         top = int(offset_height * r)
         left = int(offset_width * r)
 
-        if needs_crop:
+        try:
             bounding_boxes = query_bounding_box(sample)
+        except ValueError:
+            bounding_boxes = None
+
+        if needs_crop and bounding_boxes is not None:
             bounding_boxes = cast(
                 features.BoundingBox, F.crop(bounding_boxes, top=top, left=left, height=height, width=width)
             )
@@ -829,6 +833,8 @@ class FixedSizeCrop(Transform):
                 height=params["height"],
                 width=params["width"],
             )
+
+        if params["is_valid"] is not None:
             if isinstance(inpt, (features.Label, features.OneHotLabel, features.SegmentationMask)):
                 inpt = inpt.new_like(inpt, inpt[params["is_valid"]])  # type: ignore[arg-type]
             elif isinstance(inpt, features.BoundingBox):
@@ -844,13 +850,14 @@ class FixedSizeCrop(Transform):
 
     def forward(self, *inputs: Any) -> Any:
         sample = inputs if len(inputs) > 1 else inputs[0]
-        if not (
-            has_all(sample, features.BoundingBox)
-            and has_any(sample, PIL.Image.Image, features.Image, is_simple_tensor)
-            and has_any(sample, features.Label, features.OneHotLabel)
-        ):
+
+        if not has_any(sample, PIL.Image.Image, features.Image, is_simple_tensor):
+            raise TypeError(f"{type(self).__name__}() requires input sample to contain an tensor or PIL image.")
+
+        if has_any(sample, features.BoundingBox) and not has_any(sample, features.Label, features.OneHotLabel):
             raise TypeError(
-                f"{type(self).__name__}() requires input sample to contain Images or PIL Images, "
-                "BoundingBoxes and Labels or OneHotLabels. Sample can also contain Segmentation Masks."
+                f"If a BoundingBox is contained in the input sample, "
+                f"{type(self).__name__}() also requires it to contain a Label or OneHotLabel."
             )
+
         return super().forward(sample)

--- a/torchvision/prototype/transforms/_utils.py
+++ b/torchvision/prototype/transforms/_utils.py
@@ -15,7 +15,7 @@ def query_bounding_box(sample: Any) -> features.BoundingBox:
     if not bounding_boxes:
         raise TypeError("No bounding box was found in the sample")
     elif len(bounding_boxes) > 2:
-        raise TypeError("Found multiple bounding boxes in the sample")
+        raise ValueError("Found multiple bounding boxes in the sample")
     return bounding_boxes.pop()
 
 
@@ -42,7 +42,7 @@ def query_chw(sample: Any) -> Tuple[int, int, int]:
     if not chws:
         raise TypeError("No image was found in the sample")
     elif len(chws) > 2:
-        raise TypeError(f"Found multiple CxHxW dimensions in the sample: {sequence_to_str(sorted(chws))}")
+        raise ValueError(f"Found multiple CxHxW dimensions in the sample: {sequence_to_str(sorted(chws))}")
     return chws.pop()
 
 

--- a/torchvision/prototype/transforms/_utils.py
+++ b/torchvision/prototype/transforms/_utils.py
@@ -11,11 +11,12 @@ from .functional._meta import get_dimensions_image_pil, get_dimensions_image_ten
 
 def query_bounding_box(sample: Any) -> features.BoundingBox:
     flat_sample, _ = tree_flatten(sample)
-    for i in flat_sample:
-        if isinstance(i, features.BoundingBox):
-            return i
-
-    raise TypeError("No bounding box was found in the sample")
+    bounding_boxes = {item for item in flat_sample if isinstance(item, features.BoundingBox)}
+    if not bounding_boxes:
+        raise TypeError("No bounding box was found in the sample")
+    elif len(bounding_boxes) > 2:
+        raise TypeError("Found multiple bounding boxes in the sample")
+    return bounding_boxes.pop()
 
 
 def get_chw(image: Union[PIL.Image.Image, torch.Tensor, features.Image]) -> Tuple[int, int, int]:


### PR DESCRIPTION
This is complementary to #6459. 

---

Currently we have three transformations that don't support batched inputs:

- https://github.com/pytorch/vision/blob/b6feccbc4387766b76a3e22b13815dbbbfa87c0f/torchvision/prototype/transforms/_geometry.py#L618
- https://github.com/pytorch/vision/blob/b6feccbc4387766b76a3e22b13815dbbbfa87c0f/torchvision/prototype/transforms/_geometry.py#L777
- https://github.com/pytorch/vision/blob/b6feccbc4387766b76a3e22b13815dbbbfa87c0f/torchvision/prototype/transforms/_misc.py#L142

Here "batched" means "list of data points" rather than "tensor with batch dimensions", since the latter is not possible in a general way if each data point does not have a fixed number of bounding boxes. 

One thing all have in common is that they call `query_bounding_box` early on in `_get_params`. Currently this just extracts the first bounding box it finds in the sample and returns it. This PR changes this to go over the whole sample and only return if we find exactly one bounding box. Otherwise we fail. Thus, if the input is batched and thus contains more than one bounding box, we now fail gracefully. 

This is almost on par what we do for image dimensions with `query_chw`. The caveat is that `query_chw` allows multiple images if they have the same dimensions. However, `query_bounding_box` returns an actual bounding box and not its shape, so IMO it is justified to require exactly one.