### PR TITLE
Remove torch.jit.fuser("fuser2") in test

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1558,7 +1558,7 @@ class TestFocalLoss:
         if device == "cpu":
             scripted_focal_loss = script_fn(inputs, targets, gamma=gamma, alpha=alpha, reduction=reduction)
         else:
-            with torch.jit.fuser("fuser2"):
+            with torch.jit.fuser("fuser1"):
                 # Use fuser2 to prevent a bug on fuser: https://github.com/pytorch/pytorch/issues/75476
                 # We may remove this condition once the bug is resolved
                 scripted_focal_loss = script_fn(inputs, targets, gamma=gamma, alpha=alpha, reduction=reduction)

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1555,13 +1555,7 @@ class TestFocalLoss:
         torch.random.manual_seed(seed)
         inputs, targets = self._generate_diverse_input_target_pair(dtype=dtype, device=device)
         focal_loss = ops.sigmoid_focal_loss(inputs, targets, gamma=gamma, alpha=alpha, reduction=reduction)
-        if device == "cpu":
-            scripted_focal_loss = script_fn(inputs, targets, gamma=gamma, alpha=alpha, reduction=reduction)
-        else:
-            with torch.jit.fuser("fuser1"):
-                # Use fuser2 to prevent a bug on fuser: https://github.com/pytorch/pytorch/issues/75476
-                # We may remove this condition once the bug is resolved
-                scripted_focal_loss = script_fn(inputs, targets, gamma=gamma, alpha=alpha, reduction=reduction)
+        scripted_focal_loss = script_fn(inputs, targets, gamma=gamma, alpha=alpha, reduction=reduction)
 
         tol = 1e-3 if dtype is torch.half else 1e-5
         torch.testing.assert_close(focal_loss, scripted_focal_loss, rtol=tol, atol=tol)


### PR DESCRIPTION
Internally we're considering removing support for fuser2, so we would need to remove this special case from the test.

More context:
* This special case was added due to a bug in NNC (https://github.com/pytorch/pytorch/issues/75476). This switched the fuser for this test case from NNC, to NVFuser, which at the time was still an experimental option.
* Since then, NVFuser has replaced NNC as the default fuser. So, NVFuser will be used instead of NNC even without explicitly turning it on with `torch.jit.fuser('fuser2')` (note: fuser2 == NVFuser). The exception to this is for internal usage, where NNC is still used instead of NVFuser.
* Finally, it appears that the initial NNC bug (https://github.com/pytorch/pytorch/issues/75476) has been fixed. I verified this both locally and in CI, by changing `fuser2` (NVFuser) to `fuser1` (NNC) and running this test (as seen [here](https://github.com/pytorch/vision/pull/7069/commits/3c55605d3f49939f9c6ae2546aefece97a9e0c8f))

So, it looks like we can safely remove this special case for `fuser2` in this test, which will unblock any internal fuser migration that we may need to do.

<!-- Before submitting a PR, please make sure to check our contributing guidelines regarding code formatting, tests, and documentation: https://github.com/pytorch/vision/blob/main/CONTRIBUTING.md -->
