### PR TITLE
Patch on pad symmetric to support arbitrary dimensions

### DIFF
--- a/torchvision/transforms/functional_tensor.py
+++ b/torchvision/transforms/functional_tensor.py
@@ -341,13 +341,7 @@ def _pad_symmetric(img: Tensor, padding: List[int]) -> Tensor:
     bottom_indices = [-(i + 1) for i in range(padding[3])]
     y_indices = torch.tensor(top_indices + _y_indices + bottom_indices, device=img.device)
 
-    ndim = img.ndim
-    if ndim == 3:
-        return img[:, y_indices[:, None], x_indices[None, :]]
-    elif ndim == 4:
-        return img[:, :, y_indices[:, None], x_indices[None, :]]
-    else:
-        raise RuntimeError("Symmetric padding of N-D tensors are not supported yet")
+    return img[..., y_indices[:, None], x_indices[None, :]]
 
 
 def _parse_pad_padding(padding: Union[int, List[int]]) -> List[int]:


### PR DESCRIPTION
While scanning the code-base for perfs on V2, I noticed this idiom in the `_pad_symmetric()`. I'm not sure why the method uses the removed idiom instead of `...` which supports arbitrary dimensions. I'm also not sure why our tests pass on pad for batched videos as we don't have the reshape mitigation in `pad_image_tensor()`.

I made the change to see how the CI reacts. Let's see if we have any breakages but worth also checking if there is any gap on our testing strategy for batched videos.

cc @vfdev-5