### PR TITLE
Put back previous tolerance for test_classification and test_video

### DIFF
--- a/test/test_models.py
+++ b/test/test_models.py
@@ -686,7 +686,7 @@ def test_classification_model(model_fn, dev):
     model.eval().to(device=dev)
     x = _get_image(input_shape=input_shape, real_image=real_image, device=dev)
     out = model(x)
-    _assert_expected(out.cpu(), model_name, prec=1e-3)
+    _assert_expected(out.cpu(), model_name, prec=0.1)
     assert out.shape[-1] == num_classes
     _check_jit_scriptable(model, (x,), unwrapper=script_model_unwrapper.get(model_name, None), eager_out=out)
     _check_fx_compatible(model, x, eager_out=out)
@@ -917,7 +917,7 @@ def test_video_model(model_fn, dev):
     # RNG always on CPU, to ensure x in cuda tests is bitwise identical to x in cpu tests
     x = torch.rand(input_shape).to(device=dev)
     out = model(x)
-    _assert_expected(out.cpu(), model_name, prec=1e-5)
+    _assert_expected(out.cpu(), model_name, prec=0.1)
     assert out.shape[-1] == num_classes
     _check_jit_scriptable(model, (x,), unwrapper=script_model_unwrapper.get(model_name, None), eager_out=out)
     _check_fx_compatible(model, x, eager_out=out)


### PR DESCRIPTION
This reverts https://github.com/pytorch/vision/pull/6380 which was identified to be the cause of various recent failures https://github.com/pytorch/vision/pull/7114#issuecomment-1400861739.

This PR fixes the current model failures for video and classification (except for this weird cuda-vit_h_14 failure which is tracked in https://github.com/pytorch/vision/issues/7143.

I'll submit another PR for the detection model and mark them as flaky (like what https://github.com/pytorch/vision/pull/7130 already does)

Like all of those quick-fix PRs, this one is less than ideal. It's just a patch over an already messy situation. In the (hopefully near) future, we should focus on more robust changes like the one proposed in https://github.com/pytorch/vision/pull/7130