### PR TITLE
[Nova] Add Caller workflow for Linux Conda Builds

### DIFF
--- a/.github/workflows/build-conda-linux.yml
+++ b/.github/workflows/build-conda-linux.yml
@@ -1,0 +1,45 @@
+name: Build Linux Conda
+
+on:
+  pull_request:
+  push:
+    branches:
+      - nightly
+  workflow_dispatch:
+
+jobs:
+  generate-matrix:
+    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
+    with:
+      package-type: conda
+      os: linux
+      test-infra-repository: pytorch/test-infra
+      test-infra-ref: main
+  build:
+    needs: generate-matrix
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - repository: pytorch/vision
+            pre-script: ""
+            post-script: ""
+            conda-package-directory: packaging/torchvision
+            # TODO: Add smoke-test script once it's ready.
+            package-name: torchvision
+    name: ${{ matrix.repository }}
+    uses: pytorch/test-infra/.github/workflows/build_conda_linux.yml@main
+    with:
+      conda-package-directory: ${{ matrix.conda-package-directory }}
+      repository: ${{ matrix.repository }}
+      test-infra-repository: pytorch/test-infra
+      test-infra-ref: main
+      build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
+      pre-script: ${{ matrix.pre-script }}
+      post-script: ${{ matrix.post-script }}
+      package-name: ${{ matrix.package-name }}
+      # Using "development" as trigger event so these binaries are not uploaded
+      # to official channels yet
+      trigger-event: development
+    secrets:
+      CONDA_PYTORCHBOT_TOKEN: ${{ secrets.CONDA_PYTORCHBOT_TOKEN }}

--- a/.github/workflows/build-conda-linux.yml
+++ b/.github/workflows/build-conda-linux.yml
@@ -25,7 +25,7 @@ jobs:
             pre-script: ""
             post-script: ""
             conda-package-directory: packaging/torchvision
-            # TODO: Add smoke-test script once it's ready.
+            smoke-test-script: test/smoke_test.py
             package-name: torchvision
     name: ${{ matrix.repository }}
     uses: pytorch/test-infra/.github/workflows/build_conda_linux.yml@main


### PR DESCRIPTION
This workflow calls the workflows in pytorch/test-infra to build Linux Conda binaries for torchvision, similar to https://github.com/pytorch/vision/pull/6855 which is for wheels. We will shortly submit PR's to upload similar workflows for Mac/Windows and Wheels/Conda. This does not change the existing builds/uploads in CircleCI, and should not break any existing jobs/workflows. The purpose of this to help us ensure that these jobs are creating healthy binaries.

TO CLARIFY: this does not upload anything to nightly channels, so this PR has not effect on any existing jobs or distributed binaries.

Note: In order to have smoke tests run on these binaries after build, we should merge https://github.com/pytorch/vision/pull/6803 and pass the smoke-test script to this caller workflow.