### PR TITLE
Cleanup prototype kernels for degenerate inputs

### DIFF
--- a/test/test_prototype_transforms.py
+++ b/test/test_prototype_transforms.py
@@ -86,6 +86,8 @@ class TestSmoke:
         transforms.RandomHorizontalFlip(),
         transforms.Pad(5),
         transforms.RandomZoomOut(),
+        transforms.RandomRotation(degrees=(-45, 45)),
+        transforms.RandomAffine(degrees=(-45, 45)),
         transforms.RandomCrop([16, 16], padding=1, pad_if_needed=True),
         # TODO: Something wrong with input data setup. Let's fix that
         # transforms.RandomEqualize(),
@@ -93,8 +95,6 @@ class TestSmoke:
         # transforms.RandomPosterize(bits=4),
         # transforms.RandomSolarize(threshold=0.5),
         # transforms.RandomAdjustSharpness(sharpness_factor=0.5),
-        # transforms.RandomRotation(degrees=(-45, 45)),
-        # transforms.RandomAffine(degrees=(-45, 45)),
     )
     def test_common(self, transform, input):
         transform(input)

--- a/test/test_prototype_transforms_functional.py
+++ b/test/test_prototype_transforms_functional.py
@@ -290,7 +290,7 @@ def resize_segmentation_mask():
 @register_kernel_info_from_sample_inputs_fn
 def affine_image_tensor():
     for image, angle, translate, scale, shear in itertools.product(
-        make_images(extra_dims=((), (4,))),
+        make_images(),
         [-87, 15, 90],  # angle
         [5, -5],  # translate
         [0.77, 1.27],  # scale
@@ -329,7 +329,7 @@ def affine_bounding_box():
 @register_kernel_info_from_sample_inputs_fn
 def affine_segmentation_mask():
     for mask, angle, translate, scale, shear in itertools.product(
-        make_segmentation_masks(extra_dims=((), (4,)), num_objects=[10]),
+        make_segmentation_masks(),
         [-87, 15, 90],  # angle
         [5, -5],  # translate
         [0.77, 1.27],  # scale
@@ -347,7 +347,7 @@ def affine_segmentation_mask():
 @register_kernel_info_from_sample_inputs_fn
 def rotate_image_tensor():
     for image, angle, expand, center, fill in itertools.product(
-        make_images(extra_dims=((), (4,))),
+        make_images(),
         [-87, 15, 90],  # angle
         [True, False],  # expand
         [None, [12, 23]],  # center
@@ -382,7 +382,7 @@ def rotate_bounding_box():
 @register_kernel_info_from_sample_inputs_fn
 def rotate_segmentation_mask():
     for mask, angle, expand, center in itertools.product(
-        make_segmentation_masks(extra_dims=((), (4,)), num_objects=[10]),
+        make_segmentation_masks(),
         [-87, 15, 90],  # angle
         [True, False],  # expand
         [None, [12, 23]],  # center

--- a/torchvision/prototype/transforms/functional/_geometry.py
+++ b/torchvision/prototype/transforms/functional/_geometry.py
@@ -108,17 +108,14 @@ def resize_image_tensor(
     extra_dims = image.shape[:-3]
 
     if image.numel() > 0:
-        resized_image = _FT.resize(
+        image = _FT.resize(
             image.view(-1, num_channels, old_height, old_width),
             size=[new_height, new_width],
             interpolation=interpolation.value,
             antialias=antialias,
         )
-    else:
-        # TODO: the cloning is probably unnecessary. Review this together with the other perf candidates
-        resized_image = image.clone()
 
-    return resized_image.view(extra_dims + (num_channels, new_height, new_width))
+    return image.view(extra_dims + (num_channels, new_height, new_width))
 
 
 def resize_image_pil(
@@ -558,19 +555,16 @@ def pad_image_tensor(
     extra_dims = img.shape[:-3]
 
     if img.numel() > 0:
-        padded_image = _FT.pad(
+        image = _FT.pad(
             img=img.view(-1, num_channels, height, width), padding=padding, fill=fill, padding_mode=padding_mode
         )
-        new_height, new_width = padded_image.shape[-2:]
+        new_height, new_width = image.shape[-2:]
     else:
         left, right, top, bottom = _FT._parse_pad_padding(padding)
         new_height = height + top + bottom
         new_width = width + left + right
 
-        # TODO: the cloning is probably unnecessary. Review this together with the other perf candidates
-        padded_image = img.clone()
-
-    return padded_image.view(extra_dims + (num_channels, new_height, new_width))
+    return image.view(extra_dims + (num_channels, new_height, new_width))
 
 
 # TODO: This should be removed once pytorch pad supports non-scalar padding values

--- a/torchvision/prototype/transforms/functional/_geometry.py
+++ b/torchvision/prototype/transforms/functional/_geometry.py
@@ -226,6 +226,9 @@ def affine_image_tensor(
     fill: Optional[List[float]] = None,
     center: Optional[List[float]] = None,
 ) -> torch.Tensor:
+    if img.numel() == 0:
+        return img
+
     num_channels, height, width = img.shape[-3:]
     extra_dims = img.shape[:-3]
     img = img.view(-1, num_channels, height, width)
@@ -447,6 +450,9 @@ def rotate_image_tensor(
     fill: Optional[List[float]] = None,
     center: Optional[List[float]] = None,
 ) -> torch.Tensor:
+    if img.numel() == 0:
+        return img
+
     num_channels, height, width = img.shape[-3:]
     extra_dims = img.shape[:-3]
     img = img.view(-1, num_channels, height, width)
@@ -555,16 +561,16 @@ def pad_image_tensor(
     extra_dims = img.shape[:-3]
 
     if img.numel() > 0:
-        image = _FT.pad(
+        img = _FT.pad(
             img=img.view(-1, num_channels, height, width), padding=padding, fill=fill, padding_mode=padding_mode
         )
-        new_height, new_width = image.shape[-2:]
+        new_height, new_width = img.shape[-2:]
     else:
         left, right, top, bottom = _FT._parse_pad_padding(padding)
         new_height = height + top + bottom
         new_width = width + left + right
 
-    return image.view(extra_dims + (num_channels, new_height, new_width))
+    return img.view(extra_dims + (num_channels, new_height, new_width))
 
 
 # TODO: This should be removed once pytorch pad supports non-scalar padding values

--- a/torchvision/prototype/transforms/functional/_geometry.py
+++ b/torchvision/prototype/transforms/functional/_geometry.py
@@ -557,15 +557,16 @@ def pad_image_tensor(
     num_channels, height, width = img.shape[-3:]
     extra_dims = img.shape[:-3]
 
-    left, right, top, bottom = _FT._parse_pad_padding(padding)
-    new_height = height + top + bottom
-    new_width = width + left + right
-
     if img.numel() > 0:
         padded_image = _FT.pad(
             img=img.view(-1, num_channels, height, width), padding=padding, fill=fill, padding_mode=padding_mode
         )
+        new_height, new_width = padded_image.shape[-2:]
     else:
+        left, right, top, bottom = _FT._parse_pad_padding(padding)
+        new_height = height + top + bottom
+        new_width = width + left + right
+
         # TODO: the cloning is probably unnecessary. Review this together with the other perf candidates
         padded_image = img.clone()
 


### PR DESCRIPTION
Follow-up to #6542. Resolves

- https://github.com/pytorch/vision/pull/6542#discussion_r965006822
- https://github.com/pytorch/vision/pull/6542#pullrequestreview-1099421668
  Although cloning here is a `O(1)` operation since there is no data to copy, it also does nothing useful. Whether or not we clone or not, the `Tensor.data_ptr()` stays the same and we only create another Python object.
- https://github.com/pytorch/vision/pull/6542#pullrequestreview-1099391108

The only thing left are the xfailed reference tests introduced in #6542. As explained there, these are not bugs in the kernel, but rather in the test setup specifically the expected output computation. @vfdev-5 Could you look into these?