### PR TITLE
port RandomResize from segmentation references

### DIFF
--- a/torchvision/prototype/transforms/__init__.py
+++ b/torchvision/prototype/transforms/__init__.py
@@ -28,6 +28,7 @@ from ._geometry import (
     RandomHorizontalFlip,
     RandomIoUCrop,
     RandomPerspective,
+    RandomResize,
     RandomResizedCrop,
     RandomRotation,
     RandomShortestSize,

--- a/torchvision/prototype/transforms/_geometry.py
+++ b/torchvision/prototype/transforms/_geometry.py
@@ -869,14 +869,22 @@ class FixedSizeCrop(Transform):
 
 
 class RandomResize(Transform):
-    def __init__(self, min_size: int, max_size: int) -> None:
+    def __init__(
+        self,
+        min_size: int,
+        max_size: int,
+        interpolation: InterpolationMode = InterpolationMode.BILINEAR,
+        antialias: Optional[bool] = None,
+    ) -> None:
         super().__init__()
         self.min_size = min_size
         self.max_size = max_size
+        self.interpolation = interpolation
+        self.antialias = antialias
 
     def _get_params(self, sample: Any) -> Dict[str, Any]:
         size = int(torch.randint(self.min_size, self.max_size, ()))
         return dict(size=size)
 
     def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
-        return F.resize(inpt, params["size"])
+        return F.resize(inpt, params["size"], interpolation=self.interpolation, antialias=self.antialias)

--- a/torchvision/prototype/transforms/_geometry.py
+++ b/torchvision/prototype/transforms/_geometry.py
@@ -869,17 +869,14 @@ class FixedSizeCrop(Transform):
 
 
 class RandomResize(Transform):
-    def __init__(self, min_size: int, max_size: Optional[int] = None) -> None:
+    def __init__(self, min_size: int, max_size: int) -> None:
         super().__init__()
         self.min_size = min_size
-        self.max_size = max_size if max_size is not None else min_size
+        self.max_size = max_size
 
     def _get_params(self, sample: Any) -> Dict[str, Any]:
-        needs_resize = self.max_size > self.min_size
-        size = int(torch.randint(self.min_size, self.max_size, ())) if needs_resize else None
+        size = int(torch.randint(self.min_size, self.max_size, ()))
         return dict(size=size)
 
     def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
-        if params["size"] is not None:
-            inpt = F.resize(inpt, params["size"])
-        return inpt
+        return F.resize(inpt, params["size"])

--- a/torchvision/prototype/transforms/_geometry.py
+++ b/torchvision/prototype/transforms/_geometry.py
@@ -884,7 +884,7 @@ class RandomResize(Transform):
 
     def _get_params(self, sample: Any) -> Dict[str, Any]:
         size = int(torch.randint(self.min_size, self.max_size, ()))
-        return dict(size=size)
+        return dict(size=[size])
 
     def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
         return F.resize(inpt, params["size"], interpolation=self.interpolation, antialias=self.antialias)

--- a/torchvision/prototype/transforms/_geometry.py
+++ b/torchvision/prototype/transforms/_geometry.py
@@ -869,7 +869,7 @@ class FixedSizeCrop(Transform):
 
 
 class RandomResize(Transform):
-    def __init__(self, min_size: int, max_size: Optional[int] = None):
+    def __init__(self, min_size: int, max_size: Optional[int] = None) -> None:
         super().__init__()
         self.min_size = min_size
         self.max_size = max_size if max_size is not None else min_size

--- a/torchvision/prototype/transforms/_geometry.py
+++ b/torchvision/prototype/transforms/_geometry.py
@@ -866,3 +866,20 @@ class FixedSizeCrop(Transform):
             )
 
         return super().forward(*inputs)
+
+
+class RandomResize(Transform):
+    def __init__(self, min_size: int, max_size: Optional[int] = None):
+        super().__init__()
+        self.min_size = min_size
+        self.max_size = max_size if max_size is not None else min_size
+
+    def _get_params(self, sample: Any) -> Dict[str, Any]:
+        needs_resize = self.max_size > self.min_size
+        size = int(torch.randint(self.min_size, self.max_size, ())) if needs_resize else None
+        return dict(size=size)
+
+    def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
+        if params["size"] is not None:
+            inpt = F.resize(inpt, params["size"])
+        return inpt


### PR DESCRIPTION
https://github.com/pytorch/vision/blob/cac4e228c9ca9e7564cb34406e7ebccfdd736976/references/segmentation/transforms.py#L29-L40

Although the reference transform does not, we could expose a few parameters that could be passed to `resize` like `antialias` and `interpolation`.