### PR TITLE
[Nova] Add Linux Wheels Build Workflow

### DIFF
--- a/.github/workflows/build-wheels-linux.yml
+++ b/.github/workflows/build-wheels-linux.yml
@@ -24,7 +24,7 @@ jobs:
           - repository: pytorch/vision
             pre-script: ""
             post-script: ""
-            # TODO: add smoke-test script here once merged.
+            smoke-test-script: test/smoke_test.py
             package-name: torchvision
     name: ${{ matrix.repository }}
     uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@main

--- a/.github/workflows/build-wheels-linux.yml
+++ b/.github/workflows/build-wheels-linux.yml
@@ -1,0 +1,45 @@
+name: Build Linux Wheels
+
+on:
+  pull_request:
+  push:
+    branches:
+      - nightly
+  workflow_dispatch:
+
+jobs:
+  generate-matrix:
+    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
+    with:
+      package-type: wheel
+      os: linux
+      test-infra-repository: pytorch/test-infra
+      test-infra-ref: main
+  build:
+    needs: generate-matrix
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - repository: pytorch/vision
+            pre-script: ""
+            post-script: ""
+            # TODO: add smoke-test script here once merged.
+            package-name: torchvision
+    name: ${{ matrix.repository }}
+    uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@main
+    with:
+      repository: ${{ matrix.repository }}
+      ref: ""
+      test-infra-repository: pytorch/test-infra
+      test-infra-ref: main
+      build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
+      pre-script: ${{ matrix.pre-script }}
+      post-script: ${{ matrix.post-script }}
+      package-name: ${{ matrix.package-name }}
+      # Using "development" as trigger event so these binaries are not uploaded
+      # to official channels yet
+      trigger-event: development
+    secrets:
+      AWS_PYTORCH_UPLOADER_ACCESS_KEY_ID: ${{ secrets.AWS_PYTORCH_UPLOADER_ACCESS_KEY_ID }}
+      AWS_PYTORCH_UPLOADER_SECRET_ACCESS_KEY: ${{ secrets.AWS_PYTORCH_UPLOADER_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
This workflow calls the workflows in pytorch/test-infra to build Linux Wheels for torchvision. We will shortly submit PR's to upload similar workflows for Mac/Windows and Wheels/Conda. This does not change the existing builds/uploads in CircleCI, and should not break any existing jobs/workflows. The purpose of this to help us ensure that these jobs are creating healthy binaries. 

TO CLARIFY: this does not upload anything to nightly channels, so this PR has not effect on any existing jobs or distributed binaries.

Note: In order to have smoke tests run on these binaries after build, we should merge https://github.com/pytorch/vision/pull/6803 and pass the smoke-test script to this caller workflow.