### PR TITLE
ignore git warning 'globally'

### DIFF
--- a/test/test_prototype_transforms_functional.py
+++ b/test/test_prototype_transforms_functional.py
@@ -27,9 +27,10 @@ def script(fn):
         raise AssertionError(f"Trying to `torch.jit.script` '{fn.__name__}' raised the error above.") from error
 
 
-# Scripting a function often triggers
-# UserWarning: operator() profile_node %373 : int[] = prim::profile_ivalue(%371) does not have profile information
-# with varying numbers. Since these are uninteresting for us and only clutter the test summary, we ignore them.
+# Scripting a function often triggers a warning like
+# `UserWarning: operator() profile_node %$INT1 : int[] = prim::profile_ivalue($INT2) does not have profile information`
+# with varying `INT1` and `INT2`. Since these are uninteresting for us and only clutter the test summary, we ignore
+# them.
 ignore_jit_warning_no_profile = pytest.mark.filterwarnings(
     f"ignore:{re.escape('operator() profile_node %')}:UserWarning"
 )

--- a/test/test_prototype_transforms_functional.py
+++ b/test/test_prototype_transforms_functional.py
@@ -1,5 +1,6 @@
 import math
 import os
+import re
 
 import numpy as np
 import PIL.Image
@@ -24,6 +25,14 @@ def script(fn):
         return torch.jit.script(fn)
     except Exception as error:
         raise AssertionError(f"Trying to `torch.jit.script` '{fn.__name__}' raised the error above.") from error
+
+
+# Scripting a function often triggers
+# UserWarning: operator() profile_node %373 : int[] = prim::profile_ivalue(%371) does not have profile information
+# with varying numbers. Since these are uninteresting for us and only clutter the test summary, we ignore them.
+ignore_jit_warning_no_profile = pytest.mark.filterwarnings(
+    f"ignore:{re.escape('operator() profile_node %')}:UserWarning"
+)
 
 
 def make_info_args_kwargs_params(info, *, args_kwargs_fn, test_id=None):
@@ -87,6 +96,7 @@ class TestKernels:
         condition=lambda info: info.reference_fn is not None,
     )
 
+    @ignore_jit_warning_no_profile
     @sample_inputs
     @pytest.mark.parametrize("device", cpu_and_gpu())
     def test_scripted_vs_eager(self, info, args_kwargs, device):
@@ -218,6 +228,7 @@ class TestDispatchers:
         condition=lambda info: features.Image in info.kernels,
     )
 
+    @ignore_jit_warning_no_profile
     @image_sample_inputs
     @pytest.mark.parametrize("device", cpu_and_gpu())
     def test_scripted_smoke(self, info, args_kwargs, device):
@@ -230,6 +241,7 @@ class TestDispatchers:
 
     # TODO: We need this until the dispatchers below also have `DispatcherInfo`'s. If they do, `test_scripted_smoke`
     #  replaces this test for them.
+    @ignore_jit_warning_no_profile
     @pytest.mark.parametrize(
         "dispatcher",
         [


### PR DESCRIPTION
I often encounter a warning like

```
test/test_prototype_transforms_functional.py::TestKernels::test_scripted_vs_eager[cpu-five_crop_image_tensor-07]
  /home/philip/git/pytorch/torchvision/test/test_prototype_transforms_functional.py:98: UserWarning: operator() profile_node %373 : int[] = prim::profile_ivalue(%371)
   does not have profile information (Triggered internally at ../torch/csrc/jit/codegen/cuda/graph_fuser.cpp:105.)
    actual = kernel_scripted(*args, **kwargs)

```

when running the prototype transforms tests locally. The numbers, i.e. `%373` and `%371`, from above are changing. So far I haven't figured out a pattern or the like. 

In #6785, we added the first ignore for it and #6783 added another. I'm not keen on fixing this warning over and over if it adds no information. Thus, this PR ignores it in all of the JIT tests on the prototype transforms side.

cc @vfdev-5 @datumbox @bjuncek