### PR TITLE
[proto] Use the proper `_transformed_types` in all Transforms and eliminate unnecessary dispatching

### DIFF
--- a/test/test_prototype_transforms.py
+++ b/test/test_prototype_transforms.py
@@ -1051,7 +1051,7 @@ class TestToImageTensor:
 class TestToImagePIL:
     @pytest.mark.parametrize(
         "inpt_type",
-        [torch.Tensor, PIL.Image.Image, features.Image, np.ndarray, features.BoundingBox, str, int],
+        [torch.Tensor, features.Image, np.ndarray, features.BoundingBox, str, int],
     )
     def test__transform(self, inpt_type, mocker):
         fn = mocker.patch("torchvision.prototype.transforms.functional.to_image_pil")
@@ -1059,7 +1059,7 @@ class TestToImagePIL:
         inpt = mocker.MagicMock(spec=inpt_type)
         transform = transforms.ToImagePIL()
         transform(inpt)
-        if inpt_type in (features.BoundingBox, str, int):
+        if inpt_type in (features.BoundingBox, PIL.Image.Image, str, int):
             assert fn.call_count == 0
         else:
             fn.assert_called_once_with(inpt, mode=transform.mode)

--- a/test/test_prototype_transforms.py
+++ b/test/test_prototype_transforms.py
@@ -1031,7 +1031,7 @@ class TestTransform:
 class TestToImageTensor:
     @pytest.mark.parametrize(
         "inpt_type",
-        [torch.Tensor, PIL.Image.Image, features.Image, np.ndarray, features.BoundingBox, str, int],
+        [torch.Tensor, PIL.Image.Image, np.ndarray, features.BoundingBox, str, int],
     )
     def test__transform(self, inpt_type, mocker):
         fn = mocker.patch(
@@ -1042,10 +1042,10 @@ class TestToImageTensor:
         inpt = mocker.MagicMock(spec=inpt_type)
         transform = transforms.ToImageTensor()
         transform(inpt)
-        if inpt_type in (features.BoundingBox, str, int):
+        if inpt_type in (features.BoundingBox, features.Image, str, int):
             assert fn.call_count == 0
         else:
-            fn.assert_called_once_with(inpt, copy=transform.copy)
+            fn.assert_called_once_with(inpt)
 
 
 class TestToImagePIL:

--- a/test/test_prototype_transforms.py
+++ b/test/test_prototype_transforms.py
@@ -1031,7 +1031,7 @@ class TestTransform:
 class TestToImageTensor:
     @pytest.mark.parametrize(
         "inpt_type",
-        [torch.Tensor, PIL.Image.Image, np.ndarray, features.BoundingBox, str, int],
+        [torch.Tensor, PIL.Image.Image, features.Image, np.ndarray, features.BoundingBox, str, int],
     )
     def test__transform(self, inpt_type, mocker):
         fn = mocker.patch(
@@ -1051,7 +1051,7 @@ class TestToImageTensor:
 class TestToImagePIL:
     @pytest.mark.parametrize(
         "inpt_type",
-        [torch.Tensor, features.Image, np.ndarray, features.BoundingBox, str, int],
+        [torch.Tensor, PIL.Image.Image, features.Image, np.ndarray, features.BoundingBox, str, int],
     )
     def test__transform(self, inpt_type, mocker):
         fn = mocker.patch("torchvision.prototype.transforms.functional.to_image_pil")

--- a/test/test_prototype_transforms_functional.py
+++ b/test/test_prototype_transforms_functional.py
@@ -1899,7 +1899,6 @@ def test_to_image_tensor(inpt, copy):
     [
         torch.randint(0, 256, size=(3, 32, 32), dtype=torch.uint8),
         127 * np.ones((32, 32, 3), dtype="uint8"),
-        PIL.Image.new("RGB", (32, 32), 122),
     ],
 )
 @pytest.mark.parametrize("mode", [None, "RGB"])

--- a/test/test_prototype_transforms_functional.py
+++ b/test/test_prototype_transforms_functional.py
@@ -1867,31 +1867,23 @@ def test_midlevel_normalize_output_type():
 @pytest.mark.parametrize(
     "inpt",
     [
-        torch.randint(0, 256, size=(3, 32, 32)),
         127 * np.ones((32, 32, 3), dtype="uint8"),
         PIL.Image.new("RGB", (32, 32), 122),
     ],
 )
-@pytest.mark.parametrize("copy", [True, False])
-def test_to_image_tensor(inpt, copy):
-    output = F.to_image_tensor(inpt, copy=copy)
+def test_to_image_tensor(inpt):
+    output = F.to_image_tensor(inpt)
     assert isinstance(output, torch.Tensor)
 
     assert np.asarray(inpt).sum() == output.sum().item()
 
-    if isinstance(inpt, PIL.Image.Image) and not copy:
+    if isinstance(inpt, PIL.Image.Image):
         # we can't check this option
         # as PIL -> numpy is always copying
         return
 
-    if isinstance(inpt, PIL.Image.Image):
-        inpt.putpixel((0, 0), 11)
-    else:
-        inpt[0, 0, 0] = 11
-    if copy:
-        assert output[0, 0, 0] != 11
-    else:
-        assert output[0, 0, 0] == 11
+    inpt[0, 0, 0] = 11
+    assert output[0, 0, 0] == 11
 
 
 @pytest.mark.parametrize(

--- a/torchvision/prototype/transforms/_deprecated.py
+++ b/torchvision/prototype/transforms/_deprecated.py
@@ -16,9 +16,7 @@ from ._utils import is_simple_tensor
 
 
 class ToTensor(Transform):
-
-    # Updated transformed types for ToTensor
-    _transformed_types = (torch.Tensor, features._Feature, PIL.Image.Image, np.ndarray)
+    _transformed_types = (PIL.Image.Image, np.ndarray)
 
     def __init__(self) -> None:
         warnings.warn(
@@ -28,13 +26,12 @@ class ToTensor(Transform):
         super().__init__()
 
     def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
-        if isinstance(inpt, (PIL.Image.Image, np.ndarray)):
-            return _F.to_tensor(inpt)
-        else:
-            return inpt
+        _F.to_tensor(inpt)
 
 
 class PILToTensor(Transform):
+    _transformed_types = (PIL.Image.Image,)
+
     def __init__(self) -> None:
         warnings.warn(
             "The transform `PILToTensor()` is deprecated and will be removed in a future release. "
@@ -43,16 +40,11 @@ class PILToTensor(Transform):
         super().__init__()
 
     def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
-        if isinstance(inpt, PIL.Image.Image):
-            return _F.pil_to_tensor(inpt)
-        else:
-            return inpt
+        _F.pil_to_tensor(inpt)
 
 
 class ToPILImage(Transform):
-
-    # Updated transformed types for ToPILImage
-    _transformed_types = (torch.Tensor, features._Feature, PIL.Image.Image, np.ndarray)
+    _transformed_types = (is_simple_tensor, features.Image, np.ndarray)
 
     def __init__(self, mode: Optional[str] = None) -> None:
         warnings.warn(
@@ -63,10 +55,7 @@ class ToPILImage(Transform):
         self.mode = mode
 
     def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
-        if is_simple_tensor(inpt) or isinstance(inpt, (features.Image, np.ndarray)):
-            return _F.to_pil_image(inpt, mode=self.mode)
-        else:
-            return inpt
+        _F.to_pil_image(inpt, mode=self.mode)
 
 
 class Grayscale(Transform):

--- a/torchvision/prototype/transforms/_deprecated.py
+++ b/torchvision/prototype/transforms/_deprecated.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, Optional
 
 import numpy as np
 import PIL.Image
+import torch
 import torchvision.prototype.transforms.functional as F
 from torchvision.prototype import features
 from torchvision.prototype.features import ColorSpace
@@ -24,8 +25,8 @@ class ToTensor(Transform):
         )
         super().__init__()
 
-    def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
-        _F.to_tensor(inpt)
+    def _transform(self, inpt: Any, params: Dict[str, Any]) -> torch.Tensor:
+        return _F.to_tensor(inpt)
 
 
 class PILToTensor(Transform):
@@ -38,8 +39,8 @@ class PILToTensor(Transform):
         )
         super().__init__()
 
-    def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
-        _F.pil_to_tensor(inpt)
+    def _transform(self, inpt: Any, params: Dict[str, Any]) -> torch.Tensor:
+        return _F.pil_to_tensor(inpt)
 
 
 class ToPILImage(Transform):
@@ -53,8 +54,8 @@ class ToPILImage(Transform):
         super().__init__()
         self.mode = mode
 
-    def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
-        _F.to_pil_image(inpt, mode=self.mode)
+    def _transform(self, inpt: Any, params: Dict[str, Any]) -> PIL.Image:
+        return _F.to_pil_image(inpt, mode=self.mode)
 
 
 class Grayscale(Transform):

--- a/torchvision/prototype/transforms/_type_conversion.py
+++ b/torchvision/prototype/transforms/_type_conversion.py
@@ -40,7 +40,7 @@ class LabelToOneHot(Transform):
 
 
 class ToImageTensor(Transform):
-    _transformed_types = (is_simple_tensor, features._Feature, PIL.Image.Image, np.ndarray)
+    _transformed_types = (is_simple_tensor, features.Image, PIL.Image.Image, np.ndarray)
 
     def __init__(self, *, copy: bool = False) -> None:
         super().__init__()
@@ -52,7 +52,7 @@ class ToImageTensor(Transform):
 
 
 class ToImagePIL(Transform):
-    _transformed_types = (is_simple_tensor, features._Feature, PIL.Image.Image, np.ndarray)
+    _transformed_types = (is_simple_tensor, features.Image, PIL.Image.Image, np.ndarray)
 
     def __init__(self, *, mode: Optional[str] = None) -> None:
         super().__init__()

--- a/torchvision/prototype/transforms/_type_conversion.py
+++ b/torchvision/prototype/transforms/_type_conversion.py
@@ -42,12 +42,8 @@ class LabelToOneHot(Transform):
 class ToImageTensor(Transform):
     _transformed_types = (is_simple_tensor, PIL.Image.Image, np.ndarray)
 
-    def __init__(self, *, copy: bool = False) -> None:
-        super().__init__()
-        self.copy = copy
-
     def _transform(self, inpt: Any, params: Dict[str, Any]) -> features.Image:
-        output = F.to_image_tensor(inpt, copy=self.copy)
+        output = F.to_image_tensor(inpt)
         return features.Image(output)
 
 

--- a/torchvision/prototype/transforms/_type_conversion.py
+++ b/torchvision/prototype/transforms/_type_conversion.py
@@ -40,7 +40,7 @@ class LabelToOneHot(Transform):
 
 
 class ToImageTensor(Transform):
-    _transformed_types = (is_simple_tensor, features.Image, PIL.Image.Image, np.ndarray)
+    _transformed_types = (is_simple_tensor, PIL.Image.Image, np.ndarray)
 
     def __init__(self, *, copy: bool = False) -> None:
         super().__init__()
@@ -52,7 +52,7 @@ class ToImageTensor(Transform):
 
 
 class ToImagePIL(Transform):
-    _transformed_types = (is_simple_tensor, features.Image, PIL.Image.Image, np.ndarray)
+    _transformed_types = (is_simple_tensor, features.Image, np.ndarray)
 
     def __init__(self, *, mode: Optional[str] = None) -> None:
         super().__init__()

--- a/torchvision/prototype/transforms/_type_conversion.py
+++ b/torchvision/prototype/transforms/_type_conversion.py
@@ -11,12 +11,11 @@ from ._utils import is_simple_tensor
 
 
 class DecodeImage(Transform):
-    def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
-        if isinstance(inpt, features.EncodedImage):
-            output = F.decode_image_with_pil(inpt)
-            return features.Image(output)
-        else:
-            return inpt
+    _transformed_types = (features.EncodedImage,)
+
+    def _transform(self, inpt: Any, params: Dict[str, Any]) -> features.Image:
+        output = F.decode_image_with_pil(inpt)
+        return features.Image(output)
 
 
 class LabelToOneHot(Transform):
@@ -47,7 +46,7 @@ class ToImageTensor(Transform):
         super().__init__()
         self.copy = copy
 
-    def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
+    def _transform(self, inpt: Any, params: Dict[str, Any]) -> features.Image:
         output = F.to_image_tensor(inpt, copy=self.copy)
         return features.Image(output)
 
@@ -59,5 +58,5 @@ class ToImagePIL(Transform):
         super().__init__()
         self.mode = mode
 
-    def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
+    def _transform(self, inpt: Any, params: Dict[str, Any]) -> PIL.Image.Image:
         return F.to_image_pil(inpt, mode=self.mode)

--- a/torchvision/prototype/transforms/_type_conversion.py
+++ b/torchvision/prototype/transforms/_type_conversion.py
@@ -42,33 +42,23 @@ class LabelToOneHot(Transform):
 
 
 class ToImageTensor(Transform):
-
-    # Updated transformed types for ToImageTensor
-    _transformed_types = (torch.Tensor, features._Feature, PIL.Image.Image, np.ndarray)
+    _transformed_types = (is_simple_tensor, features._Feature, PIL.Image.Image, np.ndarray)
 
     def __init__(self, *, copy: bool = False) -> None:
         super().__init__()
         self.copy = copy
 
     def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
-        if isinstance(inpt, (features.Image, PIL.Image.Image, np.ndarray)) or is_simple_tensor(inpt):
-            output = F.to_image_tensor(inpt, copy=self.copy)
-            return features.Image(output)
-        else:
-            return inpt
+        output = F.to_image_tensor(inpt, copy=self.copy)
+        return features.Image(output)
 
 
 class ToImagePIL(Transform):
-
-    # Updated transformed types for ToImagePIL
-    _transformed_types = (torch.Tensor, features._Feature, PIL.Image.Image, np.ndarray)
+    _transformed_types = (is_simple_tensor, features._Feature, PIL.Image.Image, np.ndarray)
 
     def __init__(self, *, mode: Optional[str] = None) -> None:
         super().__init__()
         self.mode = mode
 
     def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
-        if isinstance(inpt, (features.Image, PIL.Image.Image, np.ndarray)) or is_simple_tensor(inpt):
-            return F.to_image_pil(inpt, mode=self.mode)
-        else:
-            return inpt
+        return F.to_image_pil(inpt, mode=self.mode)

--- a/torchvision/prototype/transforms/functional/_type_conversion.py
+++ b/torchvision/prototype/transforms/functional/_type_conversion.py
@@ -21,15 +21,9 @@ def decode_video_with_av(encoded_video: torch.Tensor) -> Tuple[torch.Tensor, tor
         return read_video(ReadOnlyTensorBuffer(encoded_video))  # type: ignore[arg-type]
 
 
-def to_image_tensor(image: Union[torch.Tensor, PIL.Image.Image, np.ndarray], copy: bool = False) -> torch.Tensor:
+def to_image_tensor(image: Union[torch.Tensor, PIL.Image.Image, np.ndarray]) -> torch.Tensor:
     if isinstance(image, np.ndarray):
-        image = torch.from_numpy(image)
-
-    if isinstance(image, torch.Tensor):
-        if copy:
-            return image.clone()
-        else:
-            return image
+        return torch.from_numpy(image)
 
     return _F.pil_to_tensor(image)
 

--- a/torchvision/prototype/transforms/functional/_type_conversion.py
+++ b/torchvision/prototype/transforms/functional/_type_conversion.py
@@ -1,5 +1,5 @@
 import unittest.mock
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Dict, Tuple, Union
 
 import numpy as np
 import PIL.Image

--- a/torchvision/prototype/transforms/functional/_type_conversion.py
+++ b/torchvision/prototype/transforms/functional/_type_conversion.py
@@ -34,13 +34,4 @@ def to_image_tensor(image: Union[torch.Tensor, PIL.Image.Image, np.ndarray], cop
     return _F.pil_to_tensor(image)
 
 
-def to_image_pil(
-    image: Union[torch.Tensor, PIL.Image.Image, np.ndarray], mode: Optional[str] = None
-) -> PIL.Image.Image:
-    if isinstance(image, PIL.Image.Image):
-        if mode != image.mode:
-            return image.convert(mode)
-        else:
-            return image
-
-    return _F.to_pil_image(image, mode=mode)
+to_image_pil = _F.to_pil_image


### PR DESCRIPTION
Addresses some of the remarks at #6486

This PR:
- Adds the appropriate `_transformed_types` types to all transforms
- Removes unnecessary dispatching within the `_transform()`
- Specifies where possible the return types of `_transform()`