### PR TITLE
[prototype] Minor change on `adjust_saturation_image_tensor` uint8

### DIFF
--- a/torchvision/prototype/transforms/functional/_color.py
+++ b/torchvision/prototype/transforms/functional/_color.py
@@ -53,7 +53,11 @@ def adjust_saturation_image_tensor(image: torch.Tensor, saturation_factor: float
     if c == 1:  # Match PIL behaviour
         return image
 
-    return _blend(image, _rgb_to_gray(image), saturation_factor)
+    grayscale_image = _rgb_to_gray(image, cast=False)
+    if not image.is_floating_point():
+        grayscale_image = grayscale_image.floor_()
+
+    return _blend(image, grayscale_image, saturation_factor)
 
 
 adjust_saturation_image_pil = _FP.adjust_saturation


### PR DESCRIPTION
Related to #6818

Minor perf/code-quality improvement for `adjust_saturation_image_tensor` on uint8. I should have done it as part of #6933 which introduced the parameter but missed it. Floats remain unaffected:
```
[---------------- adjust_saturation_image_tensor cpu torch.float32 ---------------]
                         |  adjust_saturation_image_tensor old  |      fn2 new     
1 threads: ------------------------------------------------------------------------
      (16, 3, 400, 400)  |           14243 (+-425) us           |  14257 (+-265) us
      (3, 400, 400)      |            569 (+-  1) us            |   567 (+-  1) us 
6 threads: ------------------------------------------------------------------------
      (16, 3, 400, 400)  |           14924 (+-250) us           |  14919 (+-308) us
      (3, 400, 400)      |            805 (+- 11) us            |   802 (+- 10) us 

Times are in microseconds (us).

[-------------- adjust_saturation_image_tensor cuda torch.float32 --------------]
                         |  adjust_saturation_image_tensor old  |     fn2 new    
1 threads: ----------------------------------------------------------------------
      (16, 3, 400, 400)  |            198 (+-  0) us            |  198 (+-  0) us
      (3, 400, 400)      |             54 (+-  1) us            |   53 (+-  1) us
6 threads: ----------------------------------------------------------------------
      (16, 3, 400, 400)  |            198 (+-  0) us            |  198 (+-  0) us
      (3, 400, 400)      |             54 (+-  1) us            |   53 (+-  1) us

Times are in microseconds (us).

[---------------- adjust_saturation_image_tensor cpu torch.uint8 ---------------]
                         |  adjust_saturation_image_tensor old  |     fn2 new    
1 threads: ----------------------------------------------------------------------
      (16, 3, 400, 400)  |             28 (+-  0) ms            |   27 (+-  0) ms
      (3, 400, 400)      |              1 (+-  0) ms            |    1 (+-  0) ms
6 threads: ----------------------------------------------------------------------
      (16, 3, 400, 400)  |             32 (+-  0) ms            |   30 (+-  0) ms
      (3, 400, 400)      |              2 (+-  0) ms            |    2 (+-  0) ms

Times are in milliseconds (ms).

[--------------- adjust_saturation_image_tensor cuda torch.uint8 ---------------]
                         |  adjust_saturation_image_tensor old  |     fn2 new    
1 threads: ----------------------------------------------------------------------
      (16, 3, 400, 400)  |            245 (+-  0) us            |  241 (+-  0) us
      (3, 400, 400)      |             72 (+-  1) us            |   70 (+-  1) us
6 threads: ----------------------------------------------------------------------
      (16, 3, 400, 400)  |            246 (+-  0) us            |  241 (+-  0) us
      (3, 400, 400)      |             72 (+-  1) us            |   69 (+-  1) us

Times are in microseconds (us).
```

cc @vfdev-5 @bjuncek @pmeier