### PR TITLE
improve perf on convert_image_dtype and add tests

### DIFF
--- a/test/prototype_transforms_kernel_infos.py
+++ b/test/prototype_transforms_kernel_infos.py
@@ -1,3 +1,4 @@
+import decimal
 import functools
 import itertools
 import math
@@ -21,6 +22,7 @@ from prototype_common_utils import (
     mark_framework_limitation,
     TestMark,
 )
+from torch.utils._pytree import tree_map
 from torchvision.prototype import features
 from torchvision.transforms.functional_tensor import _max_value as get_max_value
 
@@ -1965,11 +1967,73 @@ def sample_inputs_convert_image_dtype():
     yield ArgsKwargs(make_image_loader(color_space=features.ColorSpace.RGB), dtype=torch.uint8)
 
 
+def reference_convert_image_dtype(image, dtype=torch.float):
+    input_dtype = image.dtype
+    output_dtype = dtype
+
+    if output_dtype == input_dtype:
+        return image
+
+    def fn(value):
+        if input_dtype.is_floating_point:
+            if output_dtype.is_floating_point:
+                return value
+            else:
+                return int(decimal.Decimal(value) * torch.iinfo(output_dtype).max)
+        else:
+            input_max_value = torch.iinfo(input_dtype).max
+
+            if output_dtype.is_floating_point:
+                return float(decimal.Decimal(value) / input_max_value)
+            else:
+                output_max_value = torch.iinfo(output_dtype).max
+
+                if input_max_value > output_max_value:
+                    factor = (input_max_value + 1) // (output_max_value + 1)
+                    return value // factor
+                else:
+                    factor = (output_max_value + 1) // (input_max_value + 1)
+                    return value * factor
+
+    return torch.tensor(tree_map(fn, image.tolist()), dtype=dtype)
+
+
+def reference_inputs_convert_image_dtype():
+    for input_dtype, output_dtype in itertools.product(
+        [
+            torch.uint8,
+            torch.int16,
+            torch.int32,
+            torch.int64,
+            torch.float16,
+            torch.float32,
+            torch.float64,
+            torch.bfloat16,
+        ],
+        repeat=2,
+    ):
+        if (input_dtype == torch.float32 and output_dtype in {torch.int32, torch.int64}) or (
+            input_dtype == torch.float64 and output_dtype == torch.int64
+        ):
+            continue
+
+        if input_dtype.is_floating_point:
+            data = [0.0, 0.5, 1.0]
+        else:
+            max_value = torch.iinfo(input_dtype).max
+            data = [0, max_value // 2, max_value]
+        image = torch.tensor(data, dtype=input_dtype)
+
+        yield ArgsKwargs(image, dtype=output_dtype)
+
+
 KERNEL_INFOS.extend(
     [
         KernelInfo(
             F.convert_image_dtype,
             sample_inputs_fn=sample_inputs_convert_image_dtype,
+            reference_fn=reference_convert_image_dtype,
+            reference_inputs_fn=reference_inputs_convert_image_dtype,
             test_marks=[
                 TestMark(
                     ("TestKernels", "test_scripted_vs_eager"),
@@ -1980,6 +2044,22 @@ KERNEL_INFOS.extend(
                     pytest.mark.skip(reason="`convert_dtype_*` kernels convert the dtype by design"),
                     condition=lambda args_kwargs: args_kwargs.args[0].dtype
                     != args_kwargs.kwargs.get("dtype", torch.float32),
+                ),
+                TestMark(
+                    ("TestKernels", "test_against_reference"),
+                    pytest.mark.xfail(reason="Conversion overflows"),
+                    condition=lambda args_kwargs: (
+                        args_kwargs.args[0].dtype in {torch.float16, torch.bfloat16}
+                        and not args_kwargs.kwargs["dtype"].is_floating_point
+                    )
+                    or (
+                        args_kwargs.args[0].dtype in {torch.float16, torch.bfloat16}
+                        and args_kwargs.kwargs["dtype"] == torch.int64
+                    )
+                    or (
+                        args_kwargs.args[0].dtype in {torch.int32, torch.int64}
+                        and args_kwargs.kwargs["dtype"] == torch.float16
+                    ),
                 ),
             ],
         ),

--- a/test/prototype_transforms_kernel_infos.py
+++ b/test/prototype_transforms_kernel_infos.py
@@ -2037,7 +2037,7 @@ KERNEL_INFOS.extend(
             test_marks=[
                 TestMark(
                     ("TestKernels", "test_scripted_vs_eager"),
-                    pytest.mark.filterwarnings(f"ignore:{re.escape('operator() profile_node %36')}:UserWarning"),
+                    pytest.mark.filterwarnings(f"ignore:{re.escape('operator() profile_node %41')}:UserWarning"),
                 ),
                 TestMark(
                     ("TestKernels", "test_dtype_and_device_consistency"),

--- a/test/prototype_transforms_kernel_infos.py
+++ b/test/prototype_transforms_kernel_infos.py
@@ -1947,3 +1947,41 @@ KERNEL_INFOS.extend(
         ),
     ]
 )
+
+
+def sample_inputs_convert_image_dtype():
+    for input_dtype, output_dtype in itertools.product(
+        [torch.uint8, torch.int64, torch.float32, torch.float64], repeat=2
+    ):
+        if input_dtype.is_floating_point and output_dtype == torch.int64:
+            # conversion cannot be performed safely
+            continue
+
+        for image_loader in make_image_loaders(
+            sizes=["random"], color_spaces=[features.ColorSpace.RGB], dtypes=[input_dtype]
+        ):
+            yield ArgsKwargs(image_loader, dtype=output_dtype)
+
+    yield ArgsKwargs(make_image_loader(color_space=features.ColorSpace.RGB), dtype=torch.uint8)
+
+
+KERNEL_INFOS.extend(
+    [
+        KernelInfo(
+            F.convert_image_dtype,
+            sample_inputs_fn=sample_inputs_convert_image_dtype,
+            test_marks=[
+                TestMark(
+                    ("TestKernels", "test_scripted_vs_eager"),
+                    pytest.mark.filterwarnings(f"ignore:{re.escape('operator() profile_node %36')}:UserWarning"),
+                ),
+                TestMark(
+                    ("TestKernels", "test_dtype_and_device_consistency"),
+                    pytest.mark.skip(reason="`convert_dtype_*` kernels convert the dtype by design"),
+                    condition=lambda args_kwargs: args_kwargs.args[0].dtype
+                    != args_kwargs.kwargs.get("dtype", torch.float32),
+                ),
+            ],
+        ),
+    ]
+)

--- a/test/test_prototype_transforms_functional.py
+++ b/test/test_prototype_transforms_functional.py
@@ -26,6 +26,20 @@ def script(fn):
         raise AssertionError(f"Trying to `torch.jit.script` '{fn.__name__}' raised the error above.") from error
 
 
+def make_info_args_kwargs_params(info, *, args_kwargs_fn, test_id=None):
+    args_kwargs = list(args_kwargs_fn(info))
+    idx_field_len = len(str(len(args_kwargs)))
+    return [
+        pytest.param(
+            info,
+            args_kwargs_,
+            marks=info.get_marks(test_id, args_kwargs_) if test_id else [],
+            id=f"{info.id}-{idx:0{idx_field_len}}",
+        )
+        for idx, args_kwargs_ in enumerate(args_kwargs)
+    ]
+
+
 def make_info_args_kwargs_parametrization(infos, *, args_kwargs_fn, condition=None):
     if condition is None:
 
@@ -49,18 +63,7 @@ def make_info_args_kwargs_parametrization(infos, *, args_kwargs_fn, condition=No
             if not condition(info):
                 continue
 
-            args_kwargs = list(args_kwargs_fn(info))
-            idx_field_len = len(str(len(args_kwargs)))
-
-            for idx, args_kwargs_ in enumerate(args_kwargs):
-                argvalues.append(
-                    pytest.param(
-                        info,
-                        args_kwargs_,
-                        marks=info.get_marks(test_id, args_kwargs_),
-                        id=f"{info.id}-{idx:0{idx_field_len}}",
-                    )
-                )
+            argvalues.extend(make_info_args_kwargs_params(info, args_kwargs_fn=args_kwargs_fn, test_id=test_id))
 
         return pytest.mark.parametrize(argnames, argvalues)(test_fn)
 
@@ -232,7 +235,6 @@ class TestDispatchers:
         [
             F.clamp_bounding_box,
             F.convert_color_space,
-            F.convert_image_dtype,
             F.get_dimensions,
             F.get_image_num_channels,
             F.get_image_size,
@@ -310,6 +312,24 @@ class TestDispatchers:
 )
 def test_alias(alias, target):
     assert alias is target
+
+
+@pytest.mark.parametrize(
+    ("info", "args_kwargs"),
+    make_info_args_kwargs_params(
+        next(info for info in KERNEL_INFOS if info.kernel is F.convert_image_dtype),
+        args_kwargs_fn=lambda info: info.sample_inputs_fn(),
+    ),
+)
+@pytest.mark.parametrize("device", cpu_and_gpu())
+def test_dtype_and_device_convert_image_dtype(info, args_kwargs, device):
+    (input, *other_args), kwargs = args_kwargs.load(device)
+    dtype = other_args[0] if other_args else kwargs.get("dtype", torch.float32)
+
+    output = info.kernel(input, dtype)
+
+    assert output.dtype == dtype
+    assert output.device == input.device
 
 
 # TODO: All correctness checks below this line should be ported to be references on a `KernelInfo` in

--- a/torchvision/prototype/transforms/functional/_type_conversion.py
+++ b/torchvision/prototype/transforms/functional/_type_conversion.py
@@ -7,7 +7,7 @@ import torch
 from torchvision.io.video import read_video
 from torchvision.prototype import features
 from torchvision.prototype.utils._internal import ReadOnlyTensorBuffer
-from torchvision.transforms import functional as _F
+from torchvision.transforms import functional as _F, functional_tensor as _FT
 
 
 @torch.jit.unused
@@ -42,4 +42,64 @@ pil_to_tensor = _F.pil_to_tensor
 # prevalent and well understood. Thus, we just alias it without deprecating the old name.
 to_pil_image = to_image_pil
 
-convert_image_dtype = _F.convert_image_dtype
+
+def convert_image_dtype(image: torch.Tensor, dtype: torch.dtype = torch.float) -> torch.Tensor:
+    if not isinstance(image, torch.Tensor):
+        raise TypeError("Input img should be Tensor Image")
+
+    if image.dtype == dtype:
+        return image
+
+    float_input = image.is_floating_point()
+    if torch.jit.is_scripting():
+        # TODO: remove this branch as soon as `dtype.is_floating_point` is supported by JIT
+        float_output = torch.tensor(0, dtype=dtype).is_floating_point()
+    else:
+        float_output = dtype.is_floating_point
+
+    if float_input:
+        # float to float
+        if float_output:
+            return image.to(dtype)
+
+        # float to int
+        if (image.dtype == torch.float32 and dtype in (torch.int32, torch.int64)) or (
+            image.dtype == torch.float64 and dtype == torch.int64
+        ):
+            raise RuntimeError(f"The conversion from {image.dtype} to {dtype} cannot be performed safely.")
+
+        # For data in the range `[0.0, 1.0]`, just multiplying by the maximum value of the integer range and converting
+        # to the integer dtype  is not sufficient. For example, `torch.rand(...).mul(255).to(torch.uint8)` will only
+        # be `255` if the input is exactly `1.0`. See https://github.com/pytorch/vision/pull/2078#issuecomment-612045321
+        # for a detailed analysis.
+        # To mitigate this, we could round before we convert to the integer dtype, but this is an extra operation.
+        # Instead, we can also multiply by the maximum value plus something close to `1`. See
+        # https://github.com/pytorch/vision/pull/2078#issuecomment-613524965 for details.
+        eps = 1e-3
+        max_val = float(_FT._max_value(dtype))
+        # We need to scale first since the conversion would otherwise turn the input range `[0.0, 1.0]` into the
+        # discrete set `{0, 1}`.
+        return image.mul(max_val + 1.0 - eps).to(dtype)
+    else:
+        max_input_val = float(_FT._max_value(image.dtype))
+
+        # int to float
+        if float_output:
+            return image.to(dtype).div_(max_input_val)
+
+        # int to int
+        # TODO: The `factor`'s below are by definition powers of 2. Instead of multiplying and dividing the inputs to
+        #  get to the desired value range, we can probably speed this up significantly with bitshifts. However, we
+        #  probably need to be careful when converting from signed to unsigned dtypes and vice versa.
+        max_output_val = float(_FT._max_value(dtype))
+
+        if max_input_val > max_output_val:
+            # We technically don't need to convert to `int` here, but it speeds the division
+            factor = int((max_input_val + 1) / (max_output_val + 1))
+            # We need to scale first since the output dtype cannot hold all values in the input range
+            return image.div(factor, rounding_mode="floor").to(dtype)
+        else:
+            # We need to convert to `int` or otherwise the multiplication will turn the image into floating point. Or,
+            # to be more exact, the inplace multiplication will fail.
+            factor = int((max_output_val + 1) / (max_input_val + 1))
+            return image.to(dtype).mul_(factor)


### PR DESCRIPTION
The improvements come from using inplace operations where possible.

<details><summary>benchmark script</summary>
<p>

```python
import itertools
import pathlib
import pickle

import torch
from torch.utils import benchmark
import functools

from torchvision.prototype.transforms import functional as F

description = "PR"  # "main", "PR"


def make_inputs(*, input_dtype, output_dtype, device, shape=(3, 512, 512)):
    if input_dtype.is_floating_point:
        image = torch.rand(shape, dtype=input_dtype, device=device)
    else:
        image = torch.randint(0, torch.iinfo(input_dtype).max + 1, shape, dtype=input_dtype, device=device)
    return image, output_dtype


sub_labels_and_input_fns = [
    ("float to float", functools.partial(make_inputs, input_dtype=torch.float32, output_dtype=torch.float64)),
    ("float to   int", functools.partial(make_inputs, input_dtype=torch.float32, output_dtype=torch.uint8)),
    ("  int to float", functools.partial(make_inputs, input_dtype=torch.uint8, output_dtype=torch.float32)),
    ("  int to   int (down)", functools.partial(make_inputs, input_dtype=torch.int32, output_dtype=torch.uint8)),
    ("  int to   int (up)", functools.partial(make_inputs, input_dtype=torch.uint8, output_dtype=torch.int32)),
]


timers = [
    benchmark.Timer(
        stmt="convert_image_dtype(*inputs)",
        globals=dict(
            convert_image_dtype=F.convert_image_dtype,
            inputs=inputs_fn(device=device),
        ),
        label="convert_image_dtype perf improvements",
        sub_label=f"{device:4} / {sub_label}",
        description=description,
        num_threads=num_threads,
    )
    for (sub_label, inputs_fn), device in itertools.product(sub_labels_and_input_fns, ["cpu", "cuda"])
    for num_threads in ([1, 2, 4] if device == "cpu" else [1])
]

measurements = [timer.blocked_autorange(min_run_time=5) for timer in timers]


with open(f"{description}.measurements", "wb") as fh:
    pickle.dump(measurements, fh)

measurements = []
for file in pathlib.Path(".").glob("*.measurements"):
    with open(file, "rb") as fh:
        measurements.extend(pickle.load(fh))

comparison = benchmark.Compare(measurements)
comparison.trim_significant_figures()
comparison.print()
```

</p>
</details>

```
[----- convert_image_dtype perf improvements ------]
                                    |  main  |   PR 
1 threads: -----------------------------------------
      cpu  / float to float         |    88  |    82
      cuda / float to float         |    42  |    42
      cpu  / float to   int         |   380  |   360
      cuda / float to   int         |    46  |    50
      cpu  /   int to float         |   136  |   130
      cuda /   int to float         |    47  |    47
      cpu  /   int to   int (down)  |  1050  |  1070
      cuda /   int to   int (down)  |    44  |    44
      cpu  /   int to   int (up)    |   120  |    88
      cuda /   int to   int (up)    |    46  |    46
2 threads: -----------------------------------------
      cpu  / float to float         |    53  |    46
      cpu  / float to   int         |   210  |   199
      cpu  /   int to float         |    82  |    76
      cpu  /   int to   int (down)  |   560  |   546
      cpu  /   int to   int (up)    |    74  |    55
4 threads: -----------------------------------------
      cpu  / float to float         |    31  |    27
      cpu  / float to   int         |   115  |   108
      cpu  /   int to float         |    51  |    45
      cpu  /   int to   int (down)  |   293  |   286
      cpu  /   int to   int (up)    |    47  |    35

Times are in microseconds (us).
```

The branches that are improved are

- float to float
- float to int
- int to int (up)

Of these float to int is the most interesting for us, since we regularly to `torch.uint8` to `torch.float32` before we normalize. With this patch, we get the following diff when profiling with @vfdev-5's benchmark scripts

```diff
-      2000    0.047    0.000    0.095    0.000 /home/philip/git/pytorch/torchvision/torchvision/transforms/functional_tensor.py:68(convert_image_dtype)
+      2000    0.005    0.000    0.072    0.000 /home/philip/git/pytorch/torchvision/torchvision/prototype/transforms/functional/_type_conversion.py:46(convert_image_dtype)
```

cc @vfdev-5 @datumbox @bjuncek