### PR TITLE
fix docstring of CelebA regarding arrays

### DIFF
--- a/torchvision/datasets/celeba.py
+++ b/torchvision/datasets/celeba.py
@@ -23,10 +23,10 @@ class CelebA(VisionDataset):
             or ``landmarks``. Can also be a list to output a tuple with all specified target types.
             The targets represent:
 
-                - ``attr`` (np.array shape=(40,) dtype=int): binary (0, 1) labels for attributes
+                - ``attr`` (Tensor shape=(40,) dtype=int): binary (0, 1) labels for attributes
                 - ``identity`` (int): label for each person (data points with the same identity are the same person)
-                - ``bbox`` (np.array shape=(4,) dtype=int): bounding box (x, y, width, height)
-                - ``landmarks`` (np.array shape=(10,) dtype=int): landmark points (lefteye_x, lefteye_y, righteye_x,
+                - ``bbox`` (Tensor shape=(4,) dtype=int): bounding box (x, y, width, height)
+                - ``landmarks`` (Tensor shape=(10,) dtype=int): landmark points (lefteye_x, lefteye_y, righteye_x,
                   righteye_y, nose_x, nose_y, leftmouth_x, leftmouth_y, rightmouth_x, rightmouth_y)
 
             Defaults to ``attr``. If empty, ``None`` will be returned as target.


### PR DESCRIPTION
Although the OP originally envisioned to return `np.array`'s in #775 over the course of the review the return type was changed to plain tensors: https://github.com/pytorch/vision/pull/775#discussion_r263172787 The docstring was forgotten.

Meaning, although the docstring stated that we return `np.array`'s, we always have returned `torch.Tensor`'s. Thus, this PR just fixes the docstring to align with the behavior.