### PR TITLE
[proto] Speed-up h/v bboxes flip ops

### DIFF
--- a/test/prototype_transforms_kernel_infos.py
+++ b/test/prototype_transforms_kernel_infos.py
@@ -145,6 +145,29 @@ def sample_inputs_horizontal_flip_video():
         yield ArgsKwargs(video_loader)
 
 
+def reference_horizontal_flip_bounding_box(bounding_box, *, format, spatial_size):
+    affine_matrix = np.array(
+        [
+            [-1, 0, spatial_size[1]],
+            [0, 1, 0],
+        ],
+        dtype="float32",
+    )
+
+    expected_bboxes = reference_affine_bounding_box_helper(bounding_box, format=format, affine_matrix=affine_matrix)
+
+    return expected_bboxes
+
+
+def reference_inputs_flip_bounding_box():
+    for bounding_box_loader in make_bounding_box_loaders(extra_dims=[()]):
+        yield ArgsKwargs(
+            bounding_box_loader,
+            format=bounding_box_loader.format,
+            spatial_size=bounding_box_loader.spatial_size,
+        )
+
+
 KERNEL_INFOS.extend(
     [
         KernelInfo(
@@ -158,6 +181,8 @@ KERNEL_INFOS.extend(
         KernelInfo(
             F.horizontal_flip_bounding_box,
             sample_inputs_fn=sample_inputs_horizontal_flip_bounding_box,
+            reference_fn=reference_horizontal_flip_bounding_box,
+            reference_inputs_fn=reference_inputs_flip_bounding_box,
         ),
         KernelInfo(
             F.horizontal_flip_mask,
@@ -409,15 +434,10 @@ def _compute_affine_matrix(angle, translate, scale, shear, center):
     return true_matrix
 
 
-def reference_affine_bounding_box(bounding_box, *, format, spatial_size, angle, translate, scale, shear, center=None):
-    if center is None:
-        center = [s * 0.5 for s in spatial_size[::-1]]
+def reference_affine_bounding_box_helper(bounding_box, *, format, affine_matrix):
+    def transform(bbox, affine_matrix_, format_):
 
-    def transform(bbox):
-        affine_matrix = _compute_affine_matrix(angle, translate, scale, shear, center)
-        affine_matrix = affine_matrix[:2, :]
-
-        bbox_xyxy = F.convert_format_bounding_box(bbox, old_format=format, new_format=features.BoundingBoxFormat.XYXY)
+        bbox_xyxy = F.convert_format_bounding_box(bbox, old_format=format_, new_format=features.BoundingBoxFormat.XYXY)
         points = np.array(
             [
                 [bbox_xyxy[0].item(), bbox_xyxy[1].item(), 1.0],
@@ -426,7 +446,7 @@ def reference_affine_bounding_box(bounding_box, *, format, spatial_size, angle, 
                 [bbox_xyxy[2].item(), bbox_xyxy[3].item(), 1.0],
             ]
         )
-        transformed_points = np.matmul(points, affine_matrix.T)
+        transformed_points = np.matmul(points, affine_matrix_.T)
         out_bbox = torch.tensor(
             [
                 np.min(transformed_points[:, 0]).item(),
@@ -434,18 +454,32 @@ def reference_affine_bounding_box(bounding_box, *, format, spatial_size, angle, 
                 np.max(transformed_points[:, 0]).item(),
                 np.max(transformed_points[:, 1]).item(),
             ],
-            dtype=bbox.dtype,
-        )
+        ).to(dtype=bbox.dtype)
+        # Explicit cast with .to(dtype) removes
+        # DeprecationWarning: an integer is required (got type float).  Implicit conversion to integers using
+        # __int__ is deprecated, and may be removed in a future version of Python.
         return F.convert_format_bounding_box(out_bbox, old_format=features.BoundingBoxFormat.XYXY, new_format=format)
 
     if bounding_box.ndim < 2:
         bounding_box = [bounding_box]
 
-    expected_bboxes = [transform(bbox) for bbox in bounding_box]
+    expected_bboxes = [transform(bbox, affine_matrix, format) for bbox in bounding_box]
     if len(expected_bboxes) > 1:
         expected_bboxes = torch.stack(expected_bboxes)
     else:
         expected_bboxes = expected_bboxes[0]
+
+    return expected_bboxes
+
+
+def reference_affine_bounding_box(bounding_box, *, format, spatial_size, angle, translate, scale, shear, center=None):
+    if center is None:
+        center = [s * 0.5 for s in spatial_size[::-1]]
+
+    affine_matrix = _compute_affine_matrix(angle, translate, scale, shear, center)
+    affine_matrix = affine_matrix[:2, :]
+
+    expected_bboxes = reference_affine_bounding_box_helper(bounding_box, format=format, affine_matrix=affine_matrix)
 
     return expected_bboxes
 
@@ -643,6 +677,20 @@ def sample_inputs_vertical_flip_video():
         yield ArgsKwargs(video_loader)
 
 
+def reference_vertical_flip_bounding_box(bounding_box, *, format, spatial_size):
+    affine_matrix = np.array(
+        [
+            [1, 0, 0],
+            [0, -1, spatial_size[0]],
+        ],
+        dtype="float32",
+    )
+
+    expected_bboxes = reference_affine_bounding_box_helper(bounding_box, format=format, affine_matrix=affine_matrix)
+
+    return expected_bboxes
+
+
 KERNEL_INFOS.extend(
     [
         KernelInfo(
@@ -656,6 +704,8 @@ KERNEL_INFOS.extend(
         KernelInfo(
             F.vertical_flip_bounding_box,
             sample_inputs_fn=sample_inputs_vertical_flip_bounding_box,
+            reference_fn=reference_vertical_flip_bounding_box,
+            reference_inputs_fn=reference_inputs_flip_bounding_box,
         ),
         KernelInfo(
             F.vertical_flip_mask,

--- a/torchvision/prototype/transforms/functional/_geometry.py
+++ b/torchvision/prototype/transforms/functional/_geometry.py
@@ -31,24 +31,6 @@ def horizontal_flip_mask(mask: torch.Tensor) -> torch.Tensor:
     return horizontal_flip_image_tensor(mask)
 
 
-def horizontal_flip_bounding_box_old(
-    bounding_box: torch.Tensor, format: features.BoundingBoxFormat, spatial_size: Tuple[int, int]
-) -> torch.Tensor:
-    shape = bounding_box.shape
-
-    # TODO: Investigate if it makes sense from a performance perspective to have an implementation for every
-    #  BoundingBoxFormat instead of converting back and forth
-    bounding_box = convert_format_bounding_box(
-        bounding_box.clone(), old_format=format, new_format=features.BoundingBoxFormat.XYXY, inplace=True
-    ).reshape(-1, 4)
-
-    bounding_box[:, [0, 2]] = spatial_size[1] - bounding_box[:, [2, 0]]
-
-    return convert_format_bounding_box(
-        bounding_box, old_format=features.BoundingBoxFormat.XYXY, new_format=format, inplace=True
-    ).reshape(shape)
-
-
 def horizontal_flip_bounding_box(
     bounding_box: torch.Tensor, format: features.BoundingBoxFormat, spatial_size: Tuple[int, int]
 ) -> torch.Tensor:
@@ -85,24 +67,6 @@ vertical_flip_image_pil = _FP.vflip
 
 def vertical_flip_mask(mask: torch.Tensor) -> torch.Tensor:
     return vertical_flip_image_tensor(mask)
-
-
-def vertical_flip_bounding_box_old(
-    bounding_box: torch.Tensor, format: features.BoundingBoxFormat, spatial_size: Tuple[int, int]
-) -> torch.Tensor:
-    shape = bounding_box.shape
-
-    # TODO: Investigate if it makes sense from a performance perspective to have an implementation for every
-    #  BoundingBoxFormat instead of converting back and forth
-    bounding_box = convert_format_bounding_box(
-        bounding_box.clone(), old_format=format, new_format=features.BoundingBoxFormat.XYXY, inplace=True
-    ).reshape(-1, 4)
-
-    bounding_box[:, [1, 3]] = spatial_size[0] - bounding_box[:, [3, 1]]
-
-    return convert_format_bounding_box(
-        bounding_box, old_format=features.BoundingBoxFormat.XYXY, new_format=format, inplace=True
-    ).reshape(shape)
 
 
 def vertical_flip_bounding_box(

--- a/torchvision/prototype/transforms/functional/_geometry.py
+++ b/torchvision/prototype/transforms/functional/_geometry.py
@@ -41,9 +41,9 @@ def horizontal_flip_bounding_box(
     if format == features.BoundingBoxFormat.XYXY:
         bounding_box[:, [2, 0]] = bounding_box[:, [0, 2]].sub_(spatial_size[1]).neg_()
     elif format == features.BoundingBoxFormat.XYWH:
-        torch.sub(spatial_size[1], bounding_box[:, 0].add_(bounding_box[:, 2]), out=bounding_box[:, 0])
+        bounding_box[:, 0].add_(bounding_box[:, 2]).sub_(spatial_size[1]).neg_()
     else:  # format == features.BoundingBoxFormat.CXCYWH:
-        torch.sub(spatial_size[1], bounding_box[:, 0], out=bounding_box[:, 0])
+        bounding_box[:, 0].sub_(spatial_size[1]).neg_()
 
     return bounding_box.reshape(shape)
 
@@ -79,9 +79,9 @@ def vertical_flip_bounding_box(
     if format == features.BoundingBoxFormat.XYXY:
         bounding_box[:, [1, 3]] = bounding_box[:, [3, 1]].sub_(spatial_size[0]).neg_()
     elif format == features.BoundingBoxFormat.XYWH:
-        torch.sub(spatial_size[0], bounding_box[:, 1].add_(bounding_box[:, 3]), out=bounding_box[:, 1])
+        bounding_box[:, 1].add_(bounding_box[:, 3]).sub_(spatial_size[0]).neg_()
     else:  # format == features.BoundingBoxFormat.CXCYWH:
-        torch.sub(spatial_size[0], bounding_box[:, 1], out=bounding_box[:, 1])
+        bounding_box[:, 1].sub_(spatial_size[0]).neg_()
 
     return bounding_box.reshape(shape)
 

--- a/torchvision/prototype/transforms/functional/_geometry.py
+++ b/torchvision/prototype/transforms/functional/_geometry.py
@@ -57,11 +57,11 @@ def horizontal_flip_bounding_box(
     bounding_box = bounding_box.clone().reshape(-1, 4)
 
     if format == features.BoundingBoxFormat.XYXY:
-        bounding_box[:, [0, 2]] = spatial_size[1] - bounding_box[:, [2, 0]]
+        bounding_box[:, [2, 0]] = bounding_box[:, [0, 2]].sub_(spatial_size[1]).neg_()
     elif format == features.BoundingBoxFormat.XYWH:
-        bounding_box[:, 0] = spatial_size[1] - bounding_box[:, 0] - bounding_box[:, 2]
+        torch.sub(spatial_size[1], bounding_box[:, 0].add_(bounding_box[:, 2]), out=bounding_box[:, 0])
     else:  # format == features.BoundingBoxFormat.CXCYWH:
-        bounding_box[:, 0] = spatial_size[1] - bounding_box[:, 0]
+        torch.sub(spatial_size[1], bounding_box[:, 0], out=bounding_box[:, 0])
 
     return bounding_box.reshape(shape)
 
@@ -113,11 +113,11 @@ def vertical_flip_bounding_box(
     bounding_box = bounding_box.clone().reshape(-1, 4)
 
     if format == features.BoundingBoxFormat.XYXY:
-        bounding_box[:, [1, 3]] = spatial_size[0] - bounding_box[:, [3, 1]]
+        bounding_box[:, [1, 3]] = bounding_box[:, [3, 1]].sub_(spatial_size[0]).neg_()
     elif format == features.BoundingBoxFormat.XYWH:
-        bounding_box[:, 1] = spatial_size[0] - bounding_box[:, 1] - bounding_box[:, 3]
+        torch.sub(spatial_size[0], bounding_box[:, 1].add_(bounding_box[:, 3]), out=bounding_box[:, 1])
     else:  # format == features.BoundingBoxFormat.CXCYWH:
-        bounding_box[:, 1] = spatial_size[0] - bounding_box[:, 1]
+        torch.sub(spatial_size[0], bounding_box[:, 1], out=bounding_box[:, 1])
 
     return bounding_box.reshape(shape)
 

--- a/torchvision/prototype/transforms/functional/_geometry.py
+++ b/torchvision/prototype/transforms/functional/_geometry.py
@@ -31,7 +31,7 @@ def horizontal_flip_mask(mask: torch.Tensor) -> torch.Tensor:
     return horizontal_flip_image_tensor(mask)
 
 
-def horizontal_flip_bounding_box(
+def horizontal_flip_bounding_box_old(
     bounding_box: torch.Tensor, format: features.BoundingBoxFormat, spatial_size: Tuple[int, int]
 ) -> torch.Tensor:
     shape = bounding_box.shape
@@ -47,6 +47,23 @@ def horizontal_flip_bounding_box(
     return convert_format_bounding_box(
         bounding_box, old_format=features.BoundingBoxFormat.XYXY, new_format=format, inplace=True
     ).reshape(shape)
+
+
+def horizontal_flip_bounding_box(
+    bounding_box: torch.Tensor, format: features.BoundingBoxFormat, spatial_size: Tuple[int, int]
+) -> torch.Tensor:
+    shape = bounding_box.shape
+
+    bounding_box = bounding_box.clone().reshape(-1, 4)
+
+    if format == features.BoundingBoxFormat.XYXY:
+        bounding_box[:, [0, 2]] = spatial_size[1] - bounding_box[:, [2, 0]]
+    elif format == features.BoundingBoxFormat.XYWH:
+        bounding_box[:, 0] = spatial_size[1] - bounding_box[:, 0] - bounding_box[:, 2]
+    else:  # format == features.BoundingBoxFormat.CXCYWH:
+        bounding_box[:, 0] = spatial_size[1] - bounding_box[:, 0]
+
+    return bounding_box.reshape(shape)
 
 
 def horizontal_flip_video(video: torch.Tensor) -> torch.Tensor:
@@ -70,7 +87,7 @@ def vertical_flip_mask(mask: torch.Tensor) -> torch.Tensor:
     return vertical_flip_image_tensor(mask)
 
 
-def vertical_flip_bounding_box(
+def vertical_flip_bounding_box_old(
     bounding_box: torch.Tensor, format: features.BoundingBoxFormat, spatial_size: Tuple[int, int]
 ) -> torch.Tensor:
     shape = bounding_box.shape
@@ -86,6 +103,23 @@ def vertical_flip_bounding_box(
     return convert_format_bounding_box(
         bounding_box, old_format=features.BoundingBoxFormat.XYXY, new_format=format, inplace=True
     ).reshape(shape)
+
+
+def vertical_flip_bounding_box(
+    bounding_box: torch.Tensor, format: features.BoundingBoxFormat, spatial_size: Tuple[int, int]
+) -> torch.Tensor:
+    shape = bounding_box.shape
+
+    bounding_box = bounding_box.clone().reshape(-1, 4)
+
+    if format == features.BoundingBoxFormat.XYXY:
+        bounding_box[:, [1, 3]] = spatial_size[0] - bounding_box[:, [3, 1]]
+    elif format == features.BoundingBoxFormat.XYWH:
+        bounding_box[:, 1] = spatial_size[0] - bounding_box[:, 1] - bounding_box[:, 3]
+    else:  # format == features.BoundingBoxFormat.CXCYWH:
+        bounding_box[:, 1] = spatial_size[0] - bounding_box[:, 1]
+
+    return bounding_box.reshape(shape)
 
 
 def vertical_flip_video(video: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
```
[------------- horizontal_flip_bounding_box cpu BoundingBoxFormat.XYXY --------------]
            |  horizontal_flip_bounding_box_old v2  |  horizontal_flip_bounding_box v2
1 threads: ---------------------------------------------------------------------------
      (4,)  |                  75.4                 |                 71              
6 threads: ---------------------------------------------------------------------------
      (4,)  |                  75.8                 |                 70              

Times are in microseconds (us).

[------------- horizontal_flip_bounding_box cpu BoundingBoxFormat.XYWH --------------]
            |  horizontal_flip_bounding_box_old v2  |  horizontal_flip_bounding_box v2
1 threads: ---------------------------------------------------------------------------
      (4,)  |                  120                  |                 40              
6 threads: ---------------------------------------------------------------------------
      (4,)  |                  120                  |                 40              

Times are in microseconds (us).

[------------ horizontal_flip_bounding_box cpu BoundingBoxFormat.CXCYWH -------------]
            |  horizontal_flip_bounding_box_old v2  |  horizontal_flip_bounding_box v2
1 threads: ---------------------------------------------------------------------------
      (4,)  |                  200                  |                 40              
6 threads: ---------------------------------------------------------------------------
      (4,)  |                  200                  |                 40              

Times are in microseconds (us).

[------------ vertical_flip_bounding_box cpu BoundingBoxFormat.XYXY -------------]
            |  vertical_flip_bounding_box_old v2  |  vertical_flip_bounding_box v2
1 threads: -----------------------------------------------------------------------
      (4,)  |                  75                 |                71             
6 threads: -----------------------------------------------------------------------
      (4,)  |                  70                 |                70             

Times are in microseconds (us).

[------------ vertical_flip_bounding_box cpu BoundingBoxFormat.XYWH -------------]
            |  vertical_flip_bounding_box_old v2  |  vertical_flip_bounding_box v2
1 threads: -----------------------------------------------------------------------
      (4,)  |                 120                 |                40             
6 threads: -----------------------------------------------------------------------
      (4,)  |                 122                 |                40             

Times are in microseconds (us).

[----------- vertical_flip_bounding_box cpu BoundingBoxFormat.CXCYWH ------------]
            |  vertical_flip_bounding_box_old v2  |  vertical_flip_bounding_box v2
1 threads: -----------------------------------------------------------------------
      (4,)  |                 200                 |                40             
6 threads: -----------------------------------------------------------------------
      (4,)  |                 200                 |                40             

Times are in microseconds (us).

[------------- horizontal_flip_bounding_box cuda BoundingBoxFormat.XYXY -------------]
            |  horizontal_flip_bounding_box_old v2  |  horizontal_flip_bounding_box v2
1 threads: ---------------------------------------------------------------------------
      (4,)  |                  163                  |                163              
6 threads: ---------------------------------------------------------------------------
      (4,)  |                  163                  |                163              

Times are in microseconds (us).

[------------- horizontal_flip_bounding_box cuda BoundingBoxFormat.XYWH -------------]
            |  horizontal_flip_bounding_box_old v2  |  horizontal_flip_bounding_box v2
1 threads: ---------------------------------------------------------------------------
      (4,)  |                  233                  |                85.1             
6 threads: ---------------------------------------------------------------------------
      (4,)  |                  234                  |                84.9             

Times are in microseconds (us).

[------------ horizontal_flip_bounding_box cuda BoundingBoxFormat.CXCYWH ------------]
            |  horizontal_flip_bounding_box_old v2  |  horizontal_flip_bounding_box v2
1 threads: ---------------------------------------------------------------------------
      (4,)  |                  313                  |                74.3             
6 threads: ---------------------------------------------------------------------------
      (4,)  |                  313                  |                74.5             

Times are in microseconds (us).

[------------ vertical_flip_bounding_box cuda BoundingBoxFormat.XYXY ------------]
            |  vertical_flip_bounding_box_old v2  |  vertical_flip_bounding_box v2
1 threads: -----------------------------------------------------------------------
      (4,)  |                 163                 |               164             
6 threads: -----------------------------------------------------------------------
      (4,)  |                 163                 |               163             

Times are in microseconds (us).

[------------ vertical_flip_bounding_box cuda BoundingBoxFormat.XYWH ------------]
            |  vertical_flip_bounding_box_old v2  |  vertical_flip_bounding_box v2
1 threads: -----------------------------------------------------------------------
      (4,)  |                 234                 |               85.1            
6 threads: -----------------------------------------------------------------------
      (4,)  |                 234                 |               85.3            

Times are in microseconds (us).

[----------- vertical_flip_bounding_box cuda BoundingBoxFormat.CXCYWH -----------]
            |  vertical_flip_bounding_box_old v2  |  vertical_flip_bounding_box v2
1 threads: -----------------------------------------------------------------------
      (4,)  |                 313                 |               74.4            
6 threads: -----------------------------------------------------------------------
      (4,)  |                 312                 |               74.2            

Times are in microseconds (us).

```

Depends on https://github.com/pytorch/vision/pull/6876
