### PR TITLE
[prototype] Speed up `adjust_hue_image_tensor`

### DIFF
--- a/torchvision/prototype/transforms/functional/_color.py
+++ b/torchvision/prototype/transforms/functional/_color.py
@@ -189,13 +189,13 @@ def _rgb_to_hsv(image: torch.Tensor) -> torch.Tensor:
     channels_range = maxc - minc
     # Since `eqc => channels_range = 0`, replacing denominator with 1 when `eqc` is fine.
     ones = torch.ones_like(maxc)
-    s = channels_range.div_(torch.where(eqc, ones, maxc))
+    s = channels_range / torch.where(eqc, ones, maxc)
     # Note that `eqc => maxc = minc = r = g = b`. So the following calculation
     # of `h` would reduce to `bc - gc + 2 + rc - bc + 4 + rc - bc = 6` so it
     # would not matter what values `rc`, `gc`, and `bc` have here, and thus
     # replacing denominator with 1 when `eqc` is fine.
     channels_range_divisor = torch.where(eqc, ones, channels_range).unsqueeze_(dim=-3)
-    rc, gc, bc = ((maxc.unsqueeze(dim=-3) - image).div_(channels_range_divisor)).unbind(dim=-3)
+    rc, gc, bc = ((maxc.unsqueeze(dim=-3) - image) / channels_range_divisor).unbind(dim=-3)
 
     mask_maxc_neq_r = maxc != r
     mask_maxc_eq_g = maxc == g

--- a/torchvision/prototype/transforms/functional/_color.py
+++ b/torchvision/prototype/transforms/functional/_color.py
@@ -199,11 +199,10 @@ def _rgb_to_hsv(image: torch.Tensor) -> torch.Tensor:
 
     mask_maxc_neq_r = maxc != r
     mask_maxc_eq_g = maxc == g
-    mask_maxc_neq_g = ~mask_maxc_eq_g
 
     hg = rc.add(2.0).sub_(bc).mul_(mask_maxc_eq_g & mask_maxc_neq_r)
     hr = bc.sub_(gc).mul_(~mask_maxc_neq_r)
-    hb = gc.add_(4.0).sub_(rc).mul_(mask_maxc_neq_g & mask_maxc_neq_r)
+    hb = gc.add_(4.0).sub_(rc).mul_(mask_maxc_neq_r.logical_and_(mask_maxc_eq_g.logical_not_()))
 
     h = hr.add_(hg).add_(hb)
     h = h.mul_(1.0 / 6.0).add_(1.0).fmod_(1.0)

--- a/torchvision/prototype/transforms/functional/_color.py
+++ b/torchvision/prototype/transforms/functional/_color.py
@@ -235,7 +235,7 @@ def _hsv_to_rgb(img: torch.Tensor) -> torch.Tensor:
     a3 = torch.stack((p, p, t, v, v, q), dim=-3)
     a4 = torch.stack((a1, a2, a3), dim=-4)
 
-    return (a4.mul_(mask.to(dtype=img.dtype).unsqueeze(dim=-4))).sum(dim=-3)
+    return (a4.mul_(mask.unsqueeze(dim=-4))).sum(dim=-3)
 
 
 def adjust_hue_image_tensor(image: torch.Tensor, hue_factor: float) -> torch.Tensor:

--- a/torchvision/prototype/transforms/functional/_meta.py
+++ b/torchvision/prototype/transforms/functional/_meta.py
@@ -164,6 +164,7 @@ def convert_format_bounding_box(
     if new_format == old_format:
         return bounding_box
 
+    # TODO: Add _xywh_to_cxcywh and _cxcywh_to_xywh to improve performance
     if old_format == BoundingBoxFormat.XYWH:
         bounding_box = _xywh_to_xyxy(bounding_box, inplace)
     elif old_format == BoundingBoxFormat.CXCYWH:

--- a/torchvision/prototype/transforms/functional/_type_conversion.py
+++ b/torchvision/prototype/transforms/functional/_type_conversion.py
@@ -1,4 +1,3 @@
-import unittest.mock
 from typing import Any, Dict, Tuple, Union
 
 import numpy as np
@@ -20,6 +19,7 @@ def decode_image_with_pil(encoded_image: torch.Tensor) -> features.Image:
 
 @torch.jit.unused
 def decode_video_with_av(encoded_video: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor, Dict[str, Any]]:
+    import unittest.mock
     with unittest.mock.patch("torchvision.io.video.os.path.exists", return_value=True):
         return read_video(ReadOnlyTensorBuffer(encoded_video))  # type: ignore[arg-type]
 

--- a/torchvision/prototype/transforms/functional/_type_conversion.py
+++ b/torchvision/prototype/transforms/functional/_type_conversion.py
@@ -20,6 +20,7 @@ def decode_image_with_pil(encoded_image: torch.Tensor) -> features.Image:
 @torch.jit.unused
 def decode_video_with_av(encoded_video: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor, Dict[str, Any]]:
     import unittest.mock
+
     with unittest.mock.patch("torchvision.io.video.os.path.exists", return_value=True):
         return read_video(ReadOnlyTensorBuffer(encoded_video))  # type: ignore[arg-type]
 


### PR DESCRIPTION
Related to #6818

Small performance improvement by making use of inplace ops where possible:
```
[-------------- adjust_hue_image_tensor cpu torch.float32 ---------------]
                         |  adjust_hue_image_tensor old  |     fn2 new    
1 threads: ---------------------------------------------------------------
      (16, 3, 400, 400)  |         467 (+- 13) ms        |  450 (+- 12) ms
      (3, 400, 400)      |          14 (+-  0) ms        |   14 (+-  0) ms
6 threads: ---------------------------------------------------------------
      (16, 3, 400, 400)  |         457 (+- 13) ms        |  451 (+-  9) ms
      (3, 400, 400)      |          18 (+-  0) ms        |   17 (+-  0) ms

Times are in milliseconds (ms).

[--------------- adjust_hue_image_tensor cuda torch.float32 --------------]
                         |  adjust_hue_image_tensor old  |      fn2 new    
1 threads: ----------------------------------------------------------------
      (16, 3, 400, 400)  |        2260 (+-  0) us        |  2200 (+-  1) us
      (3, 400, 400)      |         571 (+-  2) us        |   526 (+-  1) us
6 threads: ----------------------------------------------------------------
      (16, 3, 400, 400)  |        2261 (+- 10) us        |  2200 (+- 15) us
      (3, 400, 400)      |         570 (+- 19) us        |   525 (+-  4) us

Times are in microseconds (us).

[--------------- adjust_hue_image_tensor cpu torch.uint8 ----------------]
                         |  adjust_hue_image_tensor old  |     fn2 new    
1 threads: ---------------------------------------------------------------
      (16, 3, 400, 400)  |         483 (+- 20) ms        |  461 (+- 13) ms
      (3, 400, 400)      |          15 (+-  0) ms        |   15 (+-  0) ms
6 threads: ---------------------------------------------------------------
      (16, 3, 400, 400)  |         487 (+- 15) ms        |  479 (+- 17) ms
      (3, 400, 400)      |          19 (+-  0) ms        |   18 (+-  1) ms

Times are in milliseconds (ms).

[---------------- adjust_hue_image_tensor cuda torch.uint8 ---------------]
                         |  adjust_hue_image_tensor old  |      fn2 new    
1 threads: ----------------------------------------------------------------
      (16, 3, 400, 400)  |        2433 (+-  1) us        |  2365 (+-  0) us
      (3, 400, 400)      |         623 (+-  1) us        |   580 (+-  2) us
6 threads: ----------------------------------------------------------------
      (16, 3, 400, 400)  |        2436 (+-  6) us        |  2366 (+-  0) us
      (3, 400, 400)      |         622 (+- 21) us        |   581 (+-  2) us

Times are in microseconds (us).
```

cc @vfdev-5 @bjuncek @pmeier