### PR TITLE
enable get_params alias for transforms v2

### DIFF
--- a/test/test_prototype_transforms_consistency.py
+++ b/test/test_prototype_transforms_consistency.py
@@ -660,8 +660,32 @@ def test_call_consistency(config, args_kwargs):
     [config for config in CONSISTENCY_CONFIGS if hasattr(config.legacy_cls, "get_params")],
     ids=lambda config: config.legacy_cls.__name__,
 )
-def test_get_params_consistency(config):
+def test_get_params_alias(config):
     assert config.prototype_cls.get_params is config.legacy_cls.get_params
+
+
+@pytest.mark.parametrize(
+    ("transform_cls", "args_kwargs"),
+    [
+        (prototype_transforms.RandomResizedCrop, ArgsKwargs(make_image(), scale=[0.3, 0.7], ratio=[0.5, 1.5])),
+        (prototype_transforms.RandomErasing, ArgsKwargs(make_image(), scale=(0.3, 0.7), ratio=(0.5, 1.5))),
+        (prototype_transforms.ColorJitter, ArgsKwargs(brightness=None, contrast=None, saturation=None, hue=None)),
+        (prototype_transforms.ElasticTransform, ArgsKwargs(alpha=[15.3, 27.2], sigma=[2.5, 3.9], size=[17, 31])),
+        (prototype_transforms.GaussianBlur, ArgsKwargs(0.3, 1.4)),
+        (
+            prototype_transforms.RandomAffine,
+            ArgsKwargs(degrees=[-20.0, 10.0], translate=None, scale_ranges=None, shears=None, img_size=[15, 29]),
+        ),
+        (prototype_transforms.RandomCrop, ArgsKwargs(make_image(size=(61, 47)), output_size=(19, 25))),
+        (prototype_transforms.RandomPerspective, ArgsKwargs(23, 17, 0.5)),
+        (prototype_transforms.RandomRotation, ArgsKwargs(degrees=[-20.0, 10.0])),
+        (prototype_transforms.AutoAugment, ArgsKwargs(5)),
+    ],
+)
+def test_get_params_jit(transform_cls, args_kwargs):
+    args, kwargs = args_kwargs
+
+    torch.jit.script(transform_cls.get_params)(*args, **kwargs)
 
 
 @pytest.mark.parametrize(

--- a/test/test_prototype_transforms_consistency.py
+++ b/test/test_prototype_transforms_consistency.py
@@ -656,6 +656,15 @@ def test_call_consistency(config, args_kwargs):
 
 
 @pytest.mark.parametrize(
+    "config",
+    [config for config in CONSISTENCY_CONFIGS if hasattr(config.legacy_cls, "get_params")],
+    ids=lambda config: config.legacy_cls.__name__,
+)
+def test_get_params_consistency(config):
+    assert config.prototype_cls.get_params is config.legacy_cls.get_params
+
+
+@pytest.mark.parametrize(
     ("config", "args_kwargs"),
     [
         pytest.param(

--- a/torchvision/prototype/transforms/_transform.py
+++ b/torchvision/prototype/transforms/_transform.py
@@ -65,7 +65,7 @@ class Transform(nn.Module):
 
     def __init_subclass__(cls) -> None:
         # Since `get_params` is a `@staticmethod`, we have to bind it to the class itself rather than to an instance.
-        # This method is called after subclassing has happened, i.e. `cls` is the subclass.
+        # This method is called after subclassing has happened, i.e. `cls` is the subclass, e.g. `Resize`.
         if cls._v1_transform_cls is not None and hasattr(cls._v1_transform_cls, "get_params"):
             cls.get_params = cls._v1_transform_cls.get_params  # type: ignore[attr-defined]
 


### PR DESCRIPTION
After #7135, this is trivial to achieve. If available, we simply alias `get_params` from the v1 transformation to v2. 

Although this doesn't sound like much, it is the final step of getting v2 BC with v1. Meaning, leaving bugs aside, v2 should now be a proper drop-in replacement for v1 :tada:

cc @vfdev-5 @bjuncek