### PR TITLE
remove GTSRB from detection dataset list

### DIFF
--- a/docs/source/datasets.rst
+++ b/docs/source/datasets.rst
@@ -80,7 +80,6 @@ Image detection or segmentation
     CocoDetection
     CelebA
     Cityscapes
-    GTSRB
     Kitti
     OxfordIIITPet
     SBDataset


### PR DESCRIPTION
`GTSRB` is currently listed as classification

https://github.com/pytorch/vision/blob/82c51c4899a0bf5aacb9f4d8ce5934247ef24391/docs/source/datasets.rst?plain=1#L52

as well as detection dataset:

https://github.com/pytorch/vision/blob/82c51c4899a0bf5aacb9f4d8ce5934247ef24391/docs/source/datasets.rst?plain=1#L83

Although GTSRB can provide bounding boxes (and we use them in the v2 dataset)

https://github.com/pytorch/vision/blob/82c51c4899a0bf5aacb9f4d8ce5934247ef24391/torchvision/prototype/datasets/_builtin/gtsrb.py#L78-L82

the v1 dataset only returns the label

https://github.com/pytorch/vision/blob/82c51c4899a0bf5aacb9f4d8ce5934247ef24391/torchvision/datasets/gtsrb.py#L50

Thus, this PR removes `GTSRB` from the detection dataset list.

