### PR TITLE
add test for signature consistency of prototype and legacy transforms

### DIFF
--- a/test/test_prototype_transforms_consistency.py
+++ b/test/test_prototype_transforms_consistency.py
@@ -1,11 +1,9 @@
 import enum
 import functools
-
 import inspect
 import itertools
 
 import numpy as np
-
 import PIL.Image
 import pytest
 
@@ -427,8 +425,8 @@ CONSISTENCY_CONFIGS = [
 ]
 
 
-def test_automatic_coverage_deterministic():
-    legacy = {
+def test_automatic_coverage():
+    available = {
         name
         for name, obj in legacy_transforms.__dict__.items()
         if not name.startswith("_")
@@ -454,9 +452,9 @@ def test_automatic_coverage_deterministic():
         }
     }
 
-    prototype = {config.legacy_cls.__name__ for config in CONSISTENCY_CONFIGS}
+    checked = {config.legacy_cls.__name__ for config in CONSISTENCY_CONFIGS}
 
-    missing = legacy - prototype
+    missing = available - checked
     if missing:
         raise AssertionError(
             f"The prototype transformations {sequence_to_str(sorted(missing), separate_last='and ')} "

--- a/test/test_prototype_transforms_consistency.py
+++ b/test/test_prototype_transforms_consistency.py
@@ -89,6 +89,7 @@ CONSISTENCY_CONFIGS = [
         ],
         supports_pil=False,
         make_images_kwargs=dict(DEFAULT_MAKE_IMAGES_KWARGS, dtypes=[torch.float]),
+        removed_params=["inplace"],
     ),
     ConsistencyConfig(
         prototype_transforms.Resize,
@@ -315,6 +316,7 @@ CONSISTENCY_CONFIGS = [
             ArgsKwargs(p=1, value="random"),
         ],
         supports_pil=False,
+        removed_params=["inplace"],
     ),
     ConsistencyConfig(
         prototype_transforms.ColorJitter,
@@ -375,6 +377,7 @@ CONSISTENCY_CONFIGS = [
             ArgsKwargs(degrees=30.0, fill=(2, 3, 4)),
             ArgsKwargs(degrees=30.0, center=(0, 0)),
         ],
+        removed_params=["fillcolor", "resample"],
     ),
     ConsistencyConfig(
         prototype_transforms.RandomCrop,
@@ -419,6 +422,7 @@ CONSISTENCY_CONFIGS = [
             ArgsKwargs(degrees=30.0, fill=1),
             ArgsKwargs(degrees=30.0, fill=(1, 2, 3)),
         ],
+        removed_params=["resample"],
     ),
 ]
 
@@ -477,11 +481,8 @@ def test_signature_consistency(config):
             f"the `ConsistencyConfig`."
         )
 
-    extra_without_default = {
-        param
-        for param in prototype_params.keys() - legacy_params.keys()
-        if param.default is not inspect.Parameter.empty
-    }
+    extra = prototype_params.keys() - legacy_params.keys()
+    extra_without_default = {param for param in extra if prototype_params[param].default is not inspect.Parameter.empty}
     if extra_without_default:
         raise AssertionError(
             f"The prototype transform requires the parameters {sequence_to_str(sorted(missing), separate_last='and ')}, "

--- a/test/test_prototype_transforms_consistency.py
+++ b/test/test_prototype_transforms_consistency.py
@@ -1,5 +1,7 @@
 import enum
 import functools
+
+import inspect
 import itertools
 
 import numpy as np
@@ -58,26 +60,20 @@ class ArgsKwargs:
 
 class ConsistencyConfig:
     def __init__(
-        self, prototype_cls, legacy_cls, transform_args_kwargs=None, make_images_kwargs=None, supports_pil=True
+        self,
+        prototype_cls,
+        legacy_cls,
+        args_kwargs,
+        make_images_kwargs=None,
+        supports_pil=True,
+        removed_params=(),
     ):
         self.prototype_cls = prototype_cls
         self.legacy_cls = legacy_cls
-        self.transform_args_kwargs = transform_args_kwargs or [((), dict())]
+        self.args_kwargs = args_kwargs
         self.make_images_kwargs = make_images_kwargs or DEFAULT_MAKE_IMAGES_KWARGS
         self.supports_pil = supports_pil
-
-    def parametrization(self):
-        return [
-            pytest.param(
-                self.prototype_cls,
-                self.legacy_cls,
-                args_kwargs,
-                self.make_images_kwargs,
-                self.supports_pil,
-                id=f"{self.legacy_cls.__name__}({args_kwargs})",
-            )
-            for args_kwargs in self.transform_args_kwargs
-        ]
+        self.removed_params = removed_params
 
 
 # These are here since both the prototype and legacy transform need to be constructed with the same random parameters
@@ -464,7 +460,40 @@ def test_automatic_coverage_deterministic():
         )
 
 
-def check_consistency(prototype_transform, legacy_transform, images=None, supports_pil=True):
+@pytest.mark.parametrize("config", CONSISTENCY_CONFIGS, ids=lambda config: config.legacy_cls.__name__)
+def test_signature_consistency(config):
+    legacy_params = dict(inspect.signature(config.legacy_cls).parameters)
+    prototype_params = dict(inspect.signature(config.prototype_cls).parameters)
+
+    for param in config.removed_params:
+        legacy_params.pop(param, None)
+
+    missing = legacy_params.keys() - prototype_params.keys()
+    if missing:
+        raise AssertionError(
+            f"The prototype transform does not support the parameters "
+            f"{sequence_to_str(sorted(missing), separate_last='and ')}, but the legacy transform does. "
+            f"If that is intentional, e.g. pending deprecation, please add the parameters to the `removed_params` on "
+            f"the `ConsistencyConfig`."
+        )
+
+    extra_without_default = {
+        param
+        for param in prototype_params.keys() - legacy_params.keys()
+        if param.default is not inspect.Parameter.empty
+    }
+    if extra_without_default:
+        raise AssertionError(
+            f"The prototype transform requires the parameters {sequence_to_str(sorted(missing), separate_last='and ')}, "
+            f"but the legacy transform does not. Please add a default value."
+        )
+
+    for name, legacy_param in legacy_params.items():
+        prototype_param = prototype_params[name]
+        assert prototype_param.kind is legacy_param.kind
+
+
+def check_call_consistency(prototype_transform, legacy_transform, images=None, supports_pil=True):
     if images is None:
         images = make_images(**DEFAULT_MAKE_IMAGES_KWARGS)
 
@@ -546,14 +575,18 @@ def check_consistency(prototype_transform, legacy_transform, images=None, suppor
 
 
 @pytest.mark.parametrize(
-    ("prototype_transform_cls", "legacy_transform_cls", "args_kwargs", "make_images_kwargs", "supports_pil"),
-    itertools.chain.from_iterable(config.parametrization() for config in CONSISTENCY_CONFIGS),
+    ("config", "args_kwargs"),
+    [
+        pytest.param(config, args_kwargs, id=f"{config.legacy_cls.__name__}({args_kwargs})")
+        for config in CONSISTENCY_CONFIGS
+        for args_kwargs in config.args_kwargs
+    ],
 )
-def test_consistency(prototype_transform_cls, legacy_transform_cls, args_kwargs, make_images_kwargs, supports_pil):
+def test_call_consistency(config, args_kwargs):
     args, kwargs = args_kwargs
 
     try:
-        legacy_transform = legacy_transform_cls(*args, **kwargs)
+        legacy_transform = config.legacy_cls(*args, **kwargs)
     except Exception as exc:
         raise pytest.UsageError(
             f"Initializing the legacy transform failed with the error above. "
@@ -561,15 +594,18 @@ def test_consistency(prototype_transform_cls, legacy_transform_cls, args_kwargs,
         ) from exc
 
     try:
-        prototype_transform = prototype_transform_cls(*args, **kwargs)
+        prototype_transform = config.prototype_cls(*args, **kwargs)
     except Exception as exc:
         raise AssertionError(
             "Initializing the prototype transform failed with the error above. "
             "This means there is a consistency bug in the constructor."
         ) from exc
 
-    check_consistency(
-        prototype_transform, legacy_transform, images=make_images(**make_images_kwargs), supports_pil=supports_pil
+    check_call_consistency(
+        prototype_transform,
+        legacy_transform,
+        images=make_images(**config.make_images_kwargs),
+        supports_pil=config.supports_pil,
     )
 
 
@@ -596,7 +632,7 @@ class TestContainerTransforms:
             ]
         )
 
-        check_consistency(prototype_transform, legacy_transform)
+        check_call_consistency(prototype_transform, legacy_transform)
 
     @pytest.mark.parametrize("p", [0, 0.1, 0.5, 0.9, 1])
     def test_random_apply(self, p):
@@ -615,7 +651,7 @@ class TestContainerTransforms:
             p=p,
         )
 
-        check_consistency(prototype_transform, legacy_transform)
+        check_call_consistency(prototype_transform, legacy_transform)
 
     # We can't test other values for `p` since the random parameter generation is different
     @pytest.mark.parametrize("p", [(0, 1), (1, 0)])
@@ -635,7 +671,7 @@ class TestContainerTransforms:
             p=p,
         )
 
-        check_consistency(prototype_transform, legacy_transform)
+        check_call_consistency(prototype_transform, legacy_transform)
 
 
 class TestToTensorTransforms:

--- a/torchvision/prototype/transforms/_geometry.py
+++ b/torchvision/prototype/transforms/_geometry.py
@@ -58,12 +58,12 @@ class Resize(Transform):
 
 
 class CenterCrop(Transform):
-    def __init__(self, output_size: List[int]):
+    def __init__(self, size: List[int]):
         super().__init__()
-        self.output_size = output_size
+        self.size = size
 
     def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
-        return F.center_crop(inpt, output_size=self.output_size)
+        return F.center_crop(inpt, output_size=self.size)
 
 
 class RandomResizedCrop(Transform):

--- a/torchvision/prototype/transforms/_misc.py
+++ b/torchvision/prototype/transforms/_misc.py
@@ -17,20 +17,20 @@ class Identity(Transform):
 
 
 class Lambda(Transform):
-    def __init__(self, fn: Callable[[Any], Any], *types: Type):
+    def __init__(self, lambd: Callable[[Any], Any], *types: Type):
         super().__init__()
-        self.fn = fn
+        self.lambd = lambd
         self.types = types or (object,)
 
     def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
         if isinstance(inpt, self.types):
-            return self.fn(inpt)
+            return self.lambd(inpt)
         else:
             return inpt
 
     def extra_repr(self) -> str:
         extras = []
-        name = getattr(self.fn, "__name__", None)
+        name = getattr(self.lambd, "__name__", None)
         if name:
             extras.append(name)
         extras.append(f"types={[type.__name__ for type in self.types]}")


### PR DESCRIPTION
Per title. Follow-up to https://github.com/pytorch/vision/pull/6525#discussion_r959369318 to avoid manually checking everything. In particular, the test includes

- a check that no parameter that is available on the legacy transform is missing on the prototype counterpart
- a check that potentially new parameters on the prototype transform have a default value and thus the transform can be created without passing it
- a check that parameters that are available on both transforms are of the same kind, e.g. keyword or positional

This test found two consistency bugs on `CenterCrop` and `Lambda` that were also fixed. 

Left over are two categories of signature divergences:

1. Some parameters are not included on the prototype transform since they are already deprecated and scheduled for removal before the roll-out. This includes:

    - https://github.com/pytorch/vision/blob/a5b3118f4650918d82819e80144fbdb91929f953/torchvision/transforms/transforms.py#L1408-L1414
    - https://github.com/pytorch/vision/blob/a5b3118f4650918d82819e80144fbdb91929f953/torchvision/transforms/transforms.py#L1292-L1295

    I've opted to simply ignore them in the test, since I see no reason to add them to the prototype transforms now to just remove them again before the release.
2. Some parameters are not included on the prototype transform since we no longer want the behavior, but we haven't started an official deprecation yet. This includes:

    - https://github.com/pytorch/vision/blob/a5b3118f4650918d82819e80144fbdb91929f953/torchvision/transforms/transforms.py#L251
    - https://github.com/pytorch/vision/blob/a5b3118f4650918d82819e80144fbdb91929f953/torchvision/transforms/transforms.py#L1651

    Since inplace operations can improve the performance, we might walk back on that unofficial decision and put these back after all. For now, I also added them to the ignore list for the test, but we need to decide if we want that or not.

