### PR TITLE
[WIP] Add Python 3.11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1214,6 +1214,34 @@ workflows:
           name: binary_linux_wheel_py3.10_rocm5.2
           python_version: '3.10'
           wheel_docker_image: pytorch/manylinux-rocm:5.2
+      - binary_linux_wheel:
+          conda_docker_image: pytorch/conda-builder:cpu
+          cu_version: cpu
+          name: binary_linux_wheel_py3.11_cpu
+          python_version: '3.11'
+          wheel_docker_image: pytorch/manylinux-cpu
+      - binary_linux_wheel:
+          conda_docker_image: pytorch/conda-builder:cuda116
+          cu_version: cu116
+          name: binary_linux_wheel_py3.11_cu116
+          python_version: '3.11'
+          wheel_docker_image: pytorch/manylinux-cuda116
+      - binary_linux_wheel:
+          conda_docker_image: pytorch/conda-builder:cuda117
+          cu_version: cu117
+          name: binary_linux_wheel_py3.11_cu117
+          python_version: '3.11'
+          wheel_docker_image: pytorch/manylinux-cuda117
+      - binary_linux_wheel:
+          cu_version: rocm5.1.1
+          name: binary_linux_wheel_py3.11_rocm5.1.1
+          python_version: '3.11'
+          wheel_docker_image: pytorch/manylinux-rocm:5.1.1
+      - binary_linux_wheel:
+          cu_version: rocm5.2
+          name: binary_linux_wheel_py3.11_rocm5.2
+          python_version: '3.11'
+          wheel_docker_image: pytorch/manylinux-rocm:5.2
       - binary_macos_wheel:
           conda_docker_image: pytorch/conda-builder:cpu
           cu_version: cpu
@@ -1237,6 +1265,12 @@ workflows:
           cu_version: cpu
           name: binary_macos_wheel_py3.10_cpu
           python_version: '3.10'
+          wheel_docker_image: pytorch/manylinux-cpu
+      - binary_macos_wheel:
+          conda_docker_image: pytorch/conda-builder:cpu
+          cu_version: cpu
+          name: binary_macos_wheel_py3.11_cpu
+          python_version: '3.11'
           wheel_docker_image: pytorch/manylinux-cpu
       - binary_win_wheel:
           cu_version: cpu
@@ -1336,6 +1370,23 @@ workflows:
           cu_version: cu117
           name: binary_win_wheel_py3.10_cu117
           python_version: '3.10'
+      - binary_win_wheel:
+          cu_version: cpu
+          name: binary_win_wheel_py3.11_cpu
+          python_version: '3.11'
+      - binary_win_wheel:
+          cu_version: cu116
+          filters:
+            branches:
+              only: main
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: binary_win_wheel_py3.11_cu116
+          python_version: '3.11'
+      - binary_win_wheel:
+          cu_version: cu117
+          name: binary_win_wheel_py3.11_cu117
+          python_version: '3.11'
       - binary_linux_conda:
           conda_docker_image: pytorch/conda-builder:cpu
           cu_version: cpu
@@ -1408,6 +1459,24 @@ workflows:
           name: binary_linux_conda_py3.10_cu117
           python_version: '3.10'
           wheel_docker_image: pytorch/manylinux-cuda117
+      - binary_linux_conda:
+          conda_docker_image: pytorch/conda-builder:cpu
+          cu_version: cpu
+          name: binary_linux_conda_py3.11_cpu
+          python_version: '3.11'
+          wheel_docker_image: pytorch/manylinux-cpu
+      - binary_linux_conda:
+          conda_docker_image: pytorch/conda-builder:cuda116
+          cu_version: cu116
+          name: binary_linux_conda_py3.11_cu116
+          python_version: '3.11'
+          wheel_docker_image: pytorch/manylinux-cuda116
+      - binary_linux_conda:
+          conda_docker_image: pytorch/conda-builder:cuda117
+          cu_version: cu117
+          name: binary_linux_conda_py3.11_cu117
+          python_version: '3.11'
+          wheel_docker_image: pytorch/manylinux-cuda117
       - binary_macos_conda:
           conda_docker_image: pytorch/conda-builder:cpu
           cu_version: cpu
@@ -1431,6 +1500,12 @@ workflows:
           cu_version: cpu
           name: binary_macos_conda_py3.10_cpu
           python_version: '3.10'
+          wheel_docker_image: pytorch/manylinux-cpu
+      - binary_macos_conda:
+          conda_docker_image: pytorch/conda-builder:cpu
+          cu_version: cpu
+          name: binary_macos_conda_py3.11_cpu
+          python_version: '3.11'
           wheel_docker_image: pytorch/manylinux-cpu
       - binary_win_conda:
           cu_version: cpu
@@ -1530,6 +1605,23 @@ workflows:
           cu_version: cu117
           name: binary_win_conda_py3.10_cu117
           python_version: '3.10'
+      - binary_win_conda:
+          cu_version: cpu
+          name: binary_win_conda_py3.11_cpu
+          python_version: '3.11'
+      - binary_win_conda:
+          cu_version: cu116
+          filters:
+            branches:
+              only: main
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: binary_win_conda_py3.11_cu116
+          python_version: '3.11'
+      - binary_win_conda:
+          cu_version: cu117
+          name: binary_win_conda_py3.11_cu117
+          python_version: '3.11'
       - build_docs:
           filters:
             branches:
@@ -1588,6 +1680,10 @@ workflows:
           cu_version: cpu
           name: unittest_linux_cpu_py3.10
           python_version: '3.10'
+      - unittest_linux_cpu:
+          cu_version: cpu
+          name: unittest_linux_cpu_py3.11
+          python_version: '3.11'
       - unittest_linux_gpu:
           cu_version: cu116
           filters:
@@ -1619,6 +1715,15 @@ workflows:
               - nightly
           name: unittest_linux_gpu_py3.10
           python_version: '3.10'
+      - unittest_linux_gpu:
+          cu_version: cu116
+          filters:
+            branches:
+              only:
+              - main
+              - nightly
+          name: unittest_linux_gpu_py3.11
+          python_version: '3.11'
       - unittest_windows_cpu:
           cu_version: cpu
           name: unittest_windows_cpu_py3.7
@@ -1635,6 +1740,10 @@ workflows:
           cu_version: cpu
           name: unittest_windows_cpu_py3.10
           python_version: '3.10'
+      - unittest_windows_cpu:
+          cu_version: cpu
+          name: unittest_windows_cpu_py3.11
+          python_version: '3.11'
       - unittest_windows_gpu:
           cu_version: cu116
           filters:
@@ -1666,6 +1775,15 @@ workflows:
               - nightly
           name: unittest_windows_gpu_py3.10
           python_version: '3.10'
+      - unittest_windows_gpu:
+          cu_version: cu116
+          filters:
+            branches:
+              only:
+              - main
+              - nightly
+          name: unittest_windows_gpu_py3.11
+          python_version: '3.11'
       - unittest_macos_cpu:
           cu_version: cpu
           name: unittest_macos_cpu_py3.7
@@ -1682,6 +1800,10 @@ workflows:
           cu_version: cpu
           name: unittest_macos_cpu_py3.10
           python_version: '3.10'
+      - unittest_macos_cpu:
+          cu_version: cpu
+          name: unittest_macos_cpu_py3.11
+          python_version: '3.11'
 
   cmake:
     jobs:
@@ -2177,6 +2299,114 @@ workflows:
           requires:
           - nightly_binary_linux_wheel_py3.10_rocm5.2
           subfolder: rocm5.2/
+      - binary_linux_wheel:
+          conda_docker_image: pytorch/conda-builder:cpu
+          cu_version: cpu
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_wheel_py3.11_cpu
+          python_version: '3.11'
+          wheel_docker_image: pytorch/manylinux-cpu
+      - binary_wheel_upload:
+          context: org-member
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_wheel_py3.11_cpu_upload
+          requires:
+          - nightly_binary_linux_wheel_py3.11_cpu
+          subfolder: cpu/
+      - binary_linux_wheel:
+          conda_docker_image: pytorch/conda-builder:cuda116
+          cu_version: cu116
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_wheel_py3.11_cu116
+          python_version: '3.11'
+          wheel_docker_image: pytorch/manylinux-cuda116
+      - binary_wheel_upload:
+          context: org-member
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_wheel_py3.11_cu116_upload
+          requires:
+          - nightly_binary_linux_wheel_py3.11_cu116
+          subfolder: cu116/
+      - binary_linux_wheel:
+          conda_docker_image: pytorch/conda-builder:cuda117
+          cu_version: cu117
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_wheel_py3.11_cu117
+          python_version: '3.11'
+          wheel_docker_image: pytorch/manylinux-cuda117
+      - binary_wheel_upload:
+          context: org-member
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_wheel_py3.11_cu117_upload
+          requires:
+          - nightly_binary_linux_wheel_py3.11_cu117
+          subfolder: cu117/
+      - binary_linux_wheel:
+          cu_version: rocm5.1.1
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_wheel_py3.11_rocm5.1.1
+          python_version: '3.11'
+          wheel_docker_image: pytorch/manylinux-rocm:5.1.1
+      - binary_wheel_upload:
+          context: org-member
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_wheel_py3.11_rocm5.1.1_upload
+          requires:
+          - nightly_binary_linux_wheel_py3.11_rocm5.1.1
+          subfolder: rocm5.1.1/
+      - binary_linux_wheel:
+          cu_version: rocm5.2
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_wheel_py3.11_rocm5.2
+          python_version: '3.11'
+          wheel_docker_image: pytorch/manylinux-rocm:5.2
+      - binary_wheel_upload:
+          context: org-member
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_wheel_py3.11_rocm5.2_upload
+          requires:
+          - nightly_binary_linux_wheel_py3.11_rocm5.2
+          subfolder: rocm5.2/
       - binary_macos_wheel:
           conda_docker_image: pytorch/conda-builder:cpu
           cu_version: cpu
@@ -2264,6 +2494,28 @@ workflows:
           name: nightly_binary_macos_wheel_py3.10_cpu_upload
           requires:
           - nightly_binary_macos_wheel_py3.10_cpu
+          subfolder: ''
+      - binary_macos_wheel:
+          conda_docker_image: pytorch/conda-builder:cpu
+          cu_version: cpu
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_macos_wheel_py3.11_cpu
+          python_version: '3.11'
+          wheel_docker_image: pytorch/manylinux-cpu
+      - binary_wheel_upload:
+          context: org-member
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_macos_wheel_py3.11_cpu_upload
+          requires:
+          - nightly_binary_macos_wheel_py3.11_cpu
           subfolder: ''
       - binary_win_wheel:
           cu_version: cpu
@@ -2504,6 +2756,66 @@ workflows:
           name: nightly_binary_win_wheel_py3.10_cu117_upload
           requires:
           - nightly_binary_win_wheel_py3.10_cu117
+          subfolder: cu117/
+      - binary_win_wheel:
+          cu_version: cpu
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_win_wheel_py3.11_cpu
+          python_version: '3.11'
+      - binary_wheel_upload:
+          context: org-member
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_win_wheel_py3.11_cpu_upload
+          requires:
+          - nightly_binary_win_wheel_py3.11_cpu
+          subfolder: cpu/
+      - binary_win_wheel:
+          cu_version: cu116
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_win_wheel_py3.11_cu116
+          python_version: '3.11'
+      - binary_wheel_upload:
+          context: org-member
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_win_wheel_py3.11_cu116_upload
+          requires:
+          - nightly_binary_win_wheel_py3.11_cu116
+          subfolder: cu116/
+      - binary_win_wheel:
+          cu_version: cu117
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_win_wheel_py3.11_cu117
+          python_version: '3.11'
+      - binary_wheel_upload:
+          context: org-member
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_win_wheel_py3.11_cu117_upload
+          requires:
+          - nightly_binary_win_wheel_py3.11_cu117
           subfolder: cu117/
       - binary_linux_conda:
           conda_docker_image: pytorch/conda-builder:cpu
@@ -2757,6 +3069,69 @@ workflows:
           name: nightly_binary_linux_conda_py3.10_cu117_upload
           requires:
           - nightly_binary_linux_conda_py3.10_cu117
+      - binary_linux_conda:
+          conda_docker_image: pytorch/conda-builder:cpu
+          cu_version: cpu
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_conda_py3.11_cpu
+          python_version: '3.11'
+          wheel_docker_image: pytorch/manylinux-cpu
+      - binary_conda_upload:
+          context: org-member
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_conda_py3.11_cpu_upload
+          requires:
+          - nightly_binary_linux_conda_py3.11_cpu
+      - binary_linux_conda:
+          conda_docker_image: pytorch/conda-builder:cuda116
+          cu_version: cu116
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_conda_py3.11_cu116
+          python_version: '3.11'
+          wheel_docker_image: pytorch/manylinux-cuda116
+      - binary_conda_upload:
+          context: org-member
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_conda_py3.11_cu116_upload
+          requires:
+          - nightly_binary_linux_conda_py3.11_cu116
+      - binary_linux_conda:
+          conda_docker_image: pytorch/conda-builder:cuda117
+          cu_version: cu117
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_conda_py3.11_cu117
+          python_version: '3.11'
+          wheel_docker_image: pytorch/manylinux-cuda117
+      - binary_conda_upload:
+          context: org-member
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_linux_conda_py3.11_cu117_upload
+          requires:
+          - nightly_binary_linux_conda_py3.11_cu117
       - binary_macos_conda:
           conda_docker_image: pytorch/conda-builder:cpu
           cu_version: cpu
@@ -2841,6 +3216,27 @@ workflows:
           name: nightly_binary_macos_conda_py3.10_cpu_upload
           requires:
           - nightly_binary_macos_conda_py3.10_cpu
+      - binary_macos_conda:
+          conda_docker_image: pytorch/conda-builder:cpu
+          cu_version: cpu
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_macos_conda_py3.11_cpu
+          python_version: '3.11'
+          wheel_docker_image: pytorch/manylinux-cpu
+      - binary_conda_upload:
+          context: org-member
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_macos_conda_py3.11_cpu_upload
+          requires:
+          - nightly_binary_macos_conda_py3.11_cpu
       - binary_win_conda:
           cu_version: cpu
           filters:
@@ -3069,6 +3465,63 @@ workflows:
           name: nightly_binary_win_conda_py3.10_cu117_upload
           requires:
           - nightly_binary_win_conda_py3.10_cu117
+      - binary_win_conda:
+          cu_version: cpu
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_win_conda_py3.11_cpu
+          python_version: '3.11'
+      - binary_conda_upload:
+          context: org-member
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_win_conda_py3.11_cpu_upload
+          requires:
+          - nightly_binary_win_conda_py3.11_cpu
+      - binary_win_conda:
+          cu_version: cu116
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_win_conda_py3.11_cu116
+          python_version: '3.11'
+      - binary_conda_upload:
+          context: org-member
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_win_conda_py3.11_cu116_upload
+          requires:
+          - nightly_binary_win_conda_py3.11_cu116
+      - binary_win_conda:
+          cu_version: cu117
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_win_conda_py3.11_cu117
+          python_version: '3.11'
+      - binary_conda_upload:
+          context: org-member
+          filters:
+            branches:
+              only: nightly
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          name: nightly_binary_win_conda_py3.11_cu117_upload
+          requires:
+          - nightly_binary_win_conda_py3.11_cu117
   docker_build:
     triggers:
       - schedule:

--- a/.circleci/regenerate.py
+++ b/.circleci/regenerate.py
@@ -21,7 +21,7 @@ import yaml
 from jinja2 import select_autoescape
 
 
-PYTHON_VERSIONS = ["3.7", "3.8", "3.9", "3.10"]
+PYTHON_VERSIONS = ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
 RC_PATTERN = r"/v[0-9]+(\.[0-9]+)*-rc[0-9]+/"
 

--- a/packaging/pkg_helpers.bash
+++ b/packaging/pkg_helpers.bash
@@ -142,7 +142,7 @@ retry () {
 }
 
 # Inputs:
-#   PYTHON_VERSION (3.7, 3.8, 3.9)
+#   PYTHON_VERSION (3.7, 3.8, 3.9, 3.10, 3.11)
 #   UNICODE_ABI (bool)
 #
 # Outputs:
@@ -165,6 +165,7 @@ setup_wheel_python() {
       3.8) python_abi=cp38-cp38 ;;
       3.9) python_abi=cp39-cp39 ;;
       3.10) python_abi=cp310-cp310 ;;
+      3.11) python_abi=cp311-cp311 ;;
       *)
         echo "Unrecognized PYTHON_VERSION=$PYTHON_VERSION"
         exit 1


### PR DESCRIPTION
This PR adds Python 3.11 (cp311) to the [CircleCI regenerate script](https://github.com/alihassanijr/vision/blob/main/.circleci/regenerate.py), and the package helper.

Note that torch 1.13 is built with cp311 wheels, but not torchvision.
This can be an issue for users who're upgrading to 3.11, since they'd have to build their own wheels.

@datumbox @malfet 

(Closing previous PR #6841 because I started off the 0.14 release there and rebasing was a bit of a hassle.)