### PR TITLE
[FBcode->GH] Fix vit model assert text to be compatible with torchmultimodal

### DIFF
--- a/torchvision/models/vision_transformer.py
+++ b/torchvision/models/vision_transformer.py
@@ -268,8 +268,8 @@ class VisionTransformer(nn.Module):
     def _process_input(self, x: torch.Tensor) -> torch.Tensor:
         n, c, h, w = x.shape
         p = self.patch_size
-        torch._assert(h == self.image_size, f"Wrong image height, expected {self.image_size} but got {h}!")
-        torch._assert(w == self.image_size, f"Wrong image width, expected {self.image_size} but got {w}!")
+        torch._assert(h == self.image_size, f"Wrong image height! Expected {self.image_size} but got {h}!")
+        torch._assert(w == self.image_size, f"Wrong image width! Expected {self.image_size} but got {w}!")
         n_h = h // p
         n_w = w // p
 


### PR DESCRIPTION
During FBSync I notice that the PR https://github.com/pytorch/vision/pull/6583 break [torchmultimodal's test](https://github.com/facebookresearch/multimodal/blob/main/test/models/albef/test_image_encoder.py#L52).

Here is the part that break:
```
with pytest.raises(AssertionError, match="Wrong image height!"):
```

I modify the diffs internally and this PR is to make sure fbcode and github are in sync.



