### PR TITLE
Fix windows python 3.8 required dlls not found

### DIFF
--- a/torchvision/extension.py
+++ b/torchvision/extension.py
@@ -16,6 +16,18 @@ def _has_ops():
 
 
 try:
+    # On Windows Python-3.8+ has `os.add_dll_directory` call,
+    # which is called to configure dll search path.
+    # To find cuda related dlls we need to make sure the
+    # conda environment/bin path is configured Please take a look:
+    # https://stackoverflow.com/questions/59330863/cant-import-dll-module-in-python
+    if os.name == "nt" and sys.version_info >= (3, 8) and sys.version_info < (3, 9):
+        env_path = os.environ["PATH"]
+        path_arr = env_path.split(";")
+        for path in path_arr:
+            if os.path.exists(path):
+                os.add_dll_directory(path)
+
     lib_path = _get_extension_path("_C")
     torch.ops.load_library(lib_path)
     _HAS_OPS = True

--- a/torchvision/extension.py
+++ b/torchvision/extension.py
@@ -16,7 +16,7 @@ def _has_ops():
 
 
 try:
-    # On Windows Python-3.8+ has `os.add_dll_directory` call,
+    # On Windows Python-3.8.x has `os.add_dll_directory` call,
     # which is called to configure dll search path.
     # To find cuda related dlls we need to make sure the
     # conda environment/bin path is configured Please take a look:

--- a/torchvision/extension.py
+++ b/torchvision/extension.py
@@ -26,7 +26,7 @@ try:
         path_arr = env_path.split(";")
         for path in path_arr:
             if os.path.exists(path):
-                os.add_dll_directory(path)
+                os.add_dll_directory(path)  # type: ignore[attr-defined]
 
     lib_path = _get_extension_path("_C")
     torch.ops.load_library(lib_path)


### PR DESCRIPTION
Fixes following issue:
```
C:\Miniconda\lib\site-packages\torchvision\io\image.py:13: UserWarning: Failed to load image Python extension: Could not find module 'C:\Miniconda\Lib\site-packages\torchvision\image.pyd' (or one of its dependencies). Try using the full path with constructor syntax.
torch: 1.13.0.dev20221006
  warn(f"Failed to load image Python extension: {e}")
torchvision: 0.15.0.dev20221006
torch cuda: 11.7
torch cudnn: 8500
Calling smoke_test_conv2d
Testing smoke_test_conv2d with cuda
Traceback (most recent call last):
  File "C:\Miniconda\lib\site-packages\torch\_ops.py", line 501, in __getattr__
    op, overload_names = torch._C._jit_get_operation(qualified_op_name)
RuntimeError: No such operator image::decode_png

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "./test/smoke_test/smoke_test.py", line 92, in <module>
    main()
  File "./test/smoke_test/smoke_test.py", line 87, in main
    smoke_test_torchvision()
  File "./test/smoke_test/smoke_test.py", line 41, in smoke_test_torchvision
    print("Is torchvision useable?", all(x is not None for x in [torch.ops.image.decode_png, torch.ops.torchvision.roi_align]))
  File "C:\Miniconda\lib\site-packages\torch\_ops.py", line 505, in __getattr__
    raise AttributeError(
AttributeError: '_OpNamespace' 'image' object has no attribute 'decode_png'
Error: Process completed with exit code 1.
```

Same as: https://github.com/pytorch/audio/pull/2735
