### PR TITLE
Expand prototype transforms consistency tests to all deterministic transformations

### DIFF
--- a/torchvision/prototype/transforms/_misc.py
+++ b/torchvision/prototype/transforms/_misc.py
@@ -23,7 +23,7 @@ class Lambda(Transform):
         self.types = types or (object,)
 
     def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
-        if type(inpt) in self.types:
+        if isinstance(inpt, self.types):
             return self.fn(inpt)
         else:
             return inpt


### PR DESCRIPTION
Follow-up to #6516. In addition to :point_up: this also fixes a bug in `Lambda`.