### PR TITLE
replace tensor division with scalar division and tensor multiplication

### DIFF
--- a/test/test_prototype_transforms_consistency.py
+++ b/test/test_prototype_transforms_consistency.py
@@ -163,6 +163,8 @@ CONSISTENCY_CONFIGS = [
             ArgsKwargs(torch.uint8),
         ],
         supports_pil=False,
+        # Use default tolerances of `torch.testing.assert_close`
+        closeness_kwargs=dict(rtol=None, atol=None),
     ),
     ConsistencyConfig(
         prototype_transforms.ToPILImage,

--- a/torchvision/prototype/transforms/functional/_color.py
+++ b/torchvision/prototype/transforms/functional/_color.py
@@ -180,7 +180,7 @@ def _rgb_to_hsv(image: torch.Tensor) -> torch.Tensor:
     hb = (4.0 + gc).sub_(rc).mul_(mask_maxc_neq_g & mask_maxc_neq_r)
 
     h = hr.add_(hg).add_(hb)
-    h = h.div_(6.0).add_(1.0).fmod_(1.0)
+    h = h.mul_(1.0 / 6.0).add_(1.0).fmod_(1.0)
     return torch.stack((h, s, maxc), dim=-3)
 
 
@@ -287,7 +287,7 @@ def adjust_gamma(inpt: features.InputTypeJIT, gamma: float, gain: float = 1) -> 
 def posterize_image_tensor(image: torch.Tensor, bits: int) -> torch.Tensor:
     if image.is_floating_point():
         levels = 1 << bits
-        return image.mul(levels).floor_().clamp_(0, levels - 1).div_(levels)
+        return image.mul(levels).floor_().clamp_(0, levels - 1).mul_(1.0 / levels)
     else:
         num_value_bits = _num_value_bits(image.dtype)
         if bits >= num_value_bits:

--- a/torchvision/prototype/transforms/functional/_meta.py
+++ b/torchvision/prototype/transforms/functional/_meta.py
@@ -367,7 +367,7 @@ def convert_dtype_image_tensor(image: torch.Tensor, dtype: torch.dtype = torch.f
     else:
         # int to float
         if float_output:
-            return image.to(dtype).div_(_FT._max_value(image.dtype))
+            return image.to(dtype).mul_(1.0 / _FT._max_value(image.dtype))
 
         # int to int
         num_value_bits_input = _num_value_bits(image.dtype)


### PR DESCRIPTION
As discussed in https://github.com/pytorch/vision/pull/6830#issuecomment-1302051973, a tensor vision of a Python scalar is slower than inverting the Python scalar first and performing a tensor multiplication afterwards. The linked comment identified three places where we could use that optimization:

```
[------------------------------- posterize --------------------------------]
                                      |        main       |      perf-div   
1 threads: -----------------------------------------------------------------
      (3, 512, 512), float32, cpu     |   219 (+-  2) us  |   183 (+-  1) us
      (5, 3, 512, 512), float32, cpu  |  1208 (+- 66) us  |  1123 (+-180) us

Times are in microseconds (us).
```

```
[-------------------- convert_dtype (int -> float) --------------------]
                                    |     perf-div     |       main     
1 threads: -------------------------------------------------------------
      (3, 512, 512), uint8, cpu     |   95 (+-  2) us  |  132 (+-  3) us
      (5, 3, 512, 512), uint8, cpu  |  433 (+-  9) us  |  645 (+-  5) us

Times are in microseconds (us).
```

```
[----------------------------- adjust_hue -----------------------------]
                                    |     perf-div     |       main     
1 threads: -------------------------------------------------------------
      (3, 512, 512), uint8, cpu     |   15 (+-  1) ms  |   14 (+-  1) ms
      (5, 3, 512, 512), uint8, cpu  |   92 (+-  3) ms  |   90 (+-  4) ms

Times are in milliseconds (ms).
```

Performance improvement is significant for `posterize` and `convert_dtype`. For `adjust_hue` the change is within measuring tolerance. LMK if we still want this change there.

Apart from the ops above there are a few more places that divide by a Python scalar, but they are always accompanied by a floor rounding like

https://github.com/pytorch/vision/blob/cb4413a3be28fc07ca749f2cef30aaff1439e582/torchvision/prototype/transforms/functional/_color.py#L418

Since `Tensor.mul` does not have that option we need an additional `.floor_()` afterwards eliminating the gains. 

cc @vfdev-5 @datumbox @bjuncek