### PR TITLE
Remove unnecessary `ignore` directives to fix mypy

### DIFF
--- a/torchvision/prototype/features/_feature.py
+++ b/torchvision/prototype/features/_feature.py
@@ -32,10 +32,10 @@ class _Feature(torch.Tensor):
         return (
             torch.as_tensor(  # type: ignore[return-value]
                 data,
-                dtype=dtype,  # type: ignore[arg-type]
-                device=device,  # type: ignore[arg-type]
+                dtype=dtype,
+                device=device,
             )
-            .as_subclass(cls)  # type: ignore[arg-type]
+            .as_subclass(cls)
             .requires_grad_(requires_grad)
         )
 
@@ -115,7 +115,7 @@ class _Feature(torch.Tensor):
             # Inplace `func`'s, canonically identified with a trailing underscore in their name like `.add_(...)`,
             # will retain the input type. Thus, we need to unwrap here.
             if isinstance(output, cls):
-                return output.as_subclass(torch.Tensor)  # type: ignore[arg-type]
+                return output.as_subclass(torch.Tensor)
 
             return output
 

--- a/torchvision/prototype/features/_image.py
+++ b/torchvision/prototype/features/_image.py
@@ -71,7 +71,7 @@ class Image(_Feature):
         device: Optional[Union[torch.device, str, int]] = None,
         requires_grad: bool = False,
     ) -> Image:
-        data = torch.as_tensor(data, dtype=dtype, device=device)  # type: ignore[arg-type]
+        data = torch.as_tensor(data, dtype=dtype, device=device)
         if data.ndim < 2:
             raise ValueError
         elif data.ndim == 2:

--- a/torchvision/prototype/transforms/functional/_misc.py
+++ b/torchvision/prototype/transforms/functional/_misc.py
@@ -16,7 +16,7 @@ def normalize(
         correct_type = isinstance(inpt, torch.Tensor)
     else:
         correct_type = features.is_simple_tensor(inpt) or isinstance(inpt, features.Image)
-        inpt = inpt.as_subclass(torch.Tensor)  # type: ignore[arg-type]
+        inpt = inpt.as_subclass(torch.Tensor)
     if not correct_type:
         raise TypeError(f"img should be Tensor Image. Got {type(inpt)}")
 


### PR DESCRIPTION
Fixes mypy [breakage](https://app.circleci.com/pipelines/github/pytorch/vision/20873/workflows/43be4fd8-bbae-48d0-843c-528232fa7db2/jobs/1697250) on main branch