### PR TITLE
remove default value from LabelToOneHot

### DIFF
--- a/torchvision/prototype/transforms/_type_conversion.py
+++ b/torchvision/prototype/transforms/_type_conversion.py
@@ -15,15 +15,12 @@ from torchvision.prototype.transforms.utils import is_simple_tensor
 class LabelToOneHot(Transform):
     _transformed_types = (datapoints.Label,)
 
-    def __init__(self, num_categories: int = -1):
+    def __init__(self, num_categories: int):
         super().__init__()
         self.num_categories = num_categories
 
     def _transform(self, inpt: datapoints.Label, params: Dict[str, Any]) -> datapoints.OneHotLabel:
-        num_categories = self.num_categories
-        if num_categories == -1 and inpt.categories is not None:
-            num_categories = len(inpt.categories)
-        output = one_hot(inpt.as_subclass(torch.Tensor), num_classes=num_categories)
+        output = one_hot(inpt.as_subclass(torch.Tensor), num_classes=self.num_categories)
         return datapoints.OneHotLabel(output, categories=inpt.categories)
 
     def extra_repr(self) -> str:


### PR DESCRIPTION
As noted in https://github.com/pytorch/vision/pull/7171#discussion_r1095948879, the default value of `-1` is sketchy at best. It can easily lead to silent bugs if the inference is wrong. Inferring from the `categories` field of `Label` is better in the sense that it will give the right answer. However, since `categories` is optional, we can't rely on it either.

Thus, this PR removes the default value and users have to specify the number of categories explicitly. 

One other option that depends on whether we move forward with #7171 or not is this: we use `num_categories: Optional[int] = None` and error on `< 1` in the constructor. Inside `_transform` we check whether either `self.num_categories` or `label.categories` is set and error otherwise.
