### PR TITLE
fix README rendering

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -203,13 +203,14 @@ Citing TorchVision
 ==================
 
 If you find TorchVision useful in your work, please consider citing the following BibTeX entry:
-```BibTeX
-@software{torchvision2016,
-	title        = {TorchVision: PyTorch's Computer Vision library},
-	author       = {TorchVision maintainers and contributors},
-	year         = 2016,
-	journal      = {GitHub repository},
-	publisher    = {GitHub},
-	howpublished = {\url{https://github.com/pytorch/vision}}
-}
-```
+
+.. code:: bibtex
+
+    @software{torchvision2016,
+        title        = {TorchVision: PyTorch's Computer Vision library},
+        author       = {TorchVision maintainers and contributors},
+        year         = 2016,
+        journal      = {GitHub repository},
+        publisher    = {GitHub},
+        howpublished = {\url{https://github.com/pytorch/vision}}
+    }


### PR DESCRIPTION
#6690 introduced Markdown syntax in our RST README. This breaks the [rendering](https://github.com/pytorch/vision/tree/678300d0e3f517feb096c6014ee031cfc9c1855f#readme). [Here](https://github.com/pmeier/vision/tree/readme-rendering#citing-torchvision) is the rendered version of this PR.