### PR TITLE
fix Resize for JIT single value sequences

### DIFF
--- a/test/test_prototype_transforms_consistency.py
+++ b/test/test_prototype_transforms_consistency.py
@@ -74,6 +74,7 @@ CONSISTENCY_CONFIGS = [
         legacy_transforms.Resize,
         [
             ArgsKwargs(32),
+            ArgsKwargs([32]),
             ArgsKwargs((32, 29)),
             ArgsKwargs((31, 28), interpolation=prototype_transforms.InterpolationMode.NEAREST),
             ArgsKwargs((33, 26), interpolation=prototype_transforms.InterpolationMode.BICUBIC),

--- a/torchvision/prototype/transforms/_geometry.py
+++ b/torchvision/prototype/transforms/_geometry.py
@@ -46,11 +46,16 @@ class Resize(Transform):
     ) -> None:
         super().__init__()
 
-        self.size = (
-            [size]
-            if isinstance(size, int)
-            else _setup_size(size, error_msg="Please provide only two dimensions (h, w) for size.")
-        )
+        if isinstance(size, int):
+            size = [size]
+        elif isinstance(size, (list, tuple)) and len(size) in {1, 2}:
+            size = list(size)
+        else:
+            raise ValueError(
+                f"size can either be an integer or a list or tuple of one or two integers, " f"but got {size} instead."
+            )
+        self.size = size
+
         self.interpolation = interpolation
         self.max_size = max_size
         self.antialias = antialias


### PR DESCRIPTION
`prototype.transforms.Resize` is broken for single value sequence inputs. They are required by JIT[^1] and should behave the same way as regular integer inputs 

https://github.com/pytorch/vision/blob/59dc9383e663a9bab5230370e1f0d7d14b87940f/torchvision/transforms/transforms.py#L295-L296

However, `_setup_size` parses them to `(size, size)`

https://github.com/pytorch/vision/blob/59dc9383e663a9bab5230370e1f0d7d14b87940f/torchvision/transforms/transforms.py#L1819-L1820

which triggers a different path in the kernel.

This was not caught by our tests before, since we never bothered to test the "JIT variants" since the base assumption was that we won't keep support for it. Apart from #7135, this would be a BC break nevertheless since all users can rely on that syntax although it is only required for JIT.

[^1]: I've just discovered this while working on JIT. That is unrelated to this PR.


cc @vfdev-5 @bjuncek