### PR TITLE
Switch to use conda install action for m1 builds

### DIFF
--- a/.github/workflows/build-m1-binaries.yml
+++ b/.github/workflows/build-m1-binaries.yml
@@ -36,6 +36,8 @@ jobs:
         if: ${{ (github.event_name == 'pull_request' && startsWith(github.base_ref, 'release')) || startsWith(github.ref, 'refs/heads/release') }}
         run: |
           echo "CHANNEL=test" >> "$GITHUB_ENV"
+      - name: Setup miniconda
+        uses: pytorch/test-infra/.github/actions/setup-miniconda@main
       - name: Build TorchVision M1 wheel
         shell: arch -arch arm64 bash {0}
         env:
@@ -109,12 +111,13 @@ jobs:
         if: ${{ (github.event_name == 'pull_request' && startsWith(github.base_ref, 'release')) || startsWith(github.ref, 'refs/heads/release') }}
         run: |
           echo "CHANNEL=test" >> "$GITHUB_ENV"
+      - name: Setup miniconda
+        uses: pytorch/test-infra/.github/actions/setup-miniconda@main
       - name: Install conda-build and purge previous artifacts
         shell: arch -arch arm64 bash {0}
         run: |
           conda install -yq conda-build
           conda build purge-all
-
       - name: Build TorchVision M1 conda package
         shell: arch -arch arm64 bash {0}
         env:


### PR DESCRIPTION
Usage setup-minicoda action for m1 build
We want to try to address space issues on m1. The following action:
```
pytorch/test-infra/.github/actions/setup-miniconda@main
```

Sets up miniconda in temp folder which should be cleaned between runs

Ref: https://github.com/pytorch/pytorch/issues/84841
