### PR TITLE
update usages of torch.testing internals

### DIFF
--- a/test/test_prototype_datasets_builtin.py
+++ b/test/test_prototype_datasets_builtin.py
@@ -1,4 +1,3 @@
-import functools
 import io
 import pickle
 from collections import deque
@@ -9,7 +8,7 @@ import torch
 
 import torchvision.prototype.transforms.utils
 from builtin_dataset_mocks import DATASET_MOCKS, parametrize_dataset_mocks
-from torch.testing._comparison import assert_equal, ObjectPair, TensorLikePair
+from torch.testing._comparison import not_close_error_metas, ObjectPair, TensorLikePair
 
 # TODO: replace with torchdata.dataloader2.DataLoader2 as soon as it is stable-ish
 from torch.utils.data import DataLoader
@@ -25,9 +24,12 @@ from torchvision.prototype import datapoints, datasets, transforms
 from torchvision.prototype.datasets.utils._internal import INFINITE_BUFFER_SIZE
 
 
-assert_samples_equal = functools.partial(
-    assert_equal, pair_types=(TensorLikePair, ObjectPair), rtol=0, atol=0, equal_nan=True
-)
+def assert_samples_equal(*args, msg=None, **kwargs):
+    error_metas = not_close_error_metas(
+        *args, pair_types=(TensorLikePair, ObjectPair), rtol=0, atol=0, equal_nan=True, **kwargs
+    )
+    if error_metas:
+        raise error_metas[0].to_error(msg)
 
 
 def extract_datapipes(dp):


### PR DESCRIPTION
I've merged pytorch/pytorch#90004 and pytorch/pytorch#90005 yesterday and they changed some internals that we use.


cc @bjuncek