### PR TITLE
Re-direct linux workflow to test branch that includes nvidia driver installation

### DIFF
--- a/.github/workflows/test-linux-gpu.yml
+++ b/.github/workflows/test-linux-gpu.yml
@@ -19,7 +19,7 @@ jobs:
         python_version: ["3.8"]
         cuda_arch_version: ["11.6"]
       fail-fast: false
-    uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job.yml@weiwangmeta/install_nvidia_gpu_driver
     with:
       runner: linux.g5.4xlarge.nvidia.gpu
       repository: pytorch/vision


### PR DESCRIPTION
Tries to address cuda skipped tests issue in https://github.com/pytorch/vision/actions/runs/3649640523/jobs/6164578315 