### PR TITLE
fix requires_grad passthrough

### DIFF
--- a/test/test_prototype_datapoints.py
+++ b/test/test_prototype_datapoints.py
@@ -3,6 +3,25 @@ import torch
 from torchvision.prototype import datapoints
 
 
+@pytest.mark.parametrize(
+    ("data", "input_requires_grad", "expected_requires_grad"),
+    [
+        ([0.0], None, False),
+        ([0.0], False, False),
+        ([0.0], True, True),
+        (torch.tensor([0.0], requires_grad=False), None, False),
+        (torch.tensor([0.0], requires_grad=False), False, False),
+        (torch.tensor([0.0], requires_grad=False), True, True),
+        (torch.tensor([0.0], requires_grad=True), None, True),
+        (torch.tensor([0.0], requires_grad=True), False, False),
+        (torch.tensor([0.0], requires_grad=True), True, True),
+    ],
+)
+def test_new_requires_grad(data, input_requires_grad, expected_requires_grad):
+    datapoint = datapoints.Label(data, requires_grad=input_requires_grad)
+    assert datapoint.requires_grad is expected_requires_grad
+
+
 def test_isinstance():
     assert isinstance(
         datapoints.Label([0, 1, 0], categories=["foo", "bar"]),

--- a/torchvision/prototype/datapoints/_bounding_box.py
+++ b/torchvision/prototype/datapoints/_bounding_box.py
@@ -34,7 +34,7 @@ class BoundingBox(Datapoint):
         spatial_size: Tuple[int, int],
         dtype: Optional[torch.dtype] = None,
         device: Optional[Union[torch.device, str, int]] = None,
-        requires_grad: bool = False,
+        requires_grad: Optional[bool] = None,
     ) -> BoundingBox:
         tensor = cls._to_tensor(data, dtype=dtype, device=device, requires_grad=requires_grad)
 

--- a/torchvision/prototype/datapoints/_datapoint.py
+++ b/torchvision/prototype/datapoints/_datapoint.py
@@ -23,8 +23,10 @@ class Datapoint(torch.Tensor):
         data: Any,
         dtype: Optional[torch.dtype] = None,
         device: Optional[Union[torch.device, str, int]] = None,
-        requires_grad: bool = False,
+        requires_grad: Optional[bool] = None,
     ) -> torch.Tensor:
+        if requires_grad is None:
+            requires_grad = data.requires_grad if isinstance(data, torch.Tensor) else False
         return torch.as_tensor(data, dtype=dtype, device=device).requires_grad_(requires_grad)
 
     # FIXME: this is just here for BC with the prototype datasets. Some datasets use the Datapoint directly to have a
@@ -36,7 +38,7 @@ class Datapoint(torch.Tensor):
         data: Any,
         dtype: Optional[torch.dtype] = None,
         device: Optional[Union[torch.device, str, int]] = None,
-        requires_grad: bool = False,
+        requires_grad: Optional[bool] = None,
     ) -> Datapoint:
         tensor = cls._to_tensor(data, dtype=dtype, device=device, requires_grad=requires_grad)
         return tensor.as_subclass(Datapoint)

--- a/torchvision/prototype/datapoints/_image.py
+++ b/torchvision/prototype/datapoints/_image.py
@@ -21,7 +21,7 @@ class Image(Datapoint):
         *,
         dtype: Optional[torch.dtype] = None,
         device: Optional[Union[torch.device, str, int]] = None,
-        requires_grad: bool = False,
+        requires_grad: Optional[bool] = None,
     ) -> Image:
         tensor = cls._to_tensor(data, dtype=dtype, device=device, requires_grad=requires_grad)
         if tensor.ndim < 2:

--- a/torchvision/prototype/datapoints/_label.py
+++ b/torchvision/prototype/datapoints/_label.py
@@ -27,7 +27,7 @@ class _LabelBase(Datapoint):
         categories: Optional[Sequence[str]] = None,
         dtype: Optional[torch.dtype] = None,
         device: Optional[Union[torch.device, str, int]] = None,
-        requires_grad: bool = False,
+        requires_grad: Optional[bool] = None,
     ) -> L:
         tensor = cls._to_tensor(data, dtype=dtype, device=device, requires_grad=requires_grad)
         return cls._wrap(tensor, categories=categories)

--- a/torchvision/prototype/datapoints/_mask.py
+++ b/torchvision/prototype/datapoints/_mask.py
@@ -19,7 +19,7 @@ class Mask(Datapoint):
         *,
         dtype: Optional[torch.dtype] = None,
         device: Optional[Union[torch.device, str, int]] = None,
-        requires_grad: bool = False,
+        requires_grad: Optional[bool] = None,
     ) -> Mask:
         tensor = cls._to_tensor(data, dtype=dtype, device=device, requires_grad=requires_grad)
         return cls._wrap(tensor)

--- a/torchvision/prototype/datapoints/_video.py
+++ b/torchvision/prototype/datapoints/_video.py
@@ -20,7 +20,7 @@ class Video(Datapoint):
         *,
         dtype: Optional[torch.dtype] = None,
         device: Optional[Union[torch.device, str, int]] = None,
-        requires_grad: bool = False,
+        requires_grad: Optional[bool] = None,
     ) -> Video:
         tensor = cls._to_tensor(data, dtype=dtype, device=device, requires_grad=requires_grad)
         if data.ndim < 4:


### PR DESCRIPTION
Previously, constructing a new datapoint from an existing tensor would simply overwrite the `requires_grad` flag:

https://github.com/pytorch/vision/blob/59dc9383e663a9bab5230370e1f0d7d14b87940f/torchvision/prototype/datapoints/_datapoint.py#L28

This is the correct behavior in all but one case: if we pass a tensor that has `requires_grad=True` and don't specify that in the call, the creation fails:

```python
import torch
from torchvision.prototype import datapoints

t1 = torch.rand(3, 2, 2).requires_grad_(True)
assert t1.requires_grad

i1 = datapoints.Image(t1, requires_grad=True)
assert i1.data_ptr() == t1.data_ptr()
assert i1.requires_grad

t2 = t1.clone()
assert t2.requires_grad

i2 = datapoints.Image(t2)
```

```
RuntimeError: you can only change requires_grad flags of leaf variables. If you want to use a computed variable in a subgraph that doesn't require differentiation use var_no_grad = var.detach().
```

This PR implements a passthrough for `requires_grad` in the default case if the input is a tensor. For non-tensor inputs, the behavior stays exactly the same.

cc @bjuncek