### PR TITLE
NOMRG [xplat][torchvision] Add torchvision streaming decoder

### DIFF
--- a/torchvision/csrc/io/decoder/audio_sampler.cpp
+++ b/torchvision/csrc/io/decoder/audio_sampler.cpp
@@ -1,5 +1,4 @@
 #include "audio_sampler.h"
-#include <c10/util/Logging.h>
 #include "util.h"
 
 #define AVRESAMPLE_MAX_CHANNELS 32
@@ -121,8 +120,6 @@ int AudioSampler::sample(
       return result;
     }
 
-    TORCH_CHECK_LE(result, outNumSamples);
-
     if (result) {
       if ((result = av_samples_get_buffer_size(
                nullptr,
@@ -165,8 +162,6 @@ int AudioSampler::sample(
     }
 
     av_free(tmpBuffer);
-
-    TORCH_CHECK_LE(result, outNumSamples);
 
     if (result) {
       result = av_samples_get_buffer_size(

--- a/torchvision/csrc/io/decoder/audio_stream.cpp
+++ b/torchvision/csrc/io/decoder/audio_stream.cpp
@@ -1,5 +1,4 @@
 #include "audio_stream.h"
-#include <c10/util/Logging.h>
 #include <limits>
 #include "util.h"
 

--- a/torchvision/csrc/io/decoder/decoder.cpp
+++ b/torchvision/csrc/io/decoder/decoder.cpp
@@ -1,5 +1,4 @@
 #include "decoder.h"
-#include <c10/util/Logging.h>
 #include <libavutil/avutil.h>
 #include <future>
 #include <iostream>

--- a/torchvision/csrc/io/decoder/defs.h
+++ b/torchvision/csrc/io/decoder/defs.h
@@ -17,6 +17,11 @@ extern "C" {
 #include <libswresample/swresample.h>
 #include "libswscale/swscale.h"
 }
+#ifdef USE_GLOG
+#include <glog/logging.h>
+#else
+#include <c10/util/Logging.h>
+#endif
 
 namespace ffmpeg {
 

--- a/torchvision/csrc/io/decoder/memory_buffer.cpp
+++ b/torchvision/csrc/io/decoder/memory_buffer.cpp
@@ -1,5 +1,4 @@
 #include "memory_buffer.h"
-#include <c10/util/Logging.h>
 
 namespace ffmpeg {
 

--- a/torchvision/csrc/io/decoder/seekable_buffer.cpp
+++ b/torchvision/csrc/io/decoder/seekable_buffer.cpp
@@ -1,5 +1,4 @@
 #include "seekable_buffer.h"
-#include <c10/util/Logging.h>
 #include <chrono>
 #include "memory_buffer.h"
 

--- a/torchvision/csrc/io/decoder/stream.cpp
+++ b/torchvision/csrc/io/decoder/stream.cpp
@@ -1,5 +1,4 @@
 #include "stream.h"
-#include <c10/util/Logging.h>
 #include <stdio.h>
 #include <string.h>
 #include "util.h"

--- a/torchvision/csrc/io/decoder/subtitle_sampler.cpp
+++ b/torchvision/csrc/io/decoder/subtitle_sampler.cpp
@@ -1,5 +1,4 @@
 #include "subtitle_sampler.h"
-#include <c10/util/Logging.h>
 #include "util.h"
 
 namespace ffmpeg {

--- a/torchvision/csrc/io/decoder/subtitle_stream.cpp
+++ b/torchvision/csrc/io/decoder/subtitle_stream.cpp
@@ -1,5 +1,4 @@
 #include "subtitle_stream.h"
-#include <c10/util/Logging.h>
 #include <limits>
 #include "util.h"
 

--- a/torchvision/csrc/io/decoder/sync_decoder_test.cpp
+++ b/torchvision/csrc/io/decoder/sync_decoder_test.cpp
@@ -1,4 +1,3 @@
-#include <c10/util/Logging.h>
 #include <dirent.h>
 #include <gtest/gtest.h>
 #include "memory_buffer.h"

--- a/torchvision/csrc/io/decoder/util.cpp
+++ b/torchvision/csrc/io/decoder/util.cpp
@@ -1,5 +1,4 @@
 #include "util.h"
-#include <c10/util/Logging.h>
 
 namespace ffmpeg {
 
@@ -265,7 +264,6 @@ std::string generateErrorDesc(int errorCode) {
 
 size_t serialize(const AVSubtitle& sub, ByteStorage* out) {
   const auto len = size(sub);
-  TORCH_CHECK_LE(len, out->tail());
   size_t pos = 0;
   if (!Serializer::serializeItem(out->writableTail(), len, pos, sub)) {
     return 0;

--- a/torchvision/csrc/io/decoder/video_sampler.cpp
+++ b/torchvision/csrc/io/decoder/video_sampler.cpp
@@ -1,5 +1,4 @@
 #include "video_sampler.h"
-#include <c10/util/Logging.h>
 #include "util.h"
 
 // www.ffmpeg.org/doxygen/0.5/swscale-example_8c-source.html

--- a/torchvision/csrc/io/decoder/video_stream.cpp
+++ b/torchvision/csrc/io/decoder/video_stream.cpp
@@ -1,5 +1,4 @@
 #include "video_stream.h"
-#include <c10/util/Logging.h>
 #include "util.h"
 
 namespace ffmpeg {


### PR DESCRIPTION
Summary:
added compiler flag to replace c10 log by glog and remove dependency on c10 for non-pytorch applications

(Note: this ignores all push blocking failures!)

Differential Revision: D42837755

fbshipit-source-id: cc9661905fd3f8e91aa5fee2e58e3e0dd02fa325

<!-- Before submitting a PR, please make sure to check our contributing guidelines regarding code formatting, tests, and documentation: https://github.com/pytorch/vision/blob/main/CONTRIBUTING.md -->
