### PR TITLE
remove int interpolation from elastic

### DIFF
--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -2217,10 +2217,6 @@ def test_elastic_transformation():
     with pytest.raises(ValueError, match=r"sigma is a sequence its length should be 2"):
         transforms.ElasticTransform(alpha=2.0, sigma=[1.0, 0.0, 1.0])
 
-    with pytest.warns(UserWarning, match=r"Argument interpolation should be of type InterpolationMode"):
-        t = transforms.transforms.ElasticTransform(alpha=2.0, sigma=2.0, interpolation=2)
-        assert t.interpolation == transforms.InterpolationMode.BILINEAR
-
     with pytest.raises(TypeError, match=r"fill should be int or float"):
         transforms.ElasticTransform(alpha=1.0, sigma=1.0, fill={})
 

--- a/torchvision/transforms/functional.py
+++ b/torchvision/transforms/functional.py
@@ -34,20 +34,6 @@ class InterpolationMode(Enum):
     LANCZOS = "lanczos"
 
 
-# TODO: Once torchscript supports Enums with staticmethod
-# this can be put into InterpolationMode as staticmethod
-def _interpolation_modes_from_int(i: int) -> InterpolationMode:
-    inverse_modes_mapping = {
-        0: InterpolationMode.NEAREST,
-        2: InterpolationMode.BILINEAR,
-        3: InterpolationMode.BICUBIC,
-        4: InterpolationMode.BOX,
-        5: InterpolationMode.HAMMING,
-        1: InterpolationMode.LANCZOS,
-    }
-    return inverse_modes_mapping[i]
-
-
 pil_modes_mapping = {
     InterpolationMode.NEAREST: 0,
     InterpolationMode.BILINEAR: 2,
@@ -1501,13 +1487,6 @@ def elastic_transform(
     """
     if not torch.jit.is_scripting() and not torch.jit.is_tracing():
         _log_api_usage_once(elastic_transform)
-    # Backward compatibility with integer value
-    if isinstance(interpolation, int):
-        warnings.warn(
-            "Argument interpolation should be of type InterpolationMode instead of int. "
-            "Please, use InterpolationMode enum."
-        )
-        interpolation = _interpolation_modes_from_int(interpolation)
 
     if not isinstance(displacement, torch.Tensor):
         raise TypeError("Argument displacement should be a Tensor")

--- a/torchvision/transforms/transforms.py
+++ b/torchvision/transforms/transforms.py
@@ -15,7 +15,7 @@ except ImportError:
 
 from ..utils import _log_api_usage_once
 from . import functional as F
-from .functional import _interpolation_modes_from_int, InterpolationMode
+from .functional import InterpolationMode
 
 __all__ = [
     "Compose",
@@ -2044,14 +2044,6 @@ class ElasticTransform(torch.nn.Module):
             sigma = [sigma[0], sigma[0]]
 
         self.sigma = sigma
-
-        # Backward compatibility with integer value
-        if isinstance(interpolation, int):
-            warnings.warn(
-                "Argument interpolation should be of type InterpolationMode instead of int. "
-                "Please, use InterpolationMode enum."
-            )
-            interpolation = _interpolation_modes_from_int(interpolation)
         self.interpolation = interpolation
 
         if isinstance(fill, (int, float)):


### PR DESCRIPTION
This was not included in #7176, since it seems we forgot to put a concrete removal date or better yet an actual deprecation warning in there. So we did warn, but not compliant with our BC policy. Question now is, do we want to move forward with the removal regardless of the point above or do we formally deprecate it now and remove in 0.17?

I lean towards 1., since it is unlikely someone using only `ElasticTransform` and thus has seen the concrete deprecation warnings of all other transforms and in turn most likely will also have fixed it here. However, there is no guarantee and so I'm also fine with the other option. In that case let's close this PR and open another one.

cc @vfdev-5