### PR TITLE
Extend `RandomShortestSize` to support Video specific flavour of the augmentation

### DIFF
--- a/test/test_prototype_transforms.py
+++ b/test/test_prototype_transforms.py
@@ -1379,10 +1379,9 @@ class TestScaleJitter:
 
 
 class TestRandomShortestSize:
-    def test__get_params(self, mocker):
+    @pytest.mark.parametrize("min_size,max_size", [([5, 9], 20), ([5, 9], None)])
+    def test__get_params(self, min_size, max_size, mocker):
         spatial_size = (3, 10)
-        min_size = [5, 9]
-        max_size = 20
 
         transform = transforms.RandomShortestSize(min_size=min_size, max_size=max_size)
 
@@ -1395,10 +1394,9 @@ class TestRandomShortestSize:
         assert isinstance(size, tuple) and len(size) == 2
 
         longer = max(size)
-        assert longer <= max_size
-
         shorter = min(size)
-        if longer == max_size:
+        if max_size is not None and longer == max_size:
+            assert longer <= max_size
             assert shorter <= max_size
         else:
             assert shorter in min_size

--- a/test/test_prototype_transforms.py
+++ b/test/test_prototype_transforms.py
@@ -1395,7 +1395,7 @@ class TestRandomShortestSize:
 
         longer = max(size)
         shorter = min(size)
-        if max_size is not None and longer == max_size:
+        if max_size is not None:
             assert longer <= max_size
             assert shorter <= max_size
         else:

--- a/torchvision/prototype/transforms/_geometry.py
+++ b/torchvision/prototype/transforms/_geometry.py
@@ -733,7 +733,7 @@ class RandomShortestSize(Transform):
     def __init__(
         self,
         min_size: Union[List[int], Tuple[int], int],
-        max_size: int,
+        max_size: Optional[int] = None,
         interpolation: InterpolationMode = InterpolationMode.BILINEAR,
         antialias: Optional[bool] = None,
     ):
@@ -747,7 +747,9 @@ class RandomShortestSize(Transform):
         orig_height, orig_width = query_spatial_size(sample)
 
         min_size = self.min_size[int(torch.randint(len(self.min_size), ()))]
-        r = min(min_size / min(orig_height, orig_width), self.max_size / max(orig_height, orig_width))
+        r = min_size / min(orig_height, orig_width)
+        if self.max_size is not None:
+            r = min(r, self.max_size / max(orig_height, orig_width))
 
         new_width = int(orig_width * r)
         new_height = int(orig_height * r)


### PR DESCRIPTION
Our `RandomShortestSize` implementation on the references is developed with Object Detection in mind. Videos require a slight variation (see reference implementation for [detection](https://github.com/facebookresearch/detectron2/blob/cf35922d74559fd46928dc787c1c312eb4195b41/detectron2/data/transforms/augmentation_impl.py#L129) vs [video](https://github.com/facebookresearch/pytorchvideo/blob/f4242c29a95443f23128437c0c37378069c32ffb/pytorchvideo/transforms/transforms.py#L123)).

This PR extends the transform in a BC-way so that it can support both. In particular, we make the `max_size` optional and this allows us to reparameterize the transform for videos as such:
```python
from torchvision.prototype.transforms import RandomShortestSize
import math
import torch

x = torch.randn(7, 11, 3, 450, 800)
t = RandomShortestSize(list(range(256, 320+1)))
z = t(x)
print(z.shape)

size = min(z.shape[-2:])

_, t, c, h, w = x.shape
if w < h:
    new_h = int(math.floor((float(h) / w) * size))
    new_w = size
else:
    new_h = size
    new_w = int(math.floor((float(w) / h) * size))

print(new_h, new_w)

assert (new_h, new_w) == tuple(z.shape[-2:])
```

Though the names of `min_size` and `max_size` are confusing (better names would have been `shortside_min_size_range` and `longside_max_size`), their semantics align with the arguments that `F.resize()` has for `size` and and `max_size`. On the latter the default value of `max_size` (which again applies to the longest edge) is `None`, so this transform uses the same semantics and default values as in other places of the API.