### PR TITLE
[proto] Speed improvement for autocontrast op

### DIFF
--- a/torchvision/prototype/transforms/functional/_color.py
+++ b/torchvision/prototype/transforms/functional/_color.py
@@ -221,31 +221,22 @@ def autocontrast_image_tensor(image: torch.Tensor) -> torch.Tensor:
     if c not in [1, 3]:
         raise TypeError(f"Input image tensor permitted channel values are {[1, 3]}, but found {c}")
 
-    # if img.ndim < 3:
-    #     raise TypeError(f"Input image tensor should have at least 3 dimensions, but found {img.ndim}")
-
-    # _assert_channels(img, [1, 3])
+    if image.numel() == 0:
+        # exit earlier on empty images
+        return image
 
     bound = 1.0 if image.is_floating_point() else 255.0
     dtype = image.dtype if torch.is_floating_point(image) else torch.float32
 
-    # let's squash spatial dims into a single dim, such that torch.aminmax support it
-    shape = image.shape[:-2] + (image.shape[-2] * image.shape[-1], )
-    print("shape:", shape, image.numel())
+    minimum = image.amin(dim=(-2, -1), keepdim=True).to(dtype)
+    maximum = image.amax(dim=(-2, -1), keepdim=True).to(dtype)
 
-    minimum = torch.amin(image.view(shape), dim=(-2, -1), keepdim=True)
-    maximum = torch.amax(image.view(shape), dim=(-2, -1), keepdim=True)
-    print(minimum, maximum)
-
-    minimum, maximum = torch.aminmax(image.view(shape), dim=-1, keepdim=True)
-    minimum = minimum.to(dtype).unsqueeze(-1)
-    maximum = maximum.to(dtype).unsqueeze(-1)
     scale = bound / (maximum - minimum)
     eq_idxs = maximum == minimum
     minimum[eq_idxs] = 0.0
     scale[eq_idxs] = 1.0
 
-    return ((image - minimum) * scale).clamp_(0, bound).to(image.dtype)
+    return (image - minimum).mul_(scale).clamp_(0, bound).to(image.dtype)
 
 
 autocontrast_image_pil = _FP.autocontrast


### PR DESCRIPTION
Results:

```
[---------------- Autocontrast cpu torch.uint8 ---------------]
                     |  autocontrast stable  |  autocontrast v2
1 threads: ----------------------------------------------------
      (3, 400, 400)  |          969          |        844      
6 threads: ----------------------------------------------------
      (3, 400, 400)  |          320          |        274      

Times are in microseconds (us).

[--------------- Autocontrast cuda torch.uint8 ---------------]
                     |  autocontrast stable  |  autocontrast v2
1 threads: ----------------------------------------------------
      (3, 400, 400)  |          200          |        150      
6 threads: ----------------------------------------------------
      (3, 400, 400)  |          201          |        149      

Times are in microseconds (us).

[--------------- Autocontrast cpu torch.float32 --------------]
                     |  autocontrast stable  |  autocontrast v2
1 threads: ----------------------------------------------------
      (3, 400, 400)  |          529          |        418      
6 threads: ----------------------------------------------------
      (3, 400, 400)  |          201          |        157      

Times are in microseconds (us).

[-------------- Autocontrast cuda torch.float32 --------------]
                     |  autocontrast stable  |  autocontrast v2
1 threads: ----------------------------------------------------
      (3, 400, 400)  |          166          |        115      
6 threads: ----------------------------------------------------
      (3, 400, 400)  |          165          |        114      

Times are in microseconds (us).
```



cc @datumbox @bjuncek @pmeier