### PR TITLE
Add PermuteDimensions and TransposeDimensions transforms

### DIFF
--- a/test/test_prototype_transforms.py
+++ b/test/test_prototype_transforms.py
@@ -23,6 +23,7 @@ from prototype_common_utils import (
 )
 from torchvision.ops.boxes import box_iou
 from torchvision.prototype import features, transforms
+from torchvision.prototype.transforms._utils import _isinstance
 from torchvision.transforms.functional import InterpolationMode, pil_to_tensor, to_pil_image
 
 BATCH_EXTRA_DIMS = [extra_dims for extra_dims in DEFAULT_EXTRA_DIMS if extra_dims]
@@ -1859,11 +1860,10 @@ def test_permute_dimensions(dims, inverse_dims):
         value_type = type(value)
         transformed_value = transformed_sample[key]
 
-        # make sure the transformation retains the type
-        assert isinstance(transformed_value, value_type)
-
-        if isinstance(value, torch.Tensor) and transform.dims.get(value_type) is not None:
-            assert transformed_value.permute(inverse_dims[value_type]).equal(value)
+        if _isinstance(value, (features.Image, features.is_simple_tensor, features.Video)):
+            if transform.dims.get(value_type) is not None:
+                assert transformed_value.permute(inverse_dims[value_type]).equal(value)
+            assert type(transformed_value) == torch.Tensor
         else:
             assert transformed_value is value
 
@@ -1892,11 +1892,10 @@ def test_transpose_dimensions(dims):
         value_type = type(value)
         transformed_value = transformed_sample[key]
 
-        # make sure the transformation retains the type
-        assert isinstance(transformed_value, value_type)
-
         transposed_dims = transform.dims.get(value_type)
-        if isinstance(value, torch.Tensor) and transposed_dims is not None:
-            assert transformed_value.transpose(*transposed_dims).equal(value)
+        if _isinstance(value, (features.Image, features.is_simple_tensor, features.Video)):
+            if transposed_dims is not None:
+                assert transformed_value.transpose(*transposed_dims).equal(value)
+            assert type(transformed_value) == torch.Tensor
         else:
             assert transformed_value is value

--- a/test/test_prototype_transforms.py
+++ b/test/test_prototype_transforms.py
@@ -18,6 +18,7 @@ from prototype_common_utils import (
     make_masks,
     make_one_hot_labels,
     make_segmentation_mask,
+    make_video,
     make_videos,
 )
 from torchvision.ops.boxes import box_iou
@@ -1824,5 +1825,78 @@ def test_to_dtype(dtype, expected_dtypes):
 
         if isinstance(value, torch.Tensor):
             assert transformed_value.dtype is expected_dtypes[value_type]
+        else:
+            assert transformed_value is value
+
+
+@pytest.mark.parametrize(
+    ("dims", "inverse_dims"),
+    [
+        (
+            {torch.Tensor: (1, 2, 0), features.Image: (2, 1, 0), features.Video: None},
+            {torch.Tensor: (2, 0, 1), features.Image: (2, 1, 0), features.Video: None},
+        ),
+        (
+            {torch.Tensor: (1, 2, 0), features.Image: (2, 1, 0), features.Video: (1, 2, 3, 0)},
+            {torch.Tensor: (2, 0, 1), features.Image: (2, 1, 0), features.Video: (3, 0, 1, 2)},
+        ),
+    ],
+)
+def test_permute_dimensions(dims, inverse_dims):
+    sample = dict(
+        plain_tensor=torch.testing.make_tensor((3, 28, 28), dtype=torch.uint8, device="cpu"),
+        image=make_image(),
+        bounding_box=make_bounding_box(format=features.BoundingBoxFormat.XYXY),
+        video=make_video(),
+        str="str",
+        int=0,
+    )
+
+    transform = transforms.PermuteDimensions(dims)
+    transformed_sample = transform(sample)
+
+    for key, value in sample.items():
+        value_type = type(value)
+        transformed_value = transformed_sample[key]
+
+        # make sure the transformation retains the type
+        assert isinstance(transformed_value, value_type)
+
+        if isinstance(value, torch.Tensor) and transform.dims.get(value_type) is not None:
+            assert transformed_value.permute(inverse_dims[value_type]).equal(value)
+        else:
+            assert transformed_value is value
+
+
+@pytest.mark.parametrize(
+    "dims",
+    [
+        (-1, -2),
+        {torch.Tensor: (-1, -2), features.Image: (1, 2), features.Video: None},
+    ],
+)
+def test_transpose_dimensions(dims):
+    sample = dict(
+        plain_tensor=torch.testing.make_tensor((3, 28, 28), dtype=torch.uint8, device="cpu"),
+        image=make_image(),
+        bounding_box=make_bounding_box(format=features.BoundingBoxFormat.XYXY),
+        video=make_video(),
+        str="str",
+        int=0,
+    )
+
+    transform = transforms.TransposeDimensions(dims)
+    transformed_sample = transform(sample)
+
+    for key, value in sample.items():
+        value_type = type(value)
+        transformed_value = transformed_sample[key]
+
+        # make sure the transformation retains the type
+        assert isinstance(transformed_value, value_type)
+
+        transposed_dims = transform.dims.get(value_type)
+        if isinstance(value, torch.Tensor) and transposed_dims is not None:
+            assert transformed_value.transpose(*transposed_dims).equal(value)
         else:
             assert transformed_value is value

--- a/torchvision/prototype/transforms/__init__.py
+++ b/torchvision/prototype/transforms/__init__.py
@@ -40,7 +40,17 @@ from ._geometry import (
     TenCrop,
 )
 from ._meta import ClampBoundingBoxes, ConvertBoundingBoxFormat, ConvertColorSpace, ConvertImageDtype
-from ._misc import GaussianBlur, Identity, Lambda, LinearTransformation, Normalize, RemoveSmallBoundingBoxes, ToDtype
+from ._misc import (
+    GaussianBlur,
+    Identity,
+    Lambda,
+    LinearTransformation,
+    Normalize,
+    PermuteDimensions,
+    RemoveSmallBoundingBoxes,
+    ToDtype,
+    TransposeDimensions,
+)
 from ._type_conversion import DecodeImage, LabelToOneHot, PILToTensor, ToImagePIL, ToImageTensor, ToPILImage
 
 from ._deprecated import Grayscale, RandomGrayscale, ToTensor  # usort: skip

--- a/torchvision/prototype/transforms/_misc.py
+++ b/torchvision/prototype/transforms/_misc.py
@@ -173,14 +173,13 @@ class PermuteDimensions(Transform):
             dims = defaultdict(functools.partial(_default_arg, dims))
         self.dims = dims
 
-    def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
+    def _transform(
+        self, inpt: Union[features.TensorImageType, features.TensorVideoType], params: Dict[str, Any]
+    ) -> torch.Tensor:
         dims = self.dims[type(inpt)]
         if dims is None:
-            return inpt
-        output = inpt.permute(dims)
-        if isinstance(inpt, (features.Image, features.Video)):
-            output = inpt.wrap_like(inpt, output)
-        return output
+            return inpt.as_subclass(torch.Tensor)
+        return inpt.permute(*dims)
 
 
 class TransposeDimensions(Transform):
@@ -192,15 +191,13 @@ class TransposeDimensions(Transform):
             dims = defaultdict(functools.partial(_default_arg, dims))
         self.dims = dims
 
-    def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
+    def _transform(
+        self, inpt: Union[features.TensorImageType, features.TensorVideoType], params: Dict[str, Any]
+    ) -> torch.Tensor:
         dims = self.dims[type(inpt)]
         if dims is None:
-            return inpt
-        dim0, dim1 = dims
-        output = inpt.transpose(dim0, dim1)
-        if isinstance(inpt, (features.Image, features.Video)):
-            output = inpt.wrap_like(inpt, output)
-        return output
+            return inpt.as_subclass(torch.Tensor)
+        return inpt.transpose(*dims)
 
 
 class RemoveSmallBoundingBoxes(Transform):

--- a/torchvision/prototype/transforms/_misc.py
+++ b/torchvision/prototype/transforms/_misc.py
@@ -1,5 +1,3 @@
-import functools
-from collections import defaultdict
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Type, Union
 
 import PIL.Image
@@ -9,7 +7,7 @@ from torchvision.ops import remove_small_boxes
 from torchvision.prototype import features
 from torchvision.prototype.transforms import functional as F, Transform
 
-from ._utils import _setup_float_or_seq, _setup_size, has_any, query_bounding_box
+from ._utils import _get_defaultdict, _setup_float_or_seq, _setup_size, has_any, query_bounding_box
 
 
 class Identity(Transform):
@@ -142,19 +140,13 @@ class GaussianBlur(Transform):
         return F.gaussian_blur(inpt, self.kernel_size, **params)
 
 
-def _default_arg(value: Any) -> Any:
-    return value
-
-
 class ToDtype(Transform):
     _transformed_types = (torch.Tensor,)
 
     def __init__(self, dtype: Union[torch.dtype, Dict[Type, Optional[torch.dtype]]]) -> None:
         super().__init__()
         if not isinstance(dtype, dict):
-            # This weird looking construct only exists, since `lambda`'s cannot be serialized by pickle.
-            # If it were possible, we could replace this with `defaultdict(lambda: dtype)`
-            dtype = defaultdict(functools.partial(_default_arg, dtype))
+            dtype = _get_defaultdict(dtype)
         self.dtype = dtype
 
     def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
@@ -170,7 +162,7 @@ class PermuteDimensions(Transform):
     def __init__(self, dims: Union[Sequence[int], Dict[Type, Optional[Sequence[int]]]]) -> None:
         super().__init__()
         if not isinstance(dims, dict):
-            dims = defaultdict(functools.partial(_default_arg, dims))
+            dims = _get_defaultdict(dims)
         self.dims = dims
 
     def _transform(
@@ -188,7 +180,7 @@ class TransposeDimensions(Transform):
     def __init__(self, dims: Union[Tuple[int, int], Dict[Type, Optional[Tuple[int, int]]]]) -> None:
         super().__init__()
         if not isinstance(dims, dict):
-            dims = defaultdict(functools.partial(_default_arg, dims))
+            dims = _get_defaultdict(dims)
         self.dims = dims
 
     def _transform(


### PR DESCRIPTION
Part of #6768

This PR adds the `PermuteDimensions` and `TransposeDimensions` transforms which are [useful](https://github.com/facebookresearch/pytorchvideo/blob/main/pytorchvideo/transforms/transforms.py#L317) for video training which is often needed to move the temporal dimension around.

Because the end tensors can have their dimensions completely messed, meta-data information from Images and Videos are not retrained and instead a simple tensor is assumed.

cc @vfdev-5 @bjuncek @pmeier