### PR TITLE
add mitigation for empty bounding boxes

### DIFF
--- a/torchvision/prototype/transforms/functional/_geometry.py
+++ b/torchvision/prototype/transforms/functional/_geometry.py
@@ -337,6 +337,9 @@ def _affine_bounding_box_xyxy(
     center: Optional[List[float]] = None,
     expand: bool = False,
 ) -> Tuple[torch.Tensor, Tuple[int, int]]:
+    if bounding_box.numel() == 0:
+        return bounding_box, spatial_size
+
     angle, translate, shear, center = _affine_parse_args(
         angle, translate, scale, shear, InterpolationMode.NEAREST, center
     )
@@ -1013,6 +1016,9 @@ def perspective_bounding_box(
     endpoints: Optional[List[List[int]]],
     coefficients: Optional[List[float]] = None,
 ) -> torch.Tensor:
+    if bounding_box.numel() == 0:
+        return bounding_box
+
     perspective_coeffs = _perspective_coefficients(startpoints, endpoints, coefficients)
 
     original_shape = bounding_box.shape
@@ -1203,6 +1209,9 @@ def elastic_bounding_box(
     format: features.BoundingBoxFormat,
     displacement: torch.Tensor,
 ) -> torch.Tensor:
+    if bounding_box.numel() == 0:
+        return bounding_box
+
     # TODO: add in docstring about approximation we are doing for grid inversion
     displacement = displacement.to(bounding_box.device)
 


### PR DESCRIPTION
As part of our performance optimizations we introduced `torch.aminmax` for bounding boxes in a few places. This works for degenerate inputs on CPU, but fails on CUDA:

```py
>>> t = torch.rand(0, 4)
>>> torch.aminmax(t, dim=-1)
torch.return_types.aminmax(
min=tensor([]),
max=tensor([]))
>>> torch.aminmax(t.cuda(), dim=-1)
RuntimeError: iter.numel() > 0 && iter.ntensors() - iter.noutputs() == 1 && iter.noutputs() >= 1 INTERNAL ASSERT FAILED at "../aten/src/ATen/native/cuda/Reduce.cuh":1134, please report a bug to PyTorch.
```

This already has a report in pytorch/pytorch#85439. The consensus seems to be to also let the CPU variant raise an error. Thus, to be safe, we should simply exit early for degenerate inputs like we often do for images as well.

This error never surfaced in CI since we currently don't have CUDA CI for prototypes. I made sure it works locally.

cc @vfdev-5 @datumbox @bjuncek