### PR TITLE
fix {convert_format, clamp}_bounding_box

### DIFF
--- a/torchvision/prototype/transforms/functional/_meta.py
+++ b/torchvision/prototype/transforms/functional/_meta.py
@@ -230,8 +230,10 @@ def convert_format_bounding_box(
     elif isinstance(inpt, datapoints.BoundingBox):
         if old_format is not None:
             raise ValueError("For bounding box datapoint inputs, `old_format` must not be passed.")
-        output = _convert_format_bounding_box(inpt, old_format=inpt.format, new_format=new_format, inplace=inplace)
-        return datapoints.BoundingBox.wrap_like(inpt, output)
+        output = _convert_format_bounding_box(
+            inpt.as_subclass(torch.Tensor), old_format=inpt.format, new_format=new_format, inplace=inplace
+        )
+        return datapoints.BoundingBox.wrap_like(inpt, output, format=new_format)
     else:
         raise TypeError(
             f"Input can either be a plain tensor or a bounding box datapoint, but got {type(inpt)} instead."
@@ -266,7 +268,7 @@ def clamp_bounding_box(
     elif isinstance(inpt, datapoints.BoundingBox):
         if format is not None or spatial_size is not None:
             raise ValueError("For bounding box datapoint inputs, `format` and `spatial_size` must not be passed.")
-        output = _clamp_bounding_box(inpt, format=inpt.format, spatial_size=inpt.spatial_size)
+        output = _clamp_bounding_box(inpt.as_subclass(torch.Tensor), format=inpt.format, spatial_size=inpt.spatial_size)
         return datapoints.BoundingBox.wrap_like(inpt, output)
     else:
         raise TypeError(


### PR DESCRIPTION
This fixes two things that were missed in #7227 and #7228.

1. Calling a kernel should always be done by a plain tensor. Thus, we unwrap datapoints. Otherwise we are in hot water, because internally we assume that this is the case:

   https://github.com/pytorch/vision/blob/af7c6c048d0d4540779fed1cb6020a2909a71484/torchvision/prototype/transforms/functional/_meta.py#L246-L248

   Note that the call to `convert_format_bounding_box` will fail if `bounding_box` is a `datapoint.BoundingBox` here, since we unconditionally pass the `old_format`.
2. After `convert_format_bounding_box` the format has to be updated and cannot be taken from the input by design

cc @vfdev-5 @bjuncek