### PR TITLE
pin python version for cmake workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -958,12 +958,15 @@ jobs:
     machine:
       image: ubuntu-2004-cuda-11.4:202110-01
     resource_class: gpu.nvidia.small
-    environment:
-      PYTHON_VERSION: << parameters.python_version >>
-      PYTORCH_VERSION: << parameters.pytorch_version >>
-      UNICODE_ABI: << parameters.unicode_abi >>
-      CU_VERSION: << parameters.cu_version >>
     steps:
+      - run:
+          name: debug
+          command: |
+            set -ex
+            echo $PYTHON_VERSION
+            echo $PYTORCH_VERSION
+            echo $UNICODE_ABI
+            echo $CU_VERSION
       - checkout_merge
       - designate_upload_channel
       - run:
@@ -986,7 +989,7 @@ jobs:
             curl -o conda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
             sh conda.sh -b
             source $HOME/miniconda3/bin/activate
-            conda install -yq conda-build cmake python=3.9
+            conda install -yq conda-build cmake python=<< parameters.python_version >>
             packaging/build_cmake.sh
 
   cmake_windows_cpu:
@@ -999,8 +1002,12 @@ jobs:
       - run:
           command: |
             set -ex
+            echo $CONDA_PREFIX
+            conda list || true
             source packaging/windows/internal/vc_install_helper.sh
-            packaging/build_cmake.sh
+            echo $CONDA_PREFIX
+            conda list || true
+#            packaging/build_cmake.sh
 
   cmake_windows_gpu:
     <<: *binary_common

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -959,14 +959,6 @@ jobs:
       image: ubuntu-2004-cuda-11.4:202110-01
     resource_class: gpu.nvidia.small
     steps:
-      - run:
-          name: debug
-          command: |
-            set -ex
-            echo $PYTHON_VERSION
-            echo $PYTORCH_VERSION
-            echo $UNICODE_ABI
-            echo $CU_VERSION
       - checkout_merge
       - designate_upload_channel
       - run:
@@ -1002,12 +994,8 @@ jobs:
       - run:
           command: |
             set -ex
-            echo $CONDA_PREFIX
-            conda list || true
             source packaging/windows/internal/vc_install_helper.sh
-            echo $CONDA_PREFIX
-            conda list || true
-#            packaging/build_cmake.sh
+            packaging/build_cmake.sh
 
   cmake_windows_gpu:
     <<: *binary_common

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -986,7 +986,7 @@ jobs:
             curl -o conda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
             sh conda.sh -b
             source $HOME/miniconda3/bin/activate
-            conda install -yq conda-build cmake
+            conda install -yq conda-build cmake python=3.9
             packaging/build_cmake.sh
 
   cmake_windows_cpu:

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -958,11 +958,6 @@ jobs:
     machine:
       image: ubuntu-2004-cuda-11.4:202110-01
     resource_class: gpu.nvidia.small
-    environment:
-      PYTHON_VERSION: << parameters.python_version >>
-      PYTORCH_VERSION: << parameters.pytorch_version >>
-      UNICODE_ABI: << parameters.unicode_abi >>
-      CU_VERSION: << parameters.cu_version >>
     steps:
       - checkout_merge
       - designate_upload_channel
@@ -986,7 +981,7 @@ jobs:
             curl -o conda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
             sh conda.sh -b
             source $HOME/miniconda3/bin/activate
-            conda install -yq conda-build cmake python=3.9
+            conda install -yq conda-build cmake python=<< parameters.python_version >>
             packaging/build_cmake.sh
 
   cmake_windows_cpu:

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -986,7 +986,7 @@ jobs:
             curl -o conda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
             sh conda.sh -b
             source $HOME/miniconda3/bin/activate
-            conda install -yq conda-build cmake
+            conda install -yq conda-build cmake python=3.9
             packaging/build_cmake.sh
 
   cmake_windows_cpu:

--- a/packaging/build_cmake.sh
+++ b/packaging/build_cmake.sh
@@ -25,8 +25,6 @@ if [[ "$OSTYPE" == "msys" ]]; then
     pip install dataclasses
 fi
 
-conda install -yq python=3.9
-
 setup_visual_studio_constraint
 setup_junit_results_folder
 

--- a/packaging/build_cmake.sh
+++ b/packaging/build_cmake.sh
@@ -21,7 +21,7 @@ setup_conda_pytorch_constraint
 setup_conda_cudatoolkit_plain_constraint
 
 if [[ "$OSTYPE" == "msys" ]]; then
-    conda install -yq conda-build cmake future
+    conda install -yq conda-build cmake future python=3.9
     pip install dataclasses
 fi
 

--- a/packaging/build_cmake.sh
+++ b/packaging/build_cmake.sh
@@ -21,9 +21,11 @@ setup_conda_pytorch_constraint
 setup_conda_cudatoolkit_plain_constraint
 
 if [[ "$OSTYPE" == "msys" ]]; then
-    conda install -yq conda-build cmake future python=3.9
+    conda install -yq conda-build cmake future
     pip install dataclasses
 fi
+
+conda install -yq python=3.9
 
 setup_visual_studio_constraint
 setup_junit_results_folder


### PR DESCRIPTION
On macOS, we are downloading Miniconda with 

https://github.com/pytorch/vision/blob/46b7e27122deb011a3ff09720da9c3787757f7eb/.circleci/config.yml#L986

Until late Dec 2022 this included Python 3.9. From then on, the included Python version was 3.10 and our workflows started [failing due to some unsatisfiable requirements](https://app.circleci.com/pipelines/github/pytorch/vision/22481/workflows/d5e77548-16ba-42c7-8bf0-fd7674a3a76c/jobs/1803108).

Closes https://github.com/pytorch/vision/issues/7073