### PR TITLE
fix: use `inplace=None` as default in `ops.MLP`

### DIFF
--- a/torchvision/ops/misc.py
+++ b/torchvision/ops/misc.py
@@ -268,7 +268,8 @@ class MLP(torch.nn.Sequential):
         hidden_channels (List[int]): List of the hidden channel dimensions
         norm_layer (Callable[..., torch.nn.Module], optional): Norm layer that will be stacked on top of the linear layer. If ``None`` this layer won't be used. Default: ``None``
         activation_layer (Callable[..., torch.nn.Module], optional): Activation function which will be stacked on top of the normalization layer (if not None), otherwise on top of the linear layer. If ``None`` this layer won't be used. Default: ``torch.nn.ReLU``
-        inplace (bool, optional): Parameter for the activation layer, which can optionally do the operation in-place. Default ``None``
+        inplace (bool, optional): Parameter for the activation layer, which can optionally do the operation in-place.
+            Default is ``None``, which uses the respective default values of the ``activation_layer`` and Dropout layer.
         bias (bool): Whether to use bias in the linear layer. Default ``True``
         dropout (float): The probability for the dropout layer. Default: 0.0
     """

--- a/torchvision/ops/misc.py
+++ b/torchvision/ops/misc.py
@@ -268,7 +268,7 @@ class MLP(torch.nn.Sequential):
         hidden_channels (List[int]): List of the hidden channel dimensions
         norm_layer (Callable[..., torch.nn.Module], optional): Norm layer that will be stacked on top of the linear layer. If ``None`` this layer won't be used. Default: ``None``
         activation_layer (Callable[..., torch.nn.Module], optional): Activation function which will be stacked on top of the normalization layer (if not None), otherwise on top of the linear layer. If ``None`` this layer won't be used. Default: ``torch.nn.ReLU``
-        inplace (bool): Parameter for the activation layer, which can optionally do the operation in-place. Default ``None``
+        inplace (bool, optional): Parameter for the activation layer, which can optionally do the operation in-place. Default ``None``
         bias (bool): Whether to use bias in the linear layer. Default ``True``
         dropout (float): The probability for the dropout layer. Default: 0.0
     """

--- a/torchvision/ops/misc.py
+++ b/torchvision/ops/misc.py
@@ -268,7 +268,7 @@ class MLP(torch.nn.Sequential):
         hidden_channels (List[int]): List of the hidden channel dimensions
         norm_layer (Callable[..., torch.nn.Module], optional): Norm layer that will be stacked on top of the linear layer. If ``None`` this layer won't be used. Default: ``None``
         activation_layer (Callable[..., torch.nn.Module], optional): Activation function which will be stacked on top of the normalization layer (if not None), otherwise on top of the linear layer. If ``None`` this layer won't be used. Default: ``torch.nn.ReLU``
-        inplace (bool): Parameter for the activation layer, which can optionally do the operation in-place. Default ``True``
+        inplace (bool): Parameter for the activation layer, which can optionally do the operation in-place. Default ``None``
         bias (bool): Whether to use bias in the linear layer. Default ``True``
         dropout (float): The probability for the dropout layer. Default: 0.0
     """
@@ -279,7 +279,7 @@ class MLP(torch.nn.Sequential):
         hidden_channels: List[int],
         norm_layer: Optional[Callable[..., torch.nn.Module]] = None,
         activation_layer: Optional[Callable[..., torch.nn.Module]] = torch.nn.ReLU,
-        inplace: Optional[bool] = True,
+        inplace: Optional[bool] = None,
         bias: bool = True,
         dropout: float = 0.0,
     ):


### PR DESCRIPTION
If the default is `True`, then this casues an error during backprop that a tensor required for backpropagation was changed, if `dropout>0`.

Closes #7174 

