### PR TITLE
[prototype] Reshape input before equalize

### DIFF
--- a/torchvision/prototype/transforms/functional/_color.py
+++ b/torchvision/prototype/transforms/functional/_color.py
@@ -227,7 +227,7 @@ def equalize_image_tensor(image: torch.Tensor) -> torch.Tensor:
     if image.numel() == 0:
         return image
 
-    return _equalize_image_tensor_vec(image.view(-1, height, width)).reshape(image.shape)
+    return _equalize_image_tensor_vec(image.reshape(-1, height, width)).reshape(image.shape)
 
 
 equalize_image_pil = _FP.equalize


### PR DESCRIPTION
related to #6772

The input image also requires reshape to avoid errors such as:
```
RuntimeError: view size is not compatible with input tensor's size and stride (at least one dimension spans across two contiguous subspaces). Use .reshape(...) instead.
```

We should consider on a follow up PR to update all `view()` to `reshape()` calls.