### PR TITLE
Add `prototype` sub-module to `__init__`

### DIFF
--- a/torchvision/__init__.py
+++ b/torchvision/__init__.py
@@ -3,7 +3,7 @@ import warnings
 from modulefinder import Module
 
 import torch
-from torchvision import datasets, io, models, ops, transforms, utils
+from torchvision import datasets, io, models, ops, prototype, transforms, utils
 
 from .extension import _HAS_OPS
 


### PR DESCRIPTION
Makes `prototype` sub-module reachable from torchvision package API