### PR TITLE
[proto] Speed-up crop on bboxes and tests

### DIFF
--- a/test/prototype_transforms_kernel_infos.py
+++ b/test/prototype_transforms_kernel_infos.py
@@ -862,6 +862,29 @@ def sample_inputs_crop_video():
         yield ArgsKwargs(video_loader, top=4, left=3, height=7, width=8)
 
 
+def reference_crop_bounding_box(bounding_box, *, format, top, left, height, width):
+
+    affine_matrix = np.array(
+        [
+            [1, 0, -left],
+            [0, 1, -top],
+        ],
+        dtype="float32",
+    )
+
+    expected_bboxes = reference_affine_bounding_box_helper(
+        bounding_box, format=format, affine_matrix=affine_matrix
+    )
+    return expected_bboxes, (height, width)
+
+
+def reference_inputs_crop_bounding_box():
+    for bounding_box_loader, params in itertools.product(
+        make_bounding_box_loaders(extra_dims=((), (4,))), [_CROP_PARAMS[0], _CROP_PARAMS[-1]]
+    ):
+        yield ArgsKwargs(bounding_box_loader, format=bounding_box_loader.format, **params)
+
+
 KERNEL_INFOS.extend(
     [
         KernelInfo(
@@ -875,6 +898,8 @@ KERNEL_INFOS.extend(
         KernelInfo(
             F.crop_bounding_box,
             sample_inputs_fn=sample_inputs_crop_bounding_box,
+            reference_fn=reference_crop_bounding_box,
+            reference_inputs_fn=reference_inputs_crop_bounding_box,
         ),
         KernelInfo(
             F.crop_mask,

--- a/test/prototype_transforms_kernel_infos.py
+++ b/test/prototype_transforms_kernel_infos.py
@@ -154,7 +154,7 @@ def reference_horizontal_flip_bounding_box(bounding_box, *, format, spatial_size
         dtype="float32",
     )
 
-    expected_bboxes, _ = reference_affine_bounding_box_helper(bounding_box, format=format, affine_matrix=affine_matrix)
+    expected_bboxes = reference_affine_bounding_box_helper(bounding_box, format=format, affine_matrix=affine_matrix)
 
     return expected_bboxes
 
@@ -434,73 +434,45 @@ def _compute_affine_matrix(angle, translate, scale, shear, center):
     return true_matrix
 
 
-def reference_affine_bounding_box_helper(bounding_box, *, format, affine_matrix, spatial_size=None, expand=False):
-    def transform(bbox, affine_matrix_, format_, spatial_size_, expand_):
+def reference_affine_bounding_box_helper(bounding_box, *, format, affine_matrix):
+    def transform(bbox, affine_matrix_, format_):
         # Go to float before converting to prevent precision loss in case of CXCYWH -> XYXY and W or H is 1
         in_dtype = bbox.dtype
         bbox_xyxy = F.convert_format_bounding_box(
             bbox.float(), old_format=format_, new_format=features.BoundingBoxFormat.XYXY, inplace=True
         )
-        if expand:
-            assert spatial_size_ is not None
-        points = [
-            [bbox_xyxy[0].item(), bbox_xyxy[1].item(), 1.0],
-            [bbox_xyxy[2].item(), bbox_xyxy[1].item(), 1.0],
-            [bbox_xyxy[0].item(), bbox_xyxy[3].item(), 1.0],
-            [bbox_xyxy[2].item(), bbox_xyxy[3].item(), 1.0],
-        ]
-        if expand:
-            points += [
-                # image frame
-                [0.0, 0.0, 1.0],
-                [0.0, spatial_size_[0], 1.0],
-                [spatial_size_[1], spatial_size_[0], 1.0],
-                [spatial_size_[1], 0.0, 1.0],
+        points = np.array(
+            [
+                [bbox_xyxy[0].item(), bbox_xyxy[1].item(), 1.0],
+                [bbox_xyxy[2].item(), bbox_xyxy[1].item(), 1.0],
+                [bbox_xyxy[0].item(), bbox_xyxy[3].item(), 1.0],
+                [bbox_xyxy[2].item(), bbox_xyxy[3].item(), 1.0],
             ]
-
-        points = np.array(points)
+        )
         transformed_points = np.matmul(points, affine_matrix_.T)
         out_bbox = torch.tensor(
             [
-                np.min(transformed_points[:4, 0]),
-                np.min(transformed_points[:4, 1]),
-                np.max(transformed_points[:4, 0]),
-                np.max(transformed_points[:4, 1]),
+                np.min(transformed_points[:, 0]).item(),
+                np.min(transformed_points[:, 1]).item(),
+                np.max(transformed_points[:, 0]).item(),
+                np.max(transformed_points[:, 1]).item(),
             ],
         )
         out_bbox = F.convert_format_bounding_box(
             out_bbox, old_format=features.BoundingBoxFormat.XYXY, new_format=format, inplace=True
         )
-
-        if not expand_:
-            return out_bbox.to(dtype=in_dtype)
-
-        tr_x = np.min(transformed_points[4:, 0])
-        tr_y = np.min(transformed_points[4:, 1])
-        out_bbox[0] -= tr_x
-        out_bbox[1] -= tr_y
-        out_bbox[2] -= tr_x
-        out_bbox[3] -= tr_y
-
-        height = int(spatial_size_[0] - 2 * tr_y)
-        width = int(spatial_size_[1] - 2 * tr_x)
-
-        return out_bbox.to(dtype=in_dtype), (height, width)
+        return out_bbox.to(dtype=in_dtype)
 
     if bounding_box.ndim < 2:
         bounding_box = [bounding_box]
 
-    expected_bboxes = [transform(bbox, affine_matrix, format, spatial_size, expand) for bbox in bounding_box]
-
-    expected_size = spatial_size
-    if expand:
-        expected_size = expected_bboxes[0][1]
-        expected_bboxes = [b for b, _ in expected_bboxes]
-
+    expected_bboxes = [transform(bbox, affine_matrix, format) for bbox in bounding_box]
     if len(expected_bboxes) > 1:
-        return torch.stack(expected_bboxes), expected_size
+        expected_bboxes = torch.stack(expected_bboxes)
     else:
-        return expected_bboxes[0], expected_size
+        expected_bboxes = expected_bboxes[0]
+
+    return expected_bboxes
 
 
 def reference_affine_bounding_box(bounding_box, *, format, spatial_size, angle, translate, scale, shear, center=None):
@@ -510,7 +482,7 @@ def reference_affine_bounding_box(bounding_box, *, format, spatial_size, angle, 
     affine_matrix = _compute_affine_matrix(angle, translate, scale, shear, center)
     affine_matrix = affine_matrix[:2, :]
 
-    expected_bboxes, _ = reference_affine_bounding_box_helper(bounding_box, format=format, affine_matrix=affine_matrix)
+    expected_bboxes = reference_affine_bounding_box_helper(bounding_box, format=format, affine_matrix=affine_matrix)
 
     return expected_bboxes
 
@@ -717,7 +689,7 @@ def reference_vertical_flip_bounding_box(bounding_box, *, format, spatial_size):
         dtype="float32",
     )
 
-    expected_bboxes, _ = reference_affine_bounding_box_helper(bounding_box, format=format, affine_matrix=affine_matrix)
+    expected_bboxes = reference_affine_bounding_box_helper(bounding_box, format=format, affine_matrix=affine_matrix)
 
     return expected_bboxes
 
@@ -814,33 +786,6 @@ def sample_inputs_rotate_video():
         yield ArgsKwargs(video_loader, angle=15.0)
 
 
-def reference_rotate_bounding_box(bounding_box, *, format, spatial_size, angle, expand, center):
-    if center is None:
-        center = [s * 0.5 for s in spatial_size[::-1]]
-
-    affine_matrix = _compute_affine_matrix(angle, [0.0, 0.0], 1.0, [0.0, 0.0], center)
-    affine_matrix = affine_matrix[:2, :]
-
-    expected_bboxes, (height, width)  = reference_affine_bounding_box_helper(
-        bounding_box, format=format, affine_matrix=affine_matrix, expand=expand, spatial_size=spatial_size
-    )
-
-    return expected_bboxes, (height, width)
-
-
-def reference_inputs_rotate_bounding_box():
-    for bounding_box_loader in make_bounding_box_loaders(extra_dims=((), (4,))):
-        for expand, center in [(True, None), (False, None), (False, (12, 14))]:
-            yield ArgsKwargs(
-                bounding_box_loader,
-                format=bounding_box_loader.format,
-                spatial_size=bounding_box_loader.spatial_size,
-                angle=_ROTATE_ANGLES[0],
-                expand=expand,
-                center=center,
-            )
-
-
 KERNEL_INFOS.extend(
     [
         KernelInfo(
@@ -858,8 +803,6 @@ KERNEL_INFOS.extend(
         KernelInfo(
             F.rotate_bounding_box,
             sample_inputs_fn=sample_inputs_rotate_bounding_box,
-            reference_fn=reference_rotate_bounding_box,
-            reference_inputs_fn=reference_inputs_rotate_bounding_box,
         ),
         KernelInfo(
             F.rotate_mask,
@@ -929,9 +872,7 @@ def reference_crop_bounding_box(bounding_box, *, format, top, left, height, widt
         dtype="float32",
     )
 
-    expected_bboxes, _ = reference_affine_bounding_box_helper(
-        bounding_box, format=format, affine_matrix=affine_matrix
-    )
+    expected_bboxes = reference_affine_bounding_box_helper(bounding_box, format=format, affine_matrix=affine_matrix)
     return expected_bboxes, (height, width)
 
 

--- a/test/prototype_transforms_kernel_infos.py
+++ b/test/prototype_transforms_kernel_infos.py
@@ -872,9 +872,7 @@ def reference_crop_bounding_box(bounding_box, *, format, top, left, height, widt
         dtype="float32",
     )
 
-    expected_bboxes = reference_affine_bounding_box_helper(
-        bounding_box, format=format, affine_matrix=affine_matrix
-    )
+    expected_bboxes = reference_affine_bounding_box_helper(bounding_box, format=format, affine_matrix=affine_matrix)
     return expected_bboxes, (height, width)
 
 

--- a/test/test_prototype_transforms_functional.py
+++ b/test/test_prototype_transforms_functional.py
@@ -900,7 +900,8 @@ def test_correctness_center_crop_bounding_box(device, output_size):
     def _compute_expected_bbox(bbox, output_size_):
         format_ = bbox.format
         spatial_size_ = bbox.spatial_size
-        bbox = convert_format_bounding_box(bbox, format_, features.BoundingBoxFormat.XYWH)
+        dtype = bbox.dtype
+        bbox = convert_format_bounding_box(bbox.float(), format_, features.BoundingBoxFormat.XYWH)
 
         if len(output_size_) == 1:
             output_size_.append(output_size_[-1])
@@ -913,14 +914,9 @@ def test_correctness_center_crop_bounding_box(device, output_size):
             bbox[2].item(),
             bbox[3].item(),
         ]
-        out_bbox = features.BoundingBox(
-            out_bbox,
-            format=features.BoundingBoxFormat.XYWH,
-            spatial_size=output_size_,
-            dtype=bbox.dtype,
-            device=bbox.device,
-        )
-        return convert_format_bounding_box(out_bbox, features.BoundingBoxFormat.XYWH, format_)
+        out_bbox = torch.tensor(out_bbox)
+        out_bbox = convert_format_bounding_box(out_bbox, features.BoundingBoxFormat.XYWH, format_)
+        return out_bbox.to(dtype=dtype, device=bbox.device)
 
     for bboxes in make_bounding_boxes(extra_dims=((4,),)):
         bboxes = bboxes.to(device)

--- a/torchvision/prototype/transforms/functional/_geometry.py
+++ b/torchvision/prototype/transforms/functional/_geometry.py
@@ -812,9 +812,9 @@ def crop_bounding_box(
 
     # Crop or implicit pad if left and/or top have negative values:
     if format == features.BoundingBoxFormat.XYXY:
-        sub = torch.tensor([left, top, left, top])
+        sub = torch.tensor([left, top, left, top], device=bounding_box.device)
     else:
-        sub = torch.tensor([left, top, 0, 0])
+        sub = torch.tensor([left, top, 0, 0], device=bounding_box.device)
     bounding_box.sub_(sub)
 
     return bounding_box, (height, width)

--- a/torchvision/prototype/transforms/functional/_geometry.py
+++ b/torchvision/prototype/transforms/functional/_geometry.py
@@ -815,7 +815,7 @@ def crop_bounding_box(
         sub = torch.tensor([left, top, left, top], device=bounding_box.device)
     else:
         sub = torch.tensor([left, top, 0, 0], device=bounding_box.device)
-    bounding_box.sub_(sub)
+    bounding_box = bounding_box.sub_(sub)
 
     return bounding_box, (height, width)
 

--- a/torchvision/prototype/transforms/functional/_geometry.py
+++ b/torchvision/prototype/transforms/functional/_geometry.py
@@ -801,7 +801,7 @@ crop_image_tensor = _FT.crop
 crop_image_pil = _FP.crop
 
 
-def crop_bounding_box(
+def crop_bounding_box_old(
     bounding_box: torch.Tensor,
     format: features.BoundingBoxFormat,
     top: int,
@@ -825,6 +825,27 @@ def crop_bounding_box(
         ),
         (height, width),
     )
+
+
+def crop_bounding_box(
+    bounding_box: torch.Tensor,
+    format: features.BoundingBoxFormat,
+    top: int,
+    left: int,
+    height: int,
+    width: int,
+) -> Tuple[torch.Tensor, Tuple[int, int]]:
+
+    bounding_box = bounding_box.clone()
+
+    # Crop or implicit pad if left and/or top have negative values:
+    if format == features.BoundingBoxFormat.XYXY:
+        sub = torch.tensor([left, top, left, top])
+    else:
+        sub = torch.tensor([left, top, 0, 0])
+    bounding_box.sub_(sub)
+
+    return bounding_box, (height, width)
 
 
 def crop_mask(mask: torch.Tensor, top: int, left: int, height: int, width: int) -> torch.Tensor:

--- a/torchvision/prototype/transforms/functional/_geometry.py
+++ b/torchvision/prototype/transforms/functional/_geometry.py
@@ -801,32 +801,6 @@ crop_image_tensor = _FT.crop
 crop_image_pil = _FP.crop
 
 
-def crop_bounding_box_old(
-    bounding_box: torch.Tensor,
-    format: features.BoundingBoxFormat,
-    top: int,
-    left: int,
-    height: int,
-    width: int,
-) -> Tuple[torch.Tensor, Tuple[int, int]]:
-    # TODO: Investigate if it makes sense from a performance perspective to have an implementation for every
-    #  BoundingBoxFormat instead of converting back and forth
-    bounding_box = convert_format_bounding_box(
-        bounding_box.clone(), old_format=format, new_format=features.BoundingBoxFormat.XYXY, inplace=True
-    )
-
-    # Crop or implicit pad if left and/or top have negative values:
-    bounding_box[..., 0::2] -= left
-    bounding_box[..., 1::2] -= top
-
-    return (
-        convert_format_bounding_box(
-            bounding_box, old_format=features.BoundingBoxFormat.XYXY, new_format=format, inplace=True
-        ),
-        (height, width),
-    )
-
-
 def crop_bounding_box(
     bounding_box: torch.Tensor,
     format: features.BoundingBoxFormat,


### PR DESCRIPTION
```
[-------- crop_bounding_box cpu BoundingBoxFormat.XYXY --------]
            |  crop_bounding_box_old v2  |  crop_bounding_box v2
1 threads: -----------------------------------------------------
      (4,)  |             50             |           20         
6 threads: -----------------------------------------------------
      (4,)  |             50             |           20         

Times are in microseconds (us).

[-------- crop_bounding_box cpu BoundingBoxFormat.XYWH --------]
            |  crop_bounding_box_old v2  |  crop_bounding_box v2
1 threads: -----------------------------------------------------
      (4,)  |             95             |           20         
6 threads: -----------------------------------------------------
      (4,)  |            106             |           20         

Times are in microseconds (us).

[------- crop_bounding_box cpu BoundingBoxFormat.CXCYWH -------]
            |  crop_bounding_box_old v2  |  crop_bounding_box v2
1 threads: -----------------------------------------------------
      (4,)  |            100             |           20         
6 threads: -----------------------------------------------------
      (4,)  |            100             |           20         

Times are in microseconds (us).

[------- crop_bounding_box cuda BoundingBoxFormat.XYXY --------]
            |  crop_bounding_box_old v2  |  crop_bounding_box v2
1 threads: -----------------------------------------------------
      (4,)  |            100             |           72         
6 threads: -----------------------------------------------------
      (4,)  |            100             |           71         

Times are in microseconds (us).

[------- crop_bounding_box cuda BoundingBoxFormat.XYWH --------]
            |  crop_bounding_box_old v2  |  crop_bounding_box v2
1 threads: -----------------------------------------------------
      (4,)  |            174             |          71.5        
6 threads: -----------------------------------------------------
      (4,)  |            170             |          70.9        

Times are in microseconds (us).

[------ crop_bounding_box cuda BoundingBoxFormat.CXCYWH -------]
            |  crop_bounding_box_old v2  |  crop_bounding_box v2
1 threads: -----------------------------------------------------
      (4,)  |            260             |           71         
6 threads: -----------------------------------------------------
      (4,)  |            264             |           71         

Times are in microseconds (us).


```