### PR TITLE
Add copymode calls in relocate script

### DIFF
--- a/packaging/wheel/relocate.py
+++ b/packaging/wheel/relocate.py
@@ -201,6 +201,7 @@ def relocate_elf_library(patchelf, output_dir, output_library, binary):
             new_library_path = patch_new_path(library_path, new_libraries_path)
             print(f"{library} -> {new_library_path}")
             shutil.copyfile(library_path, new_library_path)
+            shutil.copymode(library_path, new_library_path)
             new_names[library] = new_library_path
 
     print("Updating dependency names by new files")
@@ -284,6 +285,7 @@ def relocate_dll_library(dumpbin, output_dir, output_library, binary):
             new_library_path = osp.join(package_dir, library)
             print(f"{library} -> {new_library_path}")
             shutil.copyfile(library_path, new_library_path)
+            shutil.copymode(library_path, new_library_path)
 
 
 def compress_wheel(output_dir, wheel, wheel_dir, wheel_name):


### PR DESCRIPTION
`copyfile` only copies the file contents and not the metadata like the permissions. This causes issues when deploying these copied wheels.

Added a call to `copymode` to copy the permission bits as well.

Fixes: #7101 