### PR TITLE
make weights deepcopyable

### DIFF
--- a/test/test_extended_models.py
+++ b/test/test_extended_models.py
@@ -1,3 +1,4 @@
+import copy
 import os
 
 import pytest
@@ -57,6 +58,24 @@ def test_get_model_builder(name, model_fn):
 )
 def test_get_model_weights(name, weight):
     assert models.get_model_weights(name) == weight
+
+
+@pytest.mark.parametrize("copy_fn", [copy.copy, copy.deepcopy])
+@pytest.mark.parametrize(
+    "name",
+    [
+        "resnet50",
+        "retinanet_resnet50_fpn_v2",
+        "raft_large",
+        "quantized_resnet50",
+        "lraspp_mobilenet_v3_large",
+        "mvit_v1_b",
+    ],
+)
+def test_weights_copyable(copy_fn, name):
+    weights = models.get_model_weights(name)
+    copied_weights = copy_fn(weights)
+    assert copied_weights is weights
 
 
 @pytest.mark.parametrize(

--- a/test/test_extended_models.py
+++ b/test/test_extended_models.py
@@ -73,9 +73,10 @@ def test_get_model_weights(name, weight):
     ],
 )
 def test_weights_copyable(copy_fn, name):
-    weights = models.get_model_weights(name)
-    copied_weights = copy_fn(weights)
-    assert copied_weights is weights
+    model_weights = models.get_model_weights(name)
+    for weights in list(model_weights):
+        copied_weights = copy_fn(weights)
+        assert copied_weights is weights
 
 
 @pytest.mark.parametrize(

--- a/torchvision/models/_api.py
+++ b/torchvision/models/_api.py
@@ -75,6 +75,9 @@ class WeightsEnum(StrEnum):
                 return object.__getattribute__(self.value, name)
         return super().__getattr__(name)
 
+    def __deepcopy__(self, memodict=None):
+        return self
+
 
 def get_weight(name: str) -> WeightsEnum:
     """


### PR DESCRIPTION
Fixes #6871.

This patch looks really sketchy since we aren't performing any copy at all. But this is the same behavior regular enums exhibit as well:

```py
import enum
from copy import deepcopy


class Foo(enum.Enum):
    BAR = [1, 2]


bar = deepcopy(Foo.BAR)

assert bar is Foo.BAR

bar.value.append(3)
assert Foo.BAR.value == [1, 2, 3]
```

Enum values are expected to be [singletons](https://docs.python.org/3/howto/enum.html#enum-members-aka-instances) and thus copying is in fact not possible. 


cc @datumbox