### PR TITLE
[prototype] Optimize and clean up all affine methods

### DIFF
--- a/test/prototype_transforms_kernel_infos.py
+++ b/test/prototype_transforms_kernel_infos.py
@@ -915,7 +915,7 @@ KERNEL_INFOS.extend(
             reference_inputs_fn=reference_inputs_rotate_image_tensor,
             float32_vs_uint8=True,
             # TODO: investigate
-            closeness_kwargs=pil_reference_pixel_difference(100, agg_method="mean"),
+            closeness_kwargs=pil_reference_pixel_difference(110, agg_method="mean"),
             test_marks=[
                 xfail_jit_tuple_instead_of_list("fill"),
                 # TODO: check if this is a regression since it seems that should be supported if `int` is ok

--- a/test/test_prototype_transforms_consistency.py
+++ b/test/test_prototype_transforms_consistency.py
@@ -401,6 +401,7 @@ CONSISTENCY_CONFIGS = [
             ArgsKwargs(p=1, distortion_scale=0.1, fill=1),
             ArgsKwargs(p=1, distortion_scale=0.4, fill=(1, 2, 3)),
         ],
+        closeness_kwargs={"atol": 1e-6, "rtol": 1e-6},
     ),
     ConsistencyConfig(
         prototype_transforms.RandomRotation,

--- a/test/test_prototype_transforms_consistency.py
+++ b/test/test_prototype_transforms_consistency.py
@@ -401,7 +401,7 @@ CONSISTENCY_CONFIGS = [
             ArgsKwargs(p=1, distortion_scale=0.1, fill=1),
             ArgsKwargs(p=1, distortion_scale=0.4, fill=(1, 2, 3)),
         ],
-        closeness_kwargs={"atol": 1e-6, "rtol": 1e-6},
+        closeness_kwargs={"atol": None, "rtol": None},
     ),
     ConsistencyConfig(
         prototype_transforms.RandomRotation,

--- a/torchvision/prototype/transforms/functional/_geometry.py
+++ b/torchvision/prototype/transforms/functional/_geometry.py
@@ -889,39 +889,38 @@ def _pad_with_scalar_fill(
     shape = image.shape
     num_channels, height, width = shape[-3:]
 
-    if image.numel() > 0:
-        image = image.reshape(-1, num_channels, height, width)
+    batch_size = 1
+    for s in shape[:-3]:
+        batch_size *= s
 
-        if padding_mode == "edge":
-            # Similar to the padding order, `torch_pad`'s PIL's padding modes don't have the same names. Thus, we map
-            # the PIL name for the padding mode, which we are also using for our API, to the corresponding `torch_pad`
-            # name.
-            padding_mode = "replicate"
+    image = image.reshape(batch_size, num_channels, height, width)
 
-        if padding_mode == "constant":
-            image = torch_pad(image, torch_padding, mode=padding_mode, value=float(fill))
-        elif padding_mode in ("reflect", "replicate"):
-            # `torch_pad` only supports `"reflect"` or `"replicate"` padding for floating point inputs.
-            # TODO: See https://github.com/pytorch/pytorch/issues/40763
-            dtype = image.dtype
-            if not image.is_floating_point():
-                needs_cast = True
-                image = image.to(torch.float32)
-            else:
-                needs_cast = False
+    if padding_mode == "edge":
+        # Similar to the padding order, `torch_pad`'s PIL's padding modes don't have the same names. Thus, we map
+        # the PIL name for the padding mode, which we are also using for our API, to the corresponding `torch_pad`
+        # name.
+        padding_mode = "replicate"
 
-            image = torch_pad(image, torch_padding, mode=padding_mode)
+    if padding_mode == "constant":
+        image = torch_pad(image, torch_padding, mode=padding_mode, value=float(fill))
+    elif padding_mode in ("reflect", "replicate"):
+        # `torch_pad` only supports `"reflect"` or `"replicate"` padding for floating point inputs.
+        # TODO: See https://github.com/pytorch/pytorch/issues/40763
+        dtype = image.dtype
+        if not image.is_floating_point():
+            needs_cast = True
+            image = image.to(torch.float32)
+        else:
+            needs_cast = False
 
-            if needs_cast:
-                image = image.to(dtype)
-        else:  # padding_mode == "symmetric"
-            image = _FT._pad_symmetric(image, torch_padding)
+        image = torch_pad(image, torch_padding, mode=padding_mode)
 
-        new_height, new_width = image.shape[-2:]
-    else:
-        left, right, top, bottom = torch_padding
-        new_height = height + top + bottom
-        new_width = width + left + right
+        if needs_cast:
+            image = image.to(dtype)
+    else:  # padding_mode == "symmetric"
+        image = _FT._pad_symmetric(image, torch_padding)
+
+    new_height, new_width = image.shape[-2:]
 
     return image.reshape(shape[:-3] + (num_channels, new_height, new_width))
 
@@ -1030,7 +1029,23 @@ def pad(
         return pad_image_pil(inpt, padding, fill=fill, padding_mode=padding_mode)
 
 
-crop_image_tensor = _FT.crop
+def crop_image_tensor(image: torch.Tensor, top: int, left: int, height: int, width: int) -> torch.Tensor:
+    h, w = image.shape[-2:]
+
+    right = left + width
+    bottom = top + height
+
+    if left < 0 or top < 0 or right > w or bottom > h:
+        padding_ltrb = [
+            max(min(right, 0) - left, 0),
+            max(min(bottom, 0) - top, 0),
+            max(right - max(w, left), 0),
+            max(bottom - max(h, top), 0),
+        ]
+        return pad_image_tensor(image[..., max(top, 0) : bottom, max(left, 0) : right], padding_ltrb)
+    return image[..., top:bottom, left:right]
+
+
 crop_image_pil = _FP.crop
 
 
@@ -1055,7 +1070,18 @@ def crop_bounding_box(
 
 
 def crop_mask(mask: torch.Tensor, top: int, left: int, height: int, width: int) -> torch.Tensor:
-    return crop_image_tensor(mask, top, left, height, width)
+    if mask.ndim < 3:
+        mask = mask.unsqueeze(0)
+        needs_squeeze = True
+    else:
+        needs_squeeze = False
+
+    output = crop_image_tensor(mask, top, left, height, width)
+
+    if needs_squeeze:
+        output = output.squeeze(0)
+
+    return output
 
 
 def crop_video(video: torch.Tensor, top: int, left: int, height: int, width: int) -> torch.Tensor:
@@ -1152,7 +1178,7 @@ def perspective_image_tensor(
         coeffs=perspective_coeffs,
     )
 
-    ow, oh = image.shape[-1], image.shape[-2]
+    oh, ow = image.shape[-2:]
     dtype = image.dtype if fp else torch.float32
     grid = _perspective_grid(perspective_coeffs, ow=ow, oh=oh, dtype=dtype, device=image.device)
     output = _apply_grid_transform(image if fp else image.to(dtype), grid, interpolation.value, fill=fill)

--- a/torchvision/prototype/transforms/functional/_geometry.py
+++ b/torchvision/prototype/transforms/functional/_geometry.py
@@ -303,17 +303,17 @@ def _get_inverse_affine_matrix(
     tx, ty = translate
 
     # Cached results
-    cossy = math.cos(sy)
-    tansx = math.tan(sx)
-    rot_sy = rot - sy
+    cos_sy = math.cos(sy)
+    tan_sx = math.tan(sx)
+    rot_minus_sy = rot - sy
     cx_plus_tx = cx + tx
     cy_plus_ty = cy + ty
 
-    # RSS without scaling
-    a = math.cos(rot_sy) / cossy
-    b = -(a * tansx + math.sin(rot))
-    c = math.sin(rot_sy) / cossy
-    d = math.cos(rot) - c * tansx
+    # Rotate Scale Shear (RSS) without scaling
+    a = math.cos(rot_minus_sy) / cos_sy
+    b = -(a * tan_sx + math.sin(rot))
+    c = math.sin(rot_minus_sy) / cos_sy
+    d = math.cos(rot) - c * tan_sx
 
     if inverted:
         # Inverted rotation matrix with scale and shear
@@ -449,11 +449,10 @@ def _affine_grid(
     dtype = theta.dtype
     device = theta.device
 
-    d = 0.5
     base_grid = torch.empty(1, oh, ow, 3, dtype=dtype, device=device)
-    x_grid = torch.linspace(-ow * 0.5 + d, ow * 0.5 + d - 1, steps=ow, device=device)
+    x_grid = torch.linspace((1.0 - ow) * 0.5, (ow - 1.0) * 0.5, steps=ow, device=device)
     base_grid[..., 0].copy_(x_grid)
-    y_grid = torch.linspace(-oh * 0.5 + d, oh * 0.5 + d - 1, steps=oh, device=device).unsqueeze_(-1)
+    y_grid = torch.linspace((1.0 - oh) * 0.5, (oh - 1.0) * 0.5, steps=oh, device=device).unsqueeze_(-1)
     base_grid[..., 1].copy_(y_grid)
     base_grid[..., 2].fill_(1)
 

--- a/torchvision/prototype/transforms/functional/_geometry.py
+++ b/torchvision/prototype/transforms/functional/_geometry.py
@@ -514,6 +514,7 @@ def affine_image_tensor(
 
     return output
 
+
 @torch.jit.unused
 def affine_image_pil(
     image: PIL.Image.Image,

--- a/torchvision/prototype/transforms/functional/_geometry.py
+++ b/torchvision/prototype/transforms/functional/_geometry.py
@@ -287,7 +287,7 @@ def _get_inverse_affine_matrix(
     #       RotateScaleShear(a, s, (sx, sy)) =
     #       = R(a) * S(s) * SHy(sy) * SHx(sx)
     #       = [ s*cos(a - sy)/cos(sy), s*(-cos(a - sy)*tan(sx)/cos(sy) - sin(a)), 0 ]
-    #         [ s*sin(a + sy)/cos(sy), s*(-sin(a - sy)*tan(sx)/cos(sy) + cos(a)), 0 ]
+    #         [ s*sin(a - sy)/cos(sy), s*(-sin(a - sy)*tan(sx)/cos(sy) + cos(a)), 0 ]
     #         [ 0                    , 0                                      , 1 ]
     # where R is a rotation matrix, S is a scaling matrix, and SHx and SHy are the shears:
     # SHx(s) = [1, -tan(s)] and SHy(s) = [1      , 0]

--- a/torchvision/prototype/transforms/functional/_geometry.py
+++ b/torchvision/prototype/transforms/functional/_geometry.py
@@ -1538,7 +1538,7 @@ def center_crop_image_tensor(image: torch.Tensor, output_size: List[int]) -> tor
 
     if crop_height > image_height or crop_width > image_width:
         padding_ltrb = _center_crop_compute_padding(crop_height, crop_width, image_height, image_width)
-        image = _FT.torch_pad(image, _FT._parse_pad_padding(padding_ltrb), value=0.0)
+        image = torch_pad(image, _parse_pad_padding(padding_ltrb), value=0.0)
 
         image_height, image_width = image.shape[-2:]
         if crop_width == image_width and crop_height == image_height:

--- a/torchvision/prototype/transforms/functional/_geometry.py
+++ b/torchvision/prototype/transforms/functional/_geometry.py
@@ -1036,13 +1036,14 @@ def crop_image_tensor(image: torch.Tensor, top: int, left: int, height: int, wid
     bottom = top + height
 
     if left < 0 or top < 0 or right > w or bottom > h:
-        padding_ltrb = [
+        image = image[..., max(top, 0) : bottom, max(left, 0) : right]
+        torch_padding = [
             max(min(right, 0) - left, 0),
-            max(min(bottom, 0) - top, 0),
             max(right - max(w, left), 0),
+            max(min(bottom, 0) - top, 0),
             max(bottom - max(h, top), 0),
         ]
-        return pad_image_tensor(image[..., max(top, 0) : bottom, max(left, 0) : right], padding_ltrb)
+        return _pad_with_scalar_fill(image, torch_padding, fill=0, padding_mode="constant")
     return image[..., top:bottom, left:right]
 
 

--- a/torchvision/prototype/transforms/functional/_geometry.py
+++ b/torchvision/prototype/transforms/functional/_geometry.py
@@ -5,7 +5,7 @@ from typing import List, Optional, Sequence, Tuple, Union
 
 import PIL.Image
 import torch
-from torch.nn.functional import interpolate, grid_sample, pad as torch_pad
+from torch.nn.functional import grid_sample, interpolate, pad as torch_pad
 
 from torchvision.prototype import features
 from torchvision.transforms import functional_pil as _FP, functional_tensor as _FT
@@ -369,8 +369,8 @@ def _compute_affine_output_size(matrix: List[float], w: int, h: int) -> Tuple[in
 
 
 def _apply_grid_transform(
-    float_img: torch.Tensor, grid:  torch.Tensor, mode: str, fill: Optional[Union[int, float, List[float]]]
-) ->  torch.Tensor:
+    float_img: torch.Tensor, grid: torch.Tensor, mode: str, fill: Optional[Union[int, float, List[float]]]
+) -> torch.Tensor:
 
     shape = float_img.shape
     if shape[0] > 1:

--- a/torchvision/prototype/transforms/functional/_geometry.py
+++ b/torchvision/prototype/transforms/functional/_geometry.py
@@ -311,7 +311,7 @@ def _get_inverse_affine_matrix(
 
     # RSS without scaling
     a = math.cos(rot_sy) / cossy
-    b = -math.sin(rot) - a * tansx
+    b = -(a * tansx + math.sin(rot))
     c = math.sin(rot_sy) / cossy
     d = math.cos(rot) - c * tansx
 
@@ -1179,13 +1179,13 @@ def perspective_image_tensor(
         coeffs=perspective_coeffs,
     )
 
-    oh, ow = image.shape[-2:]
+    oh, ow = shape[-2:]
     dtype = image.dtype if fp else torch.float32
     grid = _perspective_grid(perspective_coeffs, ow=ow, oh=oh, dtype=dtype, device=image.device)
     output = _apply_grid_transform(image if fp else image.to(dtype), grid, interpolation.value, fill=fill)
 
     if not fp:
-        output = output.to(image.dtype)
+        output = output.round_().to(image.dtype)
 
     if needs_unsquash:
         output = output.reshape(shape)
@@ -1380,7 +1380,7 @@ def elastic_image_tensor(
     output = _apply_grid_transform(image if fp else image.to(torch.float32), grid, interpolation.value, fill=fill)
 
     if not fp:
-        output = output.to(image.dtype)
+        output = output.round_().to(image.dtype)
 
     if needs_unsquash:
         output = output.reshape(shape)


### PR DESCRIPTION
Related to #6818

**Clean ups:**
- [x] `_get_inverse_affine_matrix`
- [x] `_assert_grid_transform_inputs`
- [x] `_perspective_grid`
- [x] `_affine_bounding_box_xyxy`
- [x] `_affine_grid`

**Perfs:**
- [x] `_compute_affine_output_size`
- [x] `_apply_grid_transform`

**Affected methods (to benchmark):**
- [x] `rotate_image_tensor`
- [x] `perspective_image_tensor`
- [x] `elastic_image_tensor`
- [x] `affine_image_tensor`

**Benchmarks:**

The PR improves all the kernels across the board. There is only one reported slowdown on `elastic_image_tensor cpu torch.float32` but these 2 runs have high std. I did a few consequent runs and it looks good. I think the changes look like they give us a 10-20% speed boost. We will measure it more carefully on the placeholder ticket.

Before the PR (main branch):
```
[----- rotate_image_tensor cpu torch.float32 -----]
                         |  rotate_image_tensor old
1 threads: ----------------------------------------
      (16, 3, 400, 400)  |       129 (+- 20) ms    
      (3, 400, 400)      |         5 (+-  0) ms    

Times are in milliseconds (ms).

[----- perspective_image_tensor cpu torch.float32 -----]
                         |  perspective_image_tensor old
1 threads: ---------------------------------------------
      (16, 3, 400, 400)  |         123 (+- 30) ms       
      (3, 400, 400)      |           5 (+-  0) ms        

Times are in milliseconds (ms).

[----- affine_image_tensor cpu torch.float32 -----]
                         |  affine_image_tensor old
1 threads: ----------------------------------------
      (16, 3, 400, 400)  |       130 (+- 20) ms    
      (3, 400, 400)      |         5 (+-  0) ms    

Times are in milliseconds (ms).

[----- elastic_image_tensor cpu torch.float32 -----]
                         |  elastic_image_tensor old
1 threads: -----------------------------------------
      (16, 3, 400, 400)  |        84 (+- 22) ms     
      (3, 400, 400)      |         5 (+-  0) ms     

Times are in milliseconds (ms).

[----- rotate_image_tensor cuda torch.float32 ----]
                         |  rotate_image_tensor old
1 threads: ----------------------------------------
      (16, 3, 400, 400)  |       820 (+- 45) us    
      (3, 400, 400)      |       464 (+-  1) us    

Times are in microseconds (us).

[---- perspective_image_tensor cuda torch.float32 -----]
                         |  perspective_image_tensor old
1 threads: ---------------------------------------------
      (16, 3, 400, 400)  |         711 (+-  1) us       
      (3, 400, 400)      |         387 (+- 80) us       

Times are in microseconds (us).

[----- affine_image_tensor cuda torch.float32 ----]
                         |  affine_image_tensor old
1 threads: ----------------------------------------
      (16, 3, 400, 400)  |       615 (+-  1) us    
      (3, 400, 400)      |       576 (+- 40) us    

Times are in microseconds (us).

[---- elastic_image_tensor cuda torch.float32 -----]
                         |  elastic_image_tensor old
1 threads: -----------------------------------------
      (16, 3, 400, 400)  |       808 (+-  6) us     
      (3, 400, 400)      |       750 (+- 25) us      

Times are in microseconds (us).

[------ rotate_image_tensor cpu torch.uint8 ------]
                         |  rotate_image_tensor old
1 threads: ----------------------------------------
      (16, 3, 400, 400)  |       270 (+- 14) ms    
      (3, 400, 400)      |        13 (+-  1) ms    

Times are in milliseconds (ms).

[------ perspective_image_tensor cpu torch.uint8 ------]
                         |  perspective_image_tensor old
1 threads: ---------------------------------------------
      (16, 3, 400, 400)  |         176 (+-  8) ms       
      (3, 400, 400)      |          11 (+-  0) ms       

Times are in milliseconds (ms).

[------ affine_image_tensor cpu torch.uint8 ------]
                         |  affine_image_tensor old
1 threads: ----------------------------------------
      (16, 3, 400, 400)  |       184 (+-  4) ms    
      (3, 400, 400)      |        11 (+-  0) ms    

Times are in milliseconds (ms).

[------ elastic_image_tensor cpu torch.uint8 ------]
                         |  elastic_image_tensor old
1 threads: -----------------------------------------
      (16, 3, 400, 400)  |       182 (+- 18) ms     
      (3, 400, 400)      |        11 (+-  1) ms     

Times are in milliseconds (ms).

[------ rotate_image_tensor cuda torch.uint8 -----]
                         |  rotate_image_tensor old
1 threads: ----------------------------------------
      (16, 3, 400, 400)  |      1039 (+- 31) us    
      (3, 400, 400)      |       782 (+- 60) us    

Times are in microseconds (us).

[----- perspective_image_tensor cuda torch.uint8 ------]
                         |  perspective_image_tensor old
1 threads: ---------------------------------------------
      (16, 3, 400, 400)  |         988 (+- 60) us       
      (3, 400, 400)      |         655 (+- 50) us       

Times are in microseconds (us).

[------ affine_image_tensor cuda torch.uint8 -----]
                         |  affine_image_tensor old
1 threads: ----------------------------------------
      (16, 3, 400, 400)  |       867 (+- 40) us    
      (3, 400, 400)      |       606 (+- 21) us    

Times are in microseconds (us).

[----- elastic_image_tensor cuda torch.uint8 ------]
                         |  elastic_image_tensor old
1 threads: -----------------------------------------
      (16, 3, 400, 400)  |      1018 (+- 20) us     
      (3, 400, 400)      |       824 (+- 31) us     

Times are in microseconds (us).
```

This PR:
```
[----- rotate_image_tensor cpu torch.float32 -----]
                         |  rotate_image_tensor new
1 threads: ----------------------------------------
      (16, 3, 400, 400)  |       128 (+-  4) ms    
      (3, 400, 400)      |         5 (+-  0) ms    

Times are in milliseconds (ms).

[----- perspective_image_tensor cpu torch.float32 -----]
                         |  perspective_image_tensor new
1 threads: ---------------------------------------------
      (16, 3, 400, 400)  |         106 (+-  2) ms       
      (3, 400, 400)      |           5 (+-  0) ms       

Times are in milliseconds (ms).

[----- affine_image_tensor cpu torch.float32 -----]
                         |  affine_image_tensor new
1 threads: ----------------------------------------
      (16, 3, 400, 400)  |       113 (+-  2) ms    
      (3, 400, 400)      |         4 (+-  0) ms    

Times are in milliseconds (ms).

[----- elastic_image_tensor cpu torch.float32 -----]
                         |  elastic_image_tensor new
1 threads: -----------------------------------------
      (16, 3, 400, 400)  |       107 (+-  1) ms     
      (3, 400, 400)      |         4 (+-  0) ms    

Times are in milliseconds (ms).

[----- rotate_image_tensor cuda torch.float32 ----]
                         |  rotate_image_tensor new
1 threads: ----------------------------------------
      (16, 3, 400, 400)  |       804 (+- 45) us    
      (3, 400, 400)      |       432 (+-  1) us     

Times are in microseconds (us).

[---- perspective_image_tensor cuda torch.float32 -----]
                         |  perspective_image_tensor new
1 threads: ---------------------------------------------
      (16, 3, 400, 400)  |         631 (+-  1) us       
      (3, 400, 400)      |         334 (+-  2) us       

Times are in microseconds (us).

[----- affine_image_tensor cuda torch.float32 ----]
                         |  affine_image_tensor new
1 threads: ----------------------------------------
      (16, 3, 400, 400)  |       531 (+-  1) us    
      (3, 400, 400)      |       295 (+-  1) us     

Times are in microseconds (us).

[---- elastic_image_tensor cuda torch.float32 -----]
                         |  elastic_image_tensor new
1 threads: -----------------------------------------
      (16, 3, 400, 400)  |       785 (+-  6) us     
      (3, 400, 400)      |       555 (+-  1) us    

Times are in microseconds (us).

[------ rotate_image_tensor cpu torch.uint8 ------]
                         |  rotate_image_tensor new
1 threads: ----------------------------------------
      (16, 3, 400, 400)  |       140 (+-  1) ms    
      (3, 400, 400)      |         6 (+-  0) ms    

Times are in milliseconds (ms).

[------ perspective_image_tensor cpu torch.uint8 ------]
                         |  perspective_image_tensor new
1 threads: ---------------------------------------------
      (16, 3, 400, 400)  |         118 (+-  1) ms       
      (3, 400, 400)      |           5 (+-  0) ms       

Times are in milliseconds (ms).

[------ affine_image_tensor cpu torch.uint8 ------]
                         |  affine_image_tensor new
1 threads: ----------------------------------------
      (16, 3, 400, 400)  |       124 (+-  1) ms    
      (3, 400, 400)      |         5 (+-  0) ms    

Times are in milliseconds (ms).

[------ elastic_image_tensor cpu torch.uint8 ------]
                         |  elastic_image_tensor new
1 threads: -----------------------------------------
      (16, 3, 400, 400)  |       118 (+-  1) ms     
      (3, 400, 400)      |         5 (+-  0) ms     

Times are in milliseconds (ms).

[------ rotate_image_tensor cuda torch.uint8 -----]
                         |  rotate_image_tensor new
1 threads: ----------------------------------------
      (16, 3, 400, 400)  |       877 (+- 13) us    
      (3, 400, 400)      |       467 (+-  1) us    

Times are in microseconds (us).

[----- perspective_image_tensor cuda torch.uint8 ------]
                         |  perspective_image_tensor new
1 threads: ---------------------------------------------
      (16, 3, 400, 400)  |         751 (+-  5) us       
      (3, 400, 400)      |         365 (+-  2) us       

Times are in microseconds (us).

[------ affine_image_tensor cuda torch.uint8 -----]
                         |  affine_image_tensor new
1 threads: ----------------------------------------
      (16, 3, 400, 400)  |       654 (+-  1) us    
      (3, 400, 400)      |       325 (+-  1) us    

Times are in microseconds (us).

[----- elastic_image_tensor cuda torch.uint8 ------]
                         |  elastic_image_tensor new
1 threads: -----------------------------------------
      (16, 3, 400, 400)  |       821 (+-  4) us     
      (3, 400, 400)      |       584 (+-  1) us     

Times are in microseconds (us).
```

cc @vfdev-5 @bjuncek @pmeier