### PR TITLE
[Nova] GHA Linux GPU Job

### DIFF
--- a/.github/workflows/test-linux-gpu.yml
+++ b/.github/workflows/test-linux-gpu.yml
@@ -21,11 +21,11 @@ jobs:
       fail-fast: false
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
     with:
-      runner: linux.4xlarge.nvidia.gpu
+      runner: linux.8xlarge.nvidia.gpu
       repository: pytorch/vision
       gpu-arch-type: cuda
       gpu-arch-version: ${{ matrix.cuda_arch_version }}
-      timeout: 60
+      timeout: 120
       script: |
         # Mark Build Directory Safe
         git config --global --add safe.directory /__w/vision/vision

--- a/.github/workflows/test-linux-gpu.yml
+++ b/.github/workflows/test-linux-gpu.yml
@@ -16,12 +16,12 @@ jobs:
   tests:
     strategy:
       matrix:
-        python_version: ["3.7", "3.8", "3.9", "3.10"]
-        cuda_arch_version: ["11.6", "11.7"]
+        python_version: ["3.8"]
+        cuda_arch_version: ["11.6"]
       fail-fast: false
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
     with:
-      runner: linux.8xlarge.nvidia.gpu
+      runner: linux.g5.4xlarge.nvidia.gpu
       repository: pytorch/vision
       gpu-arch-type: cuda
       gpu-arch-version: ${{ matrix.cuda_arch_version }}

--- a/.github/workflows/test-linux-gpu.yml
+++ b/.github/workflows/test-linux-gpu.yml
@@ -1,4 +1,4 @@
-name: Unit-tests on Linux CPU
+name: Unit-tests on Linux GPU
 
 on:
   pull_request:
@@ -17,19 +17,22 @@ jobs:
     strategy:
       matrix:
         python_version: ["3.7", "3.8", "3.9", "3.10"]
+        cuda_arch_version: ["11.6", "11.7"]
       fail-fast: false
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
     with:
-      runner: linux.12xlarge
+      runner: linux.4xlarge.nvidia.gpu
       repository: pytorch/vision
+      gpu-arch-type: cuda
+      gpu-arch-version: ${{ matrix.cuda_arch_version }}
       script: |
         # Mark Build Directory Safe
         git config --global --add safe.directory /__w/vision/vision
 
         # Set up Environment Variables
         export PYTHON_VERSION="${{ matrix.python_version }}"
-        export VERSION="cpu"
-        export CUDATOOLKIT="cpuonly"
+        export VERSION="${{ matrix.cuda_arch_version }}"
+        export CUDATOOLKIT="pytorch-cuda=${VERSION}"
 
         # Set CHANNEL
         if [[ (${GITHUB_EVENT_NAME} = 'pull_request' && (${GITHUB_BASE_REF} = 'release'*)) || (${GITHUB_REF} = 'refs/heads/release'*) ]]; then

--- a/.github/workflows/test-linux-gpu.yml
+++ b/.github/workflows/test-linux-gpu.yml
@@ -25,6 +25,7 @@ jobs:
       repository: pytorch/vision
       gpu-arch-type: cuda
       gpu-arch-version: ${{ matrix.cuda_arch_version }}
+      timeout: 60
       script: |
         # Mark Build Directory Safe
         git config --global --add safe.directory /__w/vision/vision


### PR DESCRIPTION
Adding a GHA job for Linux GPU. Only added python3.8 x cuda11.6 since this is the only config for Linux GPU jobs that's run at the moment in CircleCI, other python and CUDA versions are run on main/other branches only and not per-PR.