### PR TITLE
add sequence fill support for ElasticTransform

### DIFF
--- a/test/test_transforms_tensor.py
+++ b/test/test_transforms_tensor.py
@@ -862,29 +862,31 @@ def test_gaussian_blur(device, channels, meth_kwargs):
 
 @pytest.mark.parametrize("device", cpu_and_gpu())
 @pytest.mark.parametrize(
-    "meth_kwargs",
+    "fill",
     [
-        {"fill": 1},
-        {"fill": 1.0},
-        {"fill": [1]},
-        {"fill": [1.0]},
-        {"fill": (1,)},
-        {"fill": (1.0,)},
-        {"fill": [1, 2, 3]},
-        {"fill": [1.0, 2.0, 3.0]},
-        {"fill": (1, 2, 3)},
-        {"fill": (1.0, 2.0, 3.0)},
+        1,
+        1.0,
+        [1],
+        [1.0],
+        (1,),
+        (1.0,),
+        [1, 2, 3],
+        [1.0, 2.0, 3.0],
+        (1, 2, 3),
+        (1.0, 2.0, 3.0),
     ],
 )
 @pytest.mark.parametrize("channels", [1, 3])
-def test_elastic_transform(device, channels, meth_kwargs):
-    fill = meth_kwargs.get("fill")
+def test_elastic_transform(device, channels, fill):
     if isinstance(fill, (list, tuple)) and len(fill) > 1 and channels == 1:
+        # For this the test would correctly fail, since the number of channels in the image does not match `fill`.
+        # Thus, this is not an issue in the transform, but rather a problem of parametrization that just gives the
+        # product of `fill` and `channels`.
         return
 
     _test_class_op(
         T.ElasticTransform,
-        meth_kwargs=meth_kwargs,
+        meth_kwargs=dict(fill=fill),
         channels=channels,
         device=device,
     )

--- a/test/test_transforms_tensor.py
+++ b/test/test_transforms_tensor.py
@@ -858,3 +858,33 @@ def test_gaussian_blur(device, channels, meth_kwargs):
         agg_method="max",
         tol=tol,
     )
+
+
+@pytest.mark.parametrize("device", cpu_and_gpu())
+@pytest.mark.parametrize(
+    "meth_kwargs",
+    [
+        {"fill": 1},
+        {"fill": 1.0},
+        {"fill": [1]},
+        {"fill": [1.0]},
+        {"fill": (1,)},
+        {"fill": (1.0,)},
+        {"fill": [1, 2, 3]},
+        {"fill": [1.0, 2.0, 3.0]},
+        {"fill": (1, 2, 3)},
+        {"fill": (1.0, 2.0, 3.0)},
+    ],
+)
+@pytest.mark.parametrize("channels", [1, 3])
+def test_elastic_transform(device, channels, meth_kwargs):
+    fill = meth_kwargs.get("fill")
+    if isinstance(fill, (list, tuple)) and len(fill) > 1 and channels == 1:
+        return
+
+    _test_class_op(
+        T.ElasticTransform,
+        meth_kwargs=meth_kwargs,
+        channels=channels,
+        device=device,
+    )

--- a/torchvision/transforms/functional.py
+++ b/torchvision/transforms/functional.py
@@ -1539,8 +1539,6 @@ def elastic_transform(
         fill (number or str or tuple): Pixel fill value for constant fill. Default is 0.
             If a tuple of length 3, it is used to fill R, G, B channels respectively.
             This value is only used when the padding_mode is constant.
-            Only number is supported for torch Tensor.
-            Only int or str or tuple value is supported for PIL Image.
     """
     if not torch.jit.is_scripting() and not torch.jit.is_tracing():
         _log_api_usage_once(elastic_transform)

--- a/torchvision/transforms/transforms.py
+++ b/torchvision/transforms/transforms.py
@@ -2104,8 +2104,12 @@ class ElasticTransform(torch.nn.Module):
             interpolation = _interpolation_modes_from_int(interpolation)
         self.interpolation = interpolation
 
-        if not isinstance(fill, (int, float)):
-            raise TypeError(f"fill should be int or float. Got {type(fill)}")
+        if isinstance(fill, (int, float)):
+            fill = [float(fill)]
+        elif isinstance(fill, (list, tuple)):
+            fill = [float(f) for f in fill]
+        else:
+            raise TypeError(f"fill should be int or float or a list or tuple of them. Got {type(fill)}")
         self.fill = fill
 
     @staticmethod


### PR DESCRIPTION
According to our docstring we already have it

https://github.com/pytorch/vision/blob/455eda681dc6827ecd98e0a0f4057032108f3734/torchvision/transforms/transforms.py#L2058-L2059

However, we do

https://github.com/pytorch/vision/blob/455eda681dc6827ecd98e0a0f4057032108f3734/torchvision/transforms/transforms.py#L2107-L2109

which will fail for sequences. 

cc @vfdev-5