### PR TITLE
Suppress warning when calling torch.frombuffer with non-writable buffer on VideoReader

### DIFF
--- a/torchvision/io/video_reader.py
+++ b/torchvision/io/video_reader.py
@@ -144,7 +144,10 @@ class VideoReader:
             elif self.backend == "pyav":
                 src = io.BytesIO(src)
             else:
-                src = torch.frombuffer(src, dtype=torch.uint8)
+                with warnings.catch_warnings():
+                    # Ignore the warning because we actually dont modify the buffer in this function
+                    warnings.filterwarnings("ignore", message="The given buffer is not writable")
+                    src = torch.frombuffer(src, dtype=torch.uint8)
         elif isinstance(src, torch.Tensor):
             if self.backend in ["cuda", "pyav"]:
                 raise RuntimeError(


### PR DESCRIPTION
relates to https://github.com/pytorch/vision/pull/6971 

cc @YosuaMichael 