### PR TITLE
[torchvision] Allow building torchvision operators statically

### DIFF
--- a/torchvision/csrc/macros.h
+++ b/torchvision/csrc/macros.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(TORCHVISION_BUILD_STATIC_LIBS)
 #if defined(torchvision_EXPORTS)
 #define VISION_API __declspec(dllexport)
 #else


### PR DESCRIPTION
Summary:
On Windows, build `conflicts (typically duplicate symbols errors) can arise when torchvision operators are both included into DLLs and linked statically against a binary targets.

This changes adds a directive `torchvision_BUILD_STATIC_LIBS` that allows to remove the remove the windows `__declspec(dllimport/export)` signature for those operators.

To maintain the default behavior, the new directive needs to be added a compile time to override the default behavior.

Reviewed By: lg-zhang

Differential Revision: D42917072

