### PR TITLE
use bitshifts for int to int in convert_dtype

### DIFF
--- a/torchvision/prototype/transforms/functional/_meta.py
+++ b/torchvision/prototype/transforms/functional/_meta.py
@@ -379,15 +379,7 @@ def convert_dtype_image_tensor(image: torch.Tensor, dtype: torch.dtype = torch.f
         if num_value_bits_input > num_value_bits_output:
             return image.bitwise_right_shift(num_value_bits_input - num_value_bits_output).to(dtype)
         else:
-            # The bitshift kernel is not vectorized
-            #  https://github.com/pytorch/pytorch/blob/703c19008df4700b6a522b0ae5c4b6d5ffc0906f/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp#L315-L322
-            #  This results in the multiplication actually being faster.
-            # TODO: If the bitshift kernel is optimized in core, replace the computation below with
-            #  `image.to(dtype).bitwise_left_shift_(num_value_bits_output - num_value_bits_input)`
-            max_value_input = float(_FT._max_value(dtype))
-            max_value_output = float(_FT._max_value(image.dtype))
-            factor = int((max_value_input + 1) // (max_value_output + 1))
-            return image.to(dtype).mul_(factor)
+            return image.to(dtype).bitwise_left_shift_(num_value_bits_output - num_value_bits_input)
 
 
 # We changed the name to align it with the new naming scheme. Still, `convert_image_dtype` is


### PR DESCRIPTION
```
[--- convert_dtype int -> int (down) @ torchvision==0.15.0a0+d5da6e4 ---]
                                        |        v1       |       v2     
1 threads: --------------------------------------------------------------
      (3, 512, 512) / int32 / cpu       |   1074 (+-  5)  |  100 (+-  0) 
      (3, 512, 512) / int32 / cuda      |    42 (+-  1)   |   41 (+-  0) 
      (16, 3, 512, 512) / int32 / cpu   |  21319 (+-291)  |  7362 (+-211)
      (16, 3, 512, 512) / int32 / cuda  |   644 (+-  1)   |  644 (+-  2) 
6 threads: --------------------------------------------------------------
      (3, 512, 512) / int32 / cpu       |   208 (+-  1)   |   33 (+-  0) 
      (16, 3, 512, 512) / int32 / cpu   |   5545 (+- 75)  |  4820 (+-112)

Times are in microseconds (us).

Aggregated performance change of v2 vs. v1: +37.5% (improvement)

[---- convert_dtype int -> int (up) @ torchvision==0.15.0a0+d5da6e4 ----]
                                        |        v1       |       v2     
1 threads: --------------------------------------------------------------
      (3, 512, 512) / uint8 / cpu       |   123 (+-  1)   |   90 (+-  1) 
      (3, 512, 512) / uint8 / cuda      |    46 (+-  1)   |   43 (+-  1) 
      (16, 3, 512, 512) / uint8 / cpu   |  10211 (+-169)  |  5897 (+-125)
      (16, 3, 512, 512) / uint8 / cuda  |   659 (+-  8)   |  658 (+- 19) 
6 threads: --------------------------------------------------------------
      (3, 512, 512) / uint8 / cpu       |    43 (+-  0)   |   30 (+-  0) 
      (16, 3, 512, 512) / uint8 / cpu   |   8715 (+-303)  |  2152 (+-107)

Times are in microseconds (us).

Aggregated performance change of v2 vs. v1: +19.7% (improvement)
```

Last time we measured this was in https://github.com/pytorch/vision/pull/6795#pullrequestreview-1148744830. In this PR the label `main` is equivalent to `v1` above, since it that time, we just aliased the v1 kernel. These are the relevant lines for comparison:

```
                             |  main  |   PR
1 threads: ---------------------------------
        int to   int (down)  |  1100  |  402
        int to   int (up)    |   127  |   92

Times are in microseconds (us).
```

For converting down, i.e. `int32` to `uint8`, this PR doesn't change anything. Still, this branch benefits from the bitshift vectorization:

- previously: 1100 us -> 402 us: 63.5%
- now: 1074 us -> 100 us: 90.7%

For converting up, i.e. `uint8` to `int32`, we replace an inplace multiplication with an inplace `bitwise_left_shift_`. However, the result is underwhelming

- previously: 127 us -> 92 us: 27.6%
- now: 123 us -> 90 us: 26.8%

Meaning, this PR does nothing for performance. The cleanup is good, but I expected some gains here.

@alexsamardzic Did I misunderstand your PRs? Shouldn't `bitwise_left_shift_` be quite a bit faster than `mul_` on an `int32` tensor and with Python scalars as inputs.

cc @vfdev-5 @datumbox @bjuncek