### PR TITLE
[proto] Speed up adjust color ops

### DIFF
--- a/test/test_prototype_transforms_consistency.py
+++ b/test/test_prototype_transforms_consistency.py
@@ -755,7 +755,7 @@ class TestAATransforms:
             expected_output = t_ref(inpt)
             output = t(inpt)
 
-            assert_equal(expected_output, output)
+            assert_close(expected_output, output, atol=1, rtol=0.1)
 
     @pytest.mark.parametrize(
         "inpt",
@@ -803,7 +803,7 @@ class TestAATransforms:
             expected_output = t_ref(inpt)
             output = t(inpt)
 
-            assert_equal(expected_output, output)
+            assert_close(expected_output, output, atol=1, rtol=0.1)
 
     @pytest.mark.parametrize(
         "inpt",

--- a/test/test_prototype_transforms_consistency.py
+++ b/test/test_prototype_transforms_consistency.py
@@ -308,22 +308,28 @@ CONSISTENCY_CONFIGS = [
             ArgsKwargs(brightness=0.1, contrast=0.4, saturation=0.7, hue=0.3),
         ],
     ),
-    ConsistencyConfig(
-        prototype_transforms.ElasticTransform,
-        legacy_transforms.ElasticTransform,
-        [
-            ArgsKwargs(),
-            ArgsKwargs(alpha=20.0),
-            ArgsKwargs(alpha=(15.3, 27.2)),
-            ArgsKwargs(sigma=3.0),
-            ArgsKwargs(sigma=(2.5, 3.9)),
-            ArgsKwargs(interpolation=prototype_transforms.InterpolationMode.NEAREST),
-            ArgsKwargs(interpolation=prototype_transforms.InterpolationMode.BICUBIC),
-            ArgsKwargs(fill=1),
-        ],
-        # ElasticTransform needs larger images to avoid the needed internal padding being larger than the actual image
-        make_images_kwargs=dict(DEFAULT_MAKE_IMAGES_KWARGS, sizes=[(163, 163), (72, 333), (313, 95)]),
-    ),
+    *[
+        ConsistencyConfig(
+            prototype_transforms.ElasticTransform,
+            legacy_transforms.ElasticTransform,
+            [
+                ArgsKwargs(),
+                ArgsKwargs(alpha=20.0),
+                ArgsKwargs(alpha=(15.3, 27.2)),
+                ArgsKwargs(sigma=3.0),
+                ArgsKwargs(sigma=(2.5, 3.9)),
+                ArgsKwargs(interpolation=prototype_transforms.InterpolationMode.NEAREST),
+                ArgsKwargs(interpolation=prototype_transforms.InterpolationMode.BICUBIC),
+                ArgsKwargs(fill=1),
+            ],
+            # ElasticTransform needs larger images to avoid the needed internal padding being larger than the actual image
+            make_images_kwargs=dict(DEFAULT_MAKE_IMAGES_KWARGS, sizes=[(163, 163), (72, 333), (313, 95)], dtypes=[dt]),
+            # We updated gaussian blur kernel generation with a faster and numerically more stable version
+            # This brings float32 accumulation visible in elastic transform -> we need to relax consistency tolerance
+            closeness_kwargs=ckw,
+        )
+        for dt, ckw in [(torch.uint8, {"rtol": 1e-1, "atol": 1}), (torch.float32, {"rtol": 1e-2, "atol": 1e-3})]
+    ],
     ConsistencyConfig(
         prototype_transforms.GaussianBlur,
         legacy_transforms.GaussianBlur,
@@ -333,6 +339,7 @@ CONSISTENCY_CONFIGS = [
             ArgsKwargs(kernel_size=3, sigma=0.7),
             ArgsKwargs(kernel_size=5, sigma=(0.3, 1.4)),
         ],
+        closeness_kwargs={"rtol": 1e-5, "atol": 1e-5},
     ),
     ConsistencyConfig(
         prototype_transforms.RandomAffine,
@@ -506,7 +513,6 @@ def check_call_consistency(
         image_repr = f"[{tuple(image.shape)}, {str(image.dtype).rsplit('.')[-1]}]"
 
         image_tensor = torch.Tensor(image)
-
         try:
             torch.manual_seed(0)
             output_legacy_tensor = legacy_transform(image_tensor)

--- a/test/test_prototype_transforms_consistency.py
+++ b/test/test_prototype_transforms_consistency.py
@@ -253,9 +253,10 @@ CONSISTENCY_CONFIGS = [
         legacy_transforms.RandomAdjustSharpness,
         [
             ArgsKwargs(p=0, sharpness_factor=0.5),
-            ArgsKwargs(p=1, sharpness_factor=0.3),
+            ArgsKwargs(p=1, sharpness_factor=0.2),
             ArgsKwargs(p=1, sharpness_factor=0.99),
         ],
+        closeness_kwargs={"atol": 1e-6, "rtol": 1e-6},
     ),
     ConsistencyConfig(
         prototype_transforms.RandomGrayscale,
@@ -305,8 +306,9 @@ CONSISTENCY_CONFIGS = [
             ArgsKwargs(saturation=(0.8, 0.9)),
             ArgsKwargs(hue=0.3),
             ArgsKwargs(hue=(-0.1, 0.2)),
-            ArgsKwargs(brightness=0.1, contrast=0.4, saturation=0.7, hue=0.3),
+            ArgsKwargs(brightness=0.1, contrast=0.4, saturation=0.5, hue=0.6),
         ],
+        closeness_kwargs={"atol": 1e-5, "rtol": 1e-5},
     ),
     *[
         ConsistencyConfig(

--- a/torchvision/prototype/transforms/functional/_color.py
+++ b/torchvision/prototype/transforms/functional/_color.py
@@ -2,7 +2,7 @@ import torch
 from torchvision.prototype import features
 from torchvision.transforms import functional_pil as _FP, functional_tensor as _FT
 
-from ._meta import get_dimensions_image_tensor, get_num_channels_image_tensor, rgb_to_grayscale
+from ._meta import _rgb_to_gray, get_dimensions_image_tensor, get_num_channels_image_tensor
 
 
 def _blend(image1: torch.Tensor, image2: torch.Tensor, ratio: float) -> torch.Tensor:
@@ -52,7 +52,7 @@ def adjust_saturation_image_tensor(image: torch.Tensor, saturation_factor: float
     if c == 1:  # Match PIL behaviour
         return image
 
-    return _blend(image, rgb_to_grayscale(image), saturation_factor)
+    return _blend(image, _rgb_to_gray(image), saturation_factor)
 
 
 adjust_saturation_image_pil = _FP.adjust_saturation
@@ -79,7 +79,7 @@ def adjust_contrast_image_tensor(image: torch.Tensor, contrast_factor: float) ->
     if c not in [1, 3]:
         raise TypeError(f"Input image tensor permitted channel values are {[1, 3]}, but found {c}")
     dtype = image.dtype if torch.is_floating_point(image) else torch.float32
-    grayscale_image = _FT.rgb_to_grayscale(image) if c == 3 else image
+    grayscale_image = _rgb_to_gray(image) if c == 3 else image
     mean = torch.mean(grayscale_image.to(dtype), dim=(-3, -2, -1), keepdim=True)
     return _blend(image, mean, contrast_factor)
 

--- a/torchvision/prototype/transforms/functional/_color.py
+++ b/torchvision/prototype/transforms/functional/_color.py
@@ -7,7 +7,7 @@ from ._meta import get_dimensions_image_tensor, get_num_channels_image_tensor
 
 def _blend(img1: torch.Tensor, img2: torch.Tensor, ratio: float) -> torch.Tensor:
     dtype = img1.dtype
-    fp = dtype.is_floating_point
+    fp = img1.is_floating_point()
     bound = 1.0 if fp else 255.0
     if not fp and img2.is_cuda:
         img2 = img2 * (1.0 - ratio)
@@ -52,10 +52,10 @@ def adjust_saturation_image_tensor(img: torch.Tensor, saturation_factor: float) 
     if c not in [1, 3]:
         raise TypeError(f"Input image tensor permitted channel values are {[1, 3]}, but found {c}")
 
-    if c[0] == 1:  # Match PIL behaviour
+    if c == 1:  # Match PIL behaviour
         return img
 
-    return _blend(img, _FT.rgb_to_grayscale(img), saturation_factor)
+    return _blend(img, _FT.rgb_to_grayscale(img).expand_as(img).clone(), saturation_factor)
 
 
 adjust_saturation_image_pil = _FP.adjust_saturation
@@ -87,7 +87,7 @@ def adjust_contrast_image_tensor(img: torch.Tensor, contrast_factor: float) -> t
     else:
         mean = torch.mean(img.to(dtype), dim=(-3, -2, -1), keepdim=True)
 
-    return _blend(img, mean, contrast_factor)
+    return _blend(img, mean.expand_as(img).clone(), contrast_factor)
 
 
 adjust_contrast_image_pil = _FP.adjust_contrast

--- a/torchvision/prototype/transforms/functional/_color.py
+++ b/torchvision/prototype/transforms/functional/_color.py
@@ -2,7 +2,7 @@ import torch
 from torchvision.prototype import features
 from torchvision.transforms import functional_pil as _FP, functional_tensor as _FT
 
-from ._meta import get_dimensions_image_tensor, get_num_channels_image_tensor
+from ._meta import get_dimensions_image_tensor, get_num_channels_image_tensor, rgb_to_grayscale
 
 
 def _blend(img1: torch.Tensor, img2: torch.Tensor, ratio: float) -> torch.Tensor:
@@ -52,7 +52,7 @@ def adjust_saturation_image_tensor(img: torch.Tensor, saturation_factor: float) 
     if c == 1:  # Match PIL behaviour
         return img
 
-    return _blend(img, _FT.rgb_to_grayscale(img), saturation_factor)
+    return _blend(img, rgb_to_grayscale(img), saturation_factor)
 
 
 adjust_saturation_image_pil = _FP.adjust_saturation
@@ -80,7 +80,7 @@ def adjust_contrast_image_tensor(img: torch.Tensor, contrast_factor: float) -> t
         raise TypeError(f"Input image tensor permitted channel values are {[1, 3]}, but found {c}")
     dtype = img.dtype if torch.is_floating_point(img) else torch.float32
     if c == 3:
-        mean = torch.mean(_FT.rgb_to_grayscale(img).to(dtype), dim=(-3, -2, -1), keepdim=True)
+        mean = torch.mean(rgb_to_grayscale(img).to(dtype), dim=(-3, -2, -1), keepdim=True)
     else:
         mean = torch.mean(img.to(dtype), dim=(-3, -2, -1), keepdim=True)
 

--- a/torchvision/prototype/transforms/functional/_color.py
+++ b/torchvision/prototype/transforms/functional/_color.py
@@ -79,8 +79,8 @@ def adjust_contrast_image_tensor(image: torch.Tensor, contrast_factor: float) ->
     if c not in [1, 3]:
         raise TypeError(f"Input image tensor permitted channel values are {[1, 3]}, but found {c}")
     dtype = image.dtype if torch.is_floating_point(image) else torch.float32
-    grayscale_image = _rgb_to_gray(image.to(dtype)) if c == 3 else image.to(dtype)
-    mean = torch.mean(grayscale_image, dim=(-3, -2, -1), keepdim=True)
+    grayscale_image = _rgb_to_gray(image) if c == 3 else image
+    mean = torch.mean(grayscale_image.to(dtype), dim=(-3, -2, -1), keepdim=True)
     return _blend(image, mean, contrast_factor)
 
 

--- a/torchvision/prototype/transforms/functional/_color.py
+++ b/torchvision/prototype/transforms/functional/_color.py
@@ -79,7 +79,8 @@ def adjust_contrast_image_tensor(image: torch.Tensor, contrast_factor: float) ->
     if c not in [1, 3]:
         raise TypeError(f"Input image tensor permitted channel values are {[1, 3]}, but found {c}")
     dtype = image.dtype if torch.is_floating_point(image) else torch.float32
-    mean = torch.mean((rgb_to_grayscale(image) if c == 3 else image).to(dtype), dim=(-3, -2, -1), keepdim=True)
+    grayscale_image = _FT.rgb_to_grayscale(image) if c == 3 else image
+    mean = torch.mean(grayscale_image.to(dtype), dim=(-3, -2, -1), keepdim=True)
     return _blend(image, mean, contrast_factor)
 
 

--- a/torchvision/prototype/transforms/functional/_color.py
+++ b/torchvision/prototype/transforms/functional/_color.py
@@ -79,8 +79,8 @@ def adjust_contrast_image_tensor(image: torch.Tensor, contrast_factor: float) ->
     if c not in [1, 3]:
         raise TypeError(f"Input image tensor permitted channel values are {[1, 3]}, but found {c}")
     dtype = image.dtype if torch.is_floating_point(image) else torch.float32
-    grayscale_image = _rgb_to_gray(image) if c == 3 else image
-    mean = torch.mean(grayscale_image.to(dtype), dim=(-3, -2, -1), keepdim=True)
+    grayscale_image = _rgb_to_gray(image.to(dtype)) if c == 3 else image.to(dtype)
+    mean = torch.mean(grayscale_image, dim=(-3, -2, -1), keepdim=True)
     return _blend(image, mean, contrast_factor)
 
 

--- a/torchvision/prototype/transforms/functional/_meta.py
+++ b/torchvision/prototype/transforms/functional/_meta.py
@@ -184,7 +184,31 @@ def _gray_to_rgb(grayscale: torch.Tensor) -> torch.Tensor:
     return grayscale.repeat(repeats)
 
 
-_rgb_to_gray = _FT.rgb_to_grayscale
+def rgb_to_grayscale(image: torch.Tensor, num_output_channels: int = 1) -> torch.Tensor:
+    if image.ndim < 3:
+        raise TypeError(f"Input image tensor should have at least 3 dimensions, but found {image.ndim}")
+
+    c = image.shape[-3]
+    if c not in [1, 3]:
+        raise TypeError(f"Input image tensor permitted channel values are {[1, 3]}, but found {c}")
+
+    if num_output_channels not in (1, 3):
+        raise ValueError("num_output_channels should be either 1 or 3")
+
+    if c == 3:
+        r, g, b = image.unbind(dim=-3)
+        l_img = (0.2989 * r).add_(g, alpha=0.587).add_(b, alpha=0.114)
+        l_img = l_img.to(image.dtype).unsqueeze(dim=-3)
+    else:
+        l_img = image.clone()
+
+    if num_output_channels == 3:
+        return l_img.expand(image.shape)
+
+    return l_img
+
+
+_rgb_to_gray = rgb_to_grayscale
 
 
 def convert_color_space_image_tensor(

--- a/torchvision/prototype/transforms/functional/_meta.py
+++ b/torchvision/prototype/transforms/functional/_meta.py
@@ -184,31 +184,11 @@ def _gray_to_rgb(grayscale: torch.Tensor) -> torch.Tensor:
     return grayscale.repeat(repeats)
 
 
-def rgb_to_grayscale(image: torch.Tensor, num_output_channels: int = 1) -> torch.Tensor:
-    if image.ndim < 3:
-        raise TypeError(f"Input image tensor should have at least 3 dimensions, but found {image.ndim}")
-
-    c = image.shape[-3]
-    if c not in [1, 3]:
-        raise TypeError(f"Input image tensor permitted channel values are {[1, 3]}, but found {c}")
-
-    if num_output_channels not in (1, 3):
-        raise ValueError("num_output_channels should be either 1 or 3")
-
-    if c == 3:
-        r, g, b = image.unbind(dim=-3)
-        l_img = (0.2989 * r).add_(g, alpha=0.587).add_(b, alpha=0.114)
-        l_img = l_img.to(image.dtype).unsqueeze(dim=-3)
-    else:
-        l_img = image.clone()
-
-    if num_output_channels == 3:
-        return l_img.expand(image.shape)
-
+def _rgb_to_gray(image: torch.Tensor) -> torch.Tensor:
+    r, g, b = image.unbind(dim=-3)
+    l_img = (0.2989 * r).add_(g, alpha=0.587).add_(b, alpha=0.114)
+    l_img = l_img.to(image.dtype).unsqueeze(dim=-3)
     return l_img
-
-
-_rgb_to_gray = rgb_to_grayscale
 
 
 def convert_color_space_image_tensor(

--- a/torchvision/prototype/transforms/functional/_misc.py
+++ b/torchvision/prototype/transforms/functional/_misc.py
@@ -1,7 +1,9 @@
+import math
 from typing import List, Optional, Union
 
 import PIL.Image
 import torch
+from torch.nn.functional import conv2d, pad as torch_pad
 from torchvision.prototype import features
 from torchvision.transforms import functional_tensor as _FT
 from torchvision.transforms.functional import pil_to_tensor, to_pil_image
@@ -30,6 +32,22 @@ def normalize(
     # Image or Video type should not be retained after normalization due to unknown data range
     # Thus we return Tensor for input Image
     return normalize_image_tensor(inpt, mean=mean, std=std, inplace=inplace)
+
+
+def _get_gaussian_kernel1d(kernel_size: int, sigma: float) -> torch.Tensor:
+    lim = (kernel_size - 1) / (2 * math.sqrt(2) * sigma)
+    x = torch.linspace(-lim, lim, steps=kernel_size)
+    kernel1d = torch.softmax(-x.pow_(2), dim=0)
+    return kernel1d
+
+
+def _get_gaussian_kernel2d(
+    kernel_size: List[int], sigma: List[float], dtype: torch.dtype, device: torch.device
+) -> torch.Tensor:
+    kernel1d_x = _get_gaussian_kernel1d(kernel_size[0], sigma[0]).to(device, dtype=dtype)
+    kernel1d_y = _get_gaussian_kernel1d(kernel_size[1], sigma[1]).to(device, dtype=dtype)
+    kernel2d = kernel1d_y.unsqueeze(-1) * kernel1d_x
+    return kernel2d
 
 
 def gaussian_blur_image_tensor(
@@ -70,7 +88,18 @@ def gaussian_blur_image_tensor(
     else:
         needs_unsquash = False
 
-    output = _FT.gaussian_blur(image, kernel_size, sigma)
+    dtype = image.dtype if torch.is_floating_point(image) else torch.float32
+    kernel = _get_gaussian_kernel2d(kernel_size, sigma, dtype=dtype, device=image.device)
+    kernel = kernel.expand(image.shape[-3], 1, kernel.shape[0], kernel.shape[1])
+
+    image, need_cast, need_squeeze, out_dtype = _FT._cast_squeeze_in(image, [kernel.dtype])
+
+    # padding = (left, right, top, bottom)
+    padding = [kernel_size[0] // 2, kernel_size[0] // 2, kernel_size[1] // 2, kernel_size[1] // 2]
+    output = torch_pad(image, padding, mode="reflect")
+    output = conv2d(output, kernel, groups=output.shape[-3])
+
+    output = _FT._cast_squeeze_out(output, need_cast, need_squeeze, out_dtype)
 
     if needs_unsquash:
         output = output.reshape(shape)

--- a/torchvision/transforms/functional_tensor.py
+++ b/torchvision/transforms/functional_tensor.py
@@ -816,12 +816,7 @@ def _blurred_degenerate_image(img: Tensor) -> Tensor:
     kernel /= kernel.sum()
     kernel = kernel.expand(img.shape[-3], 1, kernel.shape[0], kernel.shape[1])
 
-    result_tmp, need_cast, need_squeeze, out_dtype = _cast_squeeze_in(
-        img,
-        [
-            kernel.dtype,
-        ],
-    )
+    result_tmp, need_cast, need_squeeze, out_dtype = _cast_squeeze_in(img, [kernel.dtype])
     result_tmp = conv2d(result_tmp, kernel, groups=result_tmp.shape[-3])
     result_tmp = _cast_squeeze_out(result_tmp, need_cast, need_squeeze, out_dtype)
 


### PR DESCRIPTION
Description:
- Rewritten `_blend` op in prototype space
- Simplified `adjust_brightness`
- Optimized `_rgb_to_gray`
- Removed redundant checks 
- Follow-up PR to https://github.com/pytorch/vision/pull/6765

Results:
```
[------------------ Adjust_brightness cpu torch.uint8 ------------------]
                     |  adjust_brightness stable  |  adjust_brightness v2
1 threads: --------------------------------------------------------------
      (3, 400, 400)  |            1080            |          483         

Times are in microseconds (us).

[----------------- Adjust_contrast cpu torch.uint8 -----------------]
                     |  adjust_contrast stable  |  adjust_contrast v2
1 threads: ----------------------------------------------------------
      (3, 400, 400)  |           1150           |         926        

Times are in microseconds (us).

[------------------ Adjust_saturation cpu torch.uint8 ------------------]
                     |  adjust_saturation stable  |  adjust_saturation v2
1 threads: --------------------------------------------------------------
      (3, 400, 400)  |            1200            |          935         

Times are in microseconds (us).

[------------------ Adjust_sharpness cpu torch.uint8 -----------------]
                     |  adjust_sharpness stable  |  adjust_sharpness v2
1 threads: ------------------------------------------------------------
      (3, 400, 400)  |            4.06           |          3.64       

Times are in milliseconds (ms).

[----------------- Adjust_brightness cpu torch.float32 -----------------]
                     |  adjust_brightness stable  |  adjust_brightness v2
1 threads: --------------------------------------------------------------
      (3, 400, 400)  |            665             |          206         
6 threads: --------------------------------------------------------------
      (3, 400, 400)  |            167             |           57         

Times are in microseconds (us).

[---------------- Adjust_contrast cpu torch.float32 ----------------]
                     |  adjust_contrast stable  |  adjust_contrast v2
1 threads: ----------------------------------------------------------
      (3, 400, 400)  |           691            |         455        
6 threads: ----------------------------------------------------------
      (3, 400, 400)  |           248            |         162        

Times are in microseconds (us).

[----------------- Adjust_saturation cpu torch.float32 -----------------]
                     |  adjust_saturation stable  |  adjust_saturation v2
1 threads: --------------------------------------------------------------
      (3, 400, 400)  |            728             |          466         

Times are in microseconds (us).

[----------------- Adjust_sharpness cpu torch.float32 ----------------]
                     |  adjust_sharpness stable  |  adjust_sharpness v2
1 threads: ------------------------------------------------------------
      (3, 400, 400)  |            3100           |          2860       

Times are in microseconds (us).
```

More results in [logs](https://github.com/vfdev-5/tvapiv2_benchmarks/blob/bf1dbe56e3c1962f8e7225cc529c36777b2be123/output/20221020-111409-output-adjust-color-ops_41179579f.log), [code](https://github.com/vfdev-5/tvapiv2_benchmarks/blob/bf1dbe56e3c1962f8e7225cc529c36777b2be123/check_adjust_color_ops.py)


Logs with #6765 code + simplified adjust brightness : https://github.com/vfdev-5/tvapiv2_benchmarks/blob/ba35a27f14fd77123ea96f0c54ac9e2fb22f0f15/output/20221018-115341-output-adjust-color-ops_datumbox.log