### PR TITLE
Fix swapped width and height in DefaultBoxGenerator

### DIFF
--- a/torchvision/models/detection/anchor_utils.py
+++ b/torchvision/models/detection/anchor_utils.py
@@ -213,8 +213,8 @@ class DefaultBoxGenerator(nn.Module):
         for k, f_k in enumerate(grid_sizes):
             # Now add the default boxes for each width-height pair
             if self.steps is not None:
-                x_f_k = image_size[0] / self.steps[k]
-                y_f_k = image_size[1] / self.steps[k]
+                x_f_k = image_size[1] / self.steps[k]
+                y_f_k = image_size[0] / self.steps[k]
             else:
                 y_f_k, x_f_k = f_k
 


### PR DESCRIPTION
Fix #6550 

Changes image size convention of DefaultBoxGenerator to (h, w). I don't think this is used by models other than SSD which assumes this convention.