### PR TITLE
improve download tests and fix SBU

### DIFF
--- a/.github/workflows/tests-schedule.yml
+++ b/.github/workflows/tests-schedule.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Upgrade system packages
         run: python -m pip install --upgrade pip setuptools wheel
 
+      - name: SSL
+        run: python -c 'import ssl; print(ssl.OPENSSL_VERSION)'
+
       - name: Checkout repository
         uses: actions/checkout@v2
 

--- a/test/test_datasets_download.py
+++ b/test/test_datasets_download.py
@@ -127,7 +127,7 @@ def log_download_attempts(
                 urls_and_md5s.add((url, md5))
 
 
-def retry(fn, times=1, wait=0.0):
+def retry(fn, times=1, wait=5.0):
     tbs = []
     for _ in range(times + 1):
         try:
@@ -455,7 +455,6 @@ def make_parametrize_kwargs(download_configs):
             omniglot(),
             phototour(),
             sbdataset(),
-            sbu(),
             semeion(),
             stl10(),
             svhn(),
@@ -479,6 +478,7 @@ def test_url_is_accessible(url, md5):
     **make_parametrize_kwargs(
         itertools.chain(
             places365(),  # https://github.com/pytorch/vision/issues/6268
+            sbu(),  # https://github.com/pytorch/vision/issues/7005
         )
     )
 )

--- a/test/test_datasets_download.py
+++ b/test/test_datasets_download.py
@@ -2,6 +2,7 @@ import contextlib
 import itertools
 import tempfile
 import time
+import traceback
 import unittest.mock
 import warnings
 from datetime import datetime
@@ -126,20 +127,24 @@ def log_download_attempts(
                 urls_and_md5s.add((url, md5))
 
 
-def retry(fn, times=1, wait=5.0):
-    msgs = []
+def retry(fn, times=1, wait=0.0):
+    tbs = []
     for _ in range(times + 1):
         try:
             return fn()
         except AssertionError as error:
-            msgs.append(str(error))
+            tbs.append("".join(traceback.format_exception(type(error), error, error.__traceback__)))
             time.sleep(wait)
     else:
         raise AssertionError(
             "\n".join(
                 (
-                    f"Assertion failed {times + 1} times with {wait:.1f} seconds intermediate wait time.\n",
-                    *(f"{idx}: {error}" for idx, error in enumerate(msgs, 1)),
+                    "\n",
+                    *[f"{'_' * 40}  {idx:2d}  {'_' * 40}\n\n{tb}" for idx, tb in enumerate(tbs, 1)],
+                    (
+                        f"Assertion failed {times + 1} times with {wait:.1f} seconds intermediate wait time. "
+                        f"You can find the the full tracebacks above."
+                    ),
                 )
             )
         )
@@ -149,10 +154,12 @@ def retry(fn, times=1, wait=5.0):
 def assert_server_response_ok():
     try:
         yield
-    except URLError as error:
-        raise AssertionError("The request timed out.") from error
     except HTTPError as error:
         raise AssertionError(f"The server returned {error.code}: {error.reason}.") from error
+    except URLError as error:
+        raise AssertionError(
+            "Connection not possible due to SSL." if "SSL" in str(error) else "The request timed out."
+        ) from error
     except RecursionError as error:
         raise AssertionError(str(error)) from error
 


### PR DESCRIPTION
This PR does two things:

1. Improve the test setup. Previously, the conclusion was that SBU downloads are timing out when there are SSL issues.
2. Move SBU to the xfailed tests and thus fix #7005.

To showcase 1., [here](https://github.com/pytorch/vision/actions/runs/3631172036/jobs/6125446046) is the workflow without a patch for 2 and [here](https://github.com/pytorch/vision/actions/runs/3631319521/jobs/6125794932) with the applied patch.