### PR TITLE
[prototype] Speed up `adjust_contrast_image_tensor`

### DIFF
--- a/torchvision/prototype/transforms/functional/_color.py
+++ b/torchvision/prototype/transforms/functional/_color.py
@@ -80,8 +80,8 @@ def adjust_contrast_image_tensor(image: torch.Tensor, contrast_factor: float) ->
     if c not in [1, 3]:
         raise TypeError(f"Input image tensor permitted channel values are {[1, 3]}, but found {c}")
     dtype = image.dtype if torch.is_floating_point(image) else torch.float32
-    grayscale_image = _rgb_to_gray(image) if c == 3 else image
-    mean = torch.mean(grayscale_image.to(dtype), dim=(-3, -2, -1), keepdim=True)
+    grayscale_image = _rgb_to_gray(image, cast=False) if c == 3 else image.to(dtype)
+    mean = torch.mean(grayscale_image, dim=(-3, -2, -1), keepdim=True)
     return _blend(image, mean, contrast_factor)
 
 

--- a/torchvision/prototype/transforms/functional/_color.py
+++ b/torchvision/prototype/transforms/functional/_color.py
@@ -79,8 +79,13 @@ def adjust_contrast_image_tensor(image: torch.Tensor, contrast_factor: float) ->
     c = image.shape[-3]
     if c not in [1, 3]:
         raise TypeError(f"Input image tensor permitted channel values are {[1, 3]}, but found {c}")
-    dtype = image.dtype if torch.is_floating_point(image) else torch.float32
-    grayscale_image = _rgb_to_gray(image, cast=False) if c == 3 else image.to(dtype)
+    fp = image.is_floating_point()
+    if c == 3:
+        grayscale_image = _rgb_to_gray(image, cast=False)
+        if not fp:
+            grayscale_image = grayscale_image.floor_()
+    else:
+        grayscale_image = image if fp else image.to(torch.float32)
     mean = torch.mean(grayscale_image, dim=(-3, -2, -1), keepdim=True)
     return _blend(image, mean, contrast_factor)
 

--- a/torchvision/prototype/transforms/functional/_meta.py
+++ b/torchvision/prototype/transforms/functional/_meta.py
@@ -213,10 +213,12 @@ def _gray_to_rgb(grayscale: torch.Tensor) -> torch.Tensor:
     return grayscale.repeat(repeats)
 
 
-def _rgb_to_gray(image: torch.Tensor) -> torch.Tensor:
+def _rgb_to_gray(image: torch.Tensor, cast: bool = True) -> torch.Tensor:
     r, g, b = image.unbind(dim=-3)
-    l_img = (0.2989 * r).add_(g, alpha=0.587).add_(b, alpha=0.114)
-    l_img = l_img.to(image.dtype).unsqueeze(dim=-3)
+    l_img = r.mul(0.2989).add_(g, alpha=0.587).add_(b, alpha=0.114)
+    if cast:
+        l_img = l_img.to(image.dtype)
+    l_img = l_img.unsqueeze(dim=-3)
     return l_img
 
 


### PR DESCRIPTION
Related to #6818

Small performance improvement for uint8 images by avoiding the double casting from floats to ints and back to floats.

Floats remain unaffected, a 5% boost on uint8s:
```
[----------- adjust_contrast_image_tensor cpu torch.float32 -----------]
                         |  adjust_contrast_image_tensor old  |  fn2 new
1 threads: -------------------------------------------------------------
      (16, 3, 400, 400)  |               13600                |   13500 
      (3, 400, 400)      |                 538                |     535 
6 threads: -------------------------------------------------------------
      (16, 3, 400, 400)  |               14300                |   14300 
      (3, 400, 400)      |                 838                |     834 

Times are in microseconds (us).

[---------- adjust_contrast_image_tensor cuda torch.float32 -----------]
                         |  adjust_contrast_image_tensor old  |  fn2 new
1 threads: -------------------------------------------------------------
      (16, 3, 400, 400)  |                196                 |    196  
      (3, 400, 400)      |                 64                 |     62  
6 threads: -------------------------------------------------------------
      (16, 3, 400, 400)  |                197                 |    197  
      (3, 400, 400)      |                 64                 |     62  

Times are in microseconds (us).

[------------ adjust_contrast_image_tensor cpu torch.uint8 ------------]
                         |  adjust_contrast_image_tensor old  |  fn2 new
1 threads: -------------------------------------------------------------
      (16, 3, 400, 400)  |               26100                |   25000 
      (3, 400, 400)      |                1109                |     999 
6 threads: -------------------------------------------------------------
      (16, 3, 400, 400)  |               28300                |   30000 
      (3, 400, 400)      |                1700                |    1550 

Times are in microseconds (us).

[----------- adjust_contrast_image_tensor cuda torch.uint8 ------------]
                         |  adjust_contrast_image_tensor old  |  fn2 new
1 threads: -------------------------------------------------------------
      (16, 3, 400, 400)  |               257.3                |    242  
      (3, 400, 400)      |                89.7                |     79  
6 threads: -------------------------------------------------------------
      (16, 3, 400, 400)  |               258.1                |    242  
      (3, 400, 400)      |                90.2                |     80  

Times are in microseconds (us).
```

cc @vfdev-5 @bjuncek @pmeier