### PR TITLE
properly support deepcopying and serialization of model weights

### DIFF
--- a/test/test_extended_models.py
+++ b/test/test_extended_models.py
@@ -75,9 +75,10 @@ def test_get_model_weights(name, weight):
 )
 def test_weights_copyable(copy_fn, name):
     for weights in list(models.get_model_weights(name)):
-        # It is somewhat surprising that (deep-)copying is an identity operation here,
-        # but this is the default behavior of enums.
-        # See https://github.com/pytorch/vision/pull/7107 for details.
+        # It is somewhat surprising that (deep-)copying is an identity operation here, but this is the default behavior
+        # of enums: https://docs.python.org/3/howto/enum.html#enum-members-aka-instances
+        # Checking for equality, i.e. `==`, is sufficient (and even preferable) for our use case, should we need to drop
+        # support for the identity operation in the future.
         assert copy_fn(weights) is weights
 
 
@@ -94,9 +95,10 @@ def test_weights_copyable(copy_fn, name):
 )
 def test_weights_deserializable(name):
     for weights in list(models.get_model_weights(name)):
-        # It is somewhat surprising that deserialization is an identity operation here,
-        # but this is the default behavior of enums.
-        # See https://github.com/pytorch/vision/pull/7107 for details.
+        # It is somewhat surprising that deserialization is an identity operation here, but this is the default behavior
+        # of enums: https://docs.python.org/3/howto/enum.html#enum-members-aka-instances
+        # Checking for equality, i.e. `==`, is sufficient (and even preferable) for our use case, should we need to drop
+        # support for the identity operation in the future.
         assert pickle.loads(pickle.dumps(weights)) is weights
 
 

--- a/test/test_extended_models.py
+++ b/test/test_extended_models.py
@@ -75,7 +75,10 @@ def test_get_model_weights(name, weight):
 )
 def test_weights_copyable(copy_fn, name):
     for weights in list(models.get_model_weights(name)):
-        assert copy_fn(weights) == weights
+        # It is somewhat surprising that (deep-)copying is an identity operation here,
+        # but this is the default behavior of enums.
+        # See https://github.com/pytorch/vision/pull/7107 for details.
+        assert copy_fn(weights) is weights
 
 
 @pytest.mark.parametrize(
@@ -89,9 +92,12 @@ def test_weights_copyable(copy_fn, name):
         "mvit_v1_b",
     ],
 )
-def test_weights_de_serializable(name):
+def test_weights_deserializable(name):
     for weights in list(models.get_model_weights(name)):
-        assert pickle.loads(pickle.dumps(weights)) == weights
+        # It is somewhat surprising that deserialization is an identity operation here,
+        # but this is the default behavior of enums.
+        # See https://github.com/pytorch/vision/pull/7107 for details.
+        assert pickle.loads(pickle.dumps(weights)) is weights
 
 
 @pytest.mark.parametrize(

--- a/test/test_extended_models.py
+++ b/test/test_extended_models.py
@@ -1,5 +1,6 @@
 import copy
 import os
+import pickle
 
 import pytest
 import test_models as TM
@@ -73,10 +74,24 @@ def test_get_model_weights(name, weight):
     ],
 )
 def test_weights_copyable(copy_fn, name):
-    model_weights = models.get_model_weights(name)
-    for weights in list(model_weights):
-        copied_weights = copy_fn(weights)
-        assert copied_weights is weights
+    for weights in list(models.get_model_weights(name)):
+        assert copy_fn(weights) == weights
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "resnet50",
+        "retinanet_resnet50_fpn_v2",
+        "raft_large",
+        "quantized_resnet50",
+        "lraspp_mobilenet_v3_large",
+        "mvit_v1_b",
+    ],
+)
+def test_weights_de_serializable(name):
+    for weights in list(models.get_model_weights(name)):
+        assert pickle.loads(pickle.dumps(weights)) == weights
 
 
 @pytest.mark.parametrize(

--- a/torchvision/models/_api.py
+++ b/torchvision/models/_api.py
@@ -13,6 +13,7 @@ from torchvision._utils import StrEnum
 
 from .._internally_replaced_utils import load_state_dict_from_url
 
+
 __all__ = ["WeightsEnum", "Weights", "get_model", "get_model_builder", "get_model_weights", "get_weight", "list_models"]
 
 

--- a/torchvision/models/_api.py
+++ b/torchvision/models/_api.py
@@ -41,8 +41,10 @@ class Weights:
     def __eq__(self, other: Any) -> bool:
         # We need this custom implementation for correct deep-copy and deserialization behavior.
         # TL;DR: After the definition of an enum, creating a new instance, i.e. by deep-copying or deserializing it,
-        # involves an equality check against the defined members. Unfortunately,
-        # `fn = partial(...); assert deepcopy(fn) != fn` and thus this check fails without custom handling.
+        # involves an equality check against the defined members. Unfortunately, the `transforms` attribute is often
+        # defined with `functools.partial` and `fn = partial(...); assert deepcopy(fn) != fn`. Without custom handling
+        # for it, the check against the defined members would fail and effectively prevent the weights from being
+        # deep-copied or deserialized.
         # See https://github.com/pytorch/vision/pull/7107 for details.
         if not isinstance(other, Weights):
             return NotImplemented

--- a/torchvision/models/_api.py
+++ b/torchvision/models/_api.py
@@ -39,6 +39,11 @@ class Weights:
     meta: Dict[str, Any]
 
     def __eq__(self, other: Any) -> bool:
+        # We need this custom implementation for correct deep-copy and deserialization behavior.
+        # TL;DR: After the definition of an enum, creating a new instance, i.e. by deep-copying or deserializing it,
+        # involves an equality check against the defined members. Unfortunately,
+        # `fn = partial(...); assert deepcopy(fn) != fn` and thus this check fails without custom handling.
+        # See https://github.com/pytorch/vision/pull/7107 for details.
         if not isinstance(other, Weights):
             return NotImplemented
 

--- a/torchvision/models/_api.py
+++ b/torchvision/models/_api.py
@@ -1,10 +1,8 @@
-from __future__ import annotations
-
-import functools
 import importlib
 import inspect
 import sys
 from dataclasses import dataclass, fields
+from functools import partial
 from inspect import signature
 from types import ModuleType
 from typing import Any, Callable, cast, Dict, List, Mapping, Optional, TypeVar, Union
@@ -15,15 +13,7 @@ from torchvision._utils import StrEnum
 
 from .._internally_replaced_utils import load_state_dict_from_url
 
-__all__ = [
-    "WeightsEnum",
-    "Weights",
-    "get_model",
-    "get_model_builder",
-    "get_model_weights",
-    "get_weight",
-    "list_models",
-]
+__all__ = ["WeightsEnum", "Weights", "get_model", "get_model_builder", "get_model_weights", "get_weight", "list_models"]
 
 
 @dataclass
@@ -57,7 +47,7 @@ class Weights:
         if self.meta != other.meta:
             return False
 
-        if isinstance(self.transforms, functools.partial) and isinstance(other.transforms, functools.partial):
+        if isinstance(self.transforms, partial) and isinstance(other.transforms, partial):
             return (
                 self.transforms.func == other.transforms.func
                 and self.transforms.args == other.transforms.args

--- a/torchvision/models/resnet.py
+++ b/torchvision/models/resnet.py
@@ -7,7 +7,7 @@ from torch import Tensor
 
 from ..transforms._presets import ImageClassification
 from ..utils import _log_api_usage_once
-from ._api import register_model, TransformsFactory, Weights, WeightsEnum
+from ._api import register_model, Weights, WeightsEnum
 from ._meta import _IMAGENET_CATEGORIES
 from ._utils import _ovewrite_named_param, handle_legacy_interface
 
@@ -356,7 +356,7 @@ class ResNet34_Weights(WeightsEnum):
 class ResNet50_Weights(WeightsEnum):
     IMAGENET1K_V1 = Weights(
         url="https://download.pytorch.org/models/resnet50-0676ba61.pth",
-        transforms=TransformsFactory(ImageClassification, crop_size=224),
+        transforms=partial(ImageClassification, crop_size=224),
         meta={
             **_COMMON_META,
             "num_params": 25557032,

--- a/torchvision/models/resnet.py
+++ b/torchvision/models/resnet.py
@@ -7,7 +7,7 @@ from torch import Tensor
 
 from ..transforms._presets import ImageClassification
 from ..utils import _log_api_usage_once
-from ._api import register_model, Weights, WeightsEnum
+from ._api import register_model, TransformsFactory, Weights, WeightsEnum
 from ._meta import _IMAGENET_CATEGORIES
 from ._utils import _ovewrite_named_param, handle_legacy_interface
 
@@ -356,7 +356,7 @@ class ResNet34_Weights(WeightsEnum):
 class ResNet50_Weights(WeightsEnum):
     IMAGENET1K_V1 = Weights(
         url="https://download.pytorch.org/models/resnet50-0676ba61.pth",
-        transforms=partial(ImageClassification, crop_size=224),
+        transforms=TransformsFactory(ImageClassification, crop_size=123),
         meta={
             **_COMMON_META,
             "num_params": 25557032,

--- a/torchvision/models/resnet.py
+++ b/torchvision/models/resnet.py
@@ -356,7 +356,7 @@ class ResNet34_Weights(WeightsEnum):
 class ResNet50_Weights(WeightsEnum):
     IMAGENET1K_V1 = Weights(
         url="https://download.pytorch.org/models/resnet50-0676ba61.pth",
-        transforms=TransformsFactory(ImageClassification, crop_size=123),
+        transforms=TransformsFactory(ImageClassification, crop_size=224),
         meta={
             **_COMMON_META,
             "num_params": 25557032,


### PR DESCRIPTION
Fixes #7099 and properly addresses #6871.

The whole idea behind the `TransformsFactory` class is to reimplement `functools.partial`, but with a deepcopy / serialize behavior that better suits our needs. As OP in in #7099 describes, `functools.partial` can be deepcopied and serialized, but the result is no longer equal to input:

```py
import pickle
from copy import deepcopy
from functools import partial


def foo():
    pass


bar = partial(foo)
assert bar != deepcopy(bar)
assert bar != pickle.loads(pickle.dumps(bar))
```

However, we need this equality to work, since it is an integral part of enums. Creating a fresh enum through either of these ops, internally invokes [`Enum.__new__`](https://github.com/python/cpython/blob/a6b889e99d5a8cc63924efacda9e4d4eded4b2fc/Lib/enum.py#L531). In there, a bunch of equality checks are performed against the known members of the enum, i.e. [here](https://github.com/python/cpython/blob/a6b889e99d5a8cc63924efacda9e4d4eded4b2fc/Lib/enum.py#L541) and [here](https://github.com/python/cpython/blob/a6b889e99d5a8cc63924efacda9e4d4eded4b2fc/Lib/enum.py#L548). This ultimately leads us to [the error](https://github.com/python/cpython/blob/a6b889e99d5a8cc63924efacda9e4d4eded4b2fc/Lib/enum.py#L560) the users reported.

Together with `@dataclasses.dataclass`, the functionality that we want is trivial to implement. Re-using the example from above:

```python
import pickle
from copy import deepcopy

from torchvision.models._api import TransformsFactory


def foo():
    pass


bar = TransformsFactory(foo)
assert bar == deepcopy(bar)
assert bar == pickle.loads(pickle.dumps(bar))
```

Another option that we could do is what OP describes in #7099. Basically we need to implement a custom `__eq__` on the `Weights` class that is able to handle the `partial`. I found this a little more brittle, since we don't enforce anything about the callable and thus specializing the comparison to `partial` might lead to other errors. Note that in the `TransformsFactory` implementation, we don't need to touch this behavior at all and it is handled by `@dataclass` automatically.

ToDo:

- [ ] expand new architecture to all weights
- [ ] write tests that make sure both deepcopy and serialization works and gives the expected results