### PR TITLE
fix warnings in prototype transforms test suite

### DIFF
--- a/test/prototype_transforms_kernel_infos.py
+++ b/test/prototype_transforms_kernel_infos.py
@@ -1,6 +1,7 @@
 import functools
 import itertools
 import math
+import re
 
 import numpy as np
 import pytest
@@ -172,6 +173,12 @@ KERNEL_INFOS.extend(
         KernelInfo(
             F.horizontal_flip_bounding_box,
             sample_inputs_fn=sample_inputs_horizontal_flip_bounding_box,
+            test_marks=[
+                TestMark(
+                    ("TestKernels", "test_scripted_vs_eager"),
+                    pytest.mark.filterwarnings(f"ignore:{re.escape('operator() profile_node %72')}:UserWarning"),
+                )
+            ],
         ),
         KernelInfo(
             F.horizontal_flip_mask,
@@ -443,10 +450,10 @@ def reference_affine_bounding_box(bounding_box, *, format, spatial_size, angle, 
         transformed_points = np.matmul(points, affine_matrix.T)
         out_bbox = torch.tensor(
             [
-                np.min(transformed_points[:, 0]),
-                np.min(transformed_points[:, 1]),
-                np.max(transformed_points[:, 0]),
-                np.max(transformed_points[:, 1]),
+                np.min(transformed_points[:, 0]).item(),
+                np.min(transformed_points[:, 1]).item(),
+                np.max(transformed_points[:, 0]).item(),
+                np.max(transformed_points[:, 1]).item(),
             ],
             dtype=bbox.dtype,
         )

--- a/test/test_prototype_transforms_functional.py
+++ b/test/test_prototype_transforms_functional.py
@@ -1012,16 +1012,9 @@ def test_normalize_output_type():
 def test_to_image_tensor(inpt):
     output = F.to_image_tensor(inpt)
     assert isinstance(output, torch.Tensor)
+    assert output.shape == (3, 32, 32)
 
     assert np.asarray(inpt).sum() == output.sum().item()
-
-    if isinstance(inpt, PIL.Image.Image):
-        # we can't check this option
-        # as PIL -> numpy is always copying
-        return
-
-    inpt[0, 0, 0] = 11
-    assert output[0, 0, 0] == 11
 
 
 @pytest.mark.parametrize(

--- a/torchvision/prototype/transforms/functional/_type_conversion.py
+++ b/torchvision/prototype/transforms/functional/_type_conversion.py
@@ -27,7 +27,7 @@ def decode_video_with_av(encoded_video: torch.Tensor) -> Tuple[torch.Tensor, tor
 @torch.jit.unused
 def to_image_tensor(image: Union[torch.Tensor, PIL.Image.Image, np.ndarray]) -> features.Image:
     if isinstance(image, np.ndarray):
-        output = torch.from_numpy(image)
+        output = torch.from_numpy(image).permute((2, 0, 1))
     elif isinstance(image, PIL.Image.Image):
         output = pil_to_tensor(image)
     else:  # isinstance(inpt, torch.Tensor):

--- a/torchvision/prototype/transforms/functional/_type_conversion.py
+++ b/torchvision/prototype/transforms/functional/_type_conversion.py
@@ -27,7 +27,7 @@ def decode_video_with_av(encoded_video: torch.Tensor) -> Tuple[torch.Tensor, tor
 @torch.jit.unused
 def to_image_tensor(image: Union[torch.Tensor, PIL.Image.Image, np.ndarray]) -> features.Image:
     if isinstance(image, np.ndarray):
-        output = torch.from_numpy(image).permute((2, 0, 1))
+        output = torch.from_numpy(image).permute((2, 0, 1)).contiguous()
     elif isinstance(image, PIL.Image.Image):
         output = pil_to_tensor(image)
     else:  # isinstance(inpt, torch.Tensor):


### PR DESCRIPTION
We have quite a few warnings in our prototype test suite: https://github.com/pytorch/vision/actions/runs/3268600734/jobs/5375203177#step:13:2309 Especially, the deprecation warnings are quite large and clutter the test summary. This PR fixes the test suite to avoid warnings. 

In the future we should also check whether or not we want to put `@pytest.mark.filterwarnings("error")` onto the common tests like we do for the datasets common tests:

https://github.com/pytorch/vision/blob/0610b13ac4af3717f538454a9c6b1f441cb386f3/test/test_prototype_datasets_builtin.py#L58-L59

This would prevent warnings from creeping in.
