### PR TITLE
[prototype] Gaussian Blur clean up

### DIFF
--- a/torchvision/prototype/transforms/functional/_misc.py
+++ b/torchvision/prototype/transforms/functional/_misc.py
@@ -144,7 +144,12 @@ def gaussian_blur_image_tensor(
             output.round_()
         output = output.to(dtype)
 
-    return output.reshape(shape)
+    if ndim > 4:
+        output = output.reshape(shape)
+    elif ndim == 3:
+        output = output.squeeze(dim=0)
+
+    return output
 
 
 @torch.jit.unused

--- a/torchvision/prototype/transforms/functional/_misc.py
+++ b/torchvision/prototype/transforms/functional/_misc.py
@@ -5,7 +5,6 @@ import PIL.Image
 import torch
 from torch.nn.functional import conv2d, pad as torch_pad
 from torchvision.prototype import features
-from torchvision.transforms import functional_tensor as _FT
 from torchvision.transforms.functional import pil_to_tensor, to_pil_image
 
 


### PR DESCRIPTION
This PR:
- Cleans up the assertions on the `gaussian_blur` kernel
- Simplifies the reshaping logic
- Adds in-place ops where possible

No regression on the speed, just a small 5% improvement on CUDA:
```
[------------- gaussian_blur cpu torch.float32 -------------]
                         |        old       |        new     
1 threads: --------------------------------------------------
      (3, 400, 500)      |    4 (+-  0) ms  |    4 (+-  0) ms
      (16, 3, 400, 500)  |  306 (+-  3) ms  |  306 (+-  2) ms
6 threads: --------------------------------------------------
      (3, 400, 500)      |    6 (+-  0) ms  |    6 (+-  0) ms
      (16, 3, 400, 500)  |  334 (+-  1) ms  |  334 (+-  4) ms

Times are in milliseconds (ms).

[------------- gaussian_blur cuda torch.float32 ------------]
                         |        old       |        new     
1 threads: --------------------------------------------------
      (3, 400, 500)      |  119 (+-  1) us  |  112 (+-  1) us
      (16, 3, 400, 500)  |  266 (+-  0) us  |  266 (+-  0) us
6 threads: --------------------------------------------------
      (3, 400, 500)      |  119 (+-  2) us  |  113 (+-  2) us
      (16, 3, 400, 500)  |  266 (+-  1) us  |  266 (+-  0) us

Times are in microseconds (us).

[-------------- gaussian_blur cpu torch.uint8 --------------]
                         |        old       |        new     
1 threads: --------------------------------------------------
      (3, 400, 500)      |    5 (+-  0) ms  |    5 (+-  0) ms
      (16, 3, 400, 500)  |  355 (+-  1) ms  |  331 (+-  1) ms
6 threads: --------------------------------------------------
      (3, 400, 500)      |    7 (+-  0) ms  |    7 (+-  0) ms
      (16, 3, 400, 500)  |  383 (+-  2) ms  |  359 (+-  5) ms

Times are in milliseconds (ms).

[-------------- gaussian_blur cuda torch.uint8 -------------]
                         |        old       |        new     
1 threads: --------------------------------------------------
      (3, 400, 500)      |  150 (+-  1) us  |  142 (+-  1) us
      (16, 3, 400, 500)  |  423 (+-  0) us  |  423 (+-  0) us
6 threads: --------------------------------------------------
      (3, 400, 500)      |  150 (+-  3) us  |  142 (+-  3) us
      (16, 3, 400, 500)  |  423 (+-  0) us  |  423 (+-  0) us

Times are in microseconds (us).
```


cc @vfdev-5 @bjuncek @pmeier