### PR TITLE
CUDA 11.3 remove. New Stable version is 11.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -853,7 +853,7 @@ jobs:
     executor:
       name: windows-gpu
     environment:
-      CUDA_VERSION: "11.3"
+      CUDA_VERSION: "11.6"
       PYTHON_VERSION: << parameters.python_version >>
     steps:
       - checkout
@@ -969,6 +969,7 @@ jobs:
           command: docker run -e CU_VERSION -e PYTHON_VERSION -e UNICODE_ABI -e PYTORCH_VERSION -t --gpus all -v $PWD:$PWD -w $PWD << parameters.wheel_docker_image >> .circleci/unittest/linux/scripts/setup_env.sh
       - run:
           name: Build torchvision C++ distribution and test
+          no_output_timeout: 30m
           command: docker run -e CU_VERSION -e PYTHON_VERSION -e UNICODE_ABI -e PYTORCH_VERSION -e UPLOAD_CHANNEL -t --gpus all -v $PWD:$PWD -w $PWD << parameters.wheel_docker_image >> packaging/build_cmake.sh
 
   cmake_macos_cpu:
@@ -1006,6 +1007,9 @@ jobs:
     steps:
       - checkout_merge
       - designate_upload_channel
+      - run:
+          name: Update CUDA driver
+          command: packaging/windows/internal/driver_update.bat
       - run:
           command: |
             set -ex
@@ -1109,12 +1113,6 @@ workflows:
           python_version: '3.7'
           wheel_docker_image: pytorch/manylinux-cuda102
       - binary_linux_wheel:
-          conda_docker_image: pytorch/conda-builder:cuda113
-          cu_version: cu113
-          name: binary_linux_wheel_py3.7_cu113
-          python_version: '3.7'
-          wheel_docker_image: pytorch/manylinux-cuda113
-      - binary_linux_wheel:
           conda_docker_image: pytorch/conda-builder:cuda116
           cu_version: cu116
           name: binary_linux_wheel_py3.7_cu116
@@ -1148,12 +1146,6 @@ workflows:
           name: binary_linux_wheel_py3.8_cu102
           python_version: '3.8'
           wheel_docker_image: pytorch/manylinux-cuda102
-      - binary_linux_wheel:
-          conda_docker_image: pytorch/conda-builder:cuda113
-          cu_version: cu113
-          name: binary_linux_wheel_py3.8_cu113
-          python_version: '3.8'
-          wheel_docker_image: pytorch/manylinux-cuda113
       - binary_linux_wheel:
           conda_docker_image: pytorch/conda-builder:cuda116
           cu_version: cu116
@@ -1189,12 +1181,6 @@ workflows:
           python_version: '3.9'
           wheel_docker_image: pytorch/manylinux-cuda102
       - binary_linux_wheel:
-          conda_docker_image: pytorch/conda-builder:cuda113
-          cu_version: cu113
-          name: binary_linux_wheel_py3.9_cu113
-          python_version: '3.9'
-          wheel_docker_image: pytorch/manylinux-cuda113
-      - binary_linux_wheel:
           conda_docker_image: pytorch/conda-builder:cuda116
           cu_version: cu116
           name: binary_linux_wheel_py3.9_cu116
@@ -1228,12 +1214,6 @@ workflows:
           name: binary_linux_wheel_py3.10_cu102
           python_version: '3.10'
           wheel_docker_image: pytorch/manylinux-cuda102
-      - binary_linux_wheel:
-          conda_docker_image: pytorch/conda-builder:cuda113
-          cu_version: cu113
-          name: binary_linux_wheel_py3.10_cu113
-          python_version: '3.10'
-          wheel_docker_image: pytorch/manylinux-cuda113
       - binary_linux_wheel:
           conda_docker_image: pytorch/conda-builder:cuda116
           cu_version: cu116
@@ -1290,15 +1270,6 @@ workflows:
           name: binary_win_wheel_py3.7_cpu
           python_version: '3.7'
       - binary_win_wheel:
-          cu_version: cu113
-          filters:
-            branches:
-              only: main
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: binary_win_wheel_py3.7_cu113
-          python_version: '3.7'
-      - binary_win_wheel:
           cu_version: cu116
           filters:
             branches:
@@ -1324,15 +1295,6 @@ workflows:
             tags:
               only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
           name: binary_win_wheel_py3.8_cpu
-          python_version: '3.8'
-      - binary_win_wheel:
-          cu_version: cu113
-          filters:
-            branches:
-              only: main
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: binary_win_wheel_py3.8_cu113
           python_version: '3.8'
       - binary_win_wheel:
           cu_version: cu116
@@ -1362,15 +1324,6 @@ workflows:
           name: binary_win_wheel_py3.9_cpu
           python_version: '3.9'
       - binary_win_wheel:
-          cu_version: cu113
-          filters:
-            branches:
-              only: main
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: binary_win_wheel_py3.9_cu113
-          python_version: '3.9'
-      - binary_win_wheel:
           cu_version: cu116
           filters:
             branches:
@@ -1391,15 +1344,6 @@ workflows:
       - binary_win_wheel:
           cu_version: cpu
           name: binary_win_wheel_py3.10_cpu
-          python_version: '3.10'
-      - binary_win_wheel:
-          cu_version: cu113
-          filters:
-            branches:
-              only: main
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: binary_win_wheel_py3.10_cu113
           python_version: '3.10'
       - binary_win_wheel:
           cu_version: cu116
@@ -1427,12 +1371,6 @@ workflows:
           python_version: '3.7'
           wheel_docker_image: pytorch/manylinux-cuda102
       - binary_linux_conda:
-          conda_docker_image: pytorch/conda-builder:cuda113
-          cu_version: cu113
-          name: binary_linux_conda_py3.7_cu113
-          python_version: '3.7'
-          wheel_docker_image: pytorch/manylinux-cuda113
-      - binary_linux_conda:
           conda_docker_image: pytorch/conda-builder:cuda116
           cu_version: cu116
           name: binary_linux_conda_py3.7_cu116
@@ -1456,12 +1394,6 @@ workflows:
           name: binary_linux_conda_py3.8_cu102
           python_version: '3.8'
           wheel_docker_image: pytorch/manylinux-cuda102
-      - binary_linux_conda:
-          conda_docker_image: pytorch/conda-builder:cuda113
-          cu_version: cu113
-          name: binary_linux_conda_py3.8_cu113
-          python_version: '3.8'
-          wheel_docker_image: pytorch/manylinux-cuda113
       - binary_linux_conda:
           conda_docker_image: pytorch/conda-builder:cuda116
           cu_version: cu116
@@ -1487,12 +1419,6 @@ workflows:
           python_version: '3.9'
           wheel_docker_image: pytorch/manylinux-cuda102
       - binary_linux_conda:
-          conda_docker_image: pytorch/conda-builder:cuda113
-          cu_version: cu113
-          name: binary_linux_conda_py3.9_cu113
-          python_version: '3.9'
-          wheel_docker_image: pytorch/manylinux-cuda113
-      - binary_linux_conda:
           conda_docker_image: pytorch/conda-builder:cuda116
           cu_version: cu116
           name: binary_linux_conda_py3.9_cu116
@@ -1516,12 +1442,6 @@ workflows:
           name: binary_linux_conda_py3.10_cu102
           python_version: '3.10'
           wheel_docker_image: pytorch/manylinux-cuda102
-      - binary_linux_conda:
-          conda_docker_image: pytorch/conda-builder:cuda113
-          cu_version: cu113
-          name: binary_linux_conda_py3.10_cu113
-          python_version: '3.10'
-          wheel_docker_image: pytorch/manylinux-cuda113
       - binary_linux_conda:
           conda_docker_image: pytorch/conda-builder:cuda116
           cu_version: cu116
@@ -1568,15 +1488,6 @@ workflows:
           name: binary_win_conda_py3.7_cpu
           python_version: '3.7'
       - binary_win_conda:
-          cu_version: cu113
-          filters:
-            branches:
-              only: main
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: binary_win_conda_py3.7_cu113
-          python_version: '3.7'
-      - binary_win_conda:
           cu_version: cu116
           filters:
             branches:
@@ -1602,15 +1513,6 @@ workflows:
             tags:
               only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
           name: binary_win_conda_py3.8_cpu
-          python_version: '3.8'
-      - binary_win_conda:
-          cu_version: cu113
-          filters:
-            branches:
-              only: main
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: binary_win_conda_py3.8_cu113
           python_version: '3.8'
       - binary_win_conda:
           cu_version: cu116
@@ -1640,15 +1542,6 @@ workflows:
           name: binary_win_conda_py3.9_cpu
           python_version: '3.9'
       - binary_win_conda:
-          cu_version: cu113
-          filters:
-            branches:
-              only: main
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: binary_win_conda_py3.9_cu113
-          python_version: '3.9'
-      - binary_win_conda:
           cu_version: cu116
           filters:
             branches:
@@ -1669,15 +1562,6 @@ workflows:
       - binary_win_conda:
           cu_version: cpu
           name: binary_win_conda_py3.10_cpu
-          python_version: '3.10'
-      - binary_win_conda:
-          cu_version: cu113
-          filters:
-            branches:
-              only: main
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: binary_win_conda_py3.10_cu113
           python_version: '3.10'
       - binary_win_conda:
           cu_version: cu116
@@ -1852,16 +1736,16 @@ workflows:
           name: cmake_linux_cpu
           python_version: '3.8'
       - cmake_linux_gpu:
-          cu_version: cu113
+          cu_version: cu116
           name: cmake_linux_gpu
           python_version: '3.8'
-          wheel_docker_image: pytorch/manylinux-cuda113
+          wheel_docker_image: pytorch/manylinux-cuda116
       - cmake_windows_cpu:
           cu_version: cpu
           name: cmake_windows_cpu
           python_version: '3.8'
       - cmake_windows_gpu:
-          cu_version: cu113
+          cu_version: cu116
           name: cmake_windows_gpu
           python_version: '3.8'
       - cmake_macos_cpu:
@@ -1951,28 +1835,6 @@ workflows:
           requires:
           - nightly_binary_linux_wheel_py3.7_cu102
           subfolder: cu102/
-      - binary_linux_wheel:
-          conda_docker_image: pytorch/conda-builder:cuda113
-          cu_version: cu113
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_wheel_py3.7_cu113
-          python_version: '3.7'
-          wheel_docker_image: pytorch/manylinux-cuda113
-      - binary_wheel_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_wheel_py3.7_cu113_upload
-          requires:
-          - nightly_binary_linux_wheel_py3.7_cu113
-          subfolder: cu113/
       - binary_linux_wheel:
           conda_docker_image: pytorch/conda-builder:cuda116
           cu_version: cu116
@@ -2104,28 +1966,6 @@ workflows:
           - nightly_binary_linux_wheel_py3.8_cu102
           subfolder: cu102/
       - binary_linux_wheel:
-          conda_docker_image: pytorch/conda-builder:cuda113
-          cu_version: cu113
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_wheel_py3.8_cu113
-          python_version: '3.8'
-          wheel_docker_image: pytorch/manylinux-cuda113
-      - binary_wheel_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_wheel_py3.8_cu113_upload
-          requires:
-          - nightly_binary_linux_wheel_py3.8_cu113
-          subfolder: cu113/
-      - binary_linux_wheel:
           conda_docker_image: pytorch/conda-builder:cuda116
           cu_version: cu116
           filters:
@@ -2256,28 +2096,6 @@ workflows:
           - nightly_binary_linux_wheel_py3.9_cu102
           subfolder: cu102/
       - binary_linux_wheel:
-          conda_docker_image: pytorch/conda-builder:cuda113
-          cu_version: cu113
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_wheel_py3.9_cu113
-          python_version: '3.9'
-          wheel_docker_image: pytorch/manylinux-cuda113
-      - binary_wheel_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_wheel_py3.9_cu113_upload
-          requires:
-          - nightly_binary_linux_wheel_py3.9_cu113
-          subfolder: cu113/
-      - binary_linux_wheel:
           conda_docker_image: pytorch/conda-builder:cuda116
           cu_version: cu116
           filters:
@@ -2407,28 +2225,6 @@ workflows:
           requires:
           - nightly_binary_linux_wheel_py3.10_cu102
           subfolder: cu102/
-      - binary_linux_wheel:
-          conda_docker_image: pytorch/conda-builder:cuda113
-          cu_version: cu113
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_wheel_py3.10_cu113
-          python_version: '3.10'
-          wheel_docker_image: pytorch/manylinux-cuda113
-      - binary_wheel_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_wheel_py3.10_cu113_upload
-          requires:
-          - nightly_binary_linux_wheel_py3.10_cu113
-          subfolder: cu113/
       - binary_linux_wheel:
           conda_docker_image: pytorch/conda-builder:cuda116
           cu_version: cu116
@@ -2624,26 +2420,6 @@ workflows:
           - nightly_binary_win_wheel_py3.7_cpu
           subfolder: cpu/
       - binary_win_wheel:
-          cu_version: cu113
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_win_wheel_py3.7_cu113
-          python_version: '3.7'
-      - binary_wheel_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_win_wheel_py3.7_cu113_upload
-          requires:
-          - nightly_binary_win_wheel_py3.7_cu113
-          subfolder: cu113/
-      - binary_win_wheel:
           cu_version: cu116
           filters:
             branches:
@@ -2703,26 +2479,6 @@ workflows:
           requires:
           - nightly_binary_win_wheel_py3.8_cpu
           subfolder: cpu/
-      - binary_win_wheel:
-          cu_version: cu113
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_win_wheel_py3.8_cu113
-          python_version: '3.8'
-      - binary_wheel_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_win_wheel_py3.8_cu113_upload
-          requires:
-          - nightly_binary_win_wheel_py3.8_cu113
-          subfolder: cu113/
       - binary_win_wheel:
           cu_version: cu116
           filters:
@@ -2784,26 +2540,6 @@ workflows:
           - nightly_binary_win_wheel_py3.9_cpu
           subfolder: cpu/
       - binary_win_wheel:
-          cu_version: cu113
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_win_wheel_py3.9_cu113
-          python_version: '3.9'
-      - binary_wheel_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_win_wheel_py3.9_cu113_upload
-          requires:
-          - nightly_binary_win_wheel_py3.9_cu113
-          subfolder: cu113/
-      - binary_win_wheel:
           cu_version: cu116
           filters:
             branches:
@@ -2863,26 +2599,6 @@ workflows:
           requires:
           - nightly_binary_win_wheel_py3.10_cpu
           subfolder: cpu/
-      - binary_win_wheel:
-          cu_version: cu113
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_win_wheel_py3.10_cu113
-          python_version: '3.10'
-      - binary_wheel_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_win_wheel_py3.10_cu113_upload
-          requires:
-          - nightly_binary_win_wheel_py3.10_cu113
-          subfolder: cu113/
       - binary_win_wheel:
           cu_version: cu116
           filters:
@@ -2965,27 +2681,6 @@ workflows:
           name: nightly_binary_linux_conda_py3.7_cu102_upload
           requires:
           - nightly_binary_linux_conda_py3.7_cu102
-      - binary_linux_conda:
-          conda_docker_image: pytorch/conda-builder:cuda113
-          cu_version: cu113
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_conda_py3.7_cu113
-          python_version: '3.7'
-          wheel_docker_image: pytorch/manylinux-cuda113
-      - binary_conda_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_conda_py3.7_cu113_upload
-          requires:
-          - nightly_binary_linux_conda_py3.7_cu113
       - binary_linux_conda:
           conda_docker_image: pytorch/conda-builder:cuda116
           cu_version: cu116
@@ -3071,27 +2766,6 @@ workflows:
           requires:
           - nightly_binary_linux_conda_py3.8_cu102
       - binary_linux_conda:
-          conda_docker_image: pytorch/conda-builder:cuda113
-          cu_version: cu113
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_conda_py3.8_cu113
-          python_version: '3.8'
-          wheel_docker_image: pytorch/manylinux-cuda113
-      - binary_conda_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_conda_py3.8_cu113_upload
-          requires:
-          - nightly_binary_linux_conda_py3.8_cu113
-      - binary_linux_conda:
           conda_docker_image: pytorch/conda-builder:cuda116
           cu_version: cu116
           filters:
@@ -3176,27 +2850,6 @@ workflows:
           requires:
           - nightly_binary_linux_conda_py3.9_cu102
       - binary_linux_conda:
-          conda_docker_image: pytorch/conda-builder:cuda113
-          cu_version: cu113
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_conda_py3.9_cu113
-          python_version: '3.9'
-          wheel_docker_image: pytorch/manylinux-cuda113
-      - binary_conda_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_conda_py3.9_cu113_upload
-          requires:
-          - nightly_binary_linux_conda_py3.9_cu113
-      - binary_linux_conda:
           conda_docker_image: pytorch/conda-builder:cuda116
           cu_version: cu116
           filters:
@@ -3280,27 +2933,6 @@ workflows:
           name: nightly_binary_linux_conda_py3.10_cu102_upload
           requires:
           - nightly_binary_linux_conda_py3.10_cu102
-      - binary_linux_conda:
-          conda_docker_image: pytorch/conda-builder:cuda113
-          cu_version: cu113
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_conda_py3.10_cu113
-          python_version: '3.10'
-          wheel_docker_image: pytorch/manylinux-cuda113
-      - binary_conda_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_linux_conda_py3.10_cu113_upload
-          requires:
-          - nightly_binary_linux_conda_py3.10_cu113
       - binary_linux_conda:
           conda_docker_image: pytorch/conda-builder:cuda116
           cu_version: cu116
@@ -3447,25 +3079,6 @@ workflows:
           requires:
           - nightly_binary_win_conda_py3.7_cpu
       - binary_win_conda:
-          cu_version: cu113
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_win_conda_py3.7_cu113
-          python_version: '3.7'
-      - binary_conda_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_win_conda_py3.7_cu113_upload
-          requires:
-          - nightly_binary_win_conda_py3.7_cu113
-      - binary_win_conda:
           cu_version: cu116
           filters:
             branches:
@@ -3522,25 +3135,6 @@ workflows:
           name: nightly_binary_win_conda_py3.8_cpu_upload
           requires:
           - nightly_binary_win_conda_py3.8_cpu
-      - binary_win_conda:
-          cu_version: cu113
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_win_conda_py3.8_cu113
-          python_version: '3.8'
-      - binary_conda_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_win_conda_py3.8_cu113_upload
-          requires:
-          - nightly_binary_win_conda_py3.8_cu113
       - binary_win_conda:
           cu_version: cu116
           filters:
@@ -3599,25 +3193,6 @@ workflows:
           requires:
           - nightly_binary_win_conda_py3.9_cpu
       - binary_win_conda:
-          cu_version: cu113
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_win_conda_py3.9_cu113
-          python_version: '3.9'
-      - binary_conda_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_win_conda_py3.9_cu113_upload
-          requires:
-          - nightly_binary_win_conda_py3.9_cu113
-      - binary_win_conda:
           cu_version: cu116
           filters:
             branches:
@@ -3674,25 +3249,6 @@ workflows:
           name: nightly_binary_win_conda_py3.10_cpu_upload
           requires:
           - nightly_binary_win_conda_py3.10_cpu
-      - binary_win_conda:
-          cu_version: cu113
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_win_conda_py3.10_cu113
-          python_version: '3.10'
-      - binary_conda_upload:
-          context: org-member
-          filters:
-            branches:
-              only: nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: nightly_binary_win_conda_py3.10_cu113_upload
-          requires:
-          - nightly_binary_win_conda_py3.10_cu113
       - binary_win_conda:
           cu_version: cu116
           filters:

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -853,7 +853,7 @@ jobs:
     executor:
       name: windows-gpu
     environment:
-      CUDA_VERSION: "11.3"
+      CUDA_VERSION: "11.6"
       PYTHON_VERSION: << parameters.python_version >>
     steps:
       - checkout
@@ -969,6 +969,7 @@ jobs:
           command: docker run -e CU_VERSION -e PYTHON_VERSION -e UNICODE_ABI -e PYTORCH_VERSION -t --gpus all -v $PWD:$PWD -w $PWD << parameters.wheel_docker_image >> .circleci/unittest/linux/scripts/setup_env.sh
       - run:
           name: Build torchvision C++ distribution and test
+          no_output_timeout: 30m
           command: docker run -e CU_VERSION -e PYTHON_VERSION -e UNICODE_ABI -e PYTORCH_VERSION -e UPLOAD_CHANNEL -t --gpus all -v $PWD:$PWD -w $PWD << parameters.wheel_docker_image >> packaging/build_cmake.sh
 
   cmake_macos_cpu:
@@ -1006,6 +1007,9 @@ jobs:
     steps:
       - checkout_merge
       - designate_upload_channel
+      - run:
+          name: Update CUDA driver
+          command: packaging/windows/internal/driver_update.bat
       - run:
           command: |
             set -ex

--- a/.circleci/regenerate.py
+++ b/.circleci/regenerate.py
@@ -32,8 +32,8 @@ def build_workflows(prefix="", filter_branch=None, upload=False, indentation=6, 
         for os_type in ["linux", "macos", "win"]:
             python_versions = PYTHON_VERSIONS
             cu_versions_dict = {
-                "linux": ["cpu", "cu102", "cu113", "cu116", "cu117", "rocm5.1.1", "rocm5.2"],
-                "win": ["cpu", "cu113", "cu116", "cu117"],
+                "linux": ["cpu", "cu102", "cu116", "cu117", "rocm5.1.1", "rocm5.2"],
+                "win": ["cpu", "cu116", "cu117"],
                 "macos": ["cpu"],
             }
             cu_versions = cu_versions_dict[os_type]
@@ -123,7 +123,6 @@ def upload_doc_job(filter_branch):
 
 manylinux_images = {
     "cu102": "pytorch/manylinux-cuda102",
-    "cu113": "pytorch/manylinux-cuda113",
     "cu116": "pytorch/manylinux-cuda116",
     "cu117": "pytorch/manylinux-cuda117",
 }
@@ -266,9 +265,9 @@ def cmake_workflows(indentation=6):
         for device in device_types:
             job = {"name": f"cmake_{os_type}_{device}", "python_version": python_version}
 
-            job["cu_version"] = "cu113" if device == "gpu" else "cpu"
+            job["cu_version"] = "cu116" if device == "gpu" else "cpu"
             if device == "gpu" and os_type == "linux":
-                job["wheel_docker_image"] = "pytorch/manylinux-cuda113"
+                job["wheel_docker_image"] = "pytorch/manylinux-cuda116"
             jobs.append({f"cmake_{os_type}_{device}": job})
     return indent(indentation, jobs)
 

--- a/.circleci/unittest/windows/scripts/install.sh
+++ b/.circleci/unittest/windows/scripts/install.sh
@@ -24,8 +24,8 @@ else
     fi
 
     cuda_toolkit_pckg="cudatoolkit"
-    if [[ "$CU_VERSION" == cu116 || "$CU_VERSION" == cu117 ]]; then
-        cuda_toolkit_pckg="cuda"
+    if [[ $CUDA_VERSION == 11.6 || $CUDA_VERSION == 11.7 ]]; then
+        cuda_toolkit_pckg="pytorch-cuda"
     fi
 
     echo "Using CUDA $CUDA_VERSION as determined by CU_VERSION"

--- a/.circleci/unittest/windows/scripts/set_cuda_envs.sh
+++ b/.circleci/unittest/windows/scripts/set_cuda_envs.sh
@@ -4,7 +4,7 @@ set -ex
 echo CU_VERSION is "${CU_VERSION}"
 echo CUDA_VERSION is "${CUDA_VERSION}"
 
-# Currenly, CU_VERSION and CUDA_VERSION are not consistent. 
+# Currenly, CU_VERSION and CUDA_VERSION are not consistent.
 # to understand this code, see https://github.com/pytorch/vision/issues/4443
 version="cpu"
 if [[ ! -z "${CUDA_VERSION}" ]] ; then

--- a/packaging/build_cmake.sh
+++ b/packaging/build_cmake.sh
@@ -97,7 +97,7 @@ if [[ "$OSTYPE" == "msys" ]]; then
     "$script_dir/windows/internal/vc_env_helper.bat" "$script_dir/windows/internal/build_frcnn.bat" $PARALLELISM
     mv fasterrcnn_resnet50_fpn.pt Release
     cd Release
-    export PATH=$(cygpath -w "C:/Program Files (x86)/torchvision/bin"):$(cygpath -w $TORCH_PATH)/lib:$PATH
+    export PATH=$(cygpath -w "C:/Program Files/NVIDIA Corporation/NvToolsExt/bin/x64"):$(cygpath -w "C:/Program Files (x86)/torchvision/bin"):$(cygpath -w $TORCH_PATH)/lib:$PATH
 else
     make -j$PARALLELISM
 fi

--- a/packaging/pkg_helpers.bash
+++ b/packaging/pkg_helpers.bash
@@ -62,14 +62,6 @@ setup_cuda() {
       fi
       export TORCH_CUDA_ARCH_LIST="3.5;5.0+PTX;6.0;7.0;7.5;8.0;8.6"
       ;;
-    cu113)
-      if [[ "$OSTYPE" == "msys" ]]; then
-        export CUDA_HOME="C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v11.3"
-      else
-        export CUDA_HOME=/usr/local/cuda-11.3/
-      fi
-      export TORCH_CUDA_ARCH_LIST="3.5;5.0+PTX;6.0;7.0;7.5;8.0;8.6"
-      ;;
     cu102)
       if [[ "$OSTYPE" == "msys" ]]; then
         export CUDA_HOME="C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v10.2"
@@ -275,9 +267,6 @@ setup_conda_cudatoolkit_constraint() {
       cu116)
         export CONDA_CUDATOOLKIT_CONSTRAINT="- pytorch-cuda=11.6 # [not osx]"
         ;;
-      cu113)
-        export CONDA_CUDATOOLKIT_CONSTRAINT="- cudatoolkit >=11.3,<11.4 # [not osx]"
-        ;;
       cu102)
         export CONDA_CUDATOOLKIT_CONSTRAINT="- cudatoolkit >=10.2,<10.3 # [not osx]"
         ;;
@@ -306,9 +295,6 @@ setup_conda_cudatoolkit_plain_constraint() {
         ;;
       cu116)
         export CONDA_CUDATOOLKIT_CONSTRAINT="pytorch-cuda=11.6"
-        ;;
-      cu113)
-        export CONDA_CUDATOOLKIT_CONSTRAINT="cudatoolkit=11.3"
         ;;
       cu102)
         export CONDA_CUDATOOLKIT_CONSTRAINT="cudatoolkit=10.2"


### PR DESCRIPTION
CUDA 11.3 Removing.

Core PR: https://github.com/pytorch/pytorch/pull/84866
cc @malfet @ptrblck 