### PR TITLE
handle inplace operations in _Feature.__torch_function__

### DIFF
--- a/test/test_prototype_features.py
+++ b/test/test_prototype_features.py
@@ -1,3 +1,4 @@
+import pytest
 import torch
 from torchvision.prototype import features
 
@@ -56,6 +57,32 @@ def test_other_op_no_wrapping():
     output = label * 2
 
     assert type(output) is torch.Tensor
+
+
+@pytest.mark.parametrize(
+    "op",
+    [
+        lambda t: t.numpy(),
+        lambda t: t.tolist(),
+        lambda t: t.max(dim=-1),
+    ],
+)
+def test_no_tensor_output_op_no_wrapping(op):
+    tensor = torch.tensor([0, 1, 0], dtype=torch.int64)
+    label = features.Label(tensor, categories=["foo", "bar"])
+
+    output = op(label)
+
+    assert type(output) is not features.Label
+
+
+def test_inplace_op_no_wrapping():
+    tensor = torch.tensor([0, 1, 0], dtype=torch.int64)
+    label = features.Label(tensor, categories=["foo", "bar"])
+
+    output = label.add_(0)
+
+    assert type(output) is not features.Label
 
 
 def test_new_like():

--- a/test/test_prototype_features.py
+++ b/test/test_prototype_features.py
@@ -95,8 +95,8 @@ def test_inplace_op_no_wrapping():
 
     output = label.add_(0)
 
-    assert type(label) is features.Label
     assert type(output) is torch.Tensor
+    assert type(label) is features.Label
 
 
 def test_new_like():

--- a/test/test_prototype_features.py
+++ b/test/test_prototype_features.py
@@ -49,6 +49,19 @@ def test_clone_wrapping():
     assert label_clone.categories is label.categories
 
 
+def test_requires_grad__wrapping():
+    tensor = torch.tensor([0, 1, 0], dtype=torch.float32)
+    label = features.Label(tensor, categories=["foo", "bar"])
+
+    assert not label.requires_grad
+
+    label_requires_grad = label.requires_grad_(True)
+
+    assert type(label_requires_grad) is features.Label
+    assert label.requires_grad
+    assert label_requires_grad.requires_grad
+
+
 def test_other_op_no_wrapping():
     tensor = torch.tensor([0, 1, 0], dtype=torch.int64)
     label = features.Label(tensor, categories=["foo", "bar"])
@@ -82,7 +95,8 @@ def test_inplace_op_no_wrapping():
 
     output = label.add_(0)
 
-    assert type(output) is not features.Label
+    assert type(label) is features.Label
+    assert type(output) is torch.Tensor
 
 
 def test_new_like():

--- a/test/test_prototype_transforms_functional.py
+++ b/test/test_prototype_transforms_functional.py
@@ -907,15 +907,15 @@ def test_correctness_gaussian_blur_image_tensor(device, image_size, dt, ksize, s
     torch.testing.assert_close(out, true_out, rtol=0.0, atol=1.0, msg=f"{ksize}, {sigma}")
 
 
-def test_midlevel_normalize_output_type():
+def test_normalize_output_type():
     inpt = torch.rand(1, 3, 32, 32)
     output = F.normalize(inpt, mean=[0.5, 0.5, 0.5], std=[1.0, 1.0, 1.0])
-    assert isinstance(output, torch.Tensor)
+    assert type(output) is torch.Tensor
     torch.testing.assert_close(inpt - 0.5, output)
 
     inpt = make_image(color_space=features.ColorSpace.RGB)
     output = F.normalize(inpt, mean=[0.5, 0.5, 0.5], std=[1.0, 1.0, 1.0])
-    assert isinstance(output, torch.Tensor)
+    assert type(output) is torch.Tensor
     torch.testing.assert_close(inpt - 0.5, output)
 
 

--- a/torchvision/prototype/features/_feature.py
+++ b/torchvision/prototype/features/_feature.py
@@ -102,10 +102,11 @@ class _Feature(torch.Tensor):
             # There are two reasons we want to return the output without wrapping it:
             # 1. The `func` is not one of the exceptions. This implicitly also excludes wrapping of outputs of `func`'s
             #    that don't return a tensor in the first place, e.g. `.numpy()`, `.tolist()`, or `.max(dim=...)`.
-            # 2. The primary operand, i.e. `args[0]`, is the `_Feature`. The __torch_function__ protocol will invoke
+            # 2. The primary operand, i.e. `args[0]`, is not a `_Feature`. The __torch_function__ protocol will invoke
             #    this method on all types involved in the computation by walking the MRO upwards. For example,
-            #    `torch.Tensor(...).to(features.Image(...))` will invoke `features.Image.__torch_function__` first and
-            #    without this guard the original simple tensor would either be wrapped or we fail trying to do so.
+            #    `torch.Tensor(...).to(features.Image(...))` will invoke `features.Image.__torch_function__` with
+            #    `args = (torch.Tensor(), features.Image())`. Without this guard the original plain tensor would either
+            #    be wrapped or we fail trying to do so.
             if func not in cls._NO_WRAPPING_EXCEPTIONS or not isinstance(args[0], cls):
                 # Inplace `func`'s, canonically identified with a trailing underscore in their name like `.add_(...)`,
                 # will retain the input type. Thus, we need to unwrap here.

--- a/torchvision/prototype/features/_feature.py
+++ b/torchvision/prototype/features/_feature.py
@@ -110,7 +110,9 @@ class _Feature(torch.Tensor):
             if func not in cls._NO_WRAPPING_EXCEPTIONS or not isinstance(args[0], cls):
                 # Inplace `func`'s, canonically identified with a trailing underscore in their name like `.add_(...)`,
                 # will retain the input type. Thus, we need to unwrap here.
-                return output.as_subclass(torch.Tensor) if isinstance(output, cls) else output
+                if isinstance(output, cls):
+                    output = output.as_subclass(torch.Tensor)  # type: ignore[arg-type]
+                return output
 
             if func is torch.Tensor.clone:
                 return cls.new_like(args[0], output)

--- a/torchvision/prototype/transforms/functional/_misc.py
+++ b/torchvision/prototype/transforms/functional/_misc.py
@@ -12,12 +12,17 @@ normalize_image_tensor = _FT.normalize
 def normalize(
     inpt: features.TensorImageTypeJIT, mean: List[float], std: List[float], inplace: bool = False
 ) -> torch.Tensor:
-    if not isinstance(inpt, torch.Tensor):
-        raise TypeError(f"img should be Tensor Image. Got {type(inpt)}")
+    if torch.jit.is_scripting():
+        correct_type = isinstance(inpt, torch.Tensor)
     else:
-        # Image instance after normalization is not Image anymore due to unknown data range
-        # Thus we return Tensor for input Image
-        return normalize_image_tensor(inpt, mean=mean, std=std, inplace=inplace).as_subclass(torch.Tensor)
+        correct_type = features.is_simple_tensor(inpt) or isinstance(inpt, features.Image)
+        inpt = inpt.as_subclass(torch.Tensor)
+    if not correct_type:
+        raise TypeError(f"img should be Tensor Image. Got {type(inpt)}")
+
+    # Image instance after normalization is not Image anymore due to unknown data range
+    # Thus we return Tensor for input Image
+    return normalize_image_tensor(inpt, mean=mean, std=std, inplace=inplace)
 
 
 def gaussian_blur_image_tensor(

--- a/torchvision/prototype/transforms/functional/_misc.py
+++ b/torchvision/prototype/transforms/functional/_misc.py
@@ -17,7 +17,7 @@ def normalize(
     else:
         # Image instance after normalization is not Image anymore due to unknown data range
         # Thus we return Tensor for input Image
-        return normalize_image_tensor(inpt, mean=mean, std=std, inplace=inplace)
+        return normalize_image_tensor(inpt, mean=mean, std=std, inplace=inplace).as_subclass(torch.Tensor)
 
 
 def gaussian_blur_image_tensor(

--- a/torchvision/prototype/transforms/functional/_misc.py
+++ b/torchvision/prototype/transforms/functional/_misc.py
@@ -16,7 +16,7 @@ def normalize(
         correct_type = isinstance(inpt, torch.Tensor)
     else:
         correct_type = features.is_simple_tensor(inpt) or isinstance(inpt, features.Image)
-        inpt = inpt.as_subclass(torch.Tensor)
+        inpt = inpt.as_subclass(torch.Tensor)  # type: ignore[arg-type]
     if not correct_type:
         raise TypeError(f"img should be Tensor Image. Got {type(inpt)}")
 

--- a/torchvision/transforms/functional_tensor.py
+++ b/torchvision/transforms/functional_tensor.py
@@ -937,8 +937,7 @@ def normalize(tensor: Tensor, mean: List[float], std: List[float], inplace: bool
         mean = mean.view(-1, 1, 1)
     if std.ndim == 1:
         std = std.view(-1, 1, 1)
-    tensor.sub_(mean).div_(std)
-    return tensor
+    return tensor.sub_(mean).div_(std)
 
 
 def erase(img: Tensor, i: int, j: int, h: int, w: int, v: Tensor, inplace: bool = False) -> Tensor:


### PR DESCRIPTION
Fixes #6669. At least as far as it is possible. We can only unwrap the result of an inplace operation, i.e. what is returned by it. We cannot change the type inplace and thus we can't prevent the following:

```pycon
>>> image = features.Image(torch.rand(3, 16, 16))
>>> output = image.add_(0)
>>> type(output)
torch.Tensor
>>> type(image)
torchvision.prototype.features._image.Image
```

As you can see `output` is properly unwrapped, but we can't do that for `image` although we have no idea if the operation "invalidated" the type.
