### PR TITLE
[vision_transformer] Make the assert message more verbose

### DIFF
--- a/torchvision/models/vision_transformer.py
+++ b/torchvision/models/vision_transformer.py
@@ -268,8 +268,8 @@ class VisionTransformer(nn.Module):
     def _process_input(self, x: torch.Tensor) -> torch.Tensor:
         n, c, h, w = x.shape
         p = self.patch_size
-        torch._assert(h == self.image_size, "Wrong image height!")
-        torch._assert(w == self.image_size, "Wrong image width!")
+        torch._assert(h == self.image_size, f"Wrong image height, expected {self.image_size} but got {h}!")
+        torch._assert(w == self.image_size, f"Wrong image width, expected {self.image_size} but got {w}!")
         n_h = h // p
         n_w = w // p
 


### PR DESCRIPTION
A small patch addressing problem mentioned in https://github.com/pytorch/vision/issues/6428

Currently we give error message like:
```
Wrong image height!
```
This is not clear to users on what the expected height should be. In this PR we make this more verbose and add the input height and expected height. Now it become:
```
Wrong image height, expected 224 but got 518!
```