### PR TITLE
[bugfix] Make CUB200 labels 0-indexed.

### DIFF
--- a/torchvision/prototype/datasets/_builtin/cub200.py
+++ b/torchvision/prototype/datasets/_builtin/cub200.py
@@ -177,7 +177,10 @@ class CUB200(Dataset):
         return dict(
             prepare_ann_fn(anns_data, image.image_size),
             image=image,
-            label=Label(int(pathlib.Path(path).parent.name.rsplit(".", 1)[0]), categories=self._categories),
+            label=Label(
+                int(pathlib.Path(path).parent.name.rsplit(".", 1)[0]) - 1,
+                categories=self._categories,
+            ),
         )
 
     def _datapipe(self, resource_dps: List[IterDataPipe]) -> IterDataPipe[Dict[str, Any]]:


### PR DESCRIPTION
### Bug description:

CUB200 dataset in `torchvision.prototype.datasets` module formed labels using file paths. This resulted in labels being 1-indexed (1-200) instead of 0-indexed (0-199). A related issue from the past was with Flowers102 (`torchvision.datasets` module, #5766).

This PR simply shifts the labels and makes them zero-indexed for consistency with other datasets.
