### PR TITLE
[bugfix] Fix the output format for VideoClips.subset

### DIFF
--- a/torchvision/datasets/video_utils.py
+++ b/torchvision/datasets/video_utils.py
@@ -198,6 +198,7 @@ class VideoClips:
             _video_max_dimension=self._video_max_dimension,
             _audio_samples=self._audio_samples,
             _audio_channels=self._audio_channels,
+            output_format=self.output_format,
         )
 
     @staticmethod


### PR DESCRIPTION
Resolve the bug reported in https://github.com/pytorch/vision/issues/6696