### PR TITLE
allow nn.ModuleList in RandomApply

### DIFF
--- a/test/test_prototype_transforms_consistency.py
+++ b/test/test_prototype_transforms_consistency.py
@@ -23,6 +23,7 @@ from prototype_common_utils import (
     make_label,
     make_segmentation_mask,
 )
+from torch import nn
 from torchvision import transforms as legacy_transforms
 from torchvision._utils import sequence_to_str
 from torchvision.prototype import datapoints, transforms as prototype_transforms
@@ -761,19 +762,24 @@ class TestContainerTransforms:
         check_call_consistency(prototype_transform, legacy_transform)
 
     @pytest.mark.parametrize("p", [0, 0.1, 0.5, 0.9, 1])
-    def test_random_apply(self, p):
+    @pytest.mark.parametrize("sequence_type", [list, nn.ModuleList])
+    def test_random_apply(self, p, sequence_type):
         prototype_transform = prototype_transforms.RandomApply(
-            [
-                prototype_transforms.Resize(256),
-                prototype_transforms.CenterCrop(224),
-            ],
+            sequence_type(
+                [
+                    prototype_transforms.Resize(256),
+                    prototype_transforms.CenterCrop(224),
+                ]
+            ),
             p=p,
         )
         legacy_transform = legacy_transforms.RandomApply(
-            [
-                legacy_transforms.Resize(256),
-                legacy_transforms.CenterCrop(224),
-            ],
+            sequence_type(
+                [
+                    legacy_transforms.Resize(256),
+                    legacy_transforms.CenterCrop(224),
+                ]
+            ),
             p=p,
         )
 

--- a/torchvision/prototype/transforms/_container.py
+++ b/torchvision/prototype/transforms/_container.py
@@ -1,7 +1,9 @@
 import warnings
-from typing import Any, Callable, List, Optional, Sequence
+from typing import Any, Callable, List, Optional, Sequence, Union
 
 import torch
+
+from torch import nn
 from torchvision.prototype.transforms import Transform
 
 
@@ -25,9 +27,13 @@ class Compose(Transform):
         return "\n".join(format_string)
 
 
-class RandomApply(Compose):
-    def __init__(self, transforms: Sequence[Callable], p: float = 0.5) -> None:
-        super().__init__(transforms)
+class RandomApply(Transform):
+    def __init__(self, transforms: Union[Sequence[Callable], nn.ModuleList], p: float = 0.5) -> None:
+        super().__init__()
+
+        if not isinstance(transforms, (Sequence, nn.ModuleList)):
+            raise TypeError("Argument transforms should be a sequence of callables or a `nn.ModuleList`")
+        self.transforms = transforms
 
         if not (0.0 <= p <= 1.0):
             raise ValueError("`p` should be a floating point value in the interval [0.0, 1.0].")
@@ -40,6 +46,12 @@ class RandomApply(Compose):
             return sample
 
         return super().forward(sample)
+
+    def extra_repr(self) -> str:
+        format_string = []
+        for t in self.transforms:
+            format_string.append(f"    {t}")
+        return "\n".join(format_string)
 
 
 class RandomChoice(Transform):

--- a/torchvision/prototype/transforms/_container.py
+++ b/torchvision/prototype/transforms/_container.py
@@ -45,7 +45,9 @@ class RandomApply(Transform):
         if torch.rand(1) >= self.p:
             return sample
 
-        return super().forward(sample)
+        for transform in self.transforms:
+            sample = transform(sample)
+        return sample
 
     def extra_repr(self) -> str:
         format_string = []


### PR DESCRIPTION
This is allowed in v1 for JIT scriptability:

https://github.com/pytorch/vision/blob/1120aa9e89d86bc466bba8f10ba382a5c63d6056/torchvision/transforms/transforms.py#L495-L502

cc @vfdev-5 @bjuncek