### PR TITLE
Relaxing test_models precision (Reverting #6380)

### DIFF
--- a/test/test_models.py
+++ b/test/test_models.py
@@ -686,7 +686,7 @@ def test_classification_model(model_fn, dev):
     model.eval().to(device=dev)
     x = _get_image(input_shape=input_shape, real_image=real_image, device=dev)
     out = model(x)
-    _assert_expected(out.cpu(), model_name, prec=1e-3)
+    _assert_expected(out.cpu(), model_name, prec=0.1)
     assert out.shape[-1] == num_classes
     _check_jit_scriptable(model, (x,), unwrapper=script_model_unwrapper.get(model_name, None), eager_out=out)
     _check_fx_compatible(model, x, eager_out=out)
@@ -917,7 +917,7 @@ def test_video_model(model_fn, dev):
     # RNG always on CPU, to ensure x in cuda tests is bitwise identical to x in cpu tests
     x = torch.rand(input_shape).to(device=dev)
     out = model(x)
-    _assert_expected(out.cpu(), model_name, prec=1e-5)
+    _assert_expected(out.cpu(), model_name, prec=0.1)
     assert out.shape[-1] == num_classes
     _check_jit_scriptable(model, (x,), unwrapper=script_model_unwrapper.get(model_name, None), eager_out=out)
     _check_fx_compatible(model, x, eager_out=out)
@@ -960,7 +960,7 @@ def test_quantized_classification_model(model_fn):
     out = model(x)
 
     if model_name not in quantized_flaky_models:
-        _assert_expected(out.cpu(), model_name + "_quantized", prec=2e-2)
+        _assert_expected(out.cpu(), model_name + "_quantized", prec=0.1)
         assert out.shape[-1] == 5
         _check_jit_scriptable(model, (x,), unwrapper=script_model_unwrapper.get(model_name, None), eager_out=out)
         _check_fx_compatible(model, x, eager_out=out)


### PR DESCRIPTION
From investigation (see https://github.com/pytorch/vision/pull/7114#issuecomment-1400861739), it seems that our model test is sensitive to machine type. And after testing on AWS cluster, it seems to start failing since the PR #6380 in AWS cluster machine. To fix this, we should revert the PR and relax the precision criteria.