### PR TITLE
[WIP]Use float64 to reduce differences between cpu and gpu result in model test

### DIFF
--- a/test/test_models.py
+++ b/test/test_models.py
@@ -683,8 +683,9 @@ def test_classification_model(model_fn, dev):
     real_image = kwargs.pop("real_image", False)
 
     model = model_fn(**kwargs)
-    model.eval().to(device=dev)
-    x = _get_image(input_shape=input_shape, real_image=real_image, device=dev)
+    # We use float64 (.double()) to reduce differences between cpu and gpu result
+    model.eval().to(device=dev).double()
+    x = _get_image(input_shape=input_shape, real_image=real_image, device=dev).double()
     out = model(x)
     _assert_expected(out.cpu(), model_name, prec=1e-3)
     assert out.shape[-1] == num_classes
@@ -782,8 +783,9 @@ def test_detection_model(model_fn, dev):
     real_image = kwargs.pop("real_image", False)
 
     model = model_fn(**kwargs)
-    model.eval().to(device=dev)
-    x = _get_image(input_shape=input_shape, real_image=real_image, device=dev)
+    # We use float64 (.double()) to reduce differences between cpu and gpu result
+    model.eval().to(device=dev).double()
+    x = _get_image(input_shape=input_shape, real_image=real_image, device=dev).double()
     model_input = [x]
     with torch.no_grad(), freeze_rng_state():
         out = model(model_input)


### PR DESCRIPTION
As specified in https://github.com/pytorch/vision/issues/7098 that currently some model test are failing due to precision. I have tried to use real image and weight to resolve this issue (see https://gist.github.com/YosuaMichael/7f542cdf5e051db758e462a2a8cc50fd) however due to floating point precision, the cpu and gpu result still have a quite significant gap.

And since the root problem is the floating point precision rather than randomness, in this PR we try to resolve the issue by using `float64` instead.

Note: credits to @lezcano that give me insight to use float64 :)

cc @pmeier