### PR TITLE
refactor `prototype.transforms,RandomCrop`

### DIFF
--- a/test/test_prototype_transforms.py
+++ b/test/test_prototype_transforms.py
@@ -715,30 +715,38 @@ class TestRandomCrop:
 
         if padding is not None:
             if isinstance(padding, int):
-                h += 2 * padding
-                w += 2 * padding
+                pad_top = pad_bottom = pad_left = pad_right = padding
             elif isinstance(padding, list) and len(padding) == 2:
-                w += 2 * padding[0]
-                h += 2 * padding[1]
+                pad_left = pad_right = padding[0]
+                pad_top = pad_bottom = padding[1]
             elif isinstance(padding, list) and len(padding) == 4:
-                w += padding[0] + padding[2]
-                h += padding[1] + padding[3]
+                pad_left, pad_top, pad_right, pad_bottom = padding
 
-        expected_input_width = w
-        expected_input_height = h
+            h += pad_top + pad_bottom
+            w += pad_left + pad_right
+        else:
+            pad_left = pad_right = pad_top = pad_bottom = 0
 
         if pad_if_needed:
             if w < size[1]:
-                w += 2 * (size[1] - w)
+                diff = size[1] - w
+                pad_left += diff
+                pad_right += diff
+                w += 2 * diff
             if h < size[0]:
-                h += 2 * (size[0] - h)
+                diff = size[0] - h
+                pad_top += diff
+                pad_bottom += diff
+                h += 2 * diff
+
+        padding = [pad_left, pad_top, pad_right, pad_bottom]
 
         assert 0 <= params["top"] <= h - size[0] + 1
         assert 0 <= params["left"] <= w - size[1] + 1
         assert params["height"] == size[0]
         assert params["width"] == size[1]
-        assert params["input_width"] == expected_input_width
-        assert params["input_height"] == expected_input_height
+        assert params["needs_pad"] is any(padding)
+        assert params["padding"] == padding
 
     @pytest.mark.parametrize("padding", [None, 1, [2, 3], [1, 2, 3, 4]])
     @pytest.mark.parametrize("pad_if_needed", [False, True])

--- a/torchvision/prototype/transforms/_geometry.py
+++ b/torchvision/prototype/transforms/_geometry.py
@@ -414,7 +414,7 @@ class RandomCrop(Transform):
             _check_padding_mode_arg(padding_mode)
 
         self.padding = padding
-        self._parsed_padding = F._geometry._parse_pad_padding(padding) if padding else None
+        self._parsed_padding = F._geometry._parse_pad_padding(padding) if padding else None  # type: ignore[arg-type]
         self.pad_if_needed = pad_if_needed
         self.fill = _setup_fill_arg(fill)
         self.padding_mode = padding_mode
@@ -422,7 +422,7 @@ class RandomCrop(Transform):
     def _get_params(self, sample: Any) -> Dict[str, Any]:
         _, padded_height, padded_width = query_chw(sample)
 
-        if self.padding is not None:
+        if self._parsed_padding is not None:
             pad_left, pad_right, pad_top, pad_bottom = self._parsed_padding
             padded_height += pad_top + pad_bottom
             padded_width += pad_left + pad_right


### PR DESCRIPTION
This PR eliminates two `F.pad` calls in `RandomCrop` by computing the full padding upfront. IMO, the implementation of `_get_params` is also more clear now, but you shouldn't trust that since I'm the author of the patch :stuck_out_tongue: 

Since we are only touching the padding here, we can compare the old and new transform by ignoring the cropping altogether. Plus, since the only random behavior happens for the crop coordinate selection, we also don't need to pay attention to random behavior.

```py
import itertools
import unittest.mock

import torch

from torchvision.prototype import transforms


input_size = (32, 17)

for size, padding, pad_if_needed in itertools.product(
    [64, 16],
    [None, 5],
    [True, False],
):
    if any(size > dim for dim in input_size) and not pad_if_needed:
        continue

    old_transform = OldRandomCropWithoutCrop(size, padding=padding, pad_if_needed=pad_if_needed)
    new_transform = transforms.RandomCrop(size, padding=padding, pad_if_needed=pad_if_needed)

    image = torch.rand(3, *input_size)

    old_output = old_transform(image)

    with unittest.mock.patch("torchvision.prototype.transforms._geometry.F.crop", new=lambda x, *_, **__: x):
        new_output = new_transform(image)

    torch.testing.assert_close(new_output, old_output, rtol=0, atol=0)
```

So everything works out perfectly? No :disappointed: 

Replacing multiple `F.pad` calls with a single one only works if the later ones don't depend on the earlier ones. In general, this is only given for `padding_mode="constant"` and `padding_mode="edge"`. 

We will use this "1D" gradient image for simplification:

![input](https://user-images.githubusercontent.com/6849766/192047081-c4c4f739-f9f7-413f-849c-48fe1b9ba729.png)

Let's look at three examples for `padding_mode="reflect"`

### :heavy_check_mark: `padding` only

old: 

![old_padding](https://user-images.githubusercontent.com/6849766/192047267-3954bd13-b5f3-4f7e-b61b-3b2bcc15b35c.png)

new:

![new_padding](https://user-images.githubusercontent.com/6849766/192047360-d6586984-3928-4dda-9e43-38f190ac0388.png)

### :heavy_check_mark: `pad_if_needed` only

old: 

![old_pad_if_needed](https://user-images.githubusercontent.com/6849766/192047469-a942fb2e-9758-4baa-a65d-c6c9998ac628.png)

new:

![new_pad_if_needed](https://user-images.githubusercontent.com/6849766/192047482-1adcb2a7-7d22-43de-becd-cd2fc48adb17.png)

### :heavy_multiplication_x: `padding` and `pad_if_needed`

old: 

![old_padding_pad_if_needed](https://user-images.githubusercontent.com/6849766/192047521-bd55ac49-e35b-4411-a203-d362a2757b03.png)

new:

![new_padding_pad_if_needed](https://user-images.githubusercontent.com/6849766/192047533-23b241f3-a5a1-4266-8d26-d5caff995fb6.png)

Since the old implementation pads twice independently from each other, the second pad reflects the reflection created by the first pad. IMO, the new implementation is doing the right thing here and only reflecting once. 

My guess is that this was just an oversight in the original stable implementation. Given that this is an obscure use case anyway, i.e. setting a fixed padding as well as using the dynamic one, and is not a problem at all for the most dominant `padding_mode="constant"`, I would be ok to break BC here in favor of performance and simplified implementation. One could also argue that this can be considered a bug fix although I'm not keen on porting this change back.