### PR TITLE
Fix errors on non-contiguous tensors in `equalize()` Tensor-backend

### DIFF
--- a/torchvision/prototype/transforms/functional/_color.py
+++ b/torchvision/prototype/transforms/functional/_color.py
@@ -227,7 +227,7 @@ def equalize_image_tensor(image: torch.Tensor) -> torch.Tensor:
     if image.numel() == 0:
         return image
 
-    return _equalize_image_tensor_vec(image.view(-1, height, width)).view(image.shape)
+    return _equalize_image_tensor_vec(image.view(-1, height, width)).reshape(image.shape)
 
 
 equalize_image_pil = _FP.equalize

--- a/torchvision/transforms/functional_tensor.py
+++ b/torchvision/transforms/functional_tensor.py
@@ -875,7 +875,7 @@ def _scale_channel(img_chan: Tensor) -> Tensor:
     if img_chan.is_cuda:
         hist = torch.histc(img_chan.to(torch.float32), bins=256, min=0, max=255)
     else:
-        hist = torch.bincount(img_chan.view(-1), minlength=256)
+        hist = torch.bincount(img_chan.reshape(-1), minlength=256)
 
     nonzero_hist = hist[hist != 0]
     step = torch.div(nonzero_hist[:-1].sum(), 255, rounding_mode="floor")


### PR DESCRIPTION
The use of `view()` in `equalize()` leads to the following errors when the input is non-contiguous. The problem affects stable:
```
    hist = torch.bincount(img_chan.view(-1), minlength=256)
RuntimeError: view size is not compatible with input tensor's size and stride (at least one dimension spans across two contiguous subspaces). Use .reshape(...) instead.
```
And prototype:
```
  File "./torchvision/prototype/transforms/functional/_color.py", line 237, in equalize_video
    return equalize_image_tensor(video)
  File "./torchvision/prototype/transforms/functional/_color.py", line 230, in equalize_image_tensor
    return _equalize_image_tensor_vec(image.view(-1, height, width)).view(image.shape)
  File "./torchvision/prototype/features/_feature.py", line 94, in __torch_function__
    output = func(*args, **kwargs or dict())
RuntimeError: view size is not compatible with input tensor's size and stride (at least one dimension spans across two contiguous subspaces). Use .reshape(...) instead.
```
It was first discovered after starting doing end-to-end training with complex Augmentations using the Tensor Backend. The PR updates the use of `view()` to `reshape()` to ensure that both operators work as expected.