### PR TITLE
Make v0.14 stable version in docs

### DIFF
--- a/versions.html
+++ b/versions.html
@@ -21,10 +21,10 @@
           <a class="reference internal" href="main/">main (unstable)</a>
         </li>
         <li class="toctree-l1">
-          <a class="reference internal" href="0.14/">v0.14 (release candidate)</a>
+          <a class="reference internal" href="0.14/">v0.14 (stable release)</a>
         </li>
         <li class="toctree-l1">
-          <a class="reference internal" href="0.13/">v0.13 (stable release)</a>
+          <a class="reference internal" href="0.13/">v0.13</a>
         </li>
         <li class="toctree-l1">
           <a class="reference internal" href="0.12/">v0.12</a>


### PR DESCRIPTION
As part of release process, we make v0.14 stable version.

Note: this should be merged **after** the release of torchvision 0.14.
