### PR TITLE
reinstate Places365 download tests

### DIFF
--- a/test/test_datasets_download.py
+++ b/test/test_datasets_download.py
@@ -467,6 +467,7 @@ def make_parametrize_kwargs(download_configs):
             widerface(),
             kinetics(),
             kitti(),
+            places365(),
         )
     )
 )
@@ -481,7 +482,6 @@ def test_url_is_accessible(url, md5):
 @pytest.mark.parametrize(
     **make_parametrize_kwargs(
         itertools.chain(
-            places365(),  # https://github.com/pytorch/vision/issues/6268
             sbu(),  # https://github.com/pytorch/vision/issues/7005
         )
     )


### PR DESCRIPTION
[Website](http://places2.csail.mit.edu/) is up again and maintenance note is gone. Download links also work again so we can reinstate the download tests that we deactivated in #6389. Closes #6268.

cc @seemethere