### PR TITLE
fix prototype dataset imagenet mock data

### DIFF
--- a/.github/workflows/prototype-tests.yml
+++ b/.github/workflows/prototype-tests.yml
@@ -11,6 +11,14 @@ jobs:
           - ubuntu-latest
           - windows-latest
           - macos-latest
+        python-version:
+          - "3.7"
+          - "3.8"
+          - "3.9"
+          - "3.10"
+        flag:
+          - "--pre"
+          - ""
       fail-fast: false
 
     runs-on: ${{ matrix.os }}
@@ -19,7 +27,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v3
         with:
-          python-version: 3.7
+          python-version: ${{ matrix.python-version }}
 
       - name: Upgrade system packages
         run: python -m pip install --upgrade pip setuptools wheel
@@ -28,7 +36,10 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install PyTorch nightly builds
-        run: pip install --progress-bar=off --pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cpu/
+        run: pip install --progress-bar=off --pre torchdata torch --extra-index-url https://download.pytorch.org/whl/nightly/cpu/
+
+      - name: Upgrade numpy
+        run: pip install --upgrade ${{ matrix.flag }} numpy
 
       - name: Install torchvision
         run: pip install --progress-bar=off --no-build-isolation --editable .
@@ -43,31 +54,11 @@ jobs:
         id: setup
         run: exit 0
 
-      - name: Run prototype datapoints tests
+      - name: Run prototype datasets tests
         shell: bash
         run: |
           pytest \
             --durations=20 \
             --cov=torchvision/prototype/datapoints \
             --cov-report=term-missing \
-            test/test_prototype_datapoints*.py
-
-      - name: Run prototype transforms tests
-        if: success() || ( failure() && steps.setup.conclusion == 'success' )
-        shell: bash
-        run: |
-          pytest \
-            --durations=20 \
-            --cov=torchvision/prototype/transforms \
-            --cov-report=term-missing \
-            test/test_prototype_transforms*.py
-
-      - name: Run prototype models tests
-        if: success() || ( failure() && steps.setup.conclusion == 'success' )
-        shell: bash
-        run: |
-          pytest \
-            --durations=20 \
-            --cov=torchvision/prototype/models \
-            --cov-report=term-missing \
-            test/test_prototype_models*.py
+            test/test_prototype_datasets*.py

--- a/.github/workflows/prototype-tests.yml
+++ b/.github/workflows/prototype-tests.yml
@@ -11,14 +11,6 @@ jobs:
           - ubuntu-latest
           - windows-latest
           - macos-latest
-        python-version:
-          - "3.7"
-          - "3.8"
-          - "3.9"
-          - "3.10"
-        flag:
-          - "--pre"
-          - ""
       fail-fast: false
 
     runs-on: ${{ matrix.os }}
@@ -27,7 +19,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v3
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: 3.7
 
       - name: Upgrade system packages
         run: python -m pip install --upgrade pip setuptools wheel
@@ -36,10 +28,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install PyTorch nightly builds
-        run: pip install --progress-bar=off --pre torchdata torch --extra-index-url https://download.pytorch.org/whl/nightly/cpu/
-
-      - name: Upgrade numpy
-        run: pip install --upgrade ${{ matrix.flag }} numpy
+        run: pip install --progress-bar=off --pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cpu/
 
       - name: Install torchvision
         run: pip install --progress-bar=off --no-build-isolation --editable .
@@ -54,11 +43,31 @@ jobs:
         id: setup
         run: exit 0
 
-      - name: Run prototype datasets tests
+      - name: Run prototype datapoints tests
         shell: bash
         run: |
           pytest \
             --durations=20 \
             --cov=torchvision/prototype/datapoints \
             --cov-report=term-missing \
-            test/test_prototype_datasets*.py
+            test/test_prototype_datapoints*.py
+
+      - name: Run prototype transforms tests
+        if: success() || ( failure() && steps.setup.conclusion == 'success' )
+        shell: bash
+        run: |
+          pytest \
+            --durations=20 \
+            --cov=torchvision/prototype/transforms \
+            --cov-report=term-missing \
+            test/test_prototype_transforms*.py
+
+      - name: Run prototype models tests
+        if: success() || ( failure() && steps.setup.conclusion == 'success' )
+        shell: bash
+        run: |
+          pytest \
+            --durations=20 \
+            --cov=torchvision/prototype/models \
+            --cov-report=term-missing \
+            test/test_prototype_models*.py

--- a/test/builtin_dataset_mocks.py
+++ b/test/builtin_dataset_mocks.py
@@ -12,7 +12,6 @@ import pickle
 import random
 import shutil
 import unittest.mock
-import warnings
 import xml.etree.ElementTree as ET
 from collections import Counter, defaultdict
 
@@ -519,10 +518,22 @@ def imagenet(root, config):
         ]
         num_children = 1
         synsets.extend((0, "", "", "", num_children, [], 0, 0) for _ in range(5))
-        with warnings.catch_warnings():
-            # The warning is not for savemat, but rather for some internals savemet is using
-            warnings.filterwarnings("ignore", category=np.VisibleDeprecationWarning)
-            savemat(data_root / "meta.mat", dict(synsets=synsets))
+        synsets = np.array(
+            synsets,
+            dtype=np.dtype(
+                [
+                    ("ILSVRC2012_ID", "O"),
+                    ("WNID", "O"),
+                    ("words", "O"),
+                    ("gloss", "O"),
+                    ("num_children", "O"),
+                    ("children", "O"),
+                    ("wordnet_height", "O"),
+                    ("num_train_images", "O"),
+                ]
+            ),
+        )
+        savemat(data_root / "meta.mat", dict(synsets=synsets))
 
         make_tar(root, devkit_root.with_suffix(".tar.gz").name, compression="gz")
     else:  # config["split"] == "test"


### PR DESCRIPTION
This was reported offline by @ejguan. We previously ignored a warning there thinking that it was actually `scipy.io.savemat` that is causing it. Turns out, we were providing deprecated input data and starting with `numpy=1.24` this fails. This is visible in `torchdata` CI, e.g. https://github.com/pytorch/data/actions/runs/3579763020.

I've temporarily expanded the prototype test matrix to cover all cases.
