### PR TITLE
Try GPU tests on 11.6 and 11.8

### DIFF
--- a/.github/workflows/test-linux-gpu.yml
+++ b/.github/workflows/test-linux-gpu.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         python_version: ["3.8"]
-        cuda_arch_version: ["11.7"]
+        cuda_arch_version: ["11.6", "11.8"]
       fail-fast: false
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
     with:


### PR DESCRIPTION
<!-- Before submitting a PR, please make sure to check our contributing guidelines regarding code formatting, tests, and documentation: https://github.com/pytorch/vision/blob/main/CONTRIBUTING.md -->


EDIT: result is that it still fails with 11.8. 
Tests can't run in 11.6 (probably because torch core doesn't support it anymore)