### PR TITLE
pin pyav to <10

### DIFF
--- a/.circleci/unittest/linux/scripts/environment.yml
+++ b/.circleci/unittest/linux/scripts/environment.yml
@@ -13,4 +13,4 @@ dependencies:
   - pip:
     - future
     - scipy
-    - av
+    - av < 10

--- a/.circleci/unittest/windows/scripts/environment.yml
+++ b/.circleci/unittest/windows/scripts/environment.yml
@@ -14,6 +14,6 @@ dependencies:
   - pip:
     - future
     - scipy
-    - av != 9.1.1
+    - av !=9.1.1, <10
     - dataclasses
     - h5py

--- a/.github/workflows/test-linux-cpu.yml
+++ b/.github/workflows/test-linux-cpu.yml
@@ -56,7 +56,7 @@ jobs:
             -c nvidia "pytorch-${CHANNEL}"::pytorch[build="*${VERSION}*"] \
             "${CUDATOOLKIT}"
           ${CONDA_RUN} python3 setup.py develop
-          ${CONDA_RUN} python3 -m pip install pytest pytest-mock av
+          ${CONDA_RUN} python3 -m pip install pytest pytest-mock 'av<10'
       - name: Run tests
         shell: bash -l {0}
         env:

--- a/.github/workflows/test-m1.yml
+++ b/.github/workflows/test-m1.yml
@@ -37,7 +37,7 @@ jobs:
           conda create -yp ${ENV_NAME} python=${PY_VERS} numpy libpng jpeg scipy
           conda run -p ${ENV_NAME} python3 -mpip install --pre torch --extra-index-url=https://download.pytorch.org/whl/${CHANNEL}
           conda run -p ${ENV_NAME} python3 setup.py develop
-          conda run -p ${ENV_NAME} python3 -mpip install pytest pytest-mock av
+          conda run -p ${ENV_NAME} python3 -mpip install pytest pytest-mock 'av<10'
       - name: Run tests
         shell: arch -arch arm64 bash {0}
         env:


### PR DESCRIPTION
Closes #6790. This is meant as a short term fix to get the CI green again as there are multiple failures going on right now. As suggested offline, I think it would be best for the video maintainers to have a look and see if this comes from

1. a bug in the newly released version of `av`
2. a BC breaking change in the newly released version of `av`
3. a bug in our video ops that only now has been surfaced
4. usage of deprecated functionality in our video ops that now has been removed
5. a bug in our test setup
6. ...

If we have a clearer picture, this PR can be reverted and whatever reasonable fix can be merged.