### PR TITLE
Exclude MViT from cuda tests

### DIFF
--- a/test/test_models.py
+++ b/test/test_models.py
@@ -348,8 +348,8 @@ for m in slow_models:
 skipped_big_models = {
     "vit_h_14": {("Windows", "cpu"), ("Windows", "cuda")},
     "regnet_y_128gf": {("Windows", "cpu"), ("Windows", "cuda")},
-    "mvit_v1_b": {("Windows", "cuda")},
-    "mvit_v2_s": {("Windows", "cuda")},
+    "mvit_v1_b": {("Windows", "cuda"), ("Linux", "cuda")},
+    "mvit_v2_s": {("Windows", "cuda"), ("Linux", "cuda")},
 }
 
 


### PR DESCRIPTION
As noted at #6539, some variants are too big for the CUDA memory we got on the CI and occasionally [fail](https://app.circleci.com/pipelines/github/pytorch/vision/20083/workflows/ba8a58d7-4a6c-47bb-89db-207b3207fbfa/jobs/1632032). This is semi-random and happens from time to time. When it does, it takes down with it other models randomly (see for example maskrcnn failing as well on the linked execution).

To avoid this flakiness, we should exclude MViT from the CUDA runs.