### PR TITLE
[proto] Small optimization for gaussian_blur functional op

### DIFF
--- a/test/test_prototype_transforms_consistency.py
+++ b/test/test_prototype_transforms_consistency.py
@@ -323,6 +323,9 @@ CONSISTENCY_CONFIGS = [
         ],
         # ElasticTransform needs larger images to avoid the needed internal padding being larger than the actual image
         make_images_kwargs=dict(DEFAULT_MAKE_IMAGES_KWARGS, sizes=[(163, 163), (72, 333), (313, 95)]),
+        # We updated gaussian blur kernel generation with a faster and numerically more stable version
+        # This brings float32 accumulation visible in elastic transform -> we need to relax consistency tolerance
+        closeness_kwargs={"rtol": 1e-1, "atol": 1},
     ),
     ConsistencyConfig(
         prototype_transforms.GaussianBlur,
@@ -333,6 +336,7 @@ CONSISTENCY_CONFIGS = [
             ArgsKwargs(kernel_size=3, sigma=0.7),
             ArgsKwargs(kernel_size=5, sigma=(0.3, 1.4)),
         ],
+        closeness_kwargs={"rtol": 1e-5, "atol": 1e-5},
     ),
     ConsistencyConfig(
         prototype_transforms.RandomAffine,

--- a/test/test_prototype_transforms_consistency.py
+++ b/test/test_prototype_transforms_consistency.py
@@ -328,7 +328,7 @@ CONSISTENCY_CONFIGS = [
             # This brings float32 accumulation visible in elastic transform -> we need to relax consistency tolerance
             closeness_kwargs=ckw,
         )
-        for dt, ckw in [(torch.uint8, {"rtol": 1e-1, "atol": 1}), (torch.float32, {"rtol": 1e-3, "atol": 1e-5})]
+        for dt, ckw in [(torch.uint8, {"rtol": 1e-1, "atol": 1}), (torch.float32, {"rtol": 1e-2, "atol": 1e-3})]
     ],
     ConsistencyConfig(
         prototype_transforms.GaussianBlur,

--- a/torchvision/prototype/transforms/functional/_misc.py
+++ b/torchvision/prototype/transforms/functional/_misc.py
@@ -1,3 +1,4 @@
+import math
 from typing import List, Optional, Union
 
 import PIL.Image
@@ -30,6 +31,22 @@ def normalize(
     # Image or Video type should not be retained after normalization due to unknown data range
     # Thus we return Tensor for input Image
     return normalize_image_tensor(inpt, mean=mean, std=std, inplace=inplace)
+
+
+def _get_gaussian_kernel1d(kernel_size: int, sigma: float) -> torch.Tensor:
+    lim = (kernel_size - 1) / (2 * math.sqrt(2) * sigma)
+    x = torch.linspace(-lim, lim, steps=kernel_size)
+    kernel1d = torch.softmax(-x.pow_(2), dim=0)
+    return kernel1d
+
+
+def _get_gaussian_kernel2d(
+    kernel_size: List[int], sigma: List[float], dtype: torch.dtype, device: torch.device
+) -> torch.Tensor:
+    kernel1d_x = _get_gaussian_kernel1d(kernel_size[0], sigma[0]).to(device, dtype=dtype)
+    kernel1d_y = _get_gaussian_kernel1d(kernel_size[1], sigma[1]).to(device, dtype=dtype)
+    kernel2d = kernel1d_y.unsqueeze(-1) * kernel1d_x
+    return kernel2d
 
 
 def gaussian_blur_image_tensor(
@@ -70,7 +87,18 @@ def gaussian_blur_image_tensor(
     else:
         needs_unsquash = False
 
-    output = _FT.gaussian_blur(image, kernel_size, sigma)
+    dtype = image.dtype if torch.is_floating_point(image) else torch.float32
+    kernel = _get_gaussian_kernel2d(kernel_size, sigma, dtype=dtype, device=image.device)
+    kernel = kernel.expand(image.shape[-3], 1, kernel.shape[0], kernel.shape[1])
+
+    image, need_cast, need_squeeze, out_dtype = _FT._cast_squeeze_in(image, [kernel.dtype])
+
+    # padding = (left, right, top, bottom)
+    padding = [kernel_size[0] // 2, kernel_size[0] // 2, kernel_size[1] // 2, kernel_size[1] // 2]
+    output = _FT.torch_pad(image, padding, mode="reflect")
+    output = _FT.conv2d(output, kernel, groups=output.shape[-3])
+
+    output = _FT._cast_squeeze_out(output, need_cast, need_squeeze, out_dtype)
 
     if needs_unsquash:
         output = output.view(shape)

--- a/torchvision/prototype/transforms/functional/_misc.py
+++ b/torchvision/prototype/transforms/functional/_misc.py
@@ -3,6 +3,7 @@ from typing import List, Optional, Union
 
 import PIL.Image
 import torch
+from torch.nn.functional import conv2d, pad as torch_pad
 from torchvision.prototype import features
 from torchvision.transforms import functional_tensor as _FT
 from torchvision.transforms.functional import pil_to_tensor, to_pil_image
@@ -95,8 +96,8 @@ def gaussian_blur_image_tensor(
 
     # padding = (left, right, top, bottom)
     padding = [kernel_size[0] // 2, kernel_size[0] // 2, kernel_size[1] // 2, kernel_size[1] // 2]
-    output = _FT.torch_pad(image, padding, mode="reflect")
-    output = _FT.conv2d(output, kernel, groups=output.shape[-3])
+    output = torch_pad(image, padding, mode="reflect")
+    output = conv2d(output, kernel, groups=output.shape[-3])
 
     output = _FT._cast_squeeze_out(output, need_cast, need_squeeze, out_dtype)
 

--- a/torchvision/transforms/functional_tensor.py
+++ b/torchvision/transforms/functional_tensor.py
@@ -730,7 +730,8 @@ def _get_gaussian_kernel1d(kernel_size: int, sigma: float) -> Tensor:
     ksize_half = (kernel_size - 1) * 0.5
 
     x = torch.linspace(-ksize_half, ksize_half, steps=kernel_size)
-    kernel1d = torch.softmax(-0.5 * (x / sigma).pow(2), dim=0)
+    pdf = torch.exp(-0.5 * (x / sigma).pow(2))
+    kernel1d = pdf / pdf.sum()
 
     return kernel1d
 

--- a/torchvision/transforms/functional_tensor.py
+++ b/torchvision/transforms/functional_tensor.py
@@ -1,4 +1,3 @@
-import math
 import warnings
 from typing import List, Optional, Tuple, Union
 
@@ -727,10 +726,13 @@ def perspective(
     return _apply_grid_transform(img, grid, interpolation, fill=fill)
 
 
-def _get_gaussian_kernel1d(kernel_size: int, sigma: float) -> torch.Tensor:
-    lim = (kernel_size - 1) / (2 * math.sqrt(2) * sigma)
-    x = torch.linspace(-lim, lim, steps=kernel_size)
-    kernel1d = torch.softmax(-x.pow_(2), dim=0)
+def _get_gaussian_kernel1d(kernel_size: int, sigma: float) -> Tensor:
+    ksize_half = (kernel_size - 1) * 0.5
+
+    x = torch.linspace(-ksize_half, ksize_half, steps=kernel_size)
+    pdf = torch.exp(-0.5 * (x / sigma).pow(2))
+    kernel1d = pdf / pdf.sum()
+
     return kernel1d
 
 

--- a/torchvision/transforms/functional_tensor.py
+++ b/torchvision/transforms/functional_tensor.py
@@ -1,3 +1,4 @@
+import math
 import warnings
 from typing import List, Optional, Tuple, Union
 
@@ -726,13 +727,10 @@ def perspective(
     return _apply_grid_transform(img, grid, interpolation, fill=fill)
 
 
-def _get_gaussian_kernel1d(kernel_size: int, sigma: float) -> Tensor:
-    ksize_half = (kernel_size - 1) * 0.5
-
-    x = torch.linspace(-ksize_half, ksize_half, steps=kernel_size)
-    pdf = torch.exp(-0.5 * (x / sigma).pow(2))
-    kernel1d = pdf / pdf.sum()
-
+def _get_gaussian_kernel1d(kernel_size: int, sigma: float) -> torch.Tensor:
+    lim = (kernel_size - 1) / (2 * math.sqrt(2) * sigma)
+    x = torch.linspace(-lim, lim, steps=kernel_size)
+    kernel1d = torch.softmax(-x.pow_(2), dim=0)
     return kernel1d
 
 

--- a/torchvision/transforms/functional_tensor.py
+++ b/torchvision/transforms/functional_tensor.py
@@ -730,8 +730,7 @@ def _get_gaussian_kernel1d(kernel_size: int, sigma: float) -> Tensor:
     ksize_half = (kernel_size - 1) * 0.5
 
     x = torch.linspace(-ksize_half, ksize_half, steps=kernel_size)
-    pdf = torch.exp(-0.5 * (x / sigma).pow(2))
-    kernel1d = pdf / pdf.sum()
+    kernel1d = torch.softmax(-0.5 * (x / sigma).pow(2), dim=0)
 
     return kernel1d
 


### PR DESCRIPTION
Description:
- use softmax and multiplication to speed-up gaussian blur op

```
[-------------- Gaussian Blur cpu torch.uint8 --------------]
                     |  gaussian_blur v1  |  gaussian_blur v2
1 threads: --------------------------------------------------
      (3, 400, 400)  |        2.78        |        2.65
6 threads: --------------------------------------------------
      (3, 400, 400)  |        1.08        |        1.01

Times are in milliseconds (ms).

[-------------- Gaussian Blur cuda torch.uint8 -------------]
                     |  gaussian_blur v1  |  gaussian_blur v2
1 threads: --------------------------------------------------
      (3, 400, 400)  |        342         |        227
6 threads: --------------------------------------------------
      (3, 400, 400)  |        259         |        227

Times are in microseconds (us).

[------------- Gaussian Blur cpu torch.float32 -------------]
                     |  gaussian_blur v1  |  gaussian_blur v2
1 threads: --------------------------------------------------
      (3, 400, 400)  |        2160        |        2080
6 threads: --------------------------------------------------
      (3, 400, 400)  |         917        |         840

Times are in microseconds (us).

[------------- Gaussian Blur cuda torch.float32 ------------]
                     |  gaussian_blur v1  |  gaussian_blur v2
1 threads: --------------------------------------------------
      (3, 400, 400)  |        232         |        200
6 threads: --------------------------------------------------
      (3, 400, 400)  |        231         |        200

Times are in microseconds (us).
```
[Code source](https://github.com/vfdev-5/tvapiv2_benchmarks/blob/master/check_gaussian_blur.py)


---

This PR may also help with flaky gaussian blur tests.

Context:

Gaussian blur eager vs jit tests are flaky for uint8 input. This may be due to the fact that we cast to float32, perform the opertation in float32 and cast back to uint8. We generate conv kernels (created using exp op) in float32 and maybe accumulating precision errors.


Refs: https://github.com/pytorch/vision/pull/6755