### PR TITLE
Replace `getbands()` with `get_image_num_channels()`

### DIFF
--- a/torchvision/transforms/functional.py
+++ b/torchvision/transforms/functional.py
@@ -167,7 +167,7 @@ def to_tensor(pic) -> Tensor:
 
     if pic.mode == "1":
         img = 255 * img
-    img = img.view(pic.size[1], pic.size[0], len(pic.getbands()))
+    img = img.view(pic.size[1], pic.size[0], F_pil.get_image_num_channels(pic))
     # put it from HWC to CHW format
     img = img.permute((2, 0, 1)).contiguous()
     if isinstance(img, torch.ByteTensor):
@@ -205,7 +205,7 @@ def pil_to_tensor(pic: Any) -> Tensor:
 
     # handle PIL Image
     img = torch.as_tensor(np.array(pic, copy=True))
-    img = img.view(pic.size[1], pic.size[0], len(pic.getbands()))
+    img = img.view(pic.size[1], pic.size[0], F_pil.get_image_num_channels(pic))
     # put it from HWC to CHW format
     img = img.permute((2, 0, 1))
     return img


### PR DESCRIPTION
Though the support of `accimage` is somehow in limbo, we've previously (see #5545) fixed issues related to estimating the number of channels by removing the hardcoded `getbands()` call.

While scanning the codebase for improvements for Transforms V2, I noticed that the stable methods `to_tensor()` and `pil_to_tensor()` had still two cases where they estimated the channels directly from `getbands()`. This PR replaces those two calls with `get_image_num_channels()` which is able to handle the various PIL variants.

cc @vfdev-5