### PR TITLE
[NOMERGE] drop in transforms v2 into the v1 tests

### DIFF
--- a/test/test_functional_tensor.py
+++ b/test/test_functional_tensor.py
@@ -9,8 +9,8 @@ from typing import Sequence
 import numpy as np
 import pytest
 import torch
-import torchvision.transforms as T
-import torchvision.transforms.functional as F
+import torchvision.prototype.transforms as T
+import torchvision.prototype.transforms.functional as F
 import torchvision.transforms.functional_pil as F_pil
 import torchvision.transforms.functional_tensor as F_t
 from common_utils import (

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -7,9 +7,9 @@ from functools import partial
 import numpy as np
 import pytest
 import torch
-import torchvision.transforms as transforms
+import torchvision.prototype.transforms as transforms
+import torchvision.prototype.transforms.functional as F
 import torchvision.transforms._pil_constants as _pil_constants
-import torchvision.transforms.functional as F
 import torchvision.transforms.functional_tensor as F_t
 from PIL import Image
 from torch._utils_internal import get_file_path_2

--- a/test/test_transforms_tensor.py
+++ b/test/test_transforms_tensor.py
@@ -16,8 +16,8 @@ from common_utils import (
     get_tmp_dir,
     int_dtypes,
 )
-from torchvision import transforms as T
-from torchvision.transforms import functional as F, InterpolationMode
+from torchvision.prototype import transforms as T
+from torchvision.prototype.transforms import functional as F, InterpolationMode
 from torchvision.transforms.autoaugment import _apply_op
 
 NEAREST, NEAREST_EXACT, BILINEAR, BICUBIC = (

--- a/test/test_transforms_video.py
+++ b/test/test_transforms_video.py
@@ -15,7 +15,7 @@ except ImportError:
 
 with warnings.catch_warnings(record=True):
     warnings.simplefilter("always")
-    import torchvision.transforms._transforms_video as transforms
+    import torchvision.prototype.transforms as transforms
 
 
 class TestVideoTransforms:
@@ -28,14 +28,14 @@ class TestVideoTransforms:
         clip = torch.randint(0, 256, (numFrames, height, width, 3), dtype=torch.uint8)
         result = Compose(
             [
-                transforms.ToTensorVideo(),
-                transforms.RandomCropVideo((oheight, owidth)),
+                transforms.ToTensor(),
+                transforms.RandomCrop((oheight, owidth)),
             ]
         )(clip)
         assert result.size(2) == oheight
         assert result.size(3) == owidth
 
-        transforms.RandomCropVideo((oheight, owidth)).__repr__()
+        transforms.RandomCrop((oheight, owidth)).__repr__()
 
     def test_random_resized_crop_video(self):
         numFrames = random.randint(4, 128)
@@ -46,14 +46,14 @@ class TestVideoTransforms:
         clip = torch.randint(0, 256, (numFrames, height, width, 3), dtype=torch.uint8)
         result = Compose(
             [
-                transforms.ToTensorVideo(),
-                transforms.RandomResizedCropVideo((oheight, owidth)),
+                transforms.ToTensor(),
+                transforms.RandomResizedCrop((oheight, owidth)),
             ]
         )(clip)
         assert result.size(2) == oheight
         assert result.size(3) == owidth
 
-        transforms.RandomResizedCropVideo((oheight, owidth)).__repr__()
+        transforms.RandomResizedCrop((oheight, owidth)).__repr__()
 
     def test_center_crop_video(self):
         numFrames = random.randint(4, 128)
@@ -69,8 +69,8 @@ class TestVideoTransforms:
         clipNarrow.fill_(0)
         result = Compose(
             [
-                transforms.ToTensorVideo(),
-                transforms.CenterCropVideo((oheight, owidth)),
+                transforms.ToTensor(),
+                transforms.CenterCrop((oheight, owidth)),
             ]
         )(clip)
 
@@ -83,8 +83,8 @@ class TestVideoTransforms:
         owidth += 1
         result = Compose(
             [
-                transforms.ToTensorVideo(),
-                transforms.CenterCropVideo((oheight, owidth)),
+                transforms.ToTensor(),
+                transforms.CenterCrop((oheight, owidth)),
             ]
         )(clip)
         sum1 = result.sum()
@@ -98,8 +98,8 @@ class TestVideoTransforms:
         owidth += 1
         result = Compose(
             [
-                transforms.ToTensorVideo(),
-                transforms.CenterCropVideo((oheight, owidth)),
+                transforms.ToTensor(),
+                transforms.CenterCrop((oheight, owidth)),
             ]
         )(clip)
         sum2 = result.sum()
@@ -128,20 +128,20 @@ class TestVideoTransforms:
         clip = torch.normal(mean, std, size=(channels, numFrames, height, width))
         mean = [clip[c].mean().item() for c in range(channels)]
         std = [clip[c].std().item() for c in range(channels)]
-        normalized = transforms.NormalizeVideo(mean, std)(clip)
+        normalized = transforms.Normalize(mean, std)(clip)
         assert samples_from_standard_normal(normalized)
         random.setstate(random_state)
 
         # Checking the optional in-place behaviour
         tensor = torch.rand((3, 128, 16, 16))
-        tensor_inplace = transforms.NormalizeVideo((0.5, 0.5, 0.5), (0.5, 0.5, 0.5), inplace=True)(tensor)
+        tensor_inplace = transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5), inplace=True)(tensor)
         assert_equal(tensor, tensor_inplace)
 
-        transforms.NormalizeVideo((0.5, 0.5, 0.5), (0.5, 0.5, 0.5), inplace=True).__repr__()
+        transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5), inplace=True).__repr__()
 
     def test_to_tensor_video(self):
         numFrames, height, width = 64, 4, 4
-        trans = transforms.ToTensorVideo()
+        trans = transforms.ToTensor()
 
         with pytest.raises(TypeError):
             np_rng = np.random.RandomState(0)
@@ -165,13 +165,13 @@ class TestVideoTransforms:
         clip = torch.rand((3, 4, 112, 112), dtype=torch.float)
         hclip = clip.flip(-1)
 
-        out = transforms.RandomHorizontalFlipVideo(p=p)(clip)
+        out = transforms.RandomHorizontalFlip(p=p)(clip)
         if p == 0:
             torch.testing.assert_close(out, clip)
         elif p == 1:
             torch.testing.assert_close(out, hclip)
 
-        transforms.RandomHorizontalFlipVideo().__repr__()
+        transforms.RandomHorizontalFlip().__repr__()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR should serve as migration test whether we messed something up in transforms v2 that was enforced by the v1 tests. If CI is green here, we can be reasonably confidence that v2 is actually a drop-in replacement for v1.