### PR TITLE
fix COCO box format in dataset wrapper

### DIFF
--- a/torchvision/prototype/datapoints/_dataset_wrapper.py
+++ b/torchvision/prototype/datapoints/_dataset_wrapper.py
@@ -209,7 +209,7 @@ def coco_dectection_wrapper_factory(dataset):
         spatial_size = tuple(F.get_spatial_size(image))
         batched_target["boxes"] = datapoints.BoundingBox(
             batched_target["bbox"],
-            format=datapoints.BoundingBoxFormat.XYXY,
+            format=datapoints.BoundingBoxFormat.XYWH,
             spatial_size=spatial_size,
         )
         batched_target["masks"] = datapoints.Mask(


### PR DESCRIPTION
See this manual XYWH -> XYXY conversion in the references

https://github.com/pytorch/vision/blob/9b233d41ad71de768a1714eaeb2ebd4f893688e5/references/detection/coco_utils.py#L60-L63

or this from the datasets v2:

https://github.com/pytorch/vision/blob/9b233d41ad71de768a1714eaeb2ebd4f893688e5/torchvision/prototype/datasets/_builtin/coco.py#L128-L132

cc @vfdev-5 @bjuncek