### PR TITLE
make _setup_fill_arg serializable

### DIFF
--- a/torchvision/prototype/transforms/_utils.py
+++ b/torchvision/prototype/transforms/_utils.py
@@ -1,6 +1,6 @@
+import functools
 import numbers
 from collections import defaultdict
-
 from typing import Any, Callable, Dict, Sequence, Tuple, Type, Union
 
 import PIL.Image
@@ -43,13 +43,19 @@ def _check_fill_arg(fill: Union[FillType, Dict[Type, FillType]]) -> None:
             raise TypeError("Got inappropriate fill arg")
 
 
+def _default_fill(fill: FillType) -> FillType:
+    return fill
+
+
 def _setup_fill_arg(fill: Union[FillType, Dict[Type, FillType]]) -> Dict[Type, FillType]:
     _check_fill_arg(fill)
 
     if isinstance(fill, dict):
         return fill
 
-    return defaultdict(lambda: fill)  # type: ignore[return-value, arg-type]
+    # This weird looking construct only exists, since `lambda`'s cannot be serialized by pickle.
+    # If it were possible, we could replace this with `defaultdict(lambda: fill)`
+    return defaultdict(functools.partial(_default_fill, fill))
 
 
 def _check_padding_arg(padding: Union[int, Sequence[int]]) -> None:


### PR DESCRIPTION
Addresses #6728. The only other usages of `lambda` are happening in the AA transforms: 

https://github.com/pytorch/vision/blob/6e203b44098c3371689f56abc17b7c02bd51a261/torchvision/prototype/transforms/_auto_augment.py#L150

This was a perf optimization we did in v2. In v1 we have 

https://github.com/pytorch/vision/blob/6e203b44098c3371689f56abc17b7c02bd51a261/torchvision/transforms/autoaugment.py#L226

Since we want to use AA transforms for videos as well (we do, don't we?), we probably either need to revert this or use a similar technique I used here. I'll look into this next.

As explained in #6728, we don't have unified testing for transforms yet. Thus, I cannot guarantee that these two instances cover every non-serializable things on transforms v2. I will work on testing when video training is up and running. 