### PR TITLE
fix example galleries in documentation

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,7 @@
 matplotlib
 numpy
 sphinx-copybutton>=0.3.1
-sphinx-gallery >=0.9.0, !=0.11.0
+sphinx-gallery>=0.11.1
 sphinx==5.0.0
 tabulate
 -e git+https://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,7 @@
 matplotlib
 numpy
 sphinx-copybutton>=0.3.1
-sphinx-gallery>=0.9.0
+sphinx-gallery >=0.9.0, !=0.11.0
 sphinx==5.0.0
 tabulate
 -e git+https://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme

--- a/docs/source/_static/css/custom_torchvision.css
+++ b/docs/source/_static/css/custom_torchvision.css
@@ -21,3 +21,15 @@ article.pytorch-article .reference.download.internal, article.pytorch-article .s
 .table-weights p {
     margin-bottom: 0.2rem !important;
 }
+
+/* Fix for Sphinx gallery 0.11
+See https://github.com/sphinx-gallery/sphinx-gallery/issues/990
+*/
+article.pytorch-article .sphx-glr-thumbnails .sphx-glr-thumbcontainer {
+    width: unset;
+    margin-right: 0;
+    margin-left: 0;
+}
+article.pytorch-article div.section div.wy-table-responsive tbody td {
+    width: 50%;
+}


### PR DESCRIPTION
Fixes #6679. 

main: https://output.circle-artifacts.com/output/job/b42f472a-a9aa-491d-8a73-855038a6ab31/artifacts/0/docs/auto_examples/index.html
PR: https://output.circle-artifacts.com/output/job/b450b5e3-9474-4e1a-b0dd-c2ad9d5f5fce/artifacts/0/docs/auto_examples/index.html

If this PR is merged, I'll send a PR for the release branch.