### PR TITLE
fix flake8 repo url

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
           - black == 22.3.0
           - usort == 1.0.2
 
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/PyCQA/flake8
     rev: 5.0.4
     hooks:
       - id: flake8


### PR DESCRIPTION
We were still using the gitlab mirror, but that was deleted a few hours ago. See PyCQA/flake8#1737.

Without this the lint job fails, e.g. https://app.circleci.com/pipelines/github/pytorch/vision/21965/workflows/38624444-258d-4f64-9955-da968ebea411/jobs/1778294?invite=true#step-103-6
