### PR TITLE
fix(deform_conv):fix DCN bug with index=-1. 

### DIFF
--- a/torchvision/csrc/ops/cpu/deform_conv2d_kernel.cpp
+++ b/torchvision/csrc/ops/cpu/deform_conv2d_kernel.cpp
@@ -392,7 +392,6 @@ scalar_t get_coordinate_weight(
 ￼    return 0;
 ￼  }
 ￼
-￼
   int y_l = floor(y);
   int x_l = floor(x);
   int y_h = y_l + 1;

--- a/torchvision/csrc/ops/cpu/deform_conv2d_kernel.cpp
+++ b/torchvision/csrc/ops/cpu/deform_conv2d_kernel.cpp
@@ -388,6 +388,11 @@ scalar_t get_coordinate_weight(
     scalar_t y,
     scalar_t x,
     bool is_y_direction) {
+  if (y <= -1 || height <= y || x <= -1 || width <= x) {
+￼    return 0;
+￼  }
+￼
+￼
   int y_l = floor(y);
   int x_l = floor(x);
   int y_h = y_l + 1;

--- a/torchvision/csrc/ops/cpu/deform_conv2d_kernel.cpp
+++ b/torchvision/csrc/ops/cpu/deform_conv2d_kernel.cpp
@@ -389,8 +389,8 @@ scalar_t get_coordinate_weight(
     scalar_t x,
     bool is_y_direction) {
   if (y <= -1 || height <= y || x <= -1 || width <= x) {
-￼    return 0;
-￼  }
+￼   return 0;
+￼ }
 ￼
   int y_l = floor(y);
   int x_l = floor(x);

--- a/torchvision/csrc/ops/cuda/deform_conv2d_kernel.cu
+++ b/torchvision/csrc/ops/cuda/deform_conv2d_kernel.cu
@@ -498,6 +498,10 @@ __device__ scalar_t get_coordinate_weight(
     scalar_t y,
     scalar_t x,
     bool is_y_direction) {
+  if (y <= -1 || height <= y || x <= -1 || width <= x) {
+    return 0;
+  }
+
   index_t y_l = floor(y);
   index_t x_l = floor(x);
   index_t y_h = y_l + 1;


### PR DESCRIPTION
The DCN operator of torchvision, the backward at the boundary value index=-1 does not match the original one. Obviously, there is a limit of index=-1 in the forward calculation, but not in the backward. This PR fixes this bug.
<!-- Before submitting a PR, please make sure to check our contributing guidelines regarding code formatting, tests, and documentation: https://github.com/pytorch/vision/blob/main/CONTRIBUTING.md -->
issue: https://github.com/pytorch/vision/issues/6885