### PR TITLE
Adding feature classifications for new Video models

### DIFF
--- a/torchvision/models/video/mvit.py
+++ b/torchvision/models/video/mvit.py
@@ -666,6 +666,8 @@ def mvit_v1_b(*, weights: Optional[MViT_V1_B_Weights] = None, progress: bool = T
     Constructs a base MViTV1 architecture from
     `Multiscale Vision Transformers <https://arxiv.org/abs/2104.11227>`__.
 
+    .. betastatus:: video module
+
     Args:
         weights (:class:`~torchvision.models.video.MViT_V1_B_Weights`, optional): The
             pretrained weights to use. See
@@ -760,6 +762,8 @@ def mvit_v2_s(*, weights: Optional[MViT_V2_S_Weights] = None, progress: bool = T
     """
     Constructs a small MViTV2 architecture from
     `Multiscale Vision Transformers <https://arxiv.org/abs/2104.11227>`__.
+
+    .. betastatus:: video module
 
     Args:
         weights (:class:`~torchvision.models.video.MViT_V2_S_Weights`, optional): The

--- a/torchvision/models/video/s3d.py
+++ b/torchvision/models/video/s3d.py
@@ -186,6 +186,8 @@ def s3d(*, weights: Optional[S3D_Weights] = None, progress: bool = True, **kwarg
 
     Reference: `Rethinking Spatiotemporal Feature Learning <https://arxiv.org/abs/1712.04851>`__.
 
+    .. betastatus:: video module
+
     Args:
         weights (:class:`~torchvision.models.video.S3D_Weights`, optional): The
             pretrained weights to use. See


### PR DESCRIPTION
According to our [documentation](https://pytorch.org/vision/stable/models.html#video-classification) the video module is in Beta stage. Earlier this month we added S3D and MViT and we forgot to add the feature classification on the documentation. This PR corrects this.