### PR TITLE
swap MD5 checksums of PCAM val and test split

### DIFF
--- a/torchvision/datasets/pcam.py
+++ b/torchvision/datasets/pcam.py
@@ -44,24 +44,24 @@ class PCAM(VisionDataset):
             "images": (
                 "camelyonpatch_level_2_split_test_x.h5",
                 "1qV65ZqZvWzuIVthK8eVDhIwrbnsJdbg_",
-                "d5b63470df7cfa627aeec8b9dc0c066e",
+                "d8c2d60d490dbd479f8199bdfa0cf6ec",
             ),
             "targets": (
                 "camelyonpatch_level_2_split_test_y.h5",
                 "17BHrSrwWKjYsOgTMmoqrIjDy6Fa2o_gP",
-                "2b85f58b927af9964a4c15b8f7e8f179",
+                "60a7035772fbdb7f34eb86d4420cf66a",
             ),
         },
         "val": {
             "images": (
                 "camelyonpatch_level_2_split_valid_x.h5",
                 "1hgshYGWK8V-eGRy8LToWJJgDU_rXWVJ3",
-                "d8c2d60d490dbd479f8199bdfa0cf6ec",
+                "d5b63470df7cfa627aeec8b9dc0c066e",
             ),
             "targets": (
                 "camelyonpatch_level_2_split_valid_y.h5",
                 "1bH8ZRbhSVAhScTS0p9-ZzGnX91cHT3uO",
-                "60a7035772fbdb7f34eb86d4420cf66a",
+                "2b85f58b927af9964a4c15b8f7e8f179",
             ),
         },
     }


### PR DESCRIPTION
Fixes #6643. I've also checked the SHA256 checksums of the prototype dataset, but they are ok. 