### PR TITLE
[NOMERGE] Add optimized `_blend`

### DIFF
--- a/torchvision/transforms/functional_tensor.py
+++ b/torchvision/transforms/functional_tensor.py
@@ -262,6 +262,8 @@ def adjust_gamma(img: Tensor, gamma: float, gain: float = 1) -> Tensor:
 
 
 def _blend(img1: Tensor, img2: Tensor, ratio: float) -> Tensor:
+    if ratio == 1.0:
+        return img1
     ratio = float(ratio)
     bound = 1.0 if img1.is_floating_point() else 255.0
 

--- a/torchvision/transforms/functional_tensor.py
+++ b/torchvision/transforms/functional_tensor.py
@@ -264,7 +264,23 @@ def adjust_gamma(img: Tensor, gamma: float, gain: float = 1) -> Tensor:
 def _blend(img1: Tensor, img2: Tensor, ratio: float) -> Tensor:
     ratio = float(ratio)
     bound = 1.0 if img1.is_floating_point() else 255.0
-    return (ratio * img1 + (1.0 - ratio) * img2).clamp(0, bound).to(img1.dtype)
+
+    if img2.is_floating_point():
+        # Since img2 is float, we can do in-place ops on it. It's a throw-away tensor.
+        # Our strategy is to convert img1 to float and copy it to avoid in-place modifications,
+        # update img2 in-place and add it on the result with an in-place op.
+        result = img1 * ratio
+        img2.mul_(1.0 - ratio)
+        result.add_(img2)
+    else:
+        # Since img2 is not float, we can't do in-place ops on it.
+        # To minimize copies/adds/muls we first convert img1 to float by multiplying it with ratio/(1-ratio).
+        # This permits us to add img2 in-place to it, without further copies.
+        # To ensure we have the correct result at the end, we multiply in-place with (1-ratio).
+        result = img1 * (ratio / (1.0 - ratio))
+        result.add_(img2).mul_(1.0 - ratio)
+
+    return result.clamp_(0, bound).to(img1.dtype)
 
 
 def _rgb2hsv(img: Tensor) -> Tensor:


### PR DESCRIPTION
This PR is only to show-case the differences against the previous code. It shouldn't be merged as we should do this optimization directly to V2.

Results:
```
adjust_brightness - Winner: v2(device=cpu, dtype=torch.uint8) - v1: 0.0017781441507395356, v2: 0.0015310867200605573 - Diff: -13.89%
adjust_brightness - Winner: v2(device=cpu, dtype=torch.float32) - v1: 0.0008344144199509174, v2: 0.0005974295809864998 - Diff: -28.40%
adjust_brightness - Winner: v2(device=cuda, dtype=torch.uint8) - v1: 5.151713805971667e-05, v2: 4.7857200680300596e-05 - Diff: -7.10%
adjust_brightness - Winner: v2(device=cuda, dtype=torch.float32) - v1: 4.2962464748416095e-05, v2: 3.8983459910377864e-05 - Diff: -9.26%
adjust_contrast - Winner: v2(device=cpu, dtype=torch.uint8) - v1: 0.0019489222508855164, v2: 0.001805254714563489 - Diff: -7.37%
adjust_contrast - Winner: v2(device=cpu, dtype=torch.float32) - v1: 0.0009198985202237964, v2: 0.0007649726495146752 - Diff: -16.84%
adjust_contrast - Winner: v2(device=cuda, dtype=torch.uint8) - v1: 0.00012647993885912, v2: 0.0001235444841440767 - Diff: -2.32%
adjust_contrast - Winner: v2(device=cuda, dtype=torch.float32) - v1: 9.984084800817073e-05, v2: 9.742333088070155e-05 - Diff: -2.42%
adjust_saturation - Winner: v2(device=cpu, dtype=torch.uint8) - v1: 0.0019948067096993327, v2: 0.0018562771938741207 - Diff: -6.94%
adjust_saturation - Winner: v2(device=cpu, dtype=torch.float32) - v1: 0.0009555038996040821, v2: 0.0007746961107477546 - Diff: -18.92%
adjust_saturation - Winner: v2(device=cuda, dtype=torch.uint8) - v1: 0.0001049026179825887, v2: 0.00010217939910944551 - Diff: -2.60%
adjust_saturation - Winner: v2(device=cuda, dtype=torch.float32) - v1: 8.710524649359286e-05, v2: 8.433246007189155e-05 - Diff: -3.18%
adjust_sharpness - Winner: v2(device=cpu, dtype=torch.uint8) - v1: 0.007391045135445893, v2: 0.006958624790422618 - Diff: -5.85%
adjust_sharpness - Winner: v2(device=cpu, dtype=torch.float32) - v1: 0.004595479456475005, v2: 0.003972332294797525 - Diff: -13.56%
adjust_sharpness - Winner: v2(device=cuda, dtype=torch.uint8) - v1: 0.0001897168857976794, v2: 0.000187589162029326 - Diff: -1.12%
adjust_sharpness - Winner: v2(device=cuda, dtype=torch.float32) - v1: 0.00015073937014676631, v2: 0.00014734733151271939 - Diff: -2.25%
```

<details><summary>Benchmark Script</summary>

```python
import torch
import torch.utils.benchmark as benchmark

from torch import Tensor
from torchvision.transforms.functional_tensor import _assert_image_tensor, _assert_channels, get_dimensions, rgb_to_grayscale, _blurred_degenerate_image
from torchvision.transforms import functional_tensor as V1



def _blend(img1: Tensor, img2: Tensor, ratio: float) -> Tensor:
    if ratio == 1.0:
        return img1
    ratio = float(ratio)
    bound = 1.0 if img1.is_floating_point() else 255.0

    if img2.is_floating_point():
        # Since img2 is float, we can do in-place ops on it. It's a throw-away tensor.
        # Our strategy is to convert img1 to float and copy it to avoid in-place modifications,
        # update img2 in-place and add it on the result with an in-place op.
        result = img1 * ratio
        img2.mul_(1.0 - ratio)
        result.add_(img2)
    else:
        # Since img2 is not float, we can't do in-place ops on it.
        # To minimize copies/adds/muls we first convert img1 to float by multiplying it with ratio/(1-ratio).
        # This permits us to add img2 in-place to it, without further copies.
        # To ensure we have the correct result at the end, we multiply in-place with (1-ratio).
        result = img1 * (ratio / (1.0 - ratio))
        result.add_(img2).mul_(1.0 - ratio)

    return result.clamp_(0, bound).to(img1.dtype)


############ COPY PASTE FROM functional_tensor.py
def adjust_brightness(img: Tensor, brightness_factor: float) -> Tensor:
    if brightness_factor < 0:
        raise ValueError(f"brightness_factor ({brightness_factor}) is not non-negative.")

    _assert_image_tensor(img)

    _assert_channels(img, [1, 3])

    return _blend(img, torch.zeros_like(img), brightness_factor)


def adjust_contrast(img: Tensor, contrast_factor: float) -> Tensor:
    if contrast_factor < 0:
        raise ValueError(f"contrast_factor ({contrast_factor}) is not non-negative.")

    _assert_image_tensor(img)

    _assert_channels(img, [3, 1])
    c = get_dimensions(img)[0]
    dtype = img.dtype if torch.is_floating_point(img) else torch.float32
    if c == 3:
        mean = torch.mean(rgb_to_grayscale(img).to(dtype), dim=(-3, -2, -1), keepdim=True)
    else:
        mean = torch.mean(img.to(dtype), dim=(-3, -2, -1), keepdim=True)

    return _blend(img, mean, contrast_factor)


def adjust_saturation(img: Tensor, saturation_factor: float) -> Tensor:
    if saturation_factor < 0:
        raise ValueError(f"saturation_factor ({saturation_factor}) is not non-negative.")

    _assert_image_tensor(img)

    _assert_channels(img, [1, 3])

    if get_dimensions(img)[0] == 1:  # Match PIL behaviour
        return img

    return _blend(img, rgb_to_grayscale(img), saturation_factor)


def adjust_sharpness(img: Tensor, sharpness_factor: float) -> Tensor:
    if sharpness_factor < 0:
        raise ValueError(f"sharpness_factor ({sharpness_factor}) is not non-negative.")

    _assert_image_tensor(img)

    _assert_channels(img, [1, 3])

    if img.size(-1) <= 2 or img.size(-2) <= 2:
        return img

    return _blend(img, _blurred_degenerate_image(img), sharpness_factor)


############### BENCHMARKS

def bench_torch(fn, data, factor, runtime=10):
    for _ in range(10):
        fn(data, factor)
    results = benchmark.Timer(
                stmt=f"fn(data, {factor})",
                globals={
                    "data": data,
                    "fn": fn,
                },
                num_threads=torch.get_num_threads(),
            ).blocked_autorange(min_run_time=runtime)
    return results.median


data = torch.randint(0, 256, (10, 3, 128, 128))
data_f = data / 255.0
factor = 1.5
bench_fn = bench_torch


devices = ["cpu"]
if torch.cuda.is_available():
    devices.append("cuda")
for fn_name in ["adjust_brightness", "adjust_contrast", "adjust_saturation", "adjust_sharpness"]:
    fn_v1 = V1.__dict__[fn_name]
    fn_v2 = locals()[fn_name]
    for device in devices:
        for dtype, img in [(torch.uint8, data.to(device=device)), (torch.float32, data_f.to(device=device))]:
            v1_time = bench_fn(fn_v1, img, factor)
            v2_time = bench_fn(fn_v2, img, factor)

            winner = "v1" if v1_time < v2_time else "v2"
            print(f"{fn_name} - Winner: {winner}(device={device}, dtype={dtype}) - v1: {v1_time}, v2: {v2_time} - Diff: {100*(v2_time-v1_time)/v1_time:.2f}%")
            try:
                torch.testing.assert_close(fn_v1(img, factor), fn_v2(img, factor))
            except Exception:
                print("WARNING: fv1(x) != fv2(x)")
```
</details>