### PR TITLE
Reduce sample inputs for prototype transform kernels

### DIFF
--- a/test/prototype_common_utils.py
+++ b/test/prototype_common_utils.py
@@ -28,6 +28,7 @@ __all__ = [
     "assert_close",
     "assert_equal",
     "ArgsKwargs",
+    "VALID_EXTRA_DIMS",
     "make_image_loaders",
     "make_image",
     "make_images",
@@ -201,7 +202,10 @@ def _parse_image_size(size, *, name="size"):
         )
 
 
-DEFAULT_EXTRA_DIMS = ((), (0,), (4,), (2, 3), (5, 0), (0, 5))
+VALID_EXTRA_DIMS = ((), (4,), (2, 3))
+DEGENERATE_BATCH_DIMS = ((0,), (5, 0), (0, 5))
+
+DEFAULT_EXTRA_DIMS = (*VALID_EXTRA_DIMS, *DEGENERATE_BATCH_DIMS)
 
 
 def from_loader(loader_fn):

--- a/test/prototype_transforms_dispatcher_infos.py
+++ b/test/prototype_transforms_dispatcher_infos.py
@@ -63,7 +63,7 @@ class DispatcherInfo:
                     yield args_kwargs
 
 
-def xfail_python_scalar_arg_jit(name, *, reason=None):
+def xfail_jit_python_scalar_arg(name, *, reason=None):
     reason = reason or f"Python scalar int or float for `{name}` is not supported when scripting"
     return TestMark(
         ("TestDispatchers", "test_scripted_smoke"),
@@ -72,8 +72,8 @@ def xfail_python_scalar_arg_jit(name, *, reason=None):
     )
 
 
-def xfail_integer_size_jit(name="size"):
-    return xfail_python_scalar_arg_jit(name, reason=f"Integer `{name}` is not supported when scripting.")
+def xfail_jit_integer_size(name="size"):
+    return xfail_jit_python_scalar_arg(name, reason=f"Integer `{name}` is not supported when scripting.")
 
 
 skip_dispatch_feature = TestMark(
@@ -123,7 +123,7 @@ DISPATCHER_INFOS = [
         },
         pil_kernel_info=PILKernelInfo(F.resize_image_pil),
         test_marks=[
-            xfail_integer_size_jit(),
+            xfail_jit_integer_size(),
         ],
     ),
     DispatcherInfo(
@@ -136,7 +136,7 @@ DISPATCHER_INFOS = [
         pil_kernel_info=PILKernelInfo(F.affine_image_pil),
         test_marks=[
             xfail_dispatch_pil_if_fill_sequence_needs_broadcast,
-            xfail_python_scalar_arg_jit("shear"),
+            xfail_jit_python_scalar_arg("shear"),
         ],
     ),
     DispatcherInfo(
@@ -227,7 +227,7 @@ DISPATCHER_INFOS = [
         },
         pil_kernel_info=PILKernelInfo(F.center_crop_image_pil),
         test_marks=[
-            xfail_integer_size_jit("output_size"),
+            xfail_jit_integer_size("output_size"),
         ],
     ),
     DispatcherInfo(
@@ -237,8 +237,8 @@ DISPATCHER_INFOS = [
         },
         pil_kernel_info=PILKernelInfo(F.gaussian_blur_image_pil),
         test_marks=[
-            xfail_python_scalar_arg_jit("kernel_size"),
-            xfail_python_scalar_arg_jit("sigma"),
+            xfail_jit_python_scalar_arg("kernel_size"),
+            xfail_jit_python_scalar_arg("sigma"),
         ],
     ),
     DispatcherInfo(
@@ -335,7 +335,7 @@ DISPATCHER_INFOS = [
         },
         pil_kernel_info=PILKernelInfo(F.five_crop_image_pil),
         test_marks=[
-            xfail_integer_size_jit(),
+            xfail_jit_integer_size(),
             skip_dispatch_feature,
         ],
     ),
@@ -345,7 +345,7 @@ DISPATCHER_INFOS = [
             features.Image: F.ten_crop_image_tensor,
         },
         test_marks=[
-            xfail_integer_size_jit(),
+            xfail_jit_integer_size(),
             skip_dispatch_feature,
         ],
         pil_kernel_info=PILKernelInfo(F.ten_crop_image_pil),

--- a/test/prototype_transforms_kernel_infos.py
+++ b/test/prototype_transforms_kernel_infos.py
@@ -1123,7 +1123,13 @@ _CENTER_CROP_OUTPUT_SIZES = [[4, 3], [42, 70], [4], 3, (5, 2), (6,)]
 
 def sample_inputs_center_crop_image_tensor():
     for image_loader, output_size in itertools.product(
-        make_image_loaders(sizes=_CENTER_CROP_IMAGE_SIZES), _CENTER_CROP_OUTPUT_SIZES
+        make_image_loaders(sizes=[(16, 17)], color_spaces=[features.ColorSpace.RGB], dtypes=[torch.float32]),
+        [
+            # valid `output_size` types for which cropping is applied to both dimensions
+            *[5, (4,), (2, 3), [6], [3, 2]],
+            # `output_size`'s for which at least one dimension needs to be padded
+            *[[4, 18], [17, 5], [17, 18]],
+        ],
     ):
         yield ArgsKwargs(image_loader, output_size=output_size)
 
@@ -1146,10 +1152,9 @@ def sample_inputs_center_crop_bounding_box():
 
 
 def sample_inputs_center_crop_mask():
-    for mask_loader, output_size in itertools.product(
-        make_mask_loaders(sizes=_CENTER_CROP_IMAGE_SIZES), _CENTER_CROP_OUTPUT_SIZES
-    ):
-        yield ArgsKwargs(mask_loader, output_size=output_size)
+    for mask_loader in make_mask_loaders(sizes=["random"], num_categories=["random"], num_objects=["random"]):
+        height, width = mask_loader.shape[-2:]
+        yield ArgsKwargs(mask_loader, output_size=(height // 2, width // 2))
 
 
 def reference_inputs_center_crop_mask():

--- a/test/prototype_transforms_kernel_infos.py
+++ b/test/prototype_transforms_kernel_infos.py
@@ -1601,7 +1601,9 @@ def _get_five_ten_crop_image_size(size):
 
 def sample_inputs_five_crop_image_tensor():
     for size in _FIVE_TEN_CROP_SIZES:
-        for image_loader in make_image_loaders(sizes=[_get_five_ten_crop_image_size(size)]):
+        for image_loader in make_image_loaders(
+            sizes=[_get_five_ten_crop_image_size(size)], color_spaces=[features.ColorSpace.RGB], dtypes=[torch.float32]
+        ):
             yield ArgsKwargs(image_loader, size=size)
 
 
@@ -1613,7 +1615,9 @@ def reference_inputs_five_crop_image_tensor():
 
 def sample_inputs_ten_crop_image_tensor():
     for size, vertical_flip in itertools.product(_FIVE_TEN_CROP_SIZES, [False, True]):
-        for image_loader in make_image_loaders(sizes=[_get_five_ten_crop_image_size(size)]):
+        for image_loader in make_image_loaders(
+            sizes=[_get_five_ten_crop_image_size(size)], color_spaces=[features.ColorSpace.RGB], dtypes=[torch.float32]
+        ):
             yield ArgsKwargs(image_loader, size=size, vertical_flip=vertical_flip)
 
 

--- a/test/prototype_transforms_kernel_infos.py
+++ b/test/prototype_transforms_kernel_infos.py
@@ -725,7 +725,16 @@ _CROP_PARAMS = combinations_grid(top=[-8, 0, 9], left=[-8, 0, 9], height=[12, 20
 
 
 def sample_inputs_crop_image_tensor():
-    for image_loader, params in itertools.product(make_image_loaders(), [_CROP_PARAMS[0], _CROP_PARAMS[-1]]):
+    for image_loader, params in itertools.product(
+        make_image_loaders(sizes=[(16, 17)], color_spaces=[features.ColorSpace.RGB], dtypes=[torch.float32]),
+        [
+            dict(top=4, left=3, height=7, width=8),
+            dict(top=-1, left=3, height=7, width=8),
+            dict(top=4, left=-1, height=7, width=8),
+            dict(top=4, left=3, height=17, width=8),
+            dict(top=4, left=3, height=7, width=18),
+        ],
+    ):
         yield ArgsKwargs(image_loader, **params)
 
 
@@ -742,8 +751,8 @@ def sample_inputs_crop_bounding_box():
 
 
 def sample_inputs_crop_mask():
-    for mask_loader, params in itertools.product(make_mask_loaders(), [_CROP_PARAMS[0], _CROP_PARAMS[-1]]):
-        yield ArgsKwargs(mask_loader, **params)
+    for mask_loader in make_mask_loaders(sizes=[(16, 17)], num_categories=["random"], num_objects=["random"]):
+        yield ArgsKwargs(mask_loader, top=4, left=3, height=7, width=8)
 
 
 def reference_inputs_crop_mask():

--- a/torchvision/transforms/functional_tensor.py
+++ b/torchvision/transforms/functional_tensor.py
@@ -755,12 +755,7 @@ def gaussian_blur(img: Tensor, kernel_size: List[int], sigma: List[float]) -> Te
     kernel = _get_gaussian_kernel2d(kernel_size, sigma, dtype=dtype, device=img.device)
     kernel = kernel.expand(img.shape[-3], 1, kernel.shape[0], kernel.shape[1])
 
-    img, need_cast, need_squeeze, out_dtype = _cast_squeeze_in(
-        img,
-        [
-            kernel.dtype,
-        ],
-    )
+    img, need_cast, need_squeeze, out_dtype = _cast_squeeze_in(img, [kernel.dtype])
 
     # padding = (left, right, top, bottom)
     padding = [kernel_size[0] // 2, kernel_size[0] // 2, kernel_size[1] // 2, kernel_size[1] // 2]


### PR DESCRIPTION
Addresses 3. from #6622. 

This PR achieves a significant reduction of the number of sample inputs. Only for the bounding box kernels, the number goes up slightly. After manual inspection, it became clear that our previous sample inputs were not sufficient.

| kernel                             | # sample inputs `main` | # sample inputs PR |
|------------------------------------|------------------------|--------------------|
| `pad_image_tensor`                 | 2448                   | 108                |
| `resize_image_tensor`              | 960                    | 73                 |
| `pad_mask`                         | 864                    | 12                 |
| `center_crop_image_tensor`         | 864                    | 48                 |
| `resize_mask`                      | 720                    | 12                 |
| `center_crop_mask`                 | 648                    | 12                 |
| `affine_image_tensor`              | 624                    | 180                |
| `ten_crop_image_tensor`            | 480                    | 60                 |
| `rotate_image_tensor`              | 432                    | 84                 |
| `crop_image_tensor`                | 384                    | 30                 |
| `affine_mask`                      | 288                    | 12                 |
| `convert_color_space_image_tensor` | 288                    | 168                |
| `crop_mask`                        | 288                    | 12                 |
| `gaussian_blur_image_tensor`       | 288                    | 36                 |
| `affine_bounding_box`              | 252                    | 264                |
| `five_crop_image_tensor`           | 240                    | 30                 |
| `pad_bounding_box`                 | 108                    | 252                |
| `rotate_mask`                      | 72                     | 12                 |
| `resize_bounding_box`              | 60                     | 180                |

In total we cut the number of tests (and approximately the runtime) roughly to a third of what is was before. Plus, we even increase the coverage ever so slightly:

- `main`:
  ```
  ---------- coverage: platform linux, python 3.7.12-final-0 -----------
  Name                                                              Stmts   Miss  Cover
  -------------------------------------------------------------------------------------
  torchvision/prototype/transforms/functional/__init__.py               8      0   100%
  torchvision/prototype/transforms/functional/_augment.py              18      1    94%
  torchvision/prototype/transforms/functional/_color.py                91      0   100%
  torchvision/prototype/transforms/functional/_deprecated.py           29     17    41%
  torchvision/prototype/transforms/functional/_geometry.py            539     32    94%
  torchvision/prototype/transforms/functional/_meta.py                137     28    80%
  torchvision/prototype/transforms/functional/_misc.py                 48      7    85%
  torchvision/prototype/transforms/functional/_type_conversion.py      31      7    77%
  -------------------------------------------------------------------------------------
  TOTAL                                                               901     92    90%
  
  ===== 66202 passed, 87703 skipped, 1792 xfailed, 1 warning in 173.32s (0:02:53) =====
  ```
- PR:
  ```
  ---------- coverage: platform linux, python 3.7.12-final-0 -----------
  Name                                                              Stmts   Miss  Cover
  -------------------------------------------------------------------------------------
  torchvision/prototype/transforms/functional/__init__.py               8      0   100%
  torchvision/prototype/transforms/functional/_augment.py              18      1    94%
  torchvision/prototype/transforms/functional/_color.py                91      0   100%
  torchvision/prototype/transforms/functional/_deprecated.py           29     17    41%
  torchvision/prototype/transforms/functional/_geometry.py            539     31    94%
  torchvision/prototype/transforms/functional/_meta.py                137     25    82%
  torchvision/prototype/transforms/functional/_misc.py                 48      7    85%
  torchvision/prototype/transforms/functional/_type_conversion.py      31      7    77%
  -------------------------------------------------------------------------------------
  TOTAL                                                               901     88    90%
  
  ====== 21785 passed, 21954 skipped, 544 xfailed, 1 warning in 60.59s (0:01:00) ======
  ```