### PR TITLE
[iOS] Update Cocoapods for 0.14 release

### DIFF
--- a/ios/LibTorchvision.podspec
+++ b/ios/LibTorchvision.podspec
@@ -2,7 +2,7 @@ pytorch_version = '1.12.0'
 
 Pod::Spec.new do |s|
     s.name             = 'LibTorchvision'
-    s.version          = '0.13.0'
+    s.version          = '0.14.0'
     s.authors          = 'PyTorch Team'
     s.license          = { :type => 'BSD' }
     s.homepage         = 'https://github.com/pytorch/vision'

--- a/ios/LibTorchvision.podspec
+++ b/ios/LibTorchvision.podspec
@@ -1,4 +1,4 @@
-pytorch_version = '1.12.0'
+pytorch_version = '1.13.0'
 
 Pod::Spec.new do |s|
     s.name             = 'LibTorchvision'


### PR DESCRIPTION
Update the podspec version to 0.14 to prepare for the 0.14 pod release.
