### PR TITLE
Deprecate CUDA 11.6 from CI, move to 11.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -855,7 +855,7 @@ jobs:
     executor:
       name: windows-gpu
     environment:
-      CUDA_VERSION: "11.6"
+      CUDA_VERSION: "11.7"
       PYTHON_VERSION: << parameters.python_version >>
     steps:
       - checkout

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -855,7 +855,7 @@ jobs:
     executor:
       name: windows-gpu
     environment:
-      CUDA_VERSION: "11.6"
+      CUDA_VERSION: "11.7"
       PYTHON_VERSION: << parameters.python_version >>
     steps:
       - checkout

--- a/.circleci/unittest/windows/scripts/install.sh
+++ b/.circleci/unittest/windows/scripts/install.sh
@@ -1,3 +1,4 @@
+
 #!/usr/bin/env bash
 
 unset PYTORCH_VERSION
@@ -24,7 +25,7 @@ else
     fi
 
     cuda_toolkit_pckg="cudatoolkit"
-    if [[ $CUDA_VERSION == 11.6 || $CUDA_VERSION == 11.7 ]]; then
+    if [[ $CUDA_VERSION == 11.6 || $CUDA_VERSION == 11.7 || $CUDA_VERSION == 11.8 ]]; then
         cuda_toolkit_pckg="pytorch-cuda"
     fi
 

--- a/.github/workflows/prototype-tests-linux-gpu.yml
+++ b/.github/workflows/prototype-tests-linux-gpu.yml
@@ -17,7 +17,7 @@ jobs:
         include:
           - python-version: "3.8"
             gpu-arch-type: cuda
-            gpu-arch-version: "11.6"
+            gpu-arch-version: "11.7"
             runner: linux.4xlarge.nvidia.gpu
       fail-fast: false
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
@@ -40,7 +40,7 @@ jobs:
         PYTORCH_CHANNEL=pytorch-"${POSTFIX}"
         echo "${PYTORCH_CHANNEL}"
         echo '::endgroup::'
-                
+
         echo '::group::Set PyTorch conda mutex'
         if [[ ${{ matrix.gpu-arch-type }} = 'cuda' ]]; then
           PYTORCH_MUTEX="pytorch-cuda=${{ matrix.gpu-arch-version }}"
@@ -49,7 +49,7 @@ jobs:
         fi
         echo "${PYTORCH_MUTEX}"
         echo '::endgroup::'
-        
+
         echo '::group::Create conda environment'
         conda create --prefix $PWD/ci \
           --quiet --yes \
@@ -69,21 +69,21 @@ jobs:
           python3 -c "import torch; exit(not torch.cuda.is_available())"
         fi
         echo '::endgroup::'
-          
+
         echo '::group::Install TorchVision'
         python setup.py develop
         echo '::endgroup::'
-        
+
         echo '::group::Collect PyTorch environment information'
         python -m torch.utils.collect_env
         echo '::endgroup::'
-        
+
         echo '::group::Install testing utilities'
         pip install --progress-bar=off pytest pytest-mock pytest-cov
         echo '::endgroup::'
 
         echo '::group::Run prototype tests'
-        # We don't want to run the prototype datasets tests. Since the positional glob into `pytest`, i.e. 
+        # We don't want to run the prototype datasets tests. Since the positional glob into `pytest`, i.e.
         # `test/test_prototype*.py` takes the highest priority, neither `--ignore` nor `--ignore-glob` can help us here.
         rm test/test_prototype_datasets*.py
         pytest \

--- a/.github/workflows/test-linux-gpu.yml
+++ b/.github/workflows/test-linux-gpu.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         python_version: ["3.8"]
-        cuda_arch_version: ["11.6"]
+        cuda_arch_version: ["11.7"]
       fail-fast: false
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
     with:
@@ -45,7 +45,7 @@ jobs:
         # Create Conda Env
         conda create -yp ci_env python="${PYTHON_VERSION}" numpy libpng jpeg scipy
         conda activate /work/ci_env
-        
+
         # Install PyTorch, Torchvision, and testing libraries
         set -ex
         conda install \


### PR DESCRIPTION
Remove cuda 11.6 from CI replace with 11.7
Following the Release readme here: https://github.com/pytorch/pytorch/blob/master/RELEASE.md#release-compatibility-matrix