### PR TITLE
Try to fix mypy issue with calculate_md5

### DIFF
--- a/torchvision/datasets/utils.py
+++ b/torchvision/datasets/utils.py
@@ -65,7 +65,10 @@ def calculate_md5(fpath: str, chunk_size: int = 1024 * 1024) -> str:
     # Setting the `usedforsecurity` flag does not change anything about the functionality, but indicates that we are
     # not using the MD5 checksum for cryptography. This enables its usage in restricted environments like FIPS. Without
     # it torchvision.datasets is unusable in these environments since we perform a MD5 check everywhere.
-    md5 = hashlib.md5(**dict(usedforsecurity=False) if sys.version_info >= (3, 9) else dict())
+    if sys.version_info >= (3, 9):
+        md5 = hashlib.md5(usedforsecurity=False)
+    else:
+        md5 = hashlib.md5()
     with open(fpath, "rb") as f:
         for chunk in iter(lambda: f.read(chunk_size), b""):
             md5.update(chunk)


### PR DESCRIPTION
- https://app.circleci.com/pipelines/github/pytorch/vision/19736/workflows/98540a35-693d-4f68-92e4-cbdcc2601d81/jobs/1599504

and passing locally on python 3.9 without errors like:
```
# mypy --config-file mypy.ini
torchvision/datasets/utils.py:68: error: Argument 1 to "md5" has incompatible type "**Dict[str, bool]"; expected
"Union[bytes, Union[bytearray, memoryview, array[Any], mmap, _CData, PickleBuffer]]"  [arg-type]
        md5 = hashlib.md5(**dict(usedforsecurity=False) if sys.version_info >= (3, 9) else dict())
```
