### PR TITLE
[proto] Small optim for perspective op on images

### DIFF
--- a/torchvision/prototype/transforms/functional/_geometry.py
+++ b/torchvision/prototype/transforms/functional/_geometry.py
@@ -928,7 +928,7 @@ def _perspective_grid(coeffs: List[float], ow: int, oh: int, dtype: torch.dtype,
     base_grid[..., 1].copy_(y_grid)
     base_grid[..., 2].fill_(1)
 
-    rescaled_theta1 = theta1.transpose(1, 2) / torch.tensor([0.5 * ow, 0.5 * oh], dtype=dtype, device=device)
+    rescaled_theta1 = theta1.transpose(1, 2).div_(torch.tensor([0.5 * ow, 0.5 * oh], dtype=dtype, device=device))
     output_grid1 = base_grid.view(1, oh * ow, 3).bmm(rescaled_theta1)
     output_grid2 = base_grid.view(1, oh * ow, 3).bmm(theta2.transpose(1, 2))
 

--- a/torchvision/prototype/transforms/functional/_geometry.py
+++ b/torchvision/prototype/transforms/functional/_geometry.py
@@ -4,7 +4,8 @@ from typing import List, Optional, Sequence, Tuple, Union
 
 import PIL.Image
 import torch
-from torch.nn.functional import interpolate
+from torch.nn.functional import interpolate, pad as torch_pad
+
 from torchvision.prototype import features
 from torchvision.transforms import functional_pil as _FP, functional_tensor as _FT
 from torchvision.transforms.functional import (
@@ -15,7 +16,6 @@ from torchvision.transforms.functional import (
     pil_to_tensor,
     to_pil_image,
 )
-from torchvision.transforms.functional_tensor import _parse_pad_padding
 
 from ._meta import convert_format_bounding_box, get_spatial_size_image_pil
 

--- a/torchvision/prototype/transforms/functional/_geometry.py
+++ b/torchvision/prototype/transforms/functional/_geometry.py
@@ -962,10 +962,9 @@ def perspective_image_tensor(
     fill: features.FillTypeJIT = None,
     coefficients: Optional[List[float]] = None,
 ) -> torch.Tensor:
+    perspective_coeffs = _perspective_coefficients(startpoints, endpoints, coefficients)
     if image.numel() == 0:
         return image
-
-    perspective_coeffs = _perspective_coefficients(startpoints, endpoints, coefficients)
 
     shape = image.shape
 


### PR DESCRIPTION
- Small optim for perspective op on images
- reverted concat+single matmul trick on bboxes as it does not give any speed up and brings a slowdown for images.

```
[----------------------------------- Perspective_image_tensor cpu ----------------------------------]
                                   |  perspective_image_tensor_old v2  |  perspective_image_tensor v2
1 threads: ------------------------------------------------------------------------------------------
      (3, 400, 500) torch.uint8    |                4.8                |              4.64           
      (3, 400, 500) torch.float32  |                4.2                |              4.14           
6 threads: ------------------------------------------------------------------------------------------
      (3, 400, 500) torch.uint8    |                3.7                |              3.67           
      (3, 400, 500) torch.float32  |                3.6                |              3.52           

Times are in milliseconds (ms).

[---------------------------------- Perspective_image_tensor cuda ----------------------------------]
                                   |  perspective_image_tensor_old v2  |  perspective_image_tensor v2
1 threads: ------------------------------------------------------------------------------------------
      (3, 400, 500) torch.uint8    |                633                |              585            
      (3, 400, 500) torch.float32  |                549                |              543            
6 threads: ------------------------------------------------------------------------------------------
      (3, 400, 500) torch.uint8    |                594                |              586            
      (3, 400, 500) torch.float32  |                551                |              545            

Times are in microseconds (us).
```

cc @datumbox @bjuncek @pmeier