### PR TITLE
Cleanup weight docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -396,7 +396,7 @@ def generate_weights_table(module, table_name, metrics, dataset, include_pattern
 
     metrics_keys, metrics_names = zip(*metrics)
     column_names = (
-        ["Weight"] + list(metrics_names) + ["Params"] + [ops_name, "Size (MB)", "Recipe"]
+        ["Weight"] + list(metrics_names) + ["Params"] + [ops_name, "Recipe"]
     )  # Final column order
     column_names = [f"**{name}**" for name in column_names]  # Add bold
 
@@ -406,8 +406,7 @@ def generate_weights_table(module, table_name, metrics, dataset, include_pattern
             f":class:`{w} <{type(w).__name__}>`",
             *(w.meta["_metrics"][dataset][metric] for metric in metrics_keys),
             f"{w.meta['num_params']/1e6:.1f}M",
-            f"{w.meta['_ops']:.3f}",
-            f"{round(w.meta['_file_size'], 1):.1f}",
+            f"{w.meta['_ops']:.2f}",
             f"`link <{w.meta['recipe']}>`__",
         ]
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -367,7 +367,7 @@ def inject_weight_metadata(app, what, name, obj, options, lines):
                     k = "GIPS" if obj.__name__.endswith("_QuantizedWeights") else "GFLOPS"
                 elif k == "_file_size":
                     k = "File size"
-                    v = f"{v:.1f} MB (file size)"
+                    v = f"{v:.1f} MB"
 
                 table.append((str(k), str(v)))
             table = tabulate(table, tablefmt="rst")

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -363,12 +363,11 @@ def inject_weight_metadata(app, what, name, obj, options, lines):
                     v_sample = ", ".join(v[:max_visible])
                     v = f"{v_sample}, ... ({len(v)-max_visible} omitted)" if len(v) > max_visible else v_sample
                 elif k == "_ops":
-                    if obj.__name__.endswith("_QuantizedWeights"):
-                        v = f"{v} giga instructions per sec"
-                    else:
-                        v = f"{v} giga floating-point operations per sec"
+                    v = f"{v:.2f}"
+                    k = "GIPS" if obj.__name__.endswith("_QuantizedWeights") else "GFLOPS"
                 elif k == "_file_size":
-                    v = f"{v} MB (file size)"
+                    k = "File size"
+                    v = f"{v:.1f} MB (file size)"
 
                 table.append((str(k), str(v)))
             table = tabulate(table, tablefmt="rst")

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -367,7 +367,7 @@ def inject_weight_metadata(app, what, name, obj, options, lines):
                         v = f"{v} giga instructions per sec"
                     else:
                         v = f"{v} giga floating-point operations per sec"
-                elif k == "_weight_size":
+                elif k == "_file_size":
                     v = f"{v} MB (file size)"
 
                 table.append((str(k), str(v)))
@@ -408,7 +408,7 @@ def generate_weights_table(module, table_name, metrics, dataset, include_pattern
             *(w.meta["_metrics"][dataset][metric] for metric in metrics_keys),
             f"{w.meta['num_params']/1e6:.1f}M",
             f"{w.meta['_ops']:.3f}",
-            f"{round(w.meta['_weight_size'], 1):.1f}",
+            f"{round(w.meta['_file_size'], 1):.1f}",
             f"`link <{w.meta['recipe']}>`__",
         ]
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -412,7 +412,7 @@ def generate_weights_table(module, table_name, metrics, dataset, include_pattern
 
         content.append(row)
 
-    column_widths = ["110"] + ["18"] * len(metrics_names) + ["18"] * 3 + ["10"]
+    column_widths = ["110"] + ["18"] * len(metrics_names) + ["18"] * 2 + ["10"]
     widths_table = " ".join(column_widths)
 
     table = tabulate(content, headers=column_names, tablefmt="rst")

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -395,9 +395,7 @@ def generate_weights_table(module, table_name, metrics, dataset, include_pattern
     ops_name = "GIPS" if "QuantizedWeights" in weights_endswith else "GFLOPS"
 
     metrics_keys, metrics_names = zip(*metrics)
-    column_names = (
-        ["Weight"] + list(metrics_names) + ["Params"] + [ops_name, "Recipe"]
-    )  # Final column order
+    column_names = ["Weight"] + list(metrics_names) + ["Params"] + [ops_name, "Recipe"]  # Final column order
     column_names = [f"**{name}**" for name in column_names]  # Add bold
 
     content = []

--- a/test/common_extended_utils.py
+++ b/test/common_extended_utils.py
@@ -296,7 +296,7 @@ def get_ops(model: torch.nn.Module, weight: Weights, height=512, width=512):
     return round(flops, 3)
 
 
-def get_weight_size_mb(weight):
+def get_file_size_mb(weight):
     weights_path = os.path.join(os.getenv("HOME"), ".cache/torch/hub/checkpoints", weight.url.split("/")[-1])
     weights_size_mb = os.path.getsize(weights_path) / 1024 / 1024
 

--- a/test/test_extended_models.py
+++ b/test/test_extended_models.py
@@ -4,7 +4,7 @@ import os
 import pytest
 import test_models as TM
 import torch
-from common_extended_utils import get_ops, get_file_size_mb
+from common_extended_utils import get_file_size_mb, get_ops
 from torchvision import models
 from torchvision.models._api import get_model_weights, Weights, WeightsEnum
 from torchvision.models._utils import handle_legacy_interface

--- a/test/test_extended_models.py
+++ b/test/test_extended_models.py
@@ -4,7 +4,7 @@ import os
 import pytest
 import test_models as TM
 import torch
-from common_extended_utils import get_ops, get_weight_size_mb
+from common_extended_utils import get_ops, get_file_size_mb
 from torchvision import models
 from torchvision.models._api import get_model_weights, Weights, WeightsEnum
 from torchvision.models._utils import handle_legacy_interface
@@ -172,12 +172,12 @@ def test_schema_meta_validation(model_fn):
         "unquantized",
         "_docs",
         "_ops",
-        "_weight_size",
+        "_file_size",
     }
     # mandatory fields for each computer vision task
     classification_fields = {"categories", ("_metrics", "ImageNet-1K", "acc@1"), ("_metrics", "ImageNet-1K", "acc@5")}
     defaults = {
-        "all": {"_metrics", "min_size", "num_params", "recipe", "_docs", "_weight_size", "_ops"},
+        "all": {"_metrics", "min_size", "num_params", "recipe", "_docs", "_file_size", "_ops"},
         "models": classification_fields,
         "detection": {"categories", ("_metrics", "COCO-val2017", "box_map")},
         "quantization": classification_fields | {"backend", "unquantized"},
@@ -245,8 +245,8 @@ def test_schema_meta_validation(model_fn):
         if not w.name.isupper():
             bad_names.append(w)
 
-        if get_weight_size_mb(w) != w.meta.get("_weight_size"):
-            incorrect_meta.append((w, "_weight_size"))
+        if get_file_size_mb(w) != w.meta.get("_file_size"):
+            incorrect_meta.append((w, "_file_size"))
 
     assert not problematic_weights
     assert not incorrect_meta

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1555,13 +1555,7 @@ class TestFocalLoss:
         torch.random.manual_seed(seed)
         inputs, targets = self._generate_diverse_input_target_pair(dtype=dtype, device=device)
         focal_loss = ops.sigmoid_focal_loss(inputs, targets, gamma=gamma, alpha=alpha, reduction=reduction)
-        if device == "cpu":
-            scripted_focal_loss = script_fn(inputs, targets, gamma=gamma, alpha=alpha, reduction=reduction)
-        else:
-            with torch.jit.fuser("fuser2"):
-                # Use fuser2 to prevent a bug on fuser: https://github.com/pytorch/pytorch/issues/75476
-                # We may remove this condition once the bug is resolved
-                scripted_focal_loss = script_fn(inputs, targets, gamma=gamma, alpha=alpha, reduction=reduction)
+        scripted_focal_loss = script_fn(inputs, targets, gamma=gamma, alpha=alpha, reduction=reduction)
 
         tol = 1e-3 if dtype is torch.half else 1e-5
         torch.testing.assert_close(focal_loss, scripted_focal_loss, rtol=tol, atol=tol)

--- a/torchvision/models/alexnet.py
+++ b/torchvision/models/alexnet.py
@@ -68,7 +68,7 @@ class AlexNet_Weights(WeightsEnum):
                 }
             },
             "_ops": 0.714,
-            "_weight_size": 233.087,
+            "_file_size": 233.087,
             "_docs": """
                 These weights reproduce closely the results of the paper using a simplified training recipe.
             """,

--- a/torchvision/models/convnext.py
+++ b/torchvision/models/convnext.py
@@ -220,7 +220,7 @@ class ConvNeXt_Tiny_Weights(WeightsEnum):
                 }
             },
             "_ops": 4.456,
-            "_weight_size": 109.119,
+            "_file_size": 109.119,
         },
     )
     DEFAULT = IMAGENET1K_V1
@@ -240,7 +240,7 @@ class ConvNeXt_Small_Weights(WeightsEnum):
                 }
             },
             "_ops": 8.684,
-            "_weight_size": 191.703,
+            "_file_size": 191.703,
         },
     )
     DEFAULT = IMAGENET1K_V1
@@ -260,7 +260,7 @@ class ConvNeXt_Base_Weights(WeightsEnum):
                 }
             },
             "_ops": 15.355,
-            "_weight_size": 338.064,
+            "_file_size": 338.064,
         },
     )
     DEFAULT = IMAGENET1K_V1
@@ -280,7 +280,7 @@ class ConvNeXt_Large_Weights(WeightsEnum):
                 }
             },
             "_ops": 34.361,
-            "_weight_size": 754.537,
+            "_file_size": 754.537,
         },
     )
     DEFAULT = IMAGENET1K_V1

--- a/torchvision/models/densenet.py
+++ b/torchvision/models/densenet.py
@@ -278,7 +278,7 @@ class DenseNet121_Weights(WeightsEnum):
                 }
             },
             "_ops": 2.834,
-            "_weight_size": 30.845,
+            "_file_size": 30.845,
         },
     )
     DEFAULT = IMAGENET1K_V1
@@ -298,7 +298,7 @@ class DenseNet161_Weights(WeightsEnum):
                 }
             },
             "_ops": 7.728,
-            "_weight_size": 110.369,
+            "_file_size": 110.369,
         },
     )
     DEFAULT = IMAGENET1K_V1
@@ -318,7 +318,7 @@ class DenseNet169_Weights(WeightsEnum):
                 }
             },
             "_ops": 3.36,
-            "_weight_size": 54.708,
+            "_file_size": 54.708,
         },
     )
     DEFAULT = IMAGENET1K_V1
@@ -338,7 +338,7 @@ class DenseNet201_Weights(WeightsEnum):
                 }
             },
             "_ops": 4.291,
-            "_weight_size": 77.373,
+            "_file_size": 77.373,
         },
     )
     DEFAULT = IMAGENET1K_V1

--- a/torchvision/models/detection/faster_rcnn.py
+++ b/torchvision/models/detection/faster_rcnn.py
@@ -389,7 +389,7 @@ class FasterRCNN_ResNet50_FPN_Weights(WeightsEnum):
                 }
             },
             "_ops": 134.38,
-            "_weight_size": 159.743,
+            "_file_size": 159.743,
             "_docs": """These weights were produced by following a similar training recipe as on the paper.""",
         },
     )
@@ -410,7 +410,7 @@ class FasterRCNN_ResNet50_FPN_V2_Weights(WeightsEnum):
                 }
             },
             "_ops": 280.371,
-            "_weight_size": 167.104,
+            "_file_size": 167.104,
             "_docs": """These weights were produced using an enhanced training recipe to boost the model accuracy.""",
         },
     )
@@ -431,7 +431,7 @@ class FasterRCNN_MobileNet_V3_Large_FPN_Weights(WeightsEnum):
                 }
             },
             "_ops": 4.494,
-            "_weight_size": 74.239,
+            "_file_size": 74.239,
             "_docs": """These weights were produced by following a similar training recipe as on the paper.""",
         },
     )
@@ -452,7 +452,7 @@ class FasterRCNN_MobileNet_V3_Large_320_FPN_Weights(WeightsEnum):
                 }
             },
             "_ops": 0.719,
-            "_weight_size": 74.239,
+            "_file_size": 74.239,
             "_docs": """These weights were produced by following a similar training recipe as on the paper.""",
         },
     )

--- a/torchvision/models/detection/fcos.py
+++ b/torchvision/models/detection/fcos.py
@@ -663,7 +663,7 @@ class FCOS_ResNet50_FPN_Weights(WeightsEnum):
                 }
             },
             "_ops": 128.207,
-            "_weight_size": 123.608,
+            "_file_size": 123.608,
             "_docs": """These weights were produced by following a similar training recipe as on the paper.""",
         },
     )

--- a/torchvision/models/detection/keypoint_rcnn.py
+++ b/torchvision/models/detection/keypoint_rcnn.py
@@ -329,7 +329,7 @@ class KeypointRCNN_ResNet50_FPN_Weights(WeightsEnum):
                 }
             },
             "_ops": 133.924,
-            "_weight_size": 226.054,
+            "_file_size": 226.054,
             "_docs": """
                 These weights were produced by following a similar training recipe as on the paper but use a checkpoint
                 from an early epoch.
@@ -350,7 +350,7 @@ class KeypointRCNN_ResNet50_FPN_Weights(WeightsEnum):
                 }
             },
             "_ops": 137.42,
-            "_weight_size": 226.054,
+            "_file_size": 226.054,
             "_docs": """These weights were produced by following a similar training recipe as on the paper.""",
         },
     )

--- a/torchvision/models/detection/mask_rcnn.py
+++ b/torchvision/models/detection/mask_rcnn.py
@@ -371,7 +371,7 @@ class MaskRCNN_ResNet50_FPN_Weights(WeightsEnum):
                 }
             },
             "_ops": 134.38,
-            "_weight_size": 169.84,
+            "_file_size": 169.84,
             "_docs": """These weights were produced by following a similar training recipe as on the paper.""",
         },
     )
@@ -393,7 +393,7 @@ class MaskRCNN_ResNet50_FPN_V2_Weights(WeightsEnum):
                 }
             },
             "_ops": 333.577,
-            "_weight_size": 177.219,
+            "_file_size": 177.219,
             "_docs": """These weights were produced using an enhanced training recipe to boost the model accuracy.""",
         },
     )

--- a/torchvision/models/detection/retinanet.py
+++ b/torchvision/models/detection/retinanet.py
@@ -691,7 +691,7 @@ class RetinaNet_ResNet50_FPN_Weights(WeightsEnum):
                 }
             },
             "_ops": 151.54,
-            "_weight_size": 130.267,
+            "_file_size": 130.267,
             "_docs": """These weights were produced by following a similar training recipe as on the paper.""",
         },
     )
@@ -712,7 +712,7 @@ class RetinaNet_ResNet50_FPN_V2_Weights(WeightsEnum):
                 }
             },
             "_ops": 152.238,
-            "_weight_size": 146.037,
+            "_file_size": 146.037,
             "_docs": """These weights were produced using an enhanced training recipe to boost the model accuracy.""",
         },
     )

--- a/torchvision/models/detection/ssd.py
+++ b/torchvision/models/detection/ssd.py
@@ -40,7 +40,7 @@ class SSD300_VGG16_Weights(WeightsEnum):
                 }
             },
             "_ops": 34.858,
-            "_weight_size": 135.988,
+            "_file_size": 135.988,
             "_docs": """These weights were produced by following a similar training recipe as on the paper.""",
         },
     )

--- a/torchvision/models/detection/ssdlite.py
+++ b/torchvision/models/detection/ssdlite.py
@@ -199,7 +199,7 @@ class SSDLite320_MobileNet_V3_Large_Weights(WeightsEnum):
                 }
             },
             "_ops": 0.583,
-            "_weight_size": 13.418,
+            "_file_size": 13.418,
             "_docs": """These weights were produced by following a similar training recipe as on the paper.""",
         },
     )

--- a/torchvision/models/efficientnet.py
+++ b/torchvision/models/efficientnet.py
@@ -465,7 +465,7 @@ class EfficientNet_B0_Weights(WeightsEnum):
                 }
             },
             "_ops": 0.386,
-            "_weight_size": 20.451,
+            "_file_size": 20.451,
             "_docs": """These weights are ported from the original paper.""",
         },
     )
@@ -489,7 +489,7 @@ class EfficientNet_B1_Weights(WeightsEnum):
                 }
             },
             "_ops": 0.687,
-            "_weight_size": 30.134,
+            "_file_size": 30.134,
             "_docs": """These weights are ported from the original paper.""",
         },
     )
@@ -509,7 +509,7 @@ class EfficientNet_B1_Weights(WeightsEnum):
                 }
             },
             "_ops": 0.687,
-            "_weight_size": 30.136,
+            "_file_size": 30.136,
             "_docs": """
                 These weights improve upon the results of the original paper by using a modified version of TorchVision's
                 `new training recipe
@@ -537,7 +537,7 @@ class EfficientNet_B2_Weights(WeightsEnum):
                 }
             },
             "_ops": 1.088,
-            "_weight_size": 35.174,
+            "_file_size": 35.174,
             "_docs": """These weights are ported from the original paper.""",
         },
     )
@@ -561,7 +561,7 @@ class EfficientNet_B3_Weights(WeightsEnum):
                 }
             },
             "_ops": 1.827,
-            "_weight_size": 47.184,
+            "_file_size": 47.184,
             "_docs": """These weights are ported from the original paper.""",
         },
     )
@@ -585,7 +585,7 @@ class EfficientNet_B4_Weights(WeightsEnum):
                 }
             },
             "_ops": 4.394,
-            "_weight_size": 74.489,
+            "_file_size": 74.489,
             "_docs": """These weights are ported from the original paper.""",
         },
     )
@@ -609,7 +609,7 @@ class EfficientNet_B5_Weights(WeightsEnum):
                 }
             },
             "_ops": 10.266,
-            "_weight_size": 116.864,
+            "_file_size": 116.864,
             "_docs": """These weights are ported from the original paper.""",
         },
     )
@@ -633,7 +633,7 @@ class EfficientNet_B6_Weights(WeightsEnum):
                 }
             },
             "_ops": 19.068,
-            "_weight_size": 165.362,
+            "_file_size": 165.362,
             "_docs": """These weights are ported from the original paper.""",
         },
     )
@@ -657,7 +657,7 @@ class EfficientNet_B7_Weights(WeightsEnum):
                 }
             },
             "_ops": 37.746,
-            "_weight_size": 254.675,
+            "_file_size": 254.675,
             "_docs": """These weights are ported from the original paper.""",
         },
     )
@@ -683,7 +683,7 @@ class EfficientNet_V2_S_Weights(WeightsEnum):
                 }
             },
             "_ops": 8.366,
-            "_weight_size": 82.704,
+            "_file_size": 82.704,
             "_docs": """
                 These weights improve upon the results of the original paper by using a modified version of TorchVision's
                 `new training recipe
@@ -713,7 +713,7 @@ class EfficientNet_V2_M_Weights(WeightsEnum):
                 }
             },
             "_ops": 24.582,
-            "_weight_size": 208.01,
+            "_file_size": 208.01,
             "_docs": """
                 These weights improve upon the results of the original paper by using a modified version of TorchVision's
                 `new training recipe
@@ -746,7 +746,7 @@ class EfficientNet_V2_L_Weights(WeightsEnum):
                 }
             },
             "_ops": 56.08,
-            "_weight_size": 454.573,
+            "_file_size": 454.573,
             "_docs": """These weights are ported from the original paper.""",
         },
     )

--- a/torchvision/models/googlenet.py
+++ b/torchvision/models/googlenet.py
@@ -291,7 +291,7 @@ class GoogLeNet_Weights(WeightsEnum):
                 }
             },
             "_ops": 1.498,
-            "_weight_size": 49.731,
+            "_file_size": 49.731,
             "_docs": """These weights are ported from the original paper.""",
         },
     )

--- a/torchvision/models/inception.py
+++ b/torchvision/models/inception.py
@@ -423,7 +423,7 @@ class Inception_V3_Weights(WeightsEnum):
                 }
             },
             "_ops": 5.713,
-            "_weight_size": 103.903,
+            "_file_size": 103.903,
             "_docs": """These weights are ported from the original paper.""",
         },
     )

--- a/torchvision/models/maxvit.py
+++ b/torchvision/models/maxvit.py
@@ -787,7 +787,7 @@ class MaxVit_T_Weights(WeightsEnum):
                 }
             },
             "_ops": 5.558,
-            "_weight_size": 118.769,
+            "_file_size": 118.769,
             "_docs": """These weights reproduce closely the results of the paper using a similar training recipe.""",
         },
     )

--- a/torchvision/models/mnasnet.py
+++ b/torchvision/models/mnasnet.py
@@ -232,7 +232,7 @@ class MNASNet0_5_Weights(WeightsEnum):
                 }
             },
             "_ops": 0.104,
-            "_weight_size": 8.591,
+            "_file_size": 8.591,
             "_docs": """These weights reproduce closely the results of the paper.""",
         },
     )
@@ -254,7 +254,7 @@ class MNASNet0_75_Weights(WeightsEnum):
                 }
             },
             "_ops": 0.215,
-            "_weight_size": 12.303,
+            "_file_size": 12.303,
             "_docs": """
                 These weights were trained from scratch by using TorchVision's `new training recipe
                 <https://pytorch.org/blog/how-to-train-state-of-the-art-models-using-torchvision-latest-primitives/>`_.
@@ -278,7 +278,7 @@ class MNASNet1_0_Weights(WeightsEnum):
                 }
             },
             "_ops": 0.314,
-            "_weight_size": 16.915,
+            "_file_size": 16.915,
             "_docs": """These weights reproduce closely the results of the paper.""",
         },
     )
@@ -300,7 +300,7 @@ class MNASNet1_3_Weights(WeightsEnum):
                 }
             },
             "_ops": 0.526,
-            "_weight_size": 24.246,
+            "_file_size": 24.246,
             "_docs": """
                 These weights were trained from scratch by using TorchVision's `new training recipe
                 <https://pytorch.org/blog/how-to-train-state-of-the-art-models-using-torchvision-latest-primitives/>`_.

--- a/torchvision/models/mobilenetv2.py
+++ b/torchvision/models/mobilenetv2.py
@@ -195,7 +195,7 @@ class MobileNet_V2_Weights(WeightsEnum):
                 }
             },
             "_ops": 0.301,
-            "_weight_size": 13.555,
+            "_file_size": 13.555,
             "_docs": """These weights reproduce closely the results of the paper using a simple training recipe.""",
         },
     )
@@ -212,7 +212,7 @@ class MobileNet_V2_Weights(WeightsEnum):
                 }
             },
             "_ops": 0.301,
-            "_weight_size": 13.598,
+            "_file_size": 13.598,
             "_docs": """
                 These weights improve upon the results of the original paper by using a modified version of TorchVision's
                 `new training recipe

--- a/torchvision/models/mobilenetv3.py
+++ b/torchvision/models/mobilenetv3.py
@@ -308,7 +308,7 @@ class MobileNet_V3_Large_Weights(WeightsEnum):
                 }
             },
             "_ops": 0.217,
-            "_weight_size": 21.114,
+            "_file_size": 21.114,
             "_docs": """These weights were trained from scratch by using a simple training recipe.""",
         },
     )
@@ -326,7 +326,7 @@ class MobileNet_V3_Large_Weights(WeightsEnum):
                 }
             },
             "_ops": 0.217,
-            "_weight_size": 21.107,
+            "_file_size": 21.107,
             "_docs": """
                 These weights improve marginally upon the results of the original paper by using a modified version of
                 TorchVision's `new training recipe
@@ -352,7 +352,7 @@ class MobileNet_V3_Small_Weights(WeightsEnum):
                 }
             },
             "_ops": 0.057,
-            "_weight_size": 9.829,
+            "_file_size": 9.829,
             "_docs": """
                 These weights improve upon the results of the original paper by using a simple training recipe.
             """,

--- a/torchvision/models/optical_flow/raft.py
+++ b/torchvision/models/optical_flow/raft.py
@@ -553,7 +553,7 @@ class Raft_Large_Weights(WeightsEnum):
                 "Kitti-Train": {"per_image_epe": 5.0172, "fl_all": 17.4506},
             },
             "_ops": 211.007,
-            "_weight_size": 20.129,
+            "_file_size": 20.129,
             "_docs": """These weights were ported from the original paper. They
             are trained on :class:`~torchvision.datasets.FlyingChairs` +
             :class:`~torchvision.datasets.FlyingThings3D`.""",
@@ -573,7 +573,7 @@ class Raft_Large_Weights(WeightsEnum):
                 "Kitti-Train": {"per_image_epe": 4.5118, "fl_all": 16.0679},
             },
             "_ops": 211.007,
-            "_weight_size": 20.129,
+            "_file_size": 20.129,
             "_docs": """These weights were trained from scratch on
             :class:`~torchvision.datasets.FlyingChairs` +
             :class:`~torchvision.datasets.FlyingThings3D`.""",
@@ -593,7 +593,7 @@ class Raft_Large_Weights(WeightsEnum):
                 "Sintel-Test-Finalpass": {"epe": 3.18},
             },
             "_ops": 211.007,
-            "_weight_size": 20.129,
+            "_file_size": 20.129,
             "_docs": """
                 These weights were ported from the original paper. They are
                 trained on :class:`~torchvision.datasets.FlyingChairs` +
@@ -619,7 +619,7 @@ class Raft_Large_Weights(WeightsEnum):
                 "Sintel-Test-Finalpass": {"epe": 3.067},
             },
             "_ops": 211.007,
-            "_weight_size": 20.129,
+            "_file_size": 20.129,
             "_docs": """
                 These weights were trained from scratch. They are
                 pre-trained on :class:`~torchvision.datasets.FlyingChairs` +
@@ -645,7 +645,7 @@ class Raft_Large_Weights(WeightsEnum):
                 "Kitti-Test": {"fl_all": 5.10},
             },
             "_ops": 211.007,
-            "_weight_size": 20.129,
+            "_file_size": 20.129,
             "_docs": """
                 These weights were ported from the original paper. They are
                 pre-trained on :class:`~torchvision.datasets.FlyingChairs` +
@@ -668,7 +668,7 @@ class Raft_Large_Weights(WeightsEnum):
                 "Kitti-Test": {"fl_all": 5.19},
             },
             "_ops": 211.007,
-            "_weight_size": 20.129,
+            "_file_size": 20.129,
             "_docs": """
                 These weights were trained from scratch. They are
                 pre-trained on :class:`~torchvision.datasets.FlyingChairs` +
@@ -711,7 +711,7 @@ class Raft_Small_Weights(WeightsEnum):
                 "Kitti-Train": {"per_image_epe": 7.6557, "fl_all": 25.2801},
             },
             "_ops": 47.655,
-            "_weight_size": 3.821,
+            "_file_size": 3.821,
             "_docs": """These weights were ported from the original paper. They
             are trained on :class:`~torchvision.datasets.FlyingChairs` +
             :class:`~torchvision.datasets.FlyingThings3D`.""",
@@ -730,7 +730,7 @@ class Raft_Small_Weights(WeightsEnum):
                 "Kitti-Train": {"per_image_epe": 7.5978, "fl_all": 25.2369},
             },
             "_ops": 47.655,
-            "_weight_size": 3.821,
+            "_file_size": 3.821,
             "_docs": """These weights were trained from scratch on
             :class:`~torchvision.datasets.FlyingChairs` +
             :class:`~torchvision.datasets.FlyingThings3D`.""",

--- a/torchvision/models/quantization/googlenet.py
+++ b/torchvision/models/quantization/googlenet.py
@@ -124,7 +124,7 @@ class GoogLeNet_QuantizedWeights(WeightsEnum):
                 }
             },
             "_ops": 1.498,
-            "_weight_size": 12.618,
+            "_file_size": 12.618,
             "_docs": """
                 These weights were produced by doing Post Training Quantization (eager mode) on top of the unquantized
                 weights listed below.

--- a/torchvision/models/quantization/inception.py
+++ b/torchvision/models/quantization/inception.py
@@ -184,7 +184,7 @@ class Inception_V3_QuantizedWeights(WeightsEnum):
                 }
             },
             "_ops": 5.713,
-            "_weight_size": 23.146,
+            "_file_size": 23.146,
             "_docs": """
                 These weights were produced by doing Post Training Quantization (eager mode) on top of the unquantized
                 weights listed below.

--- a/torchvision/models/quantization/mobilenetv2.py
+++ b/torchvision/models/quantization/mobilenetv2.py
@@ -81,7 +81,7 @@ class MobileNet_V2_QuantizedWeights(WeightsEnum):
                 }
             },
             "_ops": 0.301,
-            "_weight_size": 3.423,
+            "_file_size": 3.423,
             "_docs": """
                 These weights were produced by doing Quantization Aware Training (eager mode) on top of the unquantized
                 weights listed below.

--- a/torchvision/models/quantization/mobilenetv3.py
+++ b/torchvision/models/quantization/mobilenetv3.py
@@ -176,7 +176,7 @@ class MobileNet_V3_Large_QuantizedWeights(WeightsEnum):
                 }
             },
             "_ops": 0.217,
-            "_weight_size": 21.554,
+            "_file_size": 21.554,
             "_docs": """
                 These weights were produced by doing Quantization Aware Training (eager mode) on top of the unquantized
                 weights listed below.

--- a/torchvision/models/quantization/resnet.py
+++ b/torchvision/models/quantization/resnet.py
@@ -176,7 +176,7 @@ class ResNet18_QuantizedWeights(WeightsEnum):
                 }
             },
             "_ops": 1.814,
-            "_weight_size": 11.238,
+            "_file_size": 11.238,
         },
     )
     DEFAULT = IMAGENET1K_FBGEMM_V1
@@ -197,7 +197,7 @@ class ResNet50_QuantizedWeights(WeightsEnum):
                 }
             },
             "_ops": 4.089,
-            "_weight_size": 24.759,
+            "_file_size": 24.759,
         },
     )
     IMAGENET1K_FBGEMM_V2 = Weights(
@@ -214,7 +214,7 @@ class ResNet50_QuantizedWeights(WeightsEnum):
                 }
             },
             "_ops": 4.089,
-            "_weight_size": 24.953,
+            "_file_size": 24.953,
         },
     )
     DEFAULT = IMAGENET1K_FBGEMM_V2
@@ -235,7 +235,7 @@ class ResNeXt101_32X8D_QuantizedWeights(WeightsEnum):
                 }
             },
             "_ops": 16.414,
-            "_weight_size": 86.034,
+            "_file_size": 86.034,
         },
     )
     IMAGENET1K_FBGEMM_V2 = Weights(
@@ -252,7 +252,7 @@ class ResNeXt101_32X8D_QuantizedWeights(WeightsEnum):
                 }
             },
             "_ops": 16.414,
-            "_weight_size": 86.645,
+            "_file_size": 86.645,
         },
     )
     DEFAULT = IMAGENET1K_FBGEMM_V2
@@ -274,7 +274,7 @@ class ResNeXt101_64X4D_QuantizedWeights(WeightsEnum):
                 }
             },
             "_ops": 15.46,
-            "_weight_size": 81.556,
+            "_file_size": 81.556,
         },
     )
     DEFAULT = IMAGENET1K_FBGEMM_V1

--- a/torchvision/models/quantization/shufflenetv2.py
+++ b/torchvision/models/quantization/shufflenetv2.py
@@ -140,7 +140,7 @@ class ShuffleNet_V2_X0_5_QuantizedWeights(WeightsEnum):
                 }
             },
             "_ops": 0.04,
-            "_weight_size": 1.501,
+            "_file_size": 1.501,
         },
     )
     DEFAULT = IMAGENET1K_FBGEMM_V1
@@ -161,7 +161,7 @@ class ShuffleNet_V2_X1_0_QuantizedWeights(WeightsEnum):
                 }
             },
             "_ops": 0.145,
-            "_weight_size": 2.334,
+            "_file_size": 2.334,
         },
     )
     DEFAULT = IMAGENET1K_FBGEMM_V1
@@ -183,7 +183,7 @@ class ShuffleNet_V2_X1_5_QuantizedWeights(WeightsEnum):
                 }
             },
             "_ops": 0.296,
-            "_weight_size": 3.672,
+            "_file_size": 3.672,
         },
     )
     DEFAULT = IMAGENET1K_FBGEMM_V1
@@ -205,7 +205,7 @@ class ShuffleNet_V2_X2_0_QuantizedWeights(WeightsEnum):
                 }
             },
             "_ops": 0.583,
-            "_weight_size": 7.467,
+            "_file_size": 7.467,
         },
     )
     DEFAULT = IMAGENET1K_FBGEMM_V1

--- a/torchvision/models/regnet.py
+++ b/torchvision/models/regnet.py
@@ -429,7 +429,7 @@ class RegNet_Y_400MF_Weights(WeightsEnum):
                 }
             },
             "_ops": 0.402,
-            "_weight_size": 16.806,
+            "_file_size": 16.806,
             "_docs": """These weights reproduce closely the results of the paper using a simple training recipe.""",
         },
     )
@@ -447,7 +447,7 @@ class RegNet_Y_400MF_Weights(WeightsEnum):
                 }
             },
             "_ops": 0.402,
-            "_weight_size": 16.806,
+            "_file_size": 16.806,
             "_docs": """
                 These weights improve upon the results of the original paper by using a modified version of TorchVision's
                 `new training recipe
@@ -473,7 +473,7 @@ class RegNet_Y_800MF_Weights(WeightsEnum):
                 }
             },
             "_ops": 0.834,
-            "_weight_size": 24.774,
+            "_file_size": 24.774,
             "_docs": """These weights reproduce closely the results of the paper using a simple training recipe.""",
         },
     )
@@ -491,7 +491,7 @@ class RegNet_Y_800MF_Weights(WeightsEnum):
                 }
             },
             "_ops": 0.834,
-            "_weight_size": 24.774,
+            "_file_size": 24.774,
             "_docs": """
                 These weights improve upon the results of the original paper by using a modified version of TorchVision's
                 `new training recipe
@@ -517,7 +517,7 @@ class RegNet_Y_1_6GF_Weights(WeightsEnum):
                 }
             },
             "_ops": 1.612,
-            "_weight_size": 43.152,
+            "_file_size": 43.152,
             "_docs": """These weights reproduce closely the results of the paper using a simple training recipe.""",
         },
     )
@@ -535,7 +535,7 @@ class RegNet_Y_1_6GF_Weights(WeightsEnum):
                 }
             },
             "_ops": 1.612,
-            "_weight_size": 43.152,
+            "_file_size": 43.152,
             "_docs": """
                 These weights improve upon the results of the original paper by using a modified version of TorchVision's
                 `new training recipe
@@ -561,7 +561,7 @@ class RegNet_Y_3_2GF_Weights(WeightsEnum):
                 }
             },
             "_ops": 3.176,
-            "_weight_size": 74.567,
+            "_file_size": 74.567,
             "_docs": """These weights reproduce closely the results of the paper using a simple training recipe.""",
         },
     )
@@ -579,7 +579,7 @@ class RegNet_Y_3_2GF_Weights(WeightsEnum):
                 }
             },
             "_ops": 3.176,
-            "_weight_size": 74.567,
+            "_file_size": 74.567,
             "_docs": """
                 These weights improve upon the results of the original paper by using a modified version of TorchVision's
                 `new training recipe
@@ -605,7 +605,7 @@ class RegNet_Y_8GF_Weights(WeightsEnum):
                 }
             },
             "_ops": 8.473,
-            "_weight_size": 150.701,
+            "_file_size": 150.701,
             "_docs": """These weights reproduce closely the results of the paper using a simple training recipe.""",
         },
     )
@@ -623,7 +623,7 @@ class RegNet_Y_8GF_Weights(WeightsEnum):
                 }
             },
             "_ops": 8.473,
-            "_weight_size": 150.701,
+            "_file_size": 150.701,
             "_docs": """
                 These weights improve upon the results of the original paper by using a modified version of TorchVision's
                 `new training recipe
@@ -649,7 +649,7 @@ class RegNet_Y_16GF_Weights(WeightsEnum):
                 }
             },
             "_ops": 15.912,
-            "_weight_size": 319.49,
+            "_file_size": 319.49,
             "_docs": """These weights reproduce closely the results of the paper using a simple training recipe.""",
         },
     )
@@ -667,7 +667,7 @@ class RegNet_Y_16GF_Weights(WeightsEnum):
                 }
             },
             "_ops": 15.912,
-            "_weight_size": 319.49,
+            "_file_size": 319.49,
             "_docs": """
                 These weights improve upon the results of the original paper by using a modified version of TorchVision's
                 `new training recipe
@@ -690,7 +690,7 @@ class RegNet_Y_16GF_Weights(WeightsEnum):
                 }
             },
             "_ops": 46.735,
-            "_weight_size": 319.49,
+            "_file_size": 319.49,
             "_docs": """
                 These weights are learnt via transfer learning by end-to-end fine-tuning the original
                 `SWAG <https://arxiv.org/abs/2201.08371>`_ weights on ImageNet-1K data.
@@ -713,7 +713,7 @@ class RegNet_Y_16GF_Weights(WeightsEnum):
                 }
             },
             "_ops": 15.912,
-            "_weight_size": 319.49,
+            "_file_size": 319.49,
             "_docs": """
                 These weights are composed of the original frozen `SWAG <https://arxiv.org/abs/2201.08371>`_ trunk
                 weights and a linear classifier learnt on top of them trained on ImageNet-1K data.
@@ -738,7 +738,7 @@ class RegNet_Y_32GF_Weights(WeightsEnum):
                 }
             },
             "_ops": 32.28,
-            "_weight_size": 554.076,
+            "_file_size": 554.076,
             "_docs": """These weights reproduce closely the results of the paper using a simple training recipe.""",
         },
     )
@@ -756,7 +756,7 @@ class RegNet_Y_32GF_Weights(WeightsEnum):
                 }
             },
             "_ops": 32.28,
-            "_weight_size": 554.076,
+            "_file_size": 554.076,
             "_docs": """
                 These weights improve upon the results of the original paper by using a modified version of TorchVision's
                 `new training recipe
@@ -779,7 +779,7 @@ class RegNet_Y_32GF_Weights(WeightsEnum):
                 }
             },
             "_ops": 94.826,
-            "_weight_size": 554.076,
+            "_file_size": 554.076,
             "_docs": """
                 These weights are learnt via transfer learning by end-to-end fine-tuning the original
                 `SWAG <https://arxiv.org/abs/2201.08371>`_ weights on ImageNet-1K data.
@@ -802,7 +802,7 @@ class RegNet_Y_32GF_Weights(WeightsEnum):
                 }
             },
             "_ops": 32.28,
-            "_weight_size": 554.076,
+            "_file_size": 554.076,
             "_docs": """
                 These weights are composed of the original frozen `SWAG <https://arxiv.org/abs/2201.08371>`_ trunk
                 weights and a linear classifier learnt on top of them trained on ImageNet-1K data.
@@ -828,7 +828,7 @@ class RegNet_Y_128GF_Weights(WeightsEnum):
                 }
             },
             "_ops": 374.57,
-            "_weight_size": 2461.564,
+            "_file_size": 2461.564,
             "_docs": """
                 These weights are learnt via transfer learning by end-to-end fine-tuning the original
                 `SWAG <https://arxiv.org/abs/2201.08371>`_ weights on ImageNet-1K data.
@@ -851,7 +851,7 @@ class RegNet_Y_128GF_Weights(WeightsEnum):
                 }
             },
             "_ops": 127.518,
-            "_weight_size": 2461.564,
+            "_file_size": 2461.564,
             "_docs": """
                 These weights are composed of the original frozen `SWAG <https://arxiv.org/abs/2201.08371>`_ trunk
                 weights and a linear classifier learnt on top of them trained on ImageNet-1K data.
@@ -876,7 +876,7 @@ class RegNet_X_400MF_Weights(WeightsEnum):
                 }
             },
             "_ops": 0.414,
-            "_weight_size": 21.258,
+            "_file_size": 21.258,
             "_docs": """These weights reproduce closely the results of the paper using a simple training recipe.""",
         },
     )
@@ -894,7 +894,7 @@ class RegNet_X_400MF_Weights(WeightsEnum):
                 }
             },
             "_ops": 0.414,
-            "_weight_size": 21.257,
+            "_file_size": 21.257,
             "_docs": """
                 These weights improve upon the results of the original paper by using a modified version of TorchVision's
                 `new training recipe
@@ -920,7 +920,7 @@ class RegNet_X_800MF_Weights(WeightsEnum):
                 }
             },
             "_ops": 0.8,
-            "_weight_size": 27.945,
+            "_file_size": 27.945,
             "_docs": """These weights reproduce closely the results of the paper using a simple training recipe.""",
         },
     )
@@ -938,7 +938,7 @@ class RegNet_X_800MF_Weights(WeightsEnum):
                 }
             },
             "_ops": 0.8,
-            "_weight_size": 27.945,
+            "_file_size": 27.945,
             "_docs": """
                 These weights improve upon the results of the original paper by using a modified version of TorchVision's
                 `new training recipe
@@ -964,7 +964,7 @@ class RegNet_X_1_6GF_Weights(WeightsEnum):
                 }
             },
             "_ops": 1.603,
-            "_weight_size": 35.339,
+            "_file_size": 35.339,
             "_docs": """These weights reproduce closely the results of the paper using a simple training recipe.""",
         },
     )
@@ -982,7 +982,7 @@ class RegNet_X_1_6GF_Weights(WeightsEnum):
                 }
             },
             "_ops": 1.603,
-            "_weight_size": 35.339,
+            "_file_size": 35.339,
             "_docs": """
                 These weights improve upon the results of the original paper by using a modified version of TorchVision's
                 `new training recipe
@@ -1008,7 +1008,7 @@ class RegNet_X_3_2GF_Weights(WeightsEnum):
                 }
             },
             "_ops": 3.177,
-            "_weight_size": 58.756,
+            "_file_size": 58.756,
             "_docs": """These weights reproduce closely the results of the paper using a simple training recipe.""",
         },
     )
@@ -1026,7 +1026,7 @@ class RegNet_X_3_2GF_Weights(WeightsEnum):
                 }
             },
             "_ops": 3.177,
-            "_weight_size": 58.756,
+            "_file_size": 58.756,
             "_docs": """
                 These weights improve upon the results of the original paper by using a modified version of TorchVision's
                 `new training recipe
@@ -1052,7 +1052,7 @@ class RegNet_X_8GF_Weights(WeightsEnum):
                 }
             },
             "_ops": 7.995,
-            "_weight_size": 151.456,
+            "_file_size": 151.456,
             "_docs": """These weights reproduce closely the results of the paper using a simple training recipe.""",
         },
     )
@@ -1070,7 +1070,7 @@ class RegNet_X_8GF_Weights(WeightsEnum):
                 }
             },
             "_ops": 7.995,
-            "_weight_size": 151.456,
+            "_file_size": 151.456,
             "_docs": """
                 These weights improve upon the results of the original paper by using a modified version of TorchVision's
                 `new training recipe
@@ -1096,7 +1096,7 @@ class RegNet_X_16GF_Weights(WeightsEnum):
                 }
             },
             "_ops": 15.941,
-            "_weight_size": 207.627,
+            "_file_size": 207.627,
             "_docs": """These weights reproduce closely the results of the paper using a simple training recipe.""",
         },
     )
@@ -1114,7 +1114,7 @@ class RegNet_X_16GF_Weights(WeightsEnum):
                 }
             },
             "_ops": 15.941,
-            "_weight_size": 207.627,
+            "_file_size": 207.627,
             "_docs": """
                 These weights improve upon the results of the original paper by using a modified version of TorchVision's
                 `new training recipe
@@ -1140,7 +1140,7 @@ class RegNet_X_32GF_Weights(WeightsEnum):
                 }
             },
             "_ops": 31.736,
-            "_weight_size": 412.039,
+            "_file_size": 412.039,
             "_docs": """These weights reproduce closely the results of the paper using a simple training recipe.""",
         },
     )
@@ -1158,7 +1158,7 @@ class RegNet_X_32GF_Weights(WeightsEnum):
                 }
             },
             "_ops": 31.736,
-            "_weight_size": 412.039,
+            "_file_size": 412.039,
             "_docs": """
                 These weights improve upon the results of the original paper by using a modified version of TorchVision's
                 `new training recipe

--- a/torchvision/models/resnet.py
+++ b/torchvision/models/resnet.py
@@ -324,7 +324,7 @@ class ResNet18_Weights(WeightsEnum):
                 }
             },
             "_ops": 1.814,
-            "_weight_size": 44.661,
+            "_file_size": 44.661,
             "_docs": """These weights reproduce closely the results of the paper using a simple training recipe.""",
         },
     )
@@ -346,7 +346,7 @@ class ResNet34_Weights(WeightsEnum):
                 }
             },
             "_ops": 3.664,
-            "_weight_size": 83.275,
+            "_file_size": 83.275,
             "_docs": """These weights reproduce closely the results of the paper using a simple training recipe.""",
         },
     )
@@ -368,7 +368,7 @@ class ResNet50_Weights(WeightsEnum):
                 }
             },
             "_ops": 4.089,
-            "_weight_size": 97.781,
+            "_file_size": 97.781,
             "_docs": """These weights reproduce closely the results of the paper using a simple training recipe.""",
         },
     )
@@ -386,7 +386,7 @@ class ResNet50_Weights(WeightsEnum):
                 }
             },
             "_ops": 4.089,
-            "_weight_size": 97.79,
+            "_file_size": 97.79,
             "_docs": """
                 These weights improve upon the results of the original paper by using TorchVision's `new training recipe
                 <https://pytorch.org/blog/how-to-train-state-of-the-art-models-using-torchvision-latest-primitives/>`_.
@@ -411,7 +411,7 @@ class ResNet101_Weights(WeightsEnum):
                 }
             },
             "_ops": 7.801,
-            "_weight_size": 170.511,
+            "_file_size": 170.511,
             "_docs": """These weights reproduce closely the results of the paper using a simple training recipe.""",
         },
     )
@@ -429,7 +429,7 @@ class ResNet101_Weights(WeightsEnum):
                 }
             },
             "_ops": 7.801,
-            "_weight_size": 170.53,
+            "_file_size": 170.53,
             "_docs": """
                 These weights improve upon the results of the original paper by using TorchVision's `new training recipe
                 <https://pytorch.org/blog/how-to-train-state-of-the-art-models-using-torchvision-latest-primitives/>`_.
@@ -454,7 +454,7 @@ class ResNet152_Weights(WeightsEnum):
                 }
             },
             "_ops": 11.514,
-            "_weight_size": 230.434,
+            "_file_size": 230.434,
             "_docs": """These weights reproduce closely the results of the paper using a simple training recipe.""",
         },
     )
@@ -472,7 +472,7 @@ class ResNet152_Weights(WeightsEnum):
                 }
             },
             "_ops": 11.514,
-            "_weight_size": 230.474,
+            "_file_size": 230.474,
             "_docs": """
                 These weights improve upon the results of the original paper by using TorchVision's `new training recipe
                 <https://pytorch.org/blog/how-to-train-state-of-the-art-models-using-torchvision-latest-primitives/>`_.
@@ -497,7 +497,7 @@ class ResNeXt50_32X4D_Weights(WeightsEnum):
                 }
             },
             "_ops": 4.23,
-            "_weight_size": 95.789,
+            "_file_size": 95.789,
             "_docs": """These weights reproduce closely the results of the paper using a simple training recipe.""",
         },
     )
@@ -515,7 +515,7 @@ class ResNeXt50_32X4D_Weights(WeightsEnum):
                 }
             },
             "_ops": 4.23,
-            "_weight_size": 95.833,
+            "_file_size": 95.833,
             "_docs": """
                 These weights improve upon the results of the original paper by using TorchVision's `new training recipe
                 <https://pytorch.org/blog/how-to-train-state-of-the-art-models-using-torchvision-latest-primitives/>`_.
@@ -540,7 +540,7 @@ class ResNeXt101_32X8D_Weights(WeightsEnum):
                 }
             },
             "_ops": 16.414,
-            "_weight_size": 339.586,
+            "_file_size": 339.586,
             "_docs": """These weights reproduce closely the results of the paper using a simple training recipe.""",
         },
     )
@@ -558,7 +558,7 @@ class ResNeXt101_32X8D_Weights(WeightsEnum):
                 }
             },
             "_ops": 16.414,
-            "_weight_size": 339.673,
+            "_file_size": 339.673,
             "_docs": """
                 These weights improve upon the results of the original paper by using TorchVision's `new training recipe
                 <https://pytorch.org/blog/how-to-train-state-of-the-art-models-using-torchvision-latest-primitives/>`_.
@@ -583,7 +583,7 @@ class ResNeXt101_64X4D_Weights(WeightsEnum):
                 }
             },
             "_ops": 15.46,
-            "_weight_size": 319.318,
+            "_file_size": 319.318,
             "_docs": """
                 These weights were trained from scratch by using TorchVision's `new training recipe
                 <https://pytorch.org/blog/how-to-train-state-of-the-art-models-using-torchvision-latest-primitives/>`_.
@@ -608,7 +608,7 @@ class Wide_ResNet50_2_Weights(WeightsEnum):
                 }
             },
             "_ops": 11.398,
-            "_weight_size": 131.82,
+            "_file_size": 131.82,
             "_docs": """These weights reproduce closely the results of the paper using a simple training recipe.""",
         },
     )
@@ -626,7 +626,7 @@ class Wide_ResNet50_2_Weights(WeightsEnum):
                 }
             },
             "_ops": 11.398,
-            "_weight_size": 263.124,
+            "_file_size": 263.124,
             "_docs": """
                 These weights improve upon the results of the original paper by using TorchVision's `new training recipe
                 <https://pytorch.org/blog/how-to-train-state-of-the-art-models-using-torchvision-latest-primitives/>`_.
@@ -651,7 +651,7 @@ class Wide_ResNet101_2_Weights(WeightsEnum):
                 }
             },
             "_ops": 22.753,
-            "_weight_size": 242.896,
+            "_file_size": 242.896,
             "_docs": """These weights reproduce closely the results of the paper using a simple training recipe.""",
         },
     )
@@ -669,7 +669,7 @@ class Wide_ResNet101_2_Weights(WeightsEnum):
                 }
             },
             "_ops": 22.753,
-            "_weight_size": 484.747,
+            "_file_size": 484.747,
             "_docs": """
                 These weights improve upon the results of the original paper by using TorchVision's `new training recipe
                 <https://pytorch.org/blog/how-to-train-state-of-the-art-models-using-torchvision-latest-primitives/>`_.

--- a/torchvision/models/segmentation/deeplabv3.py
+++ b/torchvision/models/segmentation/deeplabv3.py
@@ -153,7 +153,7 @@ class DeepLabV3_ResNet50_Weights(WeightsEnum):
                 }
             },
             "_ops": 178.722,
-            "_weight_size": 160.515,
+            "_file_size": 160.515,
         },
     )
     DEFAULT = COCO_WITH_VOC_LABELS_V1
@@ -174,7 +174,7 @@ class DeepLabV3_ResNet101_Weights(WeightsEnum):
                 }
             },
             "_ops": 258.743,
-            "_weight_size": 233.217,
+            "_file_size": 233.217,
         },
     )
     DEFAULT = COCO_WITH_VOC_LABELS_V1
@@ -195,7 +195,7 @@ class DeepLabV3_MobileNet_V3_Large_Weights(WeightsEnum):
                 }
             },
             "_ops": 10.452,
-            "_weight_size": 42.301,
+            "_file_size": 42.301,
         },
     )
     DEFAULT = COCO_WITH_VOC_LABELS_V1

--- a/torchvision/models/segmentation/fcn.py
+++ b/torchvision/models/segmentation/fcn.py
@@ -72,7 +72,7 @@ class FCN_ResNet50_Weights(WeightsEnum):
                 }
             },
             "_ops": 152.717,
-            "_weight_size": 135.009,
+            "_file_size": 135.009,
         },
     )
     DEFAULT = COCO_WITH_VOC_LABELS_V1
@@ -93,7 +93,7 @@ class FCN_ResNet101_Weights(WeightsEnum):
                 }
             },
             "_ops": 232.738,
-            "_weight_size": 207.711,
+            "_file_size": 207.711,
         },
     )
     DEFAULT = COCO_WITH_VOC_LABELS_V1

--- a/torchvision/models/segmentation/lraspp.py
+++ b/torchvision/models/segmentation/lraspp.py
@@ -109,7 +109,7 @@ class LRASPP_MobileNet_V3_Large_Weights(WeightsEnum):
                 }
             },
             "_ops": 2.086,
-            "_weight_size": 12.49,
+            "_file_size": 12.49,
             "_docs": """
                 These weights were trained on a subset of COCO, using only the 20 categories that are present in the
                 Pascal VOC dataset.

--- a/torchvision/models/shufflenetv2.py
+++ b/torchvision/models/shufflenetv2.py
@@ -205,7 +205,7 @@ class ShuffleNet_V2_X0_5_Weights(WeightsEnum):
                 }
             },
             "_ops": 0.04,
-            "_weight_size": 5.282,
+            "_file_size": 5.282,
             "_docs": """These weights were trained from scratch to reproduce closely the results of the paper.""",
         },
     )
@@ -227,7 +227,7 @@ class ShuffleNet_V2_X1_0_Weights(WeightsEnum):
                 }
             },
             "_ops": 0.145,
-            "_weight_size": 8.791,
+            "_file_size": 8.791,
             "_docs": """These weights were trained from scratch to reproduce closely the results of the paper.""",
         },
     )
@@ -249,7 +249,7 @@ class ShuffleNet_V2_X1_5_Weights(WeightsEnum):
                 }
             },
             "_ops": 0.296,
-            "_weight_size": 13.557,
+            "_file_size": 13.557,
             "_docs": """
                 These weights were trained from scratch by using TorchVision's `new training recipe
                 <https://pytorch.org/blog/how-to-train-state-of-the-art-models-using-torchvision-latest-primitives/>`_.
@@ -274,7 +274,7 @@ class ShuffleNet_V2_X2_0_Weights(WeightsEnum):
                 }
             },
             "_ops": 0.583,
-            "_weight_size": 28.433,
+            "_file_size": 28.433,
             "_docs": """
                 These weights were trained from scratch by using TorchVision's `new training recipe
                 <https://pytorch.org/blog/how-to-train-state-of-the-art-models-using-torchvision-latest-primitives/>`_.

--- a/torchvision/models/squeezenet.py
+++ b/torchvision/models/squeezenet.py
@@ -136,7 +136,7 @@ class SqueezeNet1_0_Weights(WeightsEnum):
                 }
             },
             "_ops": 0.819,
-            "_weight_size": 4.778,
+            "_file_size": 4.778,
         },
     )
     DEFAULT = IMAGENET1K_V1
@@ -157,7 +157,7 @@ class SqueezeNet1_1_Weights(WeightsEnum):
                 }
             },
             "_ops": 0.349,
-            "_weight_size": 4.729,
+            "_file_size": 4.729,
         },
     )
     DEFAULT = IMAGENET1K_V1

--- a/torchvision/models/swin_transformer.py
+++ b/torchvision/models/swin_transformer.py
@@ -663,7 +663,7 @@ class Swin_T_Weights(WeightsEnum):
                 }
             },
             "_ops": 4.491,
-            "_weight_size": 108.19,
+            "_file_size": 108.19,
             "_docs": """These weights reproduce closely the results of the paper using a similar training recipe.""",
         },
     )
@@ -688,7 +688,7 @@ class Swin_S_Weights(WeightsEnum):
                 }
             },
             "_ops": 8.741,
-            "_weight_size": 189.786,
+            "_file_size": 189.786,
             "_docs": """These weights reproduce closely the results of the paper using a similar training recipe.""",
         },
     )
@@ -713,7 +713,7 @@ class Swin_B_Weights(WeightsEnum):
                 }
             },
             "_ops": 15.431,
-            "_weight_size": 335.364,
+            "_file_size": 335.364,
             "_docs": """These weights reproduce closely the results of the paper using a similar training recipe.""",
         },
     )
@@ -738,7 +738,7 @@ class Swin_V2_T_Weights(WeightsEnum):
                 }
             },
             "_ops": 5.94,
-            "_weight_size": 108.626,
+            "_file_size": 108.626,
             "_docs": """These weights reproduce closely the results of the paper using a similar training recipe.""",
         },
     )
@@ -763,7 +763,7 @@ class Swin_V2_S_Weights(WeightsEnum):
                 }
             },
             "_ops": 11.546,
-            "_weight_size": 190.675,
+            "_file_size": 190.675,
             "_docs": """These weights reproduce closely the results of the paper using a similar training recipe.""",
         },
     )
@@ -788,7 +788,7 @@ class Swin_V2_B_Weights(WeightsEnum):
                 }
             },
             "_ops": 20.325,
-            "_weight_size": 336.372,
+            "_file_size": 336.372,
             "_docs": """These weights reproduce closely the results of the paper using a similar training recipe.""",
         },
     )

--- a/torchvision/models/vgg.py
+++ b/torchvision/models/vgg.py
@@ -128,7 +128,7 @@ class VGG11_Weights(WeightsEnum):
                 }
             },
             "_ops": 7.609,
-            "_weight_size": 506.84,
+            "_file_size": 506.84,
         },
     )
     DEFAULT = IMAGENET1K_V1
@@ -148,7 +148,7 @@ class VGG11_BN_Weights(WeightsEnum):
                 }
             },
             "_ops": 7.609,
-            "_weight_size": 506.881,
+            "_file_size": 506.881,
         },
     )
     DEFAULT = IMAGENET1K_V1
@@ -168,7 +168,7 @@ class VGG13_Weights(WeightsEnum):
                 }
             },
             "_ops": 11.308,
-            "_weight_size": 507.545,
+            "_file_size": 507.545,
         },
     )
     DEFAULT = IMAGENET1K_V1
@@ -188,7 +188,7 @@ class VGG13_BN_Weights(WeightsEnum):
                 }
             },
             "_ops": 11.308,
-            "_weight_size": 507.59,
+            "_file_size": 507.59,
         },
     )
     DEFAULT = IMAGENET1K_V1
@@ -208,7 +208,7 @@ class VGG16_Weights(WeightsEnum):
                 }
             },
             "_ops": 15.47,
-            "_weight_size": 527.796,
+            "_file_size": 527.796,
         },
     )
     IMAGENET1K_FEATURES = Weights(
@@ -232,7 +232,7 @@ class VGG16_Weights(WeightsEnum):
                 }
             },
             "_ops": 15.47,
-            "_weight_size": 527.802,
+            "_file_size": 527.802,
             "_docs": """
                 These weights can't be used for classification because they are missing values in the `classifier`
                 module. Only the `features` module has valid values and can be used for feature extraction. The weights
@@ -257,7 +257,7 @@ class VGG16_BN_Weights(WeightsEnum):
                 }
             },
             "_ops": 15.47,
-            "_weight_size": 527.866,
+            "_file_size": 527.866,
         },
     )
     DEFAULT = IMAGENET1K_V1
@@ -277,7 +277,7 @@ class VGG19_Weights(WeightsEnum):
                 }
             },
             "_ops": 19.632,
-            "_weight_size": 548.051,
+            "_file_size": 548.051,
         },
     )
     DEFAULT = IMAGENET1K_V1
@@ -297,7 +297,7 @@ class VGG19_BN_Weights(WeightsEnum):
                 }
             },
             "_ops": 19.632,
-            "_weight_size": 548.143,
+            "_file_size": 548.143,
         },
     )
     DEFAULT = IMAGENET1K_V1

--- a/torchvision/models/video/mvit.py
+++ b/torchvision/models/video/mvit.py
@@ -625,7 +625,7 @@ class MViT_V1_B_Weights(WeightsEnum):
                 }
             },
             "_ops": 70.599,
-            "_weight_size": 139.764,
+            "_file_size": 139.764,
         },
     )
     DEFAULT = KINETICS400_V1
@@ -658,7 +658,7 @@ class MViT_V2_S_Weights(WeightsEnum):
                 }
             },
             "_ops": 64.224,
-            "_weight_size": 131.884,
+            "_file_size": 131.884,
         },
     )
     DEFAULT = KINETICS400_V1

--- a/torchvision/models/video/resnet.py
+++ b/torchvision/models/video/resnet.py
@@ -333,7 +333,7 @@ class R3D_18_Weights(WeightsEnum):
                 }
             },
             "_ops": 40.697,
-            "_weight_size": 127.359,
+            "_file_size": 127.359,
         },
     )
     DEFAULT = KINETICS400_V1
@@ -353,7 +353,7 @@ class MC3_18_Weights(WeightsEnum):
                 }
             },
             "_ops": 43.343,
-            "_weight_size": 44.672,
+            "_file_size": 44.672,
         },
     )
     DEFAULT = KINETICS400_V1
@@ -373,7 +373,7 @@ class R2Plus1D_18_Weights(WeightsEnum):
                 }
             },
             "_ops": 40.519,
-            "_weight_size": 120.318,
+            "_file_size": 120.318,
         },
     )
     DEFAULT = KINETICS400_V1

--- a/torchvision/models/video/s3d.py
+++ b/torchvision/models/video/s3d.py
@@ -176,7 +176,7 @@ class S3D_Weights(WeightsEnum):
                 }
             },
             "_ops": 17.979,
-            "_weight_size": 31.972,
+            "_file_size": 31.972,
         },
     )
     DEFAULT = KINETICS400_V1

--- a/torchvision/models/video/swin_transformer.py
+++ b/torchvision/models/video/swin_transformer.py
@@ -531,7 +531,7 @@ class Swin3D_T_Weights(WeightsEnum):
                 }
             },
             "_ops": 43.882,
-            "_weight_size": 121.543,
+            "_file_size": 121.543,
         },
     )
     DEFAULT = KINETICS400_V1
@@ -562,7 +562,7 @@ class Swin3D_S_Weights(WeightsEnum):
                 }
             },
             "_ops": 82.841,
-            "_weight_size": 218.288,
+            "_file_size": 218.288,
         },
     )
     DEFAULT = KINETICS400_V1
@@ -593,7 +593,7 @@ class Swin3D_B_Weights(WeightsEnum):
                 }
             },
             "_ops": 140.667,
-            "_weight_size": 364.134,
+            "_file_size": 364.134,
         },
     )
     KINETICS400_IMAGENET22K_V1 = Weights(
@@ -620,7 +620,7 @@ class Swin3D_B_Weights(WeightsEnum):
                 }
             },
             "_ops": 140.667,
-            "_weight_size": 364.134,
+            "_file_size": 364.134,
         },
     )
     DEFAULT = KINETICS400_V1

--- a/torchvision/models/vision_transformer.py
+++ b/torchvision/models/vision_transformer.py
@@ -364,7 +364,7 @@ class ViT_B_16_Weights(WeightsEnum):
                 }
             },
             "_ops": 17.564,
-            "_weight_size": 330.285,
+            "_file_size": 330.285,
             "_docs": """
                 These weights were trained from scratch by using a modified version of `DeIT
                 <https://arxiv.org/abs/2012.12877>`_'s training recipe.
@@ -390,7 +390,7 @@ class ViT_B_16_Weights(WeightsEnum):
                 }
             },
             "_ops": 55.484,
-            "_weight_size": 331.398,
+            "_file_size": 331.398,
             "_docs": """
                 These weights are learnt via transfer learning by end-to-end fine-tuning the original
                 `SWAG <https://arxiv.org/abs/2201.08371>`_ weights on ImageNet-1K data.
@@ -417,7 +417,7 @@ class ViT_B_16_Weights(WeightsEnum):
                 }
             },
             "_ops": 17.564,
-            "_weight_size": 330.285,
+            "_file_size": 330.285,
             "_docs": """
                 These weights are composed of the original frozen `SWAG <https://arxiv.org/abs/2201.08371>`_ trunk
                 weights and a linear classifier learnt on top of them trained on ImageNet-1K data.
@@ -443,7 +443,7 @@ class ViT_B_32_Weights(WeightsEnum):
                 }
             },
             "_ops": 4.409,
-            "_weight_size": 336.604,
+            "_file_size": 336.604,
             "_docs": """
                 These weights were trained from scratch by using a modified version of `DeIT
                 <https://arxiv.org/abs/2012.12877>`_'s training recipe.
@@ -469,7 +469,7 @@ class ViT_L_16_Weights(WeightsEnum):
                 }
             },
             "_ops": 61.555,
-            "_weight_size": 1161.023,
+            "_file_size": 1161.023,
             "_docs": """
                 These weights were trained from scratch by using a modified version of TorchVision's
                 `new training recipe
@@ -496,7 +496,7 @@ class ViT_L_16_Weights(WeightsEnum):
                 }
             },
             "_ops": 361.986,
-            "_weight_size": 1164.258,
+            "_file_size": 1164.258,
             "_docs": """
                 These weights are learnt via transfer learning by end-to-end fine-tuning the original
                 `SWAG <https://arxiv.org/abs/2201.08371>`_ weights on ImageNet-1K data.
@@ -523,7 +523,7 @@ class ViT_L_16_Weights(WeightsEnum):
                 }
             },
             "_ops": 61.555,
-            "_weight_size": 1161.023,
+            "_file_size": 1161.023,
             "_docs": """
                 These weights are composed of the original frozen `SWAG <https://arxiv.org/abs/2201.08371>`_ trunk
                 weights and a linear classifier learnt on top of them trained on ImageNet-1K data.
@@ -549,7 +549,7 @@ class ViT_L_32_Weights(WeightsEnum):
                 }
             },
             "_ops": 15.378,
-            "_weight_size": 1169.449,
+            "_file_size": 1169.449,
             "_docs": """
                 These weights were trained from scratch by using a modified version of `DeIT
                 <https://arxiv.org/abs/2012.12877>`_'s training recipe.
@@ -579,7 +579,7 @@ class ViT_H_14_Weights(WeightsEnum):
                 }
             },
             "_ops": 1016.717,
-            "_weight_size": 2416.643,
+            "_file_size": 2416.643,
             "_docs": """
                 These weights are learnt via transfer learning by end-to-end fine-tuning the original
                 `SWAG <https://arxiv.org/abs/2201.08371>`_ weights on ImageNet-1K data.
@@ -606,7 +606,7 @@ class ViT_H_14_Weights(WeightsEnum):
                 }
             },
             "_ops": 167.295,
-            "_weight_size": 2411.209,
+            "_file_size": 2411.209,
             "_docs": """
                 These weights are composed of the original frozen `SWAG <https://arxiv.org/abs/2201.08371>`_ trunk
                 weights and a linear classifier learnt on top of them trained on ImageNet-1K data.


### PR DESCRIPTION
This PR addresses my own comments from https://github.com/pytorch/vision/pull/6936#issuecomment-1313387747

Diff looks big but it's only a few lines in `conf.py` - the rest is just pure `s/x/y`

Before:

![image](https://user-images.githubusercontent.com/1190450/211538588-a493707a-1d16-4537-b68b-a42c774e1e75.png)



After:

![image](https://user-images.githubusercontent.com/1190450/211541146-890b9741-5100-467c-888b-7ddcf32039c0.png)



Also renames the `_weight_size` key  into `_file_size` to avoid confusion with the actual size occupied in RAM by the weights, which is also something we want to document: https://github.com/pytorch/vision/issues/5982. For the same reason I removed the file size info from the main tables, because it may be more relevant to document the weight size there instead of the file size (and there is only so much column space available).