### PR TITLE
Update `ToDtype` to avoid unnecessary `to()` calls and fixing types on `Transform`

### DIFF
--- a/torchvision/prototype/transforms/_misc.py
+++ b/torchvision/prototype/transforms/_misc.py
@@ -143,7 +143,7 @@ class GaussianBlur(Transform):
 
 
 class ToDtype(Transform):
-    _transformed_types = (torch.Tensor,)
+    _transformed_types = (features.is_simple_tensor, features._Feature)
 
     def _default_dtype(self, dtype: torch.dtype) -> torch.dtype:
         return dtype
@@ -157,7 +157,10 @@ class ToDtype(Transform):
         self.dtype = dtype
 
     def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
-        return inpt.to(self.dtype[type(inpt)])
+        dtype = self.dtype.get(type(inpt))
+        if dtype is None:
+            return inpt
+        return inpt.to(dtype=dtype)
 
 
 class RemoveSmallBoundingBoxes(Transform):

--- a/torchvision/prototype/transforms/_misc.py
+++ b/torchvision/prototype/transforms/_misc.py
@@ -143,7 +143,7 @@ class GaussianBlur(Transform):
 
 
 class ToDtype(Transform):
-    _transformed_types = (features.is_simple_tensor, features._Feature)
+    _transformed_types = (torch.Tensor,)
 
     def _default_dtype(self, dtype: torch.dtype) -> torch.dtype:
         return dtype

--- a/torchvision/prototype/transforms/_misc.py
+++ b/torchvision/prototype/transforms/_misc.py
@@ -157,7 +157,7 @@ class ToDtype(Transform):
         self.dtype = dtype
 
     def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
-        dtype = self.dtype.get(type(inpt))
+        dtype = self.dtype[type(inpt)]
         if dtype is None:
             return inpt
         return inpt.to(dtype=dtype)

--- a/torchvision/prototype/transforms/_transform.py
+++ b/torchvision/prototype/transforms/_transform.py
@@ -13,11 +13,7 @@ from torchvision.utils import _log_api_usage_once
 class Transform(nn.Module):
 
     # Class attribute defining transformed types. Other types are passed-through without any transformation
-    _transformed_types: Tuple[Union[Type, Callable[[Any], bool]], ...] = (
-        features.is_simple_tensor,
-        features._Feature,
-        PIL.Image.Image,
-    )
+    _transformed_types: Tuple[Union[Type, Callable[[Any], bool]], ...] = (torch.Tensor, PIL.Image.Image)
 
     def __init__(self) -> None:
         super().__init__()

--- a/torchvision/prototype/transforms/_transform.py
+++ b/torchvision/prototype/transforms/_transform.py
@@ -12,6 +12,7 @@ from torchvision.utils import _log_api_usage_once
 class Transform(nn.Module):
 
     # Class attribute defining transformed types. Other types are passed-through without any transformation
+    # We support both Types and callables that are able to do further checks on the type of the input.
     _transformed_types: Tuple[Union[Type, Callable[[Any], bool]], ...] = (torch.Tensor, PIL.Image.Image)
 
     def __init__(self) -> None:

--- a/torchvision/prototype/transforms/_transform.py
+++ b/torchvision/prototype/transforms/_transform.py
@@ -5,7 +5,6 @@ import PIL.Image
 import torch
 from torch import nn
 from torch.utils._pytree import tree_flatten, tree_unflatten
-from torchvision.prototype import features
 from torchvision.prototype.transforms._utils import _isinstance
 from torchvision.utils import _log_api_usage_once
 


### PR DESCRIPTION
As discussed offline this PR:
- Avoids the unnecessary `.to(None)` call
- Fixes the nit on the `_transformed_types` of `Transform` to avoid the superfluous `features.is_simple_tensor, features._Feature` idiom.