### PR TITLE
[prototype] Speed improvement for normalize op

### DIFF
--- a/torchvision/prototype/transforms/functional/_misc.py
+++ b/torchvision/prototype/transforms/functional/_misc.py
@@ -20,7 +20,13 @@ def normalize_image_tensor(
             f"Expected tensor to be a tensor image of size (..., C, H, W). Got tensor.size() = {image.size()}"
         )
 
-    if (isinstance(std, (tuple, list)) and not all(std)) or std == 0:
+    if isinstance(std, (tuple, list)):
+        divzero = not all(std)
+    elif isinstance(std, (int, float)):
+        divzero = std == 0
+    else:
+        divzero = False
+    if divzero:
         raise ValueError(f"std evaluated to zero, leading to division by zero.")
 
     dtype = image.dtype

--- a/torchvision/prototype/transforms/functional/_misc.py
+++ b/torchvision/prototype/transforms/functional/_misc.py
@@ -27,7 +27,7 @@ def normalize_image_tensor(
     else:
         divzero = False
     if divzero:
-        raise ValueError(f"std evaluated to zero, leading to division by zero.")
+        raise ValueError("std evaluated to zero, leading to division by zero.")
 
     dtype = image.dtype
     device = image.device

--- a/torchvision/prototype/transforms/functional/_misc.py
+++ b/torchvision/prototype/transforms/functional/_misc.py
@@ -12,9 +12,6 @@ from torchvision.transforms.functional import pil_to_tensor, to_pil_image
 def normalize_image_tensor(
     image: torch.Tensor, mean: List[float], std: List[float], inplace: bool = False
 ) -> torch.Tensor:
-    if not isinstance(image, torch.Tensor):
-        raise TypeError("Input img should be Tensor image")
-
     if not image.is_floating_point():
         raise TypeError(f"Input tensor should be a float tensor. Got {image.dtype}.")
 
@@ -24,7 +21,7 @@ def normalize_image_tensor(
         )
 
     if (isinstance(std, (tuple, list)) and not all(std)) or std == 0:
-        raise ValueError(f"std evaluated to zero after conversion to {image.dtype}, leading to division by zero.")
+        raise ValueError(f"std evaluated to zero, leading to division by zero.")
 
     dtype = image.dtype
     device = image.device


### PR DESCRIPTION
This PR:
- Avoids the `(std == 0).any()` idiom which caused synchronization between CPU and GPU (50% improvement in CUDA)
- Minimizes memory writes by avoiding cloning (25% improvement on CPU)

The combined result is:

```
Float mean/std:
[------------- Normalize cpu torch.float32 -------------]
                     |  normalize stable  |  normalize v2
1 threads: ----------------------------------------------
      (3, 400, 400)  |        364         |      264     
6 threads: ----------------------------------------------
      (3, 400, 400)  |        497         |      351     

Times are in microseconds (us).

[------------- Normalize cuda torch.float32 ------------]
                     |  normalize stable  |  normalize v2
1 threads: ----------------------------------------------
      (3, 400, 400)  |        118         |      55.6    
6 threads: ----------------------------------------------
      (3, 400, 400)  |        118         |      55.6    

Times are in microseconds (us).


List mean/std:
[------------- Normalize cpu torch.float32 -------------]
                     |  normalize stable  |  normalize v2
1 threads: ----------------------------------------------
      (3, 400, 400)  |        378         |      271     
6 threads: ----------------------------------------------
      (3, 400, 400)  |        513         |      360     

Times are in microseconds (us).

[------------- Normalize cuda torch.float32 ------------]
                     |  normalize stable  |  normalize v2
1 threads: ----------------------------------------------
      (3, 400, 400)  |        116         |      61.6    
6 threads: ----------------------------------------------
      (3, 400, 400)  |        116         |      61.6    

Times are in microseconds (us).
```

Modified benchmark script from [here](https://github.com/vfdev-5/tvapiv2_benchmarks/blob/0d081204477a88dd3ee4d887437bf59faf4f0f3c/check_adjust_hue.py)

cc @vfdev-5 @bjuncek @pmeier