### PR TITLE
Hack to improve performance of resize op with nearest mode on 2D

### DIFF
--- a/torchvision/prototype/transforms/functional/_geometry.py
+++ b/torchvision/prototype/transforms/functional/_geometry.py
@@ -147,8 +147,6 @@ def resize_image_tensor(
             # Code is copied from _FT.resize
             # This is due to the fact that we need to apply the hack on casted image and not before
             # Otherwise, image will be copied while cast to float and interpolate will work on twice more data
-            _assert_image_tensor(image)
-
             image, need_cast, need_squeeze, out_dtype = _cast_squeeze_in(image, [torch.float32, torch.float64])
 
             shape = (image.shape[0], 2, image.shape[2], image.shape[3])

--- a/torchvision/transforms/functional_tensor.py
+++ b/torchvision/transforms/functional_tensor.py
@@ -466,17 +466,7 @@ def resize(
     # Define align_corners to avoid warnings
     align_corners = False if interpolation in ["bilinear", "bicubic"] else None
 
-    # This is a perf hack to avoid <pytorch-issue>
-    # We are transforming (1, 1, H, W) into (1, 2, H, W) to force to take channels_first path
-    do_perf_hack = False
-    if img.is_contiguous() and img.is_contiguous(memory_format=torch.channels_last) and interpolation == "nearest":
-        do_perf_hack = True
-        img = img.expand(1, 2, *img.shape[-2:])
-
     img = interpolate(img, size=size, mode=interpolation, align_corners=align_corners, antialias=antialias)
-
-    if do_perf_hack:
-        img = img[:, 0, ...]
 
     if interpolation == "bicubic" and out_dtype == torch.uint8:
         img = img.clamp(min=0, max=255)

--- a/torchvision/transforms/functional_tensor.py
+++ b/torchvision/transforms/functional_tensor.py
@@ -466,7 +466,17 @@ def resize(
     # Define align_corners to avoid warnings
     align_corners = False if interpolation in ["bilinear", "bicubic"] else None
 
+    # This is a perf hack to avoid <pytorch-issue>
+    # We are transforming (1, 1, H, W) into (1, 2, H, W) to force to take channels_first path
+    do_perf_hack = False
+    if img.is_contiguous() and img.is_contiguous(memory_format=torch.channels_last) and interpolation == "nearest":
+        do_perf_hack = True
+        img = img.expand(1, 2, *img.shape[-2:])
+
     img = interpolate(img, size=size, mode=interpolation, align_corners=align_corners, antialias=antialias)
+
+    if do_perf_hack:
+        img = img[:, 0, ...]
 
     if interpolation == "bicubic" and out_dtype == torch.uint8:
         img = img.clamp(min=0, max=255)


### PR DESCRIPTION
Benchmarks:

Main (Feature vs PIL)
```text
[--- Resize measurements: 500x600 -> 256 ---]
                         |  stable  |    v2  
1 threads: ----------------------------------
      PIL mask data      |   55.4   |        
      Feature Mask data  |          |  1009.3

Times are in microseconds (us).

[--- Resize measurements: 500x600 -> 520 ---]
                         |  stable  |    v2  
1 threads: ----------------------------------
      PIL mask data      |  178.0   |        
      Feature Mask data  |          |  3773.3

Times are in microseconds (us).

[--- Resize measurements: 500x600 -> 720 ---]
                         |  stable  |    v2  
1 threads: ----------------------------------
      PIL mask data      |  320.3   |        
      Feature Mask data  |          |  7101.1

Times are in microseconds (us).
```

This PR (Feature vs PIL)
```text
[-- Resize measurements: 500x600 -> 256 ---]
                         |  stable  |    v2
1 threads: ---------------------------------
      PIL mask data      |   53.4   |
      Feature Mask data  |          |  293.0

Times are in microseconds (us).

[-- Resize measurements: 500x600 -> 520 ---]
                         |  stable  |    v2
1 threads: ---------------------------------
      PIL mask data      |  165.9   |
      Feature Mask data  |          |  652.5

Times are in microseconds (us).

[--- Resize measurements: 500x600 -> 720 ---]
                         |  stable  |    v2
1 threads: ----------------------------------
      PIL mask data      |  297.3   |
      Feature Mask data  |          |  1105.2

Times are in microseconds (us).
```

Code:
```python
import numpy as np
import PIL
from functools import partial

import torch
import torch.utils.benchmark as benchmark

from torchvision.transforms import functional as F_stable
from torchvision.transforms.functional import InterpolationMode
from torchvision.prototype import features
from torchvision.prototype.transforms import functional as F_v2


def get_pil_mask(size):
    target_data = np.zeros(size, dtype="int32")
    target_data[110:140, 120:160] = 1
    target_data[10:40, 120:160] = 2
    target_data[110:140, 20:60] = 3
    target_data[size[0] // 2 : size[0] // 2 + 50, size[1] // 2 : size[1] // 2 + 60] = 4
    target = PIL.Image.fromarray(target_data).convert("L")
    return target


def main():
    results = []
    min_run_time = 2

    for size in [256, 520, 720]:
        pil_mask = get_pil_mask((500, 600))
        mask = features.Mask(F_v2.pil_to_tensor(pil_mask).squeeze(0))

        transform_stable = partial(F_stable.resize, size=size, interpolation=InterpolationMode.NEAREST)
        transform_v2 = partial(F_v2.resize, size=[size], interpolation=InterpolationMode.NEAREST)

        # PIL resize
        results.append(
            benchmark.Timer(
                stmt=f"transform(data)",
                globals={
                    "data": pil_mask,
                    "transform": transform_stable,
                },
                num_threads=torch.get_num_threads(),
                label=f"Resize measurements: 500x600 -> {size}",
                sub_label="PIL mask data",
                description="stable",
            ).blocked_autorange(min_run_time=min_run_time)
        )
        # Mask resize
        results.append(
            benchmark.Timer(
                stmt=f"transform(data)",
                globals={
                    "data": mask,
                    "transform": transform_v2,
                },
                num_threads=torch.get_num_threads(),
                label=f"Resize measurements: 500x600 -> {size}",
                sub_label="Feature Mask data",
                description="v2",
            ).blocked_autorange(min_run_time=min_run_time)
        )

    compare = benchmark.Compare(results)
    compare.print()


if __name__ == "__main__":
    main()

```


Using this hack we can reduce slowdown on segmentation dataaug pipeline (PIL seg mask vs features.Mask) from x10 to x2 :
```
## https://github.com/vfdev-5/tvapiv2_benchmarks
# python -u main.py segmentation --with_time --single_dtype=PIL
Timestamp: 20220929-110049
Torch version: 1.13.0.dev20220906+cu113
Torchvision version: 0.14.0a0
Num threads: 1

[ Segmentation transforms measurements ]
                      |  stable  |   v2
1 threads: -----------------------------
      PIL Image data  |   6.3    |  11.8

Times are in milliseconds (ms).


-----

-- Benchmark: Segmentation
- Stable transforms: RefCompose(
    <seg_transforms.RandomResize object at 0x7f0ad007f1c0>
    <seg_transforms.RandomHorizontalFlip object at 0x7f0ad007f340>
    <seg_transforms.RandomCrop object at 0x7f0ad007f3a0>
    <seg_transforms.PILToTensor object at 0x7f0ad007f4f0>
    <seg_transforms.ConvertImageDtype object at 0x7f0ad006d2b0>
    <seg_transforms.Normalize object at 0x7f0ad006d9a0>
)
- Transforms v2: Compose(
      SegWrapIntoFeatures()
      RandomResize(min_size=260, max_size=1040, interpolation=InterpolationMode.BILINEAR)
      RandomHorizontalFlip(p=1.0)
      PadIfSmaller(size=480)
      RandomCrop(size=(480, 480), pad_if_needed=False, padding_mode=constant)
      ToImageTensor()
      ConvertImageDtype()
      Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225], inplace=False)
)
```

