### PR TITLE
Don't use named args in MHA calls in VIT Encoder

### DIFF
--- a/torchvision/models/vision_transformer.py
+++ b/torchvision/models/vision_transformer.py
@@ -110,7 +110,7 @@ class EncoderBlock(nn.Module):
     def forward(self, input: torch.Tensor):
         torch._assert(input.dim() == 3, f"Expected (batch_size, seq_length, hidden_dim) got {input.shape}")
         x = self.ln_1(input)
-        x, _ = self.self_attention(query=x, key=x, value=x, need_weights=False)
+        x, _ = self.self_attention(x, x, x, need_weights=False)
         x = self.dropout(x)
         x = x + input
 


### PR DESCRIPTION
Currently in VIT implementation names are used for positional arguments to call `MultiheadAttention.forward`. That makes impossible model analysis with pytorch hooks (they don't see kwargs). See https://github.com/sovrasov/flops-counter.pytorch/issues/95 for example.


<!-- Before submitting a PR, please make sure to check our contributing guidelines regarding code formatting, tests, and documentation: https://github.com/pytorch/vision/blob/main/CONTRIBUTING.md -->


cc @datumbox