### PR TITLE
another round of perf improvements for equalize

### DIFF
--- a/test/prototype_transforms_kernel_infos.py
+++ b/test/prototype_transforms_kernel_infos.py
@@ -12,6 +12,8 @@ from common_utils import cycle_over
 from datasets_utils import combinations_grid
 from prototype_common_utils import (
     ArgsKwargs,
+    get_num_channels,
+    ImageLoader,
     InfoBase,
     make_bounding_box_loaders,
     make_image_loader,
@@ -1357,9 +1359,43 @@ def sample_inputs_equalize_image_tensor():
 
 
 def reference_inputs_equalize_image_tensor():
-    for image_loader in make_image_loaders(
-        extra_dims=[()], color_spaces=(features.ColorSpace.GRAY, features.ColorSpace.RGB), dtypes=[torch.uint8]
+    # We are not using `make_image_loaders` here since that uniformly samples the values over the whole value range.
+    # Since the whole point of this kernel is to transform an arbitrary distribution of values into a uniform one,
+    # the information gain is low if we already provide something really close to the expected value.
+    spatial_size = (256, 256)
+    for fn, color_space in itertools.product(
+        [
+            *[
+                lambda shape, dtype, device, low=low, high=high: torch.randint(
+                    low, high, shape, dtype=dtype, device=device
+                )
+                for low, high in [
+                    (0, 1),
+                    (255, 256),
+                    (0, 64),
+                    (64, 192),
+                    (192, 256),
+                ]
+            ],
+            *[
+                lambda shape, dtype, device, alpha=alpha, beta=beta: torch.distributions.Beta(alpha, beta)
+                .sample(shape)
+                .mul_(255)
+                .round_()
+                .to(dtype=dtype, device=device)
+                for alpha, beta in [
+                    (0.5, 0.5),
+                    (2, 2),
+                    (2, 5),
+                    (5, 2),
+                ]
+            ],
+        ],
+        [features.ColorSpace.GRAY, features.ColorSpace.RGB],
     ):
+        image_loader = ImageLoader(
+            fn, shape=(get_num_channels(color_space), *spatial_size), dtype=torch.uint8, color_space=color_space
+        )
         yield ArgsKwargs(image_loader)
 
 

--- a/torchvision/prototype/transforms/functional/_color.py
+++ b/torchvision/prototype/transforms/functional/_color.py
@@ -194,35 +194,57 @@ def equalize_image_tensor(image: torch.Tensor) -> torch.Tensor:
     if image.numel() == 0:
         return image
 
-    # input image shape should be (*, H, W)
-    shape = image.shape
-    # Compute image histogram:
-    flat_image = image.flatten(start_dim=-2).to(torch.long)  # -> [*, H * W]
-    hist = flat_image.new_zeros(shape[:-2] + (256,), dtype=torch.int32)
+    # The algorithm for histogram equalization is mirrored from PIL:
+    # https://github.com/python-pillow/Pillow/blob/eb59cb61d5239ee69cbbf12709a0c6fd7314e6d7/src/PIL/ImageOps.py#L368-L385
+    # Although PyTorch has builtin functionality for histograms, we are not using them here since they can only be
+    # applied to the complete tensor. We need to apply them to the spatial size, i.e. the last two dimensions only, and
+    # thus we would need to call them in a for loop, which is inefficient.
+    batch_shape = image.shape[:-2]
+    flat_image = image.flatten(start_dim=-2).to(torch.long)
+
+    # The histogram is computed by using the flattened image as index. For example, a pixel value of 127 in the image
+    # corresponds to adding 1 to index 127 in the histogram.
+    hist = flat_image.new_zeros(batch_shape + (256,), dtype=torch.int32)
     hist.scatter_add_(dim=-1, index=flat_image, src=hist.new_ones(1).expand_as(flat_image))
+    cum_hist = hist.cumsum(dim=-1)
 
-    # Compute image cdf
-    pixels = flat_image.size(-1)
-    chist = hist.cumsum(dim=-1)
-    # Compute steps, where step per channel is nonzero_hist[:-1].sum() // 255
-    # Trick: nonzero_hist[-1] == hist[chist.argmax()]
-    idx = chist.argmax(dim=-1).unsqueeze_(-1)
-    step = pixels - hist.gather(dim=-1, index=idx)
-    step.div_(255, rounding_mode="floor")
+    # The simplest form of lookup-table (LUT) that also achieves histogram equalization is
+    # `lut = cum_hist / flat_image.shape[-1] * 255`
+    # However, PIL uses a more elaborate scheme:
+    # 1. Instead of normalizing the cumulative histogram by the number of pixels (` / flat_image.shape[-1]` above),
+    #    it is normalized by the number of pixels that are don't have the maximum value. Note that maximum value here
+    #    does not mean 255 per se but rather the maximum value in the image, which might be or not be 255.
+    # 2. Instead of normalizing just the cumulative histogram, a constant based on the number of non-maximum is added
+    #    to it.
+    # This brings the computation of the  LUT to
+    # `lut = ((cum_hist + num_non_max_pixels // (2 * 255)) // num_non_max_pixels) * 255`
 
-    # Compute batched Look-up-table:
-    non_zero = step == 0
-    # Necessary to avoid an integer division by zero, which raises
-    clamped_step = step.clamp_(min=1)
-    chist = chist[..., :-1]
-    chist.add_(torch.div(step, 2, rounding_mode="floor")).div_(clamped_step, rounding_mode="floor").clamp_(0, 255)
-    lut = chist.to(torch.uint8)
+    # The last non-zero element in the histogram is the first element in the cumulative histogram with the maximum value
+    index = cum_hist.argmax(dim=-1)
+    num_non_max_pixels = flat_image.shape[-1] - hist.gather(dim=-1, index=index.unsqueeze_(-1))
 
-    # Pad lut with zeros
-    zeros = lut.new_zeros(1).expand(shape[:-2] + (1,))
-    lut = torch.cat([zeros, lut], dim=-1)
+    # This is performance optimization that saves us one multiplication later. With this, the LUT computation simplifies
+    # to `lut = (cum_hist + step // 2) // step` and thus saving the final multiplication by 255 while keeping the
+    # division count the same. PIL uses the variable name `step` for this, so we keep that for easier comparison.
+    step = num_non_max_pixels.div_(255, rounding_mode="floor")
 
-    return torch.where(non_zero.unsqueeze_(-1), image, lut.gather(dim=-1, index=flat_image).view_as(image))
+    # Although it looks like we could return early if we find `step == 0` like PIL does, that is unfortunately not as
+    # easy due to our support for batched images. We can only return early if `(step == 0).all()` holds. If it doesn't,
+    # we have to go through the computation below anyway. Since `step == 0` is an edge case anyway, it makes no sense to
+    # pay the runtime cost for checking it every time.
+    no_equalization = step.eq(0).unsqueeze_(-1)
+
+    # `lut[k]` is computed with `cum_hist[k-1]` with `lut[0] == (step // 2) // step == 0`. Thus, we perform the
+    # computation only for `lut[1:]` and add `lut[0] == 0` afterwards.
+    cum_hist = cum_hist[..., :-1]
+    # We need the `step.clamp_`(min=1) call here to avoid zero division. This has no effect on the returned result of
+    # this kernel since images inside the batch with `step == 0` are returned as is rather than their equalized version.
+    cum_hist.add_(step // 2).div_(step.clamp_(min=1), rounding_mode="floor").clamp_(0, 255)
+    lut = cum_hist.to(torch.uint8)
+    lut = torch.cat([lut.new_zeros(1).expand(batch_shape + (1,)), lut], dim=-1)
+    equalized_image = lut.gather(dim=-1, index=flat_image).view_as(image)
+
+    return torch.where(no_equalization, image, equalized_image)
 
 
 equalize_image_pil = _FP.equalize

--- a/torchvision/prototype/transforms/functional/_color.py
+++ b/torchvision/prototype/transforms/functional/_color.py
@@ -183,39 +183,6 @@ def autocontrast(inpt: features.InputTypeJIT) -> features.InputTypeJIT:
         return autocontrast_image_pil(inpt)
 
 
-def _equalize_image_tensor_vec(img: torch.Tensor) -> torch.Tensor:
-    # input img shape should be [N, H, W]
-    shape = img.shape
-    # Compute image histogram:
-    flat_img = img.flatten(start_dim=1).to(torch.long)  # -> [N, H * W]
-    hist = flat_img.new_zeros(shape[0], 256)
-    hist.scatter_add_(dim=1, index=flat_img, src=flat_img.new_ones(1).expand_as(flat_img))
-
-    # Compute image cdf
-    chist = hist.cumsum_(dim=1)
-    # Compute steps, where step per channel is nonzero_hist[:-1].sum() // 255
-    # Trick: nonzero_hist[:-1].sum() == chist[idx - 1], where idx = chist.argmax()
-    idx = chist.argmax(dim=1).sub_(1)
-    # If histogram is degenerate (hist of zero image), index is -1
-    neg_idx_mask = idx < 0
-    idx.clamp_(min=0)
-    step = chist.gather(dim=1, index=idx.unsqueeze(1))
-    step[neg_idx_mask] = 0
-    step.div_(255, rounding_mode="floor")
-
-    # Compute batched Look-up-table:
-    # Necessary to avoid an integer division by zero, which raises
-    clamped_step = step.clamp(min=1)
-    chist.add_(torch.div(step, 2, rounding_mode="floor")).div_(clamped_step, rounding_mode="floor").clamp_(0, 255)
-    lut = chist.to(torch.uint8)  # [N, 256]
-
-    # Pad lut with zeros
-    zeros = lut.new_zeros((1, 1)).expand(shape[0], 1)
-    lut = torch.cat([zeros, lut[:, :-1]], dim=1)
-
-    return torch.where((step == 0).unsqueeze(-1), img, lut.gather(dim=1, index=flat_img).view_as(img))
-
-
 def equalize_image_tensor(image: torch.Tensor) -> torch.Tensor:
     if image.dtype != torch.uint8:
         raise TypeError(f"Only torch.uint8 image tensors are supported, but found {image.dtype}")
@@ -227,7 +194,35 @@ def equalize_image_tensor(image: torch.Tensor) -> torch.Tensor:
     if image.numel() == 0:
         return image
 
-    return _equalize_image_tensor_vec(image.view(-1, height, width)).reshape(image.shape)
+    # input image shape should be (*, H, W)
+    shape = image.shape
+    # Compute image histogram:
+    flat_image = image.flatten(start_dim=-2).to(torch.long)  # -> [*, H * W]
+    hist = flat_image.new_zeros(shape[:-2] + (256,), dtype=torch.int32)
+    hist.scatter_add_(dim=-1, index=flat_image, src=hist.new_ones(1).expand_as(flat_image))
+
+    # Compute image cdf
+    pixels = flat_image.size(-1)
+    chist = hist.cumsum(dim=-1)
+    # Compute steps, where step per channel is nonzero_hist[:-1].sum() // 255
+    # Trick: nonzero_hist[-1] == hist[chist.argmax()]
+    idx = chist.argmax(dim=-1).unsqueeze_(-1)
+    step = pixels - hist.gather(dim=-1, index=idx)
+    step.div_(255, rounding_mode="floor")
+
+    # Compute batched Look-up-table:
+    non_zero = step == 0
+    # Necessary to avoid an integer division by zero, which raises
+    clamped_step = step.clamp_(min=1)
+    chist = chist[..., :-1]
+    chist.add_(torch.div(step, 2, rounding_mode="floor")).div_(clamped_step, rounding_mode="floor").clamp_(0, 255)
+    lut = chist.to(torch.uint8)
+
+    # Pad lut with zeros
+    zeros = lut.new_zeros(1).expand(shape[:-2] + (1,))
+    lut = torch.cat([zeros, lut], dim=-1)
+
+    return torch.where(non_zero.unsqueeze_(-1), image, lut.gather(dim=-1, index=flat_image).view_as(image))
 
 
 equalize_image_pil = _FP.equalize


### PR DESCRIPTION
_This patch was mainly authored by @lezcano, with me only making minor adjustments for JIT._

---

With this change the kernel "natively" supports arbitrary batch sizes. Furthermore, CUDA execution is quite a bit faster. CPU execution is the same within measuring tolerance.

```
[------------------------ equalize_image_tensor -------------------------]
                                                        |   main  |    PR 
1 threads: ---------------------------------------------------------------
      cpu  | (256, 256)          | noncontiguous=False  |    269  |    265
      cpu  | (256, 256)          | noncontiguous=True   |    270  |    270
      cpu  | (1, 256, 256)       | noncontiguous=False  |    270  |    270
      cpu  | (1, 256, 256)       | noncontiguous=True   |    270  |    275
      cpu  | (3, 256, 256)       | noncontiguous=False  |    636  |    630
      cpu  | (3, 256, 256)       | noncontiguous=True   |    646  |    645
      cpu  | (4, 3, 256, 256)    | noncontiguous=False  |   2270  |   2220
      cpu  | (4, 3, 256, 256)    | noncontiguous=True   |   2300  |   2340
      cpu  | (5, 4, 3, 256, 256) | noncontiguous=False  |  12000  |  13700
      cpu  | (5, 4, 3, 256, 256) | noncontiguous=True   |  12000  |  11800
      cuda | (256, 256)          | noncontiguous=False  |    230  |    169
      cuda | (256, 256)          | noncontiguous=True   |    240  |    200
      cuda | (1, 256, 256)       | noncontiguous=False  |    230  |    152
      cuda | (1, 256, 256)       | noncontiguous=True   |    230  |    153
      cuda | (3, 256, 256)       | noncontiguous=False  |    310  |    149
      cuda | (3, 256, 256)       | noncontiguous=True   |    310  |    150
      cuda | (4, 3, 256, 256)    | noncontiguous=False  |   1000  |    280
      cuda | (4, 3, 256, 256)    | noncontiguous=True   |    950  |    290
      cuda | (5, 4, 3, 256, 256) | noncontiguous=False  |   4000  |   1000
      cuda | (5, 4, 3, 256, 256) | noncontiguous=True   |   4000  |   1000
2 threads: ---------------------------------------------------------------
      cpu  | (256, 256)          | noncontiguous=False  |    279  |    266
      cpu  | (256, 256)          | noncontiguous=True   |    260  |    250
      cpu  | (1, 256, 256)       | noncontiguous=False  |    280  |    273
      cpu  | (1, 256, 256)       | noncontiguous=True   |    261  |    250
      cpu  | (3, 256, 256)       | noncontiguous=False  |    460  |    520
      cpu  | (3, 256, 256)       | noncontiguous=True   |    450  |    500
      cpu  | (4, 3, 256, 256)    | noncontiguous=False  |   1200  |   1200
      cpu  | (4, 3, 256, 256)    | noncontiguous=True   |   1300  |   1250
      cpu  | (5, 4, 3, 256, 256) | noncontiguous=False  |   5900  |   5800
      cpu  | (5, 4, 3, 256, 256) | noncontiguous=True   |   6000  |   5900
4 threads: ---------------------------------------------------------------
      cpu  | (256, 256)          | noncontiguous=False  |    280  |    210
      cpu  | (256, 256)          | noncontiguous=True   |    260  |    213
      cpu  | (1, 256, 256)       | noncontiguous=False  |    271  |    212
      cpu  | (1, 256, 256)       | noncontiguous=True   |    261  |    210
      cpu  | (3, 256, 256)       | noncontiguous=False  |    358  |    340
      cpu  | (3, 256, 256)       | noncontiguous=True   |    337  |    303
      cpu  | (4, 3, 256, 256)    | noncontiguous=False  |    680  |    682
      cpu  | (4, 3, 256, 256)    | noncontiguous=True   |    700  |    687
      cpu  | (5, 4, 3, 256, 256) | noncontiguous=False  |   3000  |   3100
      cpu  | (5, 4, 3, 256, 256) | noncontiguous=True   |   3100  |   3100

Times are in microseconds (us).
```

<details><summary>benchmark script</summary>
<p>

```python
import itertools

import torch
from torch.utils import benchmark

from torchvision.prototype.transforms import functional as F

description = "PR"  # "main", "PR"

devices = ["cpu", "cuda"]
shapes = [
    (256, 256),  # grayscale with missing channel dimension
    (1, 256, 256),  # grayscale
    (3, 256, 256),  # RGB
    (4, 3, 256, 256),  # batch of RGB images or RGB video
    (5, 4, 3, 256, 256),  # batch of RGB videos
]


timers = [
    benchmark.Timer(
        stmt="equalize_image_tensor(input)",
        globals=dict(
            equalize_image_tensor=F.equalize_image_tensor,
            input=torch.testing.make_tensor(
                shape, dtype=torch.uint8, device=device, low=0, high=256, noncontiguous=noncontiguous
            ),
        ),
        label="equalize_image_tensor",
        sub_label=f"{device!s:4} | {shape!s:19} | noncontiguous={noncontiguous}",
        description=description,
        num_threads=num_threads,
    )
    for device, shape, noncontiguous in itertools.product(devices, shapes, [False, True])
    for num_threads in ([1, 2, 4] if device == "cpu" else [1])
]

measurements = [timer.blocked_autorange(min_run_time=5) for timer in timers]
```

</p>
</details>
