### PR TITLE
[prototype] Clean up and port the resize kernel in V2

### DIFF
--- a/torchvision/prototype/transforms/functional/_geometry.py
+++ b/torchvision/prototype/transforms/functional/_geometry.py
@@ -130,7 +130,7 @@ def resize_image_tensor(
             raise ValueError("Antialias option is supported for bilinear and bicubic interpolation modes only")
 
         dtype = image.dtype
-        need_cast = dtype != torch.float32 and dtype != torch.float64
+        need_cast = dtype not in (torch.float32, torch.float64)
         if need_cast:
             image = image.to(dtype=torch.float32)
 

--- a/torchvision/prototype/transforms/functional/_geometry.py
+++ b/torchvision/prototype/transforms/functional/_geometry.py
@@ -130,8 +130,8 @@ def resize_image_tensor(
             raise ValueError("Antialias option is supported for bilinear and bicubic interpolation modes only")
 
         dtype = image.dtype
-        fp = torch.is_floating_point(image)
-        if not fp:
+        need_cast = dtype != torch.float32 and dtype != torch.float64
+        if need_cast:
             image = image.to(dtype=torch.float32)
 
         image = interpolate(
@@ -142,7 +142,7 @@ def resize_image_tensor(
             antialias=antialias,
         )
 
-        if not fp:
+        if need_cast:
             if interpolation == InterpolationMode.BICUBIC and dtype == torch.uint8:
                 image = image.clamp_(min=0, max=255)
             image = image.round_().to(dtype=dtype)

--- a/torchvision/prototype/transforms/functional/_geometry.py
+++ b/torchvision/prototype/transforms/functional/_geometry.py
@@ -116,18 +116,18 @@ def resize_image_tensor(
     max_size: Optional[int] = None,
     antialias: bool = False,
 ) -> torch.Tensor:
+    align_corners: Optional[bool] = None
+    if interpolation == InterpolationMode.BILINEAR or interpolation == InterpolationMode.BICUBIC:
+        align_corners = False
+    elif antialias:
+        raise ValueError("Antialias option is supported for bilinear and bicubic interpolation modes only")
+
     shape = image.shape
     num_channels, old_height, old_width = shape[-3:]
     new_height, new_width = _compute_resized_output_size((old_height, old_width), size=size, max_size=max_size)
 
     if image.numel() > 0:
         image = image.reshape(-1, num_channels, old_height, old_width)
-
-        align_corners: Optional[bool] = None
-        if interpolation == InterpolationMode.BILINEAR or interpolation == InterpolationMode.BICUBIC:
-            align_corners = False
-        elif antialias:
-            raise ValueError("Antialias option is supported for bilinear and bicubic interpolation modes only")
 
         dtype = image.dtype
         need_cast = dtype not in (torch.float32, torch.float64)


### PR DESCRIPTION
This PR:
- Moves the implementation of resize into V2
- Removes unnecessary logic related to reshaping from the previous implementation and performs equivalent simplifications
- Does a few minor perf optimzations such inplace clamp/round etc


No speed regression, small speed improvements due to simplified logic:
```
InterpolationMode.BICUBIC

[----------------- resize cpu torch.float32 ----------------]
                         |        old       |        new     
1 threads: --------------------------------------------------
      (3, 400, 500)      |    1 (+-  0) ms  |    1 (+-  0) ms
      (16, 3, 400, 500)  |   22 (+-  0) ms  |   22 (+-  0) ms
6 threads: --------------------------------------------------
      (3, 400, 500)      |    1 (+-  0) ms  |    1 (+-  0) ms
      (16, 3, 400, 500)  |   22 (+-  0) ms  |   22 (+-  0) ms

Times are in milliseconds (ms).

[---------------- resize cuda torch.float32 ----------------]
                         |        old       |        new     
1 threads: --------------------------------------------------
      (3, 400, 500)      |   23 (+-  0) us  |   22 (+-  0) us
      (16, 3, 400, 500)  |  104 (+-  1) us  |  104 (+-  0) us
6 threads: --------------------------------------------------
      (3, 400, 500)      |   23 (+-  0) us  |   22 (+-  0) us
      (16, 3, 400, 500)  |  104 (+-  0) us  |  104 (+-  0) us

Times are in microseconds (us).

[------------------ resize cpu torch.uint8 -----------------]
                         |        old       |        new     
1 threads: --------------------------------------------------
      (3, 400, 500)      |    2 (+-  0) ms  |    2 (+-  0) ms
      (16, 3, 400, 500)  |   45 (+-  0) ms  |   42 (+-  0) ms
6 threads: --------------------------------------------------
      (3, 400, 500)      |    2 (+-  0) ms  |    2 (+-  0) ms
      (16, 3, 400, 500)  |   47 (+-  0) ms  |   43 (+-  1) ms

Times are in milliseconds (ms).

[----------------- resize cuda torch.uint8 -----------------]
                         |        old       |        new     
1 threads: --------------------------------------------------
      (3, 400, 500)      |   60 (+-  0) us  |   56 (+-  0) us
      (16, 3, 400, 500)  |  190 (+-  0) us  |  188 (+-  0) us
6 threads: --------------------------------------------------
      (3, 400, 500)      |   61 (+-  1) us  |   56 (+-  0) us
      (16, 3, 400, 500)  |  190 (+-  1) us  |  188 (+-  0) us
Times are in microseconds (us).

InterpolationMode.BILINEAR:
[------------------ resize cpu torch.float32 -----------------]
                         |         old       |         new     
1 threads: ----------------------------------------------------
      (3, 400, 500)      |   320 (+-  1) us  |   319 (+-  1) us
      (16, 3, 400, 500)  |  6120 (+-100) us  |  6037 (+- 37) us
6 threads: ----------------------------------------------------
      (3, 400, 500)      |   372 (+-  4) us  |   370 (+-  8) us
      (16, 3, 400, 500)  |  6111 (+-174) us  |  6113 (+-109) us

Times are in microseconds (us).

[---------------- resize cuda torch.float32 ----------------]
                         |        old       |        new     
1 threads: --------------------------------------------------
      (3, 400, 500)      |   17 (+-  0) us  |   16 (+-  0) us
      (16, 3, 400, 500)  |   53 (+-  0) us  |   53 (+-  0) us
6 threads: --------------------------------------------------
      (3, 400, 500)      |   17 (+-  0) us  |   16 (+-  0) us
      (16, 3, 400, 500)  |   53 (+-  0) us  |   53 (+-  0) us

Times are in microseconds (us).

[-------------------- resize cpu torch.uint8 -------------------]
                         |         old        |         new      
1 threads: ------------------------------------------------------
      (3, 400, 500)      |   624 (+-  1) us   |   591 (+-  1) us 
      (16, 3, 400, 500)  |  27336 (+- 47) us  |  25671 (+-182) us
6 threads: ------------------------------------------------------
      (3, 400, 500)      |   797 (+- 18) us   |   777 (+- 12) us 
      (16, 3, 400, 500)  |  28049 (+-321) us  |  26405 (+-237) us

Times are in microseconds (us).

[----------------- resize cuda torch.uint8 -----------------]
                         |        old       |        new     
1 threads: --------------------------------------------------
      (3, 400, 500)      |   44 (+-  0) us  |   41 (+-  0) us
      (16, 3, 400, 500)  |  131 (+-  0) us  |  130 (+-  0) us
6 threads: --------------------------------------------------
      (3, 400, 500)      |   44 (+-  0) us  |   41 (+-  1) us
      (16, 3, 400, 500)  |  131 (+-  1) us  |  130 (+-  2) us

Times are in microseconds (us).
```

cc @vfdev-5 @bjuncek @pmeier