### PR TITLE
[ONNX] Rephrase ONNX RoiAlign warning for aligned=True

### DIFF
--- a/torchvision/ops/_register_onnx_ops.py
+++ b/torchvision/ops/_register_onnx_ops.py
@@ -45,8 +45,8 @@ def _register_custom_op():
         rois = _process_rois_for_roi_align(g, rois)
         if aligned:
             warnings.warn(
-                "ROIAlign with aligned=True is not supported in ONNX, but is supported in opset 16. "
-                "Please export with opset 16 or higher to use aligned=False."
+                "ROIAlign with aligned=True is only supported in opset >= 16. "
+                "Please export with opset 16 or higher or use aligned=False."
             )
         sampling_ratio = _process_sampling_ratio_for_roi_align(g, sampling_ratio)
         return g.op(

--- a/torchvision/ops/_register_onnx_ops.py
+++ b/torchvision/ops/_register_onnx_ops.py
@@ -46,7 +46,7 @@ def _register_custom_op():
         if aligned:
             warnings.warn(
                 "ROIAlign with aligned=True is only supported in opset >= 16. "
-                "Please export with opset 16 or higher or use aligned=False."
+                "Please export with opset 16 or higher, or use aligned=False."
             )
         sampling_ratio = _process_sampling_ratio_for_roi_align(g, sampling_ratio)
         return g.op(


### PR DESCRIPTION
Rephrase warning message when exporting `RoiAlign` in ONNX opset < 16 with `aligned=True`.