### PR TITLE
disable mypy for prototype datasets

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -37,17 +37,7 @@ allow_redefinition = True
 
 [mypy-torchvision.prototype.datasets.*]
 
-; untyped definitions and calls
-disallow_untyped_defs = True
-
-; None and Optional handling
-no_implicit_optional = True
-
-; warnings
-warn_unused_ignores = True
-
-; miscellaneous strictness flags
-allow_redefinition = True
+ignore_errors = True
 
 [mypy-torchvision.io.image.*]
 


### PR DESCRIPTION
Per title. Although there shouldn't be anything, stuff like https://github.com/pytorch/data/pull/987#issuecomment-1422440049 indicate that it might happen. Since we are currently not actively working on the prototype datasets, we shouldn't break CI over it.

The error linked above is fixed in #6068.