### PR TITLE
[Nova] Fix Refs in Build Workflow to use Default GitHub Ref

### DIFF
--- a/.github/workflows/build-conda-linux.yml
+++ b/.github/workflows/build-conda-linux.yml
@@ -32,6 +32,7 @@ jobs:
     with:
       conda-package-directory: ${{ matrix.conda-package-directory }}
       repository: ${{ matrix.repository }}
+      ref: ""
       test-infra-repository: pytorch/test-infra
       test-infra-ref: main
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}


### PR DESCRIPTION
By default, the reusable workflows will checkout out the nightly branch of vision. By passing an empty string, we make sure it uses the default ref. So if the workflow is triggered by a PR, it will checkout the repo with the PR. If triggered by nightly/release, it will checkout the nightly/release branch.

cc @seemethere