### PR TITLE
cache traceback together with exceptions

### DIFF
--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -210,7 +210,7 @@ def cache(fn):
     """
     sentinel = object()
     out_cache = {}
-    exc_cache = {}
+    exc_tb_cache = {}
 
     @functools.wraps(fn)
     def wrapper(*args, **kwargs):
@@ -220,14 +220,17 @@ def cache(fn):
         if out is not sentinel:
             return out
 
-        exc = exc_cache.get(key, sentinel)
-        if exc is not sentinel:
-            raise exc
+        exc_tb = exc_tb_cache.get(key, sentinel)
+        if exc_tb is not sentinel:
+            raise exc_tb[0].with_traceback(exc_tb[1])
 
         try:
             out = fn(*args, **kwargs)
         except Exception as exc:
-            exc_cache[key] = exc
+            # We need to cache the traceback here as well. Otherwise, each re-raise will add the internal pytest
+            # traceback frames anew, but they will only be removed once. Thus, the traceback will be ginormous hiding
+            # the actual information in the noise. See https://github.com/pytest-dev/pytest/issues/10363 for details.
+            exc_tb_cache[key] = exc, exc.__traceback__
             raise exc
 
         out_cache[key] = out


### PR DESCRIPTION
We are caching the scripting of kernels inside our prototype tests:

https://github.com/pytorch/vision/blob/11a2eeda8fb127a7ad72b4c98ca918b93055c1e7/test/test_prototype_transforms_functional.py#L21-L22

We do this because the test 

https://github.com/pytorch/vision/blob/11a2eeda8fb127a7ad72b4c98ca918b93055c1e7/test/test_prototype_transforms_functional.py#L83

is run multiple times for the same kernel, but with different sample inputs. In fact, we only have 78 `KernelInfo`'s but the test is run 7826 times. Meaning, in 99% of the runs, we script the kernel without any information gain whatsoever.

However, with the current implementation of `@cache`, the traceback of re-raised cached exceptions is not cleaned properly by `pytest`. TL;DR: the traceback of an exception is mutable. By re-raising, the `pytest` frames are getting appended over and over again, but `pytest` only removes them once. For a detailed explanation see https://github.com/pytest-dev/pytest/issues/10363.

This leads to ginormous tracebacks that drown the actual information in the noise. For example, I intentionally made `pad_bounding_box` non-scriptable:

```sh
pytest -q test/test_prototype_transforms_functional.py::TestKernels::test_scripted_vs_eager -k pad_bounding_box | wc -l
```

- `main`: 499510
- PR: 3790
- `main` without `@cache`: 3358

The few extra lines stem from the fact that the `@cache` wrapper adds minimal traceback itself.