### PR TITLE
[prototype] Speed improvement for adjust gamma op

### DIFF
--- a/torchvision/prototype/transforms/functional/_color.py
+++ b/torchvision/prototype/transforms/functional/_color.py
@@ -2,7 +2,7 @@ import torch
 from torchvision.prototype import features
 from torchvision.transforms import functional_pil as _FP, functional_tensor as _FT
 
-from ._meta import _rgb_to_gray, get_dimensions_image_tensor, get_num_channels_image_tensor, convert_dtype_image_tensor
+from ._meta import _rgb_to_gray, convert_dtype_image_tensor, get_dimensions_image_tensor, get_num_channels_image_tensor
 
 
 def _blend(image1: torch.Tensor, image2: torch.Tensor, ratio: float) -> torch.Tensor:
@@ -269,12 +269,17 @@ def adjust_gamma_image_tensor(image: torch.Tensor, gamma: float, gain: float = 1
     if gamma < 0:
         raise ValueError("Gamma should be a non-negative real number")
 
+    # The input image is either assumed to be at [0, 1] scale (if float) or is converted to that scale (if integer).
+    # Since the gamma is non-negative, the output remains at [0, 1] scale.
     if not torch.is_floating_point(image):
         output = convert_dtype_image_tensor(image, torch.float32).pow_(gamma)
     else:
         output = image.pow(gamma)
 
-    output = output.mul_(gain).clamp_(0.0, 1.0)
+    if gain != 1.0:
+        # The clamp operation is needed only if mutiplication is performed. It's only when gain != 1, that the scale
+        # of the output can go beyond [0, 1].
+        output = output.mul_(gain).clamp_(0.0, 1.0)
 
     return convert_dtype_image_tensor(output, image.dtype)
 

--- a/torchvision/prototype/transforms/functional/_color.py
+++ b/torchvision/prototype/transforms/functional/_color.py
@@ -277,7 +277,7 @@ def adjust_gamma_image_tensor(image: torch.Tensor, gamma: float, gain: float = 1
         output = image.pow(gamma)
 
     if gain != 1.0:
-        # The clamp operation is needed only if mutiplication is performed. It's only when gain != 1, that the scale
+        # The clamp operation is needed only if multiplication is performed. It's only when gain != 1, that the scale
         # of the output can go beyond [0, 1].
         output = output.mul_(gain).clamp_(0.0, 1.0)
 

--- a/torchvision/prototype/transforms/functional/_color.py
+++ b/torchvision/prototype/transforms/functional/_color.py
@@ -261,11 +261,6 @@ def adjust_gamma_image_tensor(image: torch.Tensor, gamma: float, gain: float = 1
     if not (isinstance(image, torch.Tensor)):
         raise TypeError("Input img should be Tensor image")
 
-    c = get_num_channels_image_tensor(image)
-
-    if c not in [1, 3]:
-        raise TypeError(f"Input image tensor permitted channel values are {[1, 3]}, but found {c}")
-
     if gamma < 0:
         raise ValueError("Gamma should be a non-negative real number")
 

--- a/torchvision/prototype/transforms/functional/_color.py
+++ b/torchvision/prototype/transforms/functional/_color.py
@@ -2,7 +2,7 @@ import torch
 from torchvision.prototype import features
 from torchvision.transforms import functional_pil as _FP, functional_tensor as _FT
 
-from ._meta import _rgb_to_gray, get_dimensions_image_tensor, get_num_channels_image_tensor
+from ._meta import _rgb_to_gray, get_dimensions_image_tensor, get_num_channels_image_tensor, convert_dtype_image_tensor
 
 
 def _blend(image1: torch.Tensor, image2: torch.Tensor, ratio: float) -> torch.Tensor:
@@ -257,7 +257,28 @@ def adjust_hue(inpt: features.InputTypeJIT, hue_factor: float) -> features.Input
         return adjust_hue_image_pil(inpt, hue_factor=hue_factor)
 
 
-adjust_gamma_image_tensor = _FT.adjust_gamma
+def adjust_gamma_image_tensor(image: torch.Tensor, gamma: float, gain: float = 1.0) -> torch.Tensor:
+    if not (isinstance(image, torch.Tensor)):
+        raise TypeError("Input img should be Tensor image")
+
+    c = get_num_channels_image_tensor(image)
+
+    if c not in [1, 3]:
+        raise TypeError(f"Input image tensor permitted channel values are {[1, 3]}, but found {c}")
+
+    if gamma < 0:
+        raise ValueError("Gamma should be a non-negative real number")
+
+    if not torch.is_floating_point(image):
+        output = convert_dtype_image_tensor(image, torch.float32).pow_(gamma)
+    else:
+        output = image.pow(gamma)
+
+    output = output.mul_(gain).clamp_(0.0, 1.0)
+
+    return convert_dtype_image_tensor(output, image.dtype)
+
+
 adjust_gamma_image_pil = _FP.adjust_gamma
 
 


### PR DESCRIPTION
```
[---------------- Adjust_gamma cpu torch.uint8 ---------------]
                     |  adjust_gamma stable  |  adjust_gamma v2
1 threads: ----------------------------------------------------
      (3, 400, 400)  |          1300         |         828     
6 threads: ----------------------------------------------------
      (3, 400, 400)  |          1610         |        1070     

Times are in microseconds (us).

[--------------- Adjust_gamma cuda torch.uint8 ---------------]
                     |  adjust_gamma stable  |  adjust_gamma v2
1 threads: ----------------------------------------------------
      (3, 400, 400)  |          83.2         |        41.7     
6 threads: ----------------------------------------------------
      (3, 400, 400)  |          82.8         |        41.7     

Times are in microseconds (us).

[--------------- Adjust_gamma cpu torch.float32 --------------]
                     |  adjust_gamma stable  |  adjust_gamma v2
1 threads: ----------------------------------------------------
      (3, 400, 400)  |          8.09         |        7.74     
6 threads: ----------------------------------------------------
      (3, 400, 400)  |          6.30         |        5.87     

Times are in milliseconds (ms).

[-------------- Adjust_gamma cuda torch.float32 --------------]
                     |  adjust_gamma stable  |  adjust_gamma v2
1 threads: ----------------------------------------------------
      (3, 400, 400)  |          30.2         |        9.0      
6 threads: ----------------------------------------------------
      (3, 400, 400)  |          30.2         |        8.8      

Times are in microseconds (us).
```

Benchmark script from [here](https://github.com/vfdev-5/tvapiv2_benchmarks/blob/0d081204477a88dd3ee4d887437bf59faf4f0f3c/check_adjust_hue.py)

cc @vfdev-5 @bjuncek @pmeier