### PR TITLE
[WIP] Separate the model test in GHA linux cpu

### DIFF
--- a/.github/workflows/test-linux-cpu-model.yml
+++ b/.github/workflows/test-linux-cpu-model.yml
@@ -16,7 +16,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        python_version: ["3.7", "3.8", "3.9", "3.10"]
+        python_version: ["3.8"]
       fail-fast: false
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
     with:
@@ -30,7 +30,6 @@ jobs:
         export PYTHON_VERSION="${{ matrix.python_version }}"
         export VERSION="cpu"
         export CUDATOOLKIT="cpuonly"
-        export PYTEST_ADDITIONAL_ARGS="${{ matrix.pytest_additional_args }}"
 
         # Set CHANNEL
         if [[ (${GITHUB_EVENT_NAME} = 'pull_request' && (${GITHUB_BASE_REF} = 'release'*)) || (${GITHUB_REF} = 'refs/heads/release'*) ]]; then
@@ -55,4 +54,4 @@ jobs:
 
         # Run Tests
         python3 -m torch.utils.collect_env
-        python3 -m pytest --junitxml=test-results/junit.xml -v --durations 20 -m "not model_test"
+        python3 -m pytest --junitxml=test-results/junit.xml -v --durations 20 -m "model_test"

--- a/pytest.ini
+++ b/pytest.ini
@@ -11,3 +11,5 @@ addopts =
 testpaths =
     test
 xfail_strict = True
+markers =
+    model_test

--- a/test/test_backbone_utils.py
+++ b/test/test_backbone_utils.py
@@ -11,6 +11,9 @@ from torchvision.models.detection.backbone_utils import BackboneWithFPN, mobilen
 from torchvision.models.feature_extraction import create_feature_extractor, get_graph_node_names
 
 
+pytestmark = pytest.mark.model_test
+
+
 @pytest.mark.parametrize("backbone_name", ("resnet18", "resnet50"))
 def test_resnet_fpn_backbone(backbone_name):
     x = torch.rand(1, 3, 300, 300, dtype=torch.float32, device="cpu")

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -21,6 +21,9 @@ from torchvision import models, transforms
 from torchvision.models import get_model_builder, list_models
 
 
+pytestmark = pytest.mark.model_test
+
+
 ACCEPT = os.getenv("EXPECTTEST_ACCEPT", "0") == "1"
 SKIP_BIG_MODEL = os.getenv("SKIP_BIG_MODEL", "1") == "1"
 


### PR DESCRIPTION
As part of https://github.com/pytorch/vision/issues/7000, in this PR we want to separate the model test on the GHA workflow of linux cpu.