### PR TITLE
More prototype Transforms cleanups

### DIFF
--- a/torchvision/prototype/features/_encoded.py
+++ b/torchvision/prototype/features/_encoded.py
@@ -9,7 +9,6 @@ import torch
 from torchvision.prototype.utils._internal import fromfile, ReadOnlyTensorBuffer
 
 from ._feature import _Feature
-from ._image import Image
 
 D = TypeVar("D", bound="EncodedData")
 

--- a/torchvision/prototype/features/_encoded.py
+++ b/torchvision/prototype/features/_encoded.py
@@ -46,11 +46,6 @@ class EncodedImage(EncodedData):
 
         return self._image_size
 
-    def decode(self) -> Image:
-        # TODO: this is useful for developing and debugging but we should remove or at least revisit this before we
-        #  promote this out of the prototype state
-        return self._F.decode_image_with_pil(self)
-
 
 class EncodedVideo(EncodedData):
     pass

--- a/torchvision/prototype/features/_encoded.py
+++ b/torchvision/prototype/features/_encoded.py
@@ -49,7 +49,7 @@ class EncodedImage(EncodedData):
     def decode(self) -> Image:
         # TODO: this is useful for developing and debugging but we should remove or at least revisit this before we
         #  promote this out of the prototype state
-        return Image(self._F.decode_image_with_pil(self))
+        return self._F.decode_image_with_pil(self)
 
 
 class EncodedVideo(EncodedData):

--- a/torchvision/prototype/transforms/_misc.py
+++ b/torchvision/prototype/transforms/_misc.py
@@ -105,10 +105,9 @@ class Normalize(Transform):
         return F.normalize(inpt, mean=self.mean, std=self.std)
 
     def forward(self, *inpts: Any) -> Any:
-        sample = inpts if len(inpts) > 1 else inpts[0]
-        if has_any(sample, PIL.Image.Image):
+        if has_any(inpts, PIL.Image.Image):
             raise TypeError(f"{type(self).__name__}() does not support PIL images.")
-        return super().forward(sample)
+        return super().forward(*inpts)
 
 
 class GaussianBlur(Transform):

--- a/torchvision/prototype/transforms/_misc.py
+++ b/torchvision/prototype/transforms/_misc.py
@@ -94,7 +94,7 @@ class LinearTransformation(Transform):
 
 
 class Normalize(Transform):
-    _transformed_types = (PIL.Image.Image, features.Image, is_simple_tensor)
+    _transformed_types = (features.Image, is_simple_tensor)
 
     def __init__(self, mean: Sequence[float], std: Sequence[float]):
         super().__init__()
@@ -103,6 +103,12 @@ class Normalize(Transform):
 
     def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
         return F.normalize(inpt, mean=self.mean, std=self.std)
+
+    def forward(self, *inpts: Any) -> Any:
+        sample = inpts if len(inpts) > 1 else inpts[0]
+        if has_any(sample, PIL.Image.Image):
+            raise TypeError(f"{type(self).__name__}() does not support PIL images.")
+        return super().forward(sample)
 
 
 class GaussianBlur(Transform):

--- a/torchvision/prototype/transforms/_type_conversion.py
+++ b/torchvision/prototype/transforms/_type_conversion.py
@@ -43,8 +43,7 @@ class ToImageTensor(Transform):
     _transformed_types = (is_simple_tensor, PIL.Image.Image, np.ndarray)
 
     def _transform(self, inpt: Any, params: Dict[str, Any]) -> features.Image:
-        output = F.to_image_tensor(inpt)
-        return features.Image(output)
+        return F.to_image_tensor(inpt)
 
 
 class ToImagePIL(Transform):

--- a/torchvision/prototype/transforms/_type_conversion.py
+++ b/torchvision/prototype/transforms/_type_conversion.py
@@ -14,8 +14,7 @@ class DecodeImage(Transform):
     _transformed_types = (features.EncodedImage,)
 
     def _transform(self, inpt: Any, params: Dict[str, Any]) -> features.Image:
-        output = F.decode_image_with_pil(inpt)
-        return features.Image(output)
+        return F.decode_image_with_pil(inpt)
 
 
 class LabelToOneHot(Transform):

--- a/torchvision/prototype/transforms/functional/_misc.py
+++ b/torchvision/prototype/transforms/functional/_misc.py
@@ -17,9 +17,12 @@ normalize_image_tensor = _FT.normalize
 def normalize(
     inpt: Union[torch.Tensor, features.Image], mean: List[float], std: List[float], inplace: bool = False
 ) -> torch.Tensor:
-    # Image instance after normalization is not Image anymore due to unknown data range
-    # Thus we return Tensor for input Image
-    return normalize_image_tensor(inpt, mean=mean, std=std, inplace=inplace)
+    if not isinstance(inpt, torch.Tensor):
+        raise TypeError(f"img should be Tensor Image. Got {type(inpt)}")
+    else:
+        # Image instance after normalization is not Image anymore due to unknown data range
+        # Thus we return Tensor for input Image
+        return normalize_image_tensor(inpt, mean=mean, std=std, inplace=inplace)
 
 
 def gaussian_blur_image_tensor(

--- a/torchvision/prototype/transforms/functional/_misc.py
+++ b/torchvision/prototype/transforms/functional/_misc.py
@@ -16,13 +16,8 @@ normalize_image_tensor = _FT.normalize
 
 def normalize(
     inpt: Union[torch.Tensor, features.Image], mean: List[float], std: List[float], inplace: bool = False
-) -> DType:
-    if not isinstance(inpt, torch.Tensor):
-        raise TypeError(f"img should be Tensor Image. Got {type(inpt)}")
-    else:
-        # Image instance after normalization is not Image anymore due to unknown data range
-        # Thus we return Tensor for input Image
-        return normalize_image_tensor(inpt, mean=mean, std=std, inplace=inplace)
+) -> torch.Tensor:
+    return normalize_image_tensor(inpt, mean=mean, std=std, inplace=inplace)
 
 
 def gaussian_blur_image_tensor(

--- a/torchvision/prototype/transforms/functional/_misc.py
+++ b/torchvision/prototype/transforms/functional/_misc.py
@@ -17,6 +17,8 @@ normalize_image_tensor = _FT.normalize
 def normalize(
     inpt: Union[torch.Tensor, features.Image], mean: List[float], std: List[float], inplace: bool = False
 ) -> torch.Tensor:
+    # Image instance after normalization is not Image anymore due to unknown data range
+    # Thus we return Tensor for input Image
     return normalize_image_tensor(inpt, mean=mean, std=std, inplace=inplace)
 
 

--- a/torchvision/prototype/transforms/functional/_type_conversion.py
+++ b/torchvision/prototype/transforms/functional/_type_conversion.py
@@ -10,11 +10,11 @@ from torchvision.prototype.utils._internal import ReadOnlyTensorBuffer
 from torchvision.transforms import functional as _F
 
 
-def decode_image_with_pil(encoded_image: torch.Tensor) -> torch.Tensor:
+def decode_image_with_pil(encoded_image: torch.Tensor) -> features.Image:
     image = torch.as_tensor(np.array(PIL.Image.open(ReadOnlyTensorBuffer(encoded_image)), copy=True))
     if image.ndim == 2:
         image = image.unsqueeze(2)
-    return image.permute(2, 0, 1)
+    return features.Image(image.permute(2, 0, 1))
 
 
 def decode_video_with_av(encoded_video: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor, Dict[str, Any]]:

--- a/torchvision/prototype/transforms/functional/_type_conversion.py
+++ b/torchvision/prototype/transforms/functional/_type_conversion.py
@@ -5,6 +5,7 @@ import numpy as np
 import PIL.Image
 import torch
 from torchvision.io.video import read_video
+from torchvision.prototype import features
 from torchvision.prototype.utils._internal import ReadOnlyTensorBuffer
 from torchvision.transforms import functional as _F
 
@@ -21,11 +22,12 @@ def decode_video_with_av(encoded_video: torch.Tensor) -> Tuple[torch.Tensor, tor
         return read_video(ReadOnlyTensorBuffer(encoded_video))  # type: ignore[arg-type]
 
 
-def to_image_tensor(image: Union[torch.Tensor, PIL.Image.Image, np.ndarray]) -> torch.Tensor:
+def to_image_tensor(image: Union[torch.Tensor, PIL.Image.Image, np.ndarray]) -> features.Image:
     if isinstance(image, np.ndarray):
-        return torch.from_numpy(image)
-
-    return _F.pil_to_tensor(image)
+        output = torch.from_numpy(image)
+    else:
+        output = _F.pil_to_tensor(image)
+    return features.Image(output)
 
 
 to_image_pil = _F.to_pil_image


### PR DESCRIPTION
This PR:
- Makes Normalize verify input on forward instead on the kernel
- The kernel `to_image_tensor` returns `features.Image` instead of plain tensor.
- The kernel `decode_image_with_pil` returns `features.Image` instead of plain tensor.