### PR TITLE
Fix license file deprecation warning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 universal=1
 
 [metadata]
-license_file = LICENSE
+license_files = LICENSE
 
 [pep8]
 max-line-length = 120


### PR DESCRIPTION
So after a long time I was again setting my system for torchvision. I got this warning.

![image](https://user-images.githubusercontent.com/47158509/211886131-457bfcf5-1322-4d27-a023-4296a34a2a15.png)


This should probably fix it. 