### PR TITLE
improve performance of invert_image_tensor

### DIFF
--- a/torchvision/prototype/transforms/functional/_color.py
+++ b/torchvision/prototype/transforms/functional/_color.py
@@ -435,7 +435,14 @@ def equalize(inpt: features.InputTypeJIT) -> features.InputTypeJIT:
         return equalize_image_pil(inpt)
 
 
-invert_image_tensor = _FT.invert
+def invert_image_tensor(image: torch.Tensor):
+    num_channels, height, width = get_dimensions_image_tensor(image)
+    if num_channels not in (1, 3):
+        raise TypeError(f"Input image tensor can have 1 or 3 channels, but found {num_channels}")
+
+    return 1.0 - image if image.is_floating_point() else image.bitwise_not()
+
+
 invert_image_pil = _FP.invert
 
 


### PR DESCRIPTION
Per title. The benchmark script from #6818 yields the following

```
[--------- invert @ torchvision==0.15.0a0+62da7d4 ---------]
                                            |   v1   |   v2 
1 threads: -------------------------------------------------
      (1, 512, 512)       / uint8   / cpu   |    84  |     8
      (1, 512, 512)       / uint8   / cuda  |    20  |     4
      (1, 512, 512)       / float32 / cpu   |    28  |    27
      (1, 512, 512)       / float32 / cuda  |    20  |     6
      (3, 512, 512)       / uint8   / cpu   |   230  |    18
      (3, 512, 512)       / uint8   / cuda  |    30  |     4
      (3, 512, 512)       / float32 / cpu   |    61  |    62
      (3, 512, 512)       / float32 / cuda  |    40  |    27
      (5, 3, 512, 512)    / uint8   / cpu   |  1100  |    75
      (5, 3, 512, 512)    / uint8   / cuda  |    91  |    34
      (5, 3, 512, 512)    / float32 / cpu   |   500  |   500
      (5, 3, 512, 512)    / float32 / cuda  |   144  |   134
      (4, 5, 3, 512, 512) / uint8   / cpu   |  4400  |   400
      (4, 5, 3, 512, 512) / uint8   / cuda  |   400  |   133
      (4, 5, 3, 512, 512) / float32 / cpu   |  8000  |  7100
      (4, 5, 3, 512, 512) / float32 / cuda  |   540  |   535
2 threads: -------------------------------------------------
      (1, 512, 512)       / uint8   / cpu   |    49  |     7
      (1, 512, 512)       / float32 / cpu   |    21  |    20
      (3, 512, 512)       / uint8   / cpu   |   100  |    13
      (3, 512, 512)       / float32 / cpu   |    40  |    38
      (5, 3, 512, 512)    / uint8   / cpu   |   587  |    42
      (5, 3, 512, 512)    / float32 / cpu   |   150  |   150
      (4, 5, 3, 512, 512) / uint8   / cpu   |  2300  |   140
      (4, 5, 3, 512, 512) / float32 / cpu   |  7000  |  6600
4 threads: -------------------------------------------------
      (1, 512, 512)       / uint8   / cpu   |    30  |     6
      (1, 512, 512)       / float32 / cpu   |    16  |    14
      (3, 512, 512)       / uint8   / cpu   |    70  |    10
      (3, 512, 512)       / float32 / cpu   |    26  |    25
      (5, 3, 512, 512)    / uint8   / cpu   |   300  |    25
      (5, 3, 512, 512)    / float32 / cpu   |    83  |    90
      (4, 5, 3, 512, 512) / uint8   / cpu   |  1170  |    80
      (4, 5, 3, 512, 512) / float32 / cpu   |  6000  |  6000

Times are in microseconds (us).

Performance increased for images by roughly 12.5x.
Performance increased for videos by roughly 14.9x.
```

`uint8` is much faster now, while `float32` is on par with what we had before.