### PR TITLE
[Nova] Migrate Linux CPU job to Generic Job

### DIFF
--- a/.github/workflows/test-linux-cpu.yml
+++ b/.github/workflows/test-linux-cpu.yml
@@ -18,10 +18,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-      - name: Set Channel
-        if: ${{ (github.event_name == 'pull_request' && startsWith(github.base_ref, 'release')) || startsWith(github.ref, 'refs/heads/release') }}
-        run: |
-          echo "CHANNEL=test" >> "$GITHUB_ENV"
   tests:
     strategy:
       matrix:
@@ -31,23 +27,27 @@ jobs:
     with:
       runner: linux.12xlarge
       script: |
+        # Mark Build Directory Safe
+        git config --global --add safe.directory /__w/vision/vision
+
+        # Set up Environment Variables
         export ENV_NAME=conda-env-"${{ github.run_id }}"
         export PYTHON_VERSION="${{ matrix.py_vers }}"
         export VERSION="cpu"
         export CUDATOOLKIT="cpuonly"
+
+        # Set CHANNEL
         if [[${{ (github.event_name == 'pull_request' && startsWith(github.base_ref, 'release')) || startsWith(github.ref, 'refs/heads/release') }} ]]; then
           export CHANNEL=test
         else
           export CHANNEL=nightly
         fi
 
-        git config --global --add safe.directory /__w/vision/vision
-        # . ~/miniconda3/etc/profile.d/conda.sh
+        # Create Conda Env
         conda create -yp "${ENV_NAME}" python="${PYTHON_VERSION}" numpy libpng jpeg scipy
-        # echo "CONDA_RUN=conda run -p ${ENV_NAME}" >> "$GITHUB_ENV"
         export CONDA_RUN="conda run -p ${ENV_NAME}"
         
-        # export PATH=~/miniconda3/bin:$PATH
+        # Install PyTorch, Torchvision, and testing libraries
         set -ex
         ${CONDA_RUN} conda install \
           --yes \
@@ -57,51 +57,6 @@ jobs:
         ${CONDA_RUN} python3 setup.py develop
         ${CONDA_RUN} python3 -m pip install pytest pytest-mock 'av<10'
 
+        # Run Tests
         ${CONDA_RUN} python3 -m torch.utils.collect_env
         ${CONDA_RUN} python3 -m pytest --junitxml=test-results/junit.xml -v --durations 20
-
-    # steps:
-    #   - name: Checkout repository
-    #     uses: actions/checkout@v2
-    #   - name: Set Release CHANNEL (for release)
-    #     if: ${{ (github.event_name == 'pull_request' && startsWith(github.base_ref, 'release')) || startsWith(github.ref, 'refs/heads/release') }}
-    #     run: |
-    #       echo "CHANNEL=test" >> "$GITHUB_ENV"
-    #   - name: Setup Conda
-    #     shell: bash -l {0}
-    #     env:
-    #       ENV_NAME: conda-env-${{ github.run_id }}
-    #       PY_VERS: ${{ matrix.py_vers }}
-    #     run: |
-    #       git config --global --add safe.directory /__w/vision/vision
-    #       . ~/miniconda3/etc/profile.d/conda.sh
-    #       conda create -yp ${ENV_NAME} python=${PY_VERS} numpy libpng jpeg scipy
-    #       echo "CONDA_RUN=conda run -p ${ENV_NAME}" >> "$GITHUB_ENV"
-    #   - name: Install TorchVision
-    #     shell: bash -l {0}
-    #     env:
-    #       VERSION: cpu
-    #       CUDATOOLKIT: cpuonly
-    #     run: |
-    #       # Needed for JPEG library detection as setup.py detects conda presence
-    #       # by running `shutil.which('conda')`
-    #       export PATH=~/miniconda3/bin:$PATH
-    #       set -ex
-    #       ${CONDA_RUN} conda install \
-    #         --yes \
-    #         -c "pytorch-${CHANNEL}" \
-    #         -c nvidia "pytorch-${CHANNEL}"::pytorch[build="*${VERSION}*"] \
-    #         "${CUDATOOLKIT}"
-    #       ${CONDA_RUN} python3 setup.py develop
-    #       ${CONDA_RUN} python3 -m pip install pytest pytest-mock 'av<10'
-    #   - name: Run tests
-    #     shell: bash -l {0}
-    #     env:
-    #       ENV_NAME: conda-env-${{ github.run_id }}
-    #       PY_VERS: ${{ matrix.py_vers }}
-    #     run: |
-    #       . ~/miniconda3/etc/profile.d/conda.sh
-    #       set -ex
-    #       ${CONDA_RUN} python3 -m torch.utils.collect_env
-    #       ${CONDA_RUN} python3 -m pytest --junitxml=test-results/junit.xml -v --durations 20
-    #       conda env remove -p ${ENV_NAME}

--- a/.github/workflows/test-linux-cpu.yml
+++ b/.github/workflows/test-linux-cpu.yml
@@ -13,11 +13,6 @@ env:
   CHANNEL: "nightly"
 
 jobs:
-  setup:
-    runs-on: linux.12xlarge
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
   tests:
     strategy:
       matrix:
@@ -26,37 +21,38 @@ jobs:
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
     with:
       runner: linux.12xlarge
+      repository: pytorch/vision
+      ref: main
       script: |
         # Mark Build Directory Safe
         git config --global --add safe.directory /__w/vision/vision
 
         # Set up Environment Variables
-        export ENV_NAME=conda-env-"${{ github.run_id }}"
         export PYTHON_VERSION="${{ matrix.py_vers }}"
         export VERSION="cpu"
         export CUDATOOLKIT="cpuonly"
 
         # Set CHANNEL
-        if [[${{ (github.event_name == 'pull_request' && startsWith(github.base_ref, 'release')) || startsWith(github.ref, 'refs/heads/release') }} ]]; then
+        if [[ (${GITHUB_EVENT_NAME} = 'pull_request' && (${GITHUB_BASE_REF} = 'release'*)) || (${GITHUB_REF} = 'refs/heads/release'*) ]]; then
           export CHANNEL=test
         else
           export CHANNEL=nightly
         fi
 
         # Create Conda Env
-        conda create -yp "${ENV_NAME}" python="${PYTHON_VERSION}" numpy libpng jpeg scipy
-        export CONDA_RUN="conda run -p ${ENV_NAME}"
+        conda create -yp ci_env python="${PYTHON_VERSION}" numpy libpng jpeg scipy
+        conda activate ci_env
         
         # Install PyTorch, Torchvision, and testing libraries
         set -ex
-        ${CONDA_RUN} conda install \
+        conda install \
           --yes \
           -c "pytorch-${CHANNEL}" \
           -c nvidia "pytorch-${CHANNEL}"::pytorch[build="*${VERSION}*"] \
           "${CUDATOOLKIT}"
-        ${CONDA_RUN} python3 setup.py develop
-        ${CONDA_RUN} python3 -m pip install pytest pytest-mock 'av<10'
+        python3 setup.py develop
+        python3 -m pip install pytest pytest-mock 'av<10'
 
         # Run Tests
-        ${CONDA_RUN} python3 -m torch.utils.collect_env
-        ${CONDA_RUN} python3 -m pytest --junitxml=test-results/junit.xml -v --durations 20
+        python3 -m torch.utils.collect_env
+        python3 -m pytest --junitxml=test-results/junit.xml -v --durations 20

--- a/.github/workflows/test-linux-cpu.yml
+++ b/.github/workflows/test-linux-cpu.yml
@@ -22,7 +22,6 @@ jobs:
     with:
       runner: linux.12xlarge
       repository: pytorch/vision
-      ref: main
       script: |
         # Mark Build Directory Safe
         git config --global --add safe.directory /__w/vision/vision

--- a/.github/workflows/test-linux-cpu.yml
+++ b/.github/workflows/test-linux-cpu.yml
@@ -14,6 +14,7 @@ env:
 
 jobs:
   setup:
+    runs-on: linux.12xlarge
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/test-linux-cpu.yml
+++ b/.github/workflows/test-linux-cpu.yml
@@ -52,7 +52,7 @@ jobs:
         ${CONDA_RUN} conda install \
           --yes \
           -c "pytorch-${CHANNEL}" \
-          -c nvidia "pytorch-${CHANNEL}"::pytorch[build="*{VERSION}*"] \
+          -c nvidia "pytorch-${CHANNEL}"::pytorch[build="*${VERSION}*"] \
           "${CUDATOOLKIT}"
         ${CONDA_RUN} python3 setup.py develop
         ${CONDA_RUN} python3 -m pip install pytest pytest-mock 'av<10'

--- a/.github/workflows/test-linux-cpu.yml
+++ b/.github/workflows/test-linux-cpu.yml
@@ -41,7 +41,7 @@ jobs:
 
         # Create Conda Env
         conda create -yp ci_env python="${PYTHON_VERSION}" numpy libpng jpeg scipy
-        conda activate ci_env
+        conda activate /work/ci_env
         
         # Install PyTorch, Torchvision, and testing libraries
         set -ex

--- a/.github/workflows/test-linux-cpu.yml
+++ b/.github/workflows/test-linux-cpu.yml
@@ -14,57 +14,87 @@ env:
 
 jobs:
   tests:
-    name: "Unit-tests on Linux CPU"
-    runs-on: [self-hosted, linux.12xlarge]
-    container:
-      image: pytorch/conda-builder:cpu
     strategy:
       matrix:
         py_vers: ["3.7", "3.8", "3.9", "3.10"]
       fail-fast: false
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-      - name: Set Release CHANNEL (for release)
+      - name: Set Channel
         if: ${{ (github.event_name == 'pull_request' && startsWith(github.base_ref, 'release')) || startsWith(github.ref, 'refs/heads/release') }}
         run: |
           echo "CHANNEL=test" >> "$GITHUB_ENV"
-      - name: Setup Conda
-        shell: bash -l {0}
-        env:
-          ENV_NAME: conda-env-${{ github.run_id }}
-          PY_VERS: ${{ matrix.py_vers }}
-        run: |
-          git config --global --add safe.directory /__w/vision/vision
-          . ~/miniconda3/etc/profile.d/conda.sh
-          conda create -yp ${ENV_NAME} python=${PY_VERS} numpy libpng jpeg scipy
-          echo "CONDA_RUN=conda run -p ${ENV_NAME}" >> "$GITHUB_ENV"
-      - name: Install TorchVision
-        shell: bash -l {0}
-        env:
-          VERSION: cpu
-          CUDATOOLKIT: cpuonly
-        run: |
-          # Needed for JPEG library detection as setup.py detects conda presence
-          # by running `shutil.which('conda')`
-          export PATH=~/miniconda3/bin:$PATH
-          set -ex
-          ${CONDA_RUN} conda install \
-            --yes \
-            -c "pytorch-${CHANNEL}" \
-            -c nvidia "pytorch-${CHANNEL}"::pytorch[build="*${VERSION}*"] \
-            "${CUDATOOLKIT}"
-          ${CONDA_RUN} python3 setup.py develop
-          ${CONDA_RUN} python3 -m pip install pytest pytest-mock 'av<10'
-      - name: Run tests
-        shell: bash -l {0}
-        env:
-          ENV_NAME: conda-env-${{ github.run_id }}
-          PY_VERS: ${{ matrix.py_vers }}
-        run: |
-          . ~/miniconda3/etc/profile.d/conda.sh
-          set -ex
-          ${CONDA_RUN} python3 -m torch.utils.collect_env
-          ${CONDA_RUN} python3 -m pytest --junitxml=test-results/junit.xml -v --durations 20
-          conda env remove -p ${ENV_NAME}
+      - id: Run Tests
+        uses: pytorch/test-infra/.github/workflows/linux_job.yml
+        with:
+          runner: linux.12xlarge
+          script: |
+            ENV_NAME = conda-env-${{ github.run_id }}
+            PYTHON_VERSION = ${{ matrix.py_vers }}
+
+            git config --global --add safe.directory /__w/vision/vision
+            . ~/miniconda3/etc/profile.d/conda.sh
+            conda create -yp ${ENV_NAME} python=${PY_VERS} numpy libpng jpeg scipy
+            echo "CONDA_RUN=conda run -p ${ENV_NAME}" >> "$GITHUB_ENV"
+            
+            export PATH=~/miniconda3/bin:$PATH
+            set -ex
+            ${CONDA_RUN} conda install \
+              --yes \
+              -c "pytorch-${CHANNEL}" \
+              -c nvidia "pytorch-${CHANNEL}"::pytorch[build="*${VERSION}*"] \
+              "${CUDATOOLKIT}"
+            ${CONDA_RUN} python3 setup.py develop
+            ${CONDA_RUN} python3 -m pip install pytest pytest-mock 'av<10'
+
+            . ~/miniconda3/etc/profile.d/conda.sh
+            set -ex
+            ${CONDA_RUN} python3 -m torch.utils.collect_env
+            ${CONDA_RUN} python3 -m pytest --junitxml=test-results/junit.xml -v --durations 20
+
+    # steps:
+    #   - name: Checkout repository
+    #     uses: actions/checkout@v2
+    #   - name: Set Release CHANNEL (for release)
+    #     if: ${{ (github.event_name == 'pull_request' && startsWith(github.base_ref, 'release')) || startsWith(github.ref, 'refs/heads/release') }}
+    #     run: |
+    #       echo "CHANNEL=test" >> "$GITHUB_ENV"
+    #   - name: Setup Conda
+    #     shell: bash -l {0}
+    #     env:
+    #       ENV_NAME: conda-env-${{ github.run_id }}
+    #       PY_VERS: ${{ matrix.py_vers }}
+    #     run: |
+    #       git config --global --add safe.directory /__w/vision/vision
+    #       . ~/miniconda3/etc/profile.d/conda.sh
+    #       conda create -yp ${ENV_NAME} python=${PY_VERS} numpy libpng jpeg scipy
+    #       echo "CONDA_RUN=conda run -p ${ENV_NAME}" >> "$GITHUB_ENV"
+    #   - name: Install TorchVision
+    #     shell: bash -l {0}
+    #     env:
+    #       VERSION: cpu
+    #       CUDATOOLKIT: cpuonly
+    #     run: |
+    #       # Needed for JPEG library detection as setup.py detects conda presence
+    #       # by running `shutil.which('conda')`
+    #       export PATH=~/miniconda3/bin:$PATH
+    #       set -ex
+    #       ${CONDA_RUN} conda install \
+    #         --yes \
+    #         -c "pytorch-${CHANNEL}" \
+    #         -c nvidia "pytorch-${CHANNEL}"::pytorch[build="*${VERSION}*"] \
+    #         "${CUDATOOLKIT}"
+    #       ${CONDA_RUN} python3 setup.py develop
+    #       ${CONDA_RUN} python3 -m pip install pytest pytest-mock 'av<10'
+    #   - name: Run tests
+    #     shell: bash -l {0}
+    #     env:
+    #       ENV_NAME: conda-env-${{ github.run_id }}
+    #       PY_VERS: ${{ matrix.py_vers }}
+    #     run: |
+    #       . ~/miniconda3/etc/profile.d/conda.sh
+    #       set -ex
+    #       ${CONDA_RUN} python3 -m torch.utils.collect_env
+    #       ${CONDA_RUN} python3 -m pytest --junitxml=test-results/junit.xml -v --durations 20
+    #       conda env remove -p ${ENV_NAME}

--- a/.github/workflows/test-linux-cpu.yml
+++ b/.github/workflows/test-linux-cpu.yml
@@ -31,13 +31,14 @@ jobs:
     with:
       runner: linux.12xlarge
       script: |
-        ENV_NAME = conda-env-${{ github.run_id }}
-        PYTHON_VERSION = ${{ matrix.py_vers }}
+        export ENV_NAME=conda-env-"${{ github.run_id }}"
+        export PYTHON_VERSION="${{ matrix.py_vers }}"
 
         git config --global --add safe.directory /__w/vision/vision
         . ~/miniconda3/etc/profile.d/conda.sh
-        conda create -yp ${ENV_NAME} python=${PY_VERS} numpy libpng jpeg scipy
-        echo "CONDA_RUN=conda run -p ${ENV_NAME}" >> "$GITHUB_ENV"
+        conda create -yp "${ENV_NAME}" python="${PYTHON_VERSION}" numpy libpng jpeg scipy
+        # echo "CONDA_RUN=conda run -p ${ENV_NAME}" >> "$GITHUB_ENV"
+        export CONDA_RUN="conda run -p ${ENV_NAME}"
         
         export PATH=~/miniconda3/bin:$PATH
         set -ex
@@ -49,8 +50,6 @@ jobs:
         ${CONDA_RUN} python3 setup.py develop
         ${CONDA_RUN} python3 -m pip install pytest pytest-mock 'av<10'
 
-        . ~/miniconda3/etc/profile.d/conda.sh
-        set -ex
         ${CONDA_RUN} python3 -m torch.utils.collect_env
         ${CONDA_RUN} python3 -m pytest --junitxml=test-results/junit.xml -v --durations 20
 

--- a/.github/workflows/test-linux-cpu.yml
+++ b/.github/workflows/test-linux-cpu.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           echo "CHANNEL=test" >> "$GITHUB_ENV"
       - id: Run Tests
-        uses: pytorch/test-infra/.github/workflows/linux_job.yml
+        uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
         with:
           runner: linux.12xlarge
           script: |

--- a/.github/workflows/test-linux-cpu.yml
+++ b/.github/workflows/test-linux-cpu.yml
@@ -13,11 +13,7 @@ env:
   CHANNEL: "nightly"
 
 jobs:
-  tests:
-    strategy:
-      matrix:
-        py_vers: ["3.7", "3.8", "3.9", "3.10"]
-      fail-fast: false
+  setup:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -25,33 +21,37 @@ jobs:
         if: ${{ (github.event_name == 'pull_request' && startsWith(github.base_ref, 'release')) || startsWith(github.ref, 'refs/heads/release') }}
         run: |
           echo "CHANNEL=test" >> "$GITHUB_ENV"
-      - id: Run Tests
-        uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
-        with:
-          runner: linux.12xlarge
-          script: |
-            ENV_NAME = conda-env-${{ github.run_id }}
-            PYTHON_VERSION = ${{ matrix.py_vers }}
+  tests:
+    strategy:
+      matrix:
+        py_vers: ["3.7", "3.8", "3.9", "3.10"]
+      fail-fast: false
+    uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
+    with:
+      runner: linux.12xlarge
+      script: |
+        ENV_NAME = conda-env-${{ github.run_id }}
+        PYTHON_VERSION = ${{ matrix.py_vers }}
 
-            git config --global --add safe.directory /__w/vision/vision
-            . ~/miniconda3/etc/profile.d/conda.sh
-            conda create -yp ${ENV_NAME} python=${PY_VERS} numpy libpng jpeg scipy
-            echo "CONDA_RUN=conda run -p ${ENV_NAME}" >> "$GITHUB_ENV"
-            
-            export PATH=~/miniconda3/bin:$PATH
-            set -ex
-            ${CONDA_RUN} conda install \
-              --yes \
-              -c "pytorch-${CHANNEL}" \
-              -c nvidia "pytorch-${CHANNEL}"::pytorch[build="*${VERSION}*"] \
-              "${CUDATOOLKIT}"
-            ${CONDA_RUN} python3 setup.py develop
-            ${CONDA_RUN} python3 -m pip install pytest pytest-mock 'av<10'
+        git config --global --add safe.directory /__w/vision/vision
+        . ~/miniconda3/etc/profile.d/conda.sh
+        conda create -yp ${ENV_NAME} python=${PY_VERS} numpy libpng jpeg scipy
+        echo "CONDA_RUN=conda run -p ${ENV_NAME}" >> "$GITHUB_ENV"
+        
+        export PATH=~/miniconda3/bin:$PATH
+        set -ex
+        ${CONDA_RUN} conda install \
+          --yes \
+          -c "pytorch-${CHANNEL}" \
+          -c nvidia "pytorch-${CHANNEL}"::pytorch[build="*${VERSION}*"] \
+          "${CUDATOOLKIT}"
+        ${CONDA_RUN} python3 setup.py develop
+        ${CONDA_RUN} python3 -m pip install pytest pytest-mock 'av<10'
 
-            . ~/miniconda3/etc/profile.d/conda.sh
-            set -ex
-            ${CONDA_RUN} python3 -m torch.utils.collect_env
-            ${CONDA_RUN} python3 -m pytest --junitxml=test-results/junit.xml -v --durations 20
+        . ~/miniconda3/etc/profile.d/conda.sh
+        set -ex
+        ${CONDA_RUN} python3 -m torch.utils.collect_env
+        ${CONDA_RUN} python3 -m pytest --junitxml=test-results/junit.xml -v --durations 20
 
     # steps:
     #   - name: Checkout repository

--- a/.github/workflows/test-linux-cpu.yml
+++ b/.github/workflows/test-linux-cpu.yml
@@ -35,12 +35,12 @@ jobs:
         export PYTHON_VERSION="${{ matrix.py_vers }}"
 
         git config --global --add safe.directory /__w/vision/vision
-        . ~/miniconda3/etc/profile.d/conda.sh
+        # . ~/miniconda3/etc/profile.d/conda.sh
         conda create -yp "${ENV_NAME}" python="${PYTHON_VERSION}" numpy libpng jpeg scipy
         # echo "CONDA_RUN=conda run -p ${ENV_NAME}" >> "$GITHUB_ENV"
         export CONDA_RUN="conda run -p ${ENV_NAME}"
         
-        export PATH=~/miniconda3/bin:$PATH
+        # export PATH=~/miniconda3/bin:$PATH
         set -ex
         ${CONDA_RUN} conda install \
           --yes \

--- a/.github/workflows/test-linux-cpu.yml
+++ b/.github/workflows/test-linux-cpu.yml
@@ -33,6 +33,11 @@ jobs:
       script: |
         export ENV_NAME=conda-env-"${{ github.run_id }}"
         export PYTHON_VERSION="${{ matrix.py_vers }}"
+        if [[${{ (github.event_name == 'pull_request' && startsWith(github.base_ref, 'release')) || startsWith(github.ref, 'refs/heads/release') }} ]]; then
+          export CHANNEL=test
+        else
+          export CHANNEL=nightly
+        fi
 
         git config --global --add safe.directory /__w/vision/vision
         # . ~/miniconda3/etc/profile.d/conda.sh

--- a/.github/workflows/test-linux-cpu.yml
+++ b/.github/workflows/test-linux-cpu.yml
@@ -33,6 +33,8 @@ jobs:
       script: |
         export ENV_NAME=conda-env-"${{ github.run_id }}"
         export PYTHON_VERSION="${{ matrix.py_vers }}"
+        export VERSION="cpu"
+        export CUDATOOLKIT="cpuonly"
         if [[${{ (github.event_name == 'pull_request' && startsWith(github.base_ref, 'release')) || startsWith(github.ref, 'refs/heads/release') }} ]]; then
           export CHANNEL=test
         else
@@ -50,7 +52,7 @@ jobs:
         ${CONDA_RUN} conda install \
           --yes \
           -c "pytorch-${CHANNEL}" \
-          -c nvidia "pytorch-${CHANNEL}"::pytorch[build="*${VERSION}*"] \
+          -c nvidia "pytorch-${CHANNEL}"::pytorch[build="*{VERSION}*"] \
           "${CUDATOOLKIT}"
         ${CONDA_RUN} python3 setup.py develop
         ${CONDA_RUN} python3 -m pip install pytest pytest-mock 'av<10'


### PR DESCRIPTION
Migrating the Linux CPU Testing job to the Generic Linux Job format that will be used long-term for CI jobs.
