### PR TITLE
[proto] Fix kernel passthrough and types of Normalize

### DIFF
--- a/test/test_prototype_transforms_functional.py
+++ b/test/test_prototype_transforms_functional.py
@@ -1844,22 +1844,20 @@ def test_correctness_elastic_image_or_mask_tensor(device, fn, make_samples):
 
 def test_midlevel_normalize_output_type():
     inpt = torch.rand(1, 3, 32, 32)
-    output = F.normalize(inpt, mean=(0.5, 0.5, 0.5), std=(1.0, 1.0, 1.0))
+    output = F.normalize(inpt, mean=[0.5, 0.5, 0.5], std=[1.0, 1.0, 1.0])
     assert isinstance(output, torch.Tensor)
     torch.testing.assert_close(inpt - 0.5, output)
 
     inpt = make_segmentation_mask()
-    output = F.normalize(inpt, mean=(0.5, 0.5, 0.5), std=(1.0, 1.0, 1.0))
-    assert isinstance(output, features.SegmentationMask)
-    torch.testing.assert_close(inpt, output)
+    with pytest.raises(TypeError, match="Input tensor should be a float tensor."):
+        F.normalize(inpt, mean=[0.5, 0.5, 0.5], std=[1.0, 1.0, 1.0])
 
     inpt = make_bounding_box(format="XYXY")
-    output = F.normalize(inpt, mean=(0.5, 0.5, 0.5), std=(1.0, 1.0, 1.0))
-    assert isinstance(output, features.BoundingBox)
-    torch.testing.assert_close(inpt, output)
+    with pytest.raises(TypeError, match="Tensor is not a torch image."):
+        F.normalize(inpt, mean=[0.5, 0.5, 0.5], std=[1.0, 1.0, 1.0])
 
     inpt = make_image(color_space=features.ColorSpace.RGB)
-    output = F.normalize(inpt, mean=(0.5, 0.5, 0.5), std=(1.0, 1.0, 1.0))
+    output = F.normalize(inpt, mean=[0.5, 0.5, 0.5], std=[1.0, 1.0, 1.0])
     assert isinstance(output, torch.Tensor)
     torch.testing.assert_close(inpt - 0.5, output)
 

--- a/test/test_prototype_transforms_functional.py
+++ b/test/test_prototype_transforms_functional.py
@@ -1848,14 +1848,6 @@ def test_midlevel_normalize_output_type():
     assert isinstance(output, torch.Tensor)
     torch.testing.assert_close(inpt - 0.5, output)
 
-    inpt = make_segmentation_mask()
-    with pytest.raises(TypeError, match="Input tensor should be a float tensor."):
-        F.normalize(inpt, mean=[0.5, 0.5, 0.5], std=[1.0, 1.0, 1.0])
-
-    inpt = make_bounding_box(format="XYXY")
-    with pytest.raises(TypeError, match="Tensor is not a torch image."):
-        F.normalize(inpt, mean=[0.5, 0.5, 0.5], std=[1.0, 1.0, 1.0])
-
     inpt = make_image(color_space=features.ColorSpace.RGB)
     output = F.normalize(inpt, mean=[0.5, 0.5, 0.5], std=[1.0, 1.0, 1.0])
     assert isinstance(output, torch.Tensor)

--- a/torchvision/prototype/transforms/_misc.py
+++ b/torchvision/prototype/transforms/_misc.py
@@ -10,6 +10,8 @@ from torchvision.prototype.transforms import functional as F, Transform
 from torchvision.prototype.transforms._utils import query_bounding_box
 from torchvision.transforms.transforms import _setup_size
 
+from ._utils import is_simple_tensor
+
 
 class Identity(Transform):
     def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
@@ -91,10 +93,12 @@ class LinearTransformation(Transform):
 
 
 class Normalize(Transform):
-    def __init__(self, mean: List[float], std: List[float]):
+    _transformed_types = (PIL.Image.Image, features.Image, is_simple_tensor)
+
+    def __init__(self, mean: Sequence[float], std: Sequence[float]):
         super().__init__()
-        self.mean = mean
-        self.std = std
+        self.mean = list(mean)
+        self.std = list(std)
 
     def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
         return F.normalize(inpt, mean=self.mean, std=self.std)

--- a/torchvision/prototype/transforms/_misc.py
+++ b/torchvision/prototype/transforms/_misc.py
@@ -1,5 +1,5 @@
 import functools
-from typing import Any, Callable, Dict, List, Sequence, Type, Union
+from typing import Any, Callable, Dict, Sequence, Type, Union
 
 import PIL.Image
 

--- a/torchvision/prototype/transforms/functional/_misc.py
+++ b/torchvision/prototype/transforms/functional/_misc.py
@@ -15,9 +15,7 @@ normalize_image_tensor = _FT.normalize
 
 
 def normalize(inpt: DType, mean: List[float], std: List[float], inplace: bool = False) -> DType:
-    if isinstance(inpt, features._Feature) and not isinstance(inpt, features.Image):
-        return inpt
-    elif isinstance(inpt, PIL.Image.Image):
+    if isinstance(inpt, PIL.Image.Image):
         raise TypeError("Unsupported input type")
     else:
         # Image instance after normalization is not Image anymore due to unknown data range

--- a/torchvision/prototype/transforms/functional/_misc.py
+++ b/torchvision/prototype/transforms/functional/_misc.py
@@ -15,7 +15,7 @@ normalize_image_tensor = _FT.normalize
 
 
 def normalize(
-    inpt: Union[torch.Tensor, features._Feature], mean: List[float], std: List[float], inplace: bool = False
+    inpt: Union[torch.Tensor, features.Image], mean: List[float], std: List[float], inplace: bool = False
 ) -> DType:
     if not isinstance(inpt, torch.Tensor):
         raise TypeError(f"img should be Tensor Image. Got {type(inpt)}")

--- a/torchvision/prototype/transforms/functional/_misc.py
+++ b/torchvision/prototype/transforms/functional/_misc.py
@@ -14,7 +14,9 @@ DType = Union[torch.Tensor, PIL.Image.Image, features._Feature]
 normalize_image_tensor = _FT.normalize
 
 
-def normalize(inpt: DType, mean: List[float], std: List[float], inplace: bool = False) -> DType:
+def normalize(
+    inpt: Union[torch.Tensor, features._Feature], mean: List[float], std: List[float], inplace: bool = False
+) -> DType:
     if not isinstance(inpt, torch.Tensor):
         raise TypeError(f"img should be Tensor Image. Got {type(inpt)}")
     else:

--- a/torchvision/prototype/transforms/functional/_misc.py
+++ b/torchvision/prototype/transforms/functional/_misc.py
@@ -15,8 +15,8 @@ normalize_image_tensor = _FT.normalize
 
 
 def normalize(inpt: DType, mean: List[float], std: List[float], inplace: bool = False) -> DType:
-    if isinstance(inpt, PIL.Image.Image):
-        raise TypeError("Unsupported input type")
+    if not isinstance(inpt, torch.Tensor):
+        raise TypeError(f"img should be Tensor Image. Got {type(inpt)}")
     else:
         # Image instance after normalization is not Image anymore due to unknown data range
         # Thus we return Tensor for input Image


### PR DESCRIPTION
Addresses some of the remarks at #6486

Depends on #6487

This PR:
- Ensures `Normalize` uses the right `_transformed_types`
- Removes the passthrough functionality from the `F.normalize()` kernel
- Updates the error message to the one on main branch