### PR TITLE
don't fail linux CPU tests fast

### DIFF
--- a/.github/workflows/test-linux-cpu.yml
+++ b/.github/workflows/test-linux-cpu.yml
@@ -21,6 +21,7 @@ jobs:
     strategy:
       matrix:
         py_vers: ["3.7", "3.8", "3.9", "3.10"]
+      fail-fast: false
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Without this, if one of the jobs fails, all other jobs will be aborted. That is usually not what we want. @osalpekar if this was intentional, feel free to close the PR.
