### PR TITLE
upgrade flake8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
           - usort == 1.0.2
 
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.9.2
+    rev: 5.0.4
     hooks:
       - id: flake8
         args: [--config=setup.cfg]


### PR DESCRIPTION
Our current version

https://github.com/pytorch/vision/blob/1d7d92cb10c18b750a86acd0d971d114c34a40c4/.pre-commit-config.yaml#L22

is quite outdated. Yesterdays release of [`importlib-metadata==5.0.0`](https://pypi.org/project/importlib-metadata/5.0.0/) breaks `flake8==3.9.2` since it uses a now removed functionality.

Instead of upgrading `flake8`, we could also pin `importlib-metadata` and stick with our old `flake8` version, but I see no point. LMK if you think different.
