### PR TITLE
fix resize for segmentation masks without channel dimension

### DIFF
--- a/torchvision/prototype/transforms/functional/_geometry.py
+++ b/torchvision/prototype/transforms/functional/_geometry.py
@@ -135,7 +135,20 @@ def resize_image_pil(
 def resize_segmentation_mask(
     segmentation_mask: torch.Tensor, size: List[int], max_size: Optional[int] = None
 ) -> torch.Tensor:
-    return resize_image_tensor(segmentation_mask, size=size, interpolation=InterpolationMode.NEAREST, max_size=max_size)
+    if segmentation_mask.ndim < 3:
+        segmentation_mask = segmentation_mask.unsqueeze(0)
+        needs_squeeze = True
+    else:
+        needs_squeeze = False
+
+    output = resize_image_tensor(
+        segmentation_mask, size=size, interpolation=InterpolationMode.NEAREST, max_size=max_size
+    )
+
+    if needs_squeeze:
+        output = output.squeeze(0)
+
+    return output
 
 
 def resize_bounding_box(

--- a/torchvision/transforms/functional_tensor.py
+++ b/torchvision/transforms/functional_tensor.py
@@ -132,7 +132,7 @@ def hflip(img: Tensor) -> Tensor:
 def crop(img: Tensor, top: int, left: int, height: int, width: int) -> Tensor:
     _assert_image_tensor(img)
 
-    w, h = get_image_size(img)
+    _, h, w = get_dimensions(img)
     right = left + width
     bottom = top + height
 

--- a/torchvision/transforms/functional_tensor.py
+++ b/torchvision/transforms/functional_tensor.py
@@ -132,7 +132,7 @@ def hflip(img: Tensor) -> Tensor:
 def crop(img: Tensor, top: int, left: int, height: int, width: int) -> Tensor:
     _assert_image_tensor(img)
 
-    _, h, w = get_dimensions(img)
+    w, h = get_image_size(img)
     right = left + width
     bottom = top + height
 


### PR DESCRIPTION
Follow-up to #6574.

```py
import torch

from torchvision.prototype import features
from torchvision.prototype.transforms import functional as F

size = (16, 31)

segmentation_mask = features.SegmentationMask(torch.randint(0, 10, size))

print(segmentation_mask.shape, F.resize(segmentation_mask, size).shape)

```

```
torch.Size([16, 31]) torch.Size([1, 16, 31])
```

This was not detected in #6574 since kernel works without adding an explicit channel dimension, but it doesn't remove it again. This happens because

https://github.com/pytorch/vision/blob/b4686f2b7409d1783dfbb951492cd59bfed08bce/torchvision/prototype/transforms/functional/_geometry.py#L106

returns `1` for the number of channels if we have no channel dimension:

https://github.com/pytorch/vision/blob/b4686f2b7409d1783dfbb951492cd59bfed08bce/torchvision/transforms/functional_tensor.py#L24-L26