### PR TITLE
Suppress warning when calling torch.frombuffer with non-writable buffer on _video_opt.py

### DIFF
--- a/torchvision/io/_video_opt.py
+++ b/torchvision/io/_video_opt.py
@@ -336,7 +336,10 @@ def _read_video_from_memory(
     _validate_pts(audio_pts_range)
 
     if not isinstance(video_data, torch.Tensor):
-        video_data = torch.frombuffer(video_data, dtype=torch.uint8)
+        with warnings.catch_warnings():
+            # Ignore the warning because we actually dont modify the buffer in this function
+            warnings.filterwarnings("ignore", message="The given buffer is not writable")
+            video_data = torch.frombuffer(video_data, dtype=torch.uint8)
 
     result = torch.ops.video_reader.read_video_from_memory(
         video_data,
@@ -378,7 +381,10 @@ def _read_video_timestamps_from_memory(
     is much faster than read_video(...)
     """
     if not isinstance(video_data, torch.Tensor):
-        video_data = torch.frombuffer(video_data, dtype=torch.uint8)
+        with warnings.catch_warnings():
+            # Ignore the warning because we actually dont modify the buffer in this function
+            warnings.filterwarnings("ignore", message="The given buffer is not writable")
+            video_data = torch.frombuffer(video_data, dtype=torch.uint8)
     result = torch.ops.video_reader.read_video_from_memory(
         video_data,
         0,  # seek_frame_margin
@@ -416,7 +422,10 @@ def _probe_video_from_memory(
     This function is torchscriptable
     """
     if not isinstance(video_data, torch.Tensor):
-        video_data = torch.frombuffer(video_data, dtype=torch.uint8)
+        with warnings.catch_warnings():
+            # Ignore the warning because we actually dont modify the buffer in this function
+            warnings.filterwarnings("ignore", message="The given buffer is not writable")
+            video_data = torch.frombuffer(video_data, dtype=torch.uint8)
     result = torch.ops.video_reader.probe_video_from_memory(video_data)
     vtimebase, vfps, vduration, atimebase, asample_rate, aduration = result
     info = _fill_info(vtimebase, vfps, vduration, atimebase, asample_rate, aduration)


### PR DESCRIPTION
When calling the functions `_probe_video_from_memory`, `_read_video_from_memory` with input video of type bytes, we often get warnings:

```
/home/users/repos/vision/torchvision/io/_video_opt.py:339: UserWarning: The given buffer is not writable, and PyTorch does not support non-writable tensors. This means you can write to the underlying (supposedly non-writable) buffer using the tensor. You may want to copy the buffer to protect its data or make it writable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at /opt/conda/conda-bld/pytorch_1666163540856/work/torch/csrc/utils/tensor_new.cpp:1563.)
  video_data = torch.frombuffer(video_data, dtype=torch.uint8)
```
From the warning content, it seems that as long we dont modify the tensor in the function, it should be safe.

This PR will suppress the warning when we call the `torch.frombuffer` where the warning comes from.

Here is a script to check whether the warnings is still appearing or not:
```
from torchvision.io import _read_video_from_memory, _probe_video_from_memory

video_path = "<path_to_any_video_file>"
with open(video_path, "rb") as fin:
    video_bytes = fin.read()

# Should produce warnings without this PR
video_metadata = _probe_video_from_memory(video_bytes)
video_decoded = _read_video_from_memory(video_bytes, video_width=64)
```
