### PR TITLE
[proto] Small optims for elastic op on bboxes

### DIFF
--- a/test/prototype_transforms_kernel_infos.py
+++ b/test/prototype_transforms_kernel_infos.py
@@ -25,7 +25,7 @@ from prototype_common_utils import (
 )
 from torch.utils._pytree import tree_map
 from torchvision.prototype import features
-from torchvision.transforms.functional_tensor import _max_value as get_max_value
+from torchvision.transforms.functional_tensor import _max_value as get_max_value, _parse_pad_padding
 
 __all__ = ["KernelInfo", "KERNEL_INFOS"]
 
@@ -1078,6 +1078,38 @@ def sample_inputs_pad_video():
         yield ArgsKwargs(video_loader, padding=[1])
 
 
+def reference_pad_bounding_box(bounding_box, *, format, spatial_size, padding, padding_mode):
+
+    left, right, top, bottom = _parse_pad_padding(padding)
+
+    affine_matrix = np.array(
+        [
+            [1, 0, left],
+            [0, 1, top],
+        ],
+        dtype="float32",
+    )
+
+    height = spatial_size[0] + top + bottom
+    width = spatial_size[1] + left + right
+
+    expected_bboxes = reference_affine_bounding_box_helper(bounding_box, format=format, affine_matrix=affine_matrix)
+    return expected_bboxes, (height, width)
+
+
+def reference_inputs_pad_bounding_box():
+    for bounding_box_loader, padding in itertools.product(
+        make_bounding_box_loaders(extra_dims=((), (4,))), [1, (1,), (1, 2), (1, 2, 3, 4), [1], [1, 2], [1, 2, 3, 4]]
+    ):
+        yield ArgsKwargs(
+            bounding_box_loader,
+            format=bounding_box_loader.format,
+            spatial_size=bounding_box_loader.spatial_size,
+            padding=padding,
+            padding_mode="constant",
+        )
+
+
 KERNEL_INFOS.extend(
     [
         KernelInfo(
@@ -1097,6 +1129,8 @@ KERNEL_INFOS.extend(
         KernelInfo(
             F.pad_bounding_box,
             sample_inputs_fn=sample_inputs_pad_bounding_box,
+            reference_fn=reference_pad_bounding_box,
+            reference_inputs_fn=reference_inputs_pad_bounding_box,
             test_marks=[
                 xfail_jit_python_scalar_arg("padding"),
                 xfail_jit_tuple_instead_of_list("padding"),

--- a/torchvision/prototype/transforms/functional/_geometry.py
+++ b/torchvision/prototype/transforms/functional/_geometry.py
@@ -1047,13 +1047,13 @@ def elastic_image_pil(
     return to_pil_image(output, mode=image.mode)
 
 
-def _create_identity_grid(size: Tuple[int, int]) -> torch.Tensor:
+def _create_identity_grid(size: Tuple[int, int], device: torch.device) -> torch.Tensor:
     sy, sx = size
-    base_grid = torch.empty(1, sy, sx, 2)
-    x_grid = torch.linspace((-sx + 1) / sx, (sx - 1) / sx, sx)
+    base_grid = torch.empty(1, sy, sx, 2, device=device)
+    x_grid = torch.linspace((-sx + 1) / sx, (sx - 1) / sx, sx, device=device)
     base_grid[..., 0].copy_(x_grid)
 
-    y_grid = torch.linspace((-sy + 1) / sy, (sy - 1) / sy, sy).unsqueeze_(-1)
+    y_grid = torch.linspace((-sy + 1) / sy, (sy - 1) / sy, sy, device=device).unsqueeze_(-1)
     base_grid[..., 1].copy_(y_grid)
 
     return base_grid
@@ -1076,7 +1076,7 @@ def elastic_bounding_box(
     # Or add spatial_size arg and check displacement shape
     spatial_size = displacement.shape[-3], displacement.shape[-2]
 
-    id_grid = _create_identity_grid(spatial_size).to(bounding_box.device)
+    id_grid = _create_identity_grid(spatial_size, bounding_box.device)
     # We construct an approximation of inverse grid as inv_grid = id_grid - displacement
     # This is not an exact inverse of the grid
     inv_grid = id_grid.sub_(displacement)

--- a/torchvision/prototype/transforms/functional/_geometry.py
+++ b/torchvision/prototype/transforms/functional/_geometry.py
@@ -1084,7 +1084,9 @@ def elastic_bounding_box(
 
     # Get points from bboxes
     points = bounding_box[:, [[0, 1], [2, 1], [2, 3], [0, 3]]].reshape(-1, 2)
-    index_xy = points.ceil_().to(dtype=torch.long)
+    if points.is_floating_point():
+        points = points.ceil_()
+    index_xy = points.to(dtype=torch.long)
     index_x, index_y = index_xy[:, 0], index_xy[:, 1]
 
     # Transform points:

--- a/torchvision/prototype/transforms/functional/_geometry.py
+++ b/torchvision/prototype/transforms/functional/_geometry.py
@@ -768,14 +768,11 @@ def pad_bounding_box(
 
     left, right, top, bottom = _parse_pad_padding(padding)
 
-    bounding_box = bounding_box.clone()
-
-    # this works without conversion since padding only affects xy coordinates
-    bounding_box[..., 0] += left
-    bounding_box[..., 1] += top
     if format == features.BoundingBoxFormat.XYXY:
-        bounding_box[..., 2] += left
-        bounding_box[..., 3] += top
+        pad = [left, top, left, top]
+    else:
+        pad = [left, top, 0, 0]
+    bounding_box = bounding_box + torch.tensor(pad, dtype=bounding_box.dtype, device=bounding_box.device)
 
     height, width = spatial_size
     height += top + bottom
@@ -821,14 +818,13 @@ def crop_bounding_box(
     width: int,
 ) -> Tuple[torch.Tensor, Tuple[int, int]]:
 
-    bounding_box = bounding_box.clone()
-
     # Crop or implicit pad if left and/or top have negative values:
     if format == features.BoundingBoxFormat.XYXY:
-        sub = torch.tensor([left, top, left, top], device=bounding_box.device)
+        sub = [left, top, left, top]
     else:
-        sub = torch.tensor([left, top, 0, 0], device=bounding_box.device)
-    bounding_box = bounding_box.sub_(sub)
+        sub = [left, top, 0, 0]
+
+    bounding_box = bounding_box - torch.tensor(sub, dtype=bounding_box.dtype, device=bounding_box.device)
 
     return bounding_box, (height, width)
 


### PR DESCRIPTION
```
[--------- elastic_bounding_box cpu BoundingBoxFormat.XYXY ----------]
            |  elastic_bounding_box_old v2  |  elastic_bounding_box v2
1 threads: -----------------------------------------------------------
      (4,)  |              230              |            190          
6 threads: -----------------------------------------------------------
      (4,)  |              300              |            200          

Times are in microseconds (us).

[--------- elastic_bounding_box cpu BoundingBoxFormat.XYWH ----------]
            |  elastic_bounding_box_old v2  |  elastic_bounding_box v2
1 threads: -----------------------------------------------------------
      (4,)  |              310              |            260          
6 threads: -----------------------------------------------------------
      (4,)  |              330              |            280          

Times are in microseconds (us).

[-------- elastic_bounding_box cpu BoundingBoxFormat.CXCYWH ---------]
            |  elastic_bounding_box_old v2  |  elastic_bounding_box v2
1 threads: -----------------------------------------------------------
      (4,)  |              351              |            300          
6 threads: -----------------------------------------------------------
      (4,)  |              379              |            330          

Times are in microseconds (us).

[--------- elastic_bounding_box cuda BoundingBoxFormat.XYXY ---------]
            |  elastic_bounding_box_old v2  |  elastic_bounding_box v2
1 threads: -----------------------------------------------------------
      (4,)  |              440              |            380          
6 threads: -----------------------------------------------------------
      (4,)  |              440              |            380          

Times are in microseconds (us).

[--------- elastic_bounding_box cuda BoundingBoxFormat.XYWH ---------]
            |  elastic_bounding_box_old v2  |  elastic_bounding_box v2
1 threads: -----------------------------------------------------------
      (4,)  |              560              |            490          
6 threads: -----------------------------------------------------------
      (4,)  |              560              |            490          

Times are in microseconds (us).

[-------- elastic_bounding_box cuda BoundingBoxFormat.CXCYWH --------]
            |  elastic_bounding_box_old v2  |  elastic_bounding_box v2
1 threads: -----------------------------------------------------------
      (4,)  |              640              |            570          
6 threads: -----------------------------------------------------------
      (4,)  |              640              |            570          

Times are in microseconds (us).

```