### PR TITLE
Fix some annotations in transforms v2 for JIT v1 compatibility

### DIFF
--- a/test/prototype_transforms_dispatcher_infos.py
+++ b/test/prototype_transforms_dispatcher_infos.py
@@ -96,14 +96,6 @@ def xfail_jit_python_scalar_arg(name, *, reason=None):
     )
 
 
-# FIXME: same treatment as for kernels
-def xfail_jit_tuple_instead_of_list(name, *, reason=None):
-    return xfail_jit(
-        reason or f"Passing a tuple instead of a list for `{name}` is not supported when scripting",
-        condition=lambda args_kwargs: isinstance(args_kwargs.kwargs.get(name), tuple),
-    )
-
-
 skip_dispatch_datapoint = TestMark(
     ("TestDispatchers", "test_dispatch_datapoint"),
     pytest.mark.skip(reason="Dispatcher doesn't support arbitrary datapoint dispatch."),
@@ -247,7 +239,7 @@ DISPATCHER_INFOS = [
                 and args_kwargs.kwargs.get("padding_mode", "constant") == "constant",
             ),
             xfail_jit("F.pad only supports vector fills for list of floats", condition=pad_xfail_jit_fill_condition),
-            xfail_jit_tuple_instead_of_list("padding"),
+            xfail_jit_python_scalar_arg("padding"),
         ],
     ),
     DispatcherInfo(

--- a/test/prototype_transforms_dispatcher_infos.py
+++ b/test/prototype_transforms_dispatcher_infos.py
@@ -96,6 +96,7 @@ def xfail_jit_python_scalar_arg(name, *, reason=None):
     )
 
 
+# FIXME: same treatment as for kernels
 def xfail_jit_tuple_instead_of_list(name, *, reason=None):
     return xfail_jit(
         reason or f"Passing a tuple instead of a list for `{name}` is not supported when scripting",
@@ -103,11 +104,13 @@ def xfail_jit_tuple_instead_of_list(name, *, reason=None):
     )
 
 
+# FIXME: same treatment as for kernels
 def is_list_of_ints(args_kwargs):
     fill = args_kwargs.kwargs.get("fill")
     return isinstance(fill, list) and any(isinstance(scalar_fill, int) for scalar_fill in fill)
 
 
+# FIXME: same treatment as for kernels
 def xfail_jit_list_of_ints(name, *, reason=None):
     return xfail_jit(
         reason or f"Passing a list of integers for `{name}` is not supported when scripting",
@@ -188,9 +191,7 @@ DISPATCHER_INFOS = [
         test_marks=[
             xfail_dispatch_pil_if_fill_sequence_needs_broadcast,
             xfail_jit_python_scalar_arg("shear"),
-            xfail_jit_tuple_instead_of_list("fill"),
-            # TODO: check if this is a regression since it seems that should be supported if `int` is ok
-            xfail_jit_list_of_ints("fill"),
+            xfail_jit_python_scalar_arg("fill"),
         ],
     ),
     DispatcherInfo(
@@ -212,11 +213,7 @@ DISPATCHER_INFOS = [
             datapoints.Mask: F.rotate_mask,
         },
         pil_kernel_info=PILKernelInfo(F.rotate_image_pil),
-        test_marks=[
-            xfail_jit_tuple_instead_of_list("fill"),
-            # TODO: check if this is a regression since it seems that should be supported if `int` is ok
-            xfail_jit_list_of_ints("fill"),
-        ],
+        test_marks=[xfail_jit_python_scalar_arg("fill")],
     ),
     DispatcherInfo(
         F.crop,
@@ -260,9 +257,6 @@ DISPATCHER_INFOS = [
                 and args_kwargs.kwargs.get("padding_mode", "constant") == "constant",
             ),
             xfail_jit_tuple_instead_of_list("padding"),
-            xfail_jit_tuple_instead_of_list("fill"),
-            # TODO: check if this is a regression since it seems that should be supported if `int` is ok
-            xfail_jit_list_of_ints("fill"),
         ],
     ),
     DispatcherInfo(
@@ -276,6 +270,7 @@ DISPATCHER_INFOS = [
         pil_kernel_info=PILKernelInfo(F.perspective_image_pil),
         test_marks=[
             xfail_dispatch_pil_if_fill_sequence_needs_broadcast,
+            xfail_jit_python_scalar_arg("fill"),
         ],
     ),
     DispatcherInfo(
@@ -287,6 +282,7 @@ DISPATCHER_INFOS = [
             datapoints.Mask: F.elastic_mask,
         },
         pil_kernel_info=PILKernelInfo(F.elastic_image_pil),
+        test_marks=[xfail_jit_python_scalar_arg("fill")],
     ),
     DispatcherInfo(
         F.center_crop,

--- a/test/prototype_transforms_dispatcher_infos.py
+++ b/test/prototype_transforms_dispatcher_infos.py
@@ -104,20 +104,6 @@ def xfail_jit_tuple_instead_of_list(name, *, reason=None):
     )
 
 
-# FIXME: same treatment as for kernels
-def is_list_of_ints(args_kwargs):
-    fill = args_kwargs.kwargs.get("fill")
-    return isinstance(fill, list) and any(isinstance(scalar_fill, int) for scalar_fill in fill)
-
-
-# FIXME: same treatment as for kernels
-def xfail_jit_list_of_ints(name, *, reason=None):
-    return xfail_jit(
-        reason or f"Passing a list of integers for `{name}` is not supported when scripting",
-        condition=is_list_of_ints,
-    )
-
-
 skip_dispatch_datapoint = TestMark(
     ("TestDispatchers", "test_dispatch_datapoint"),
     pytest.mark.skip(reason="Dispatcher doesn't support arbitrary datapoint dispatch."),

--- a/test/prototype_transforms_dispatcher_infos.py
+++ b/test/prototype_transforms_dispatcher_infos.py
@@ -3,7 +3,7 @@ import collections.abc
 import pytest
 import torchvision.prototype.transforms.functional as F
 from prototype_common_utils import InfoBase, TestMark
-from prototype_transforms_kernel_infos import KERNEL_INFOS
+from prototype_transforms_kernel_infos import KERNEL_INFOS, pad_xfail_jit_fill_condition
 from torchvision.prototype import datapoints
 
 __all__ = ["DispatcherInfo", "DISPATCHER_INFOS"]
@@ -133,6 +133,13 @@ multi_crop_skips = [
 multi_crop_skips.append(skip_dispatch_datapoint)
 
 
+def xfails_pil(reason, *, condition=None):
+    return [
+        TestMark(("TestDispatchers", test_name), pytest.mark.xfail(reason=reason), condition=condition)
+        for test_name in ["test_dispatch_pil", "test_pil_output_type"]
+    ]
+
+
 def fill_sequence_needs_broadcast(args_kwargs):
     (image_loader, *_), kwargs = args_kwargs
     try:
@@ -146,11 +153,8 @@ def fill_sequence_needs_broadcast(args_kwargs):
     return image_loader.num_channels > 1
 
 
-xfail_dispatch_pil_if_fill_sequence_needs_broadcast = TestMark(
-    ("TestDispatchers", "test_dispatch_pil"),
-    pytest.mark.xfail(
-        reason="PIL kernel doesn't support sequences of length 1 for `fill` if the number of color channels is larger."
-    ),
+xfails_pil_if_fill_sequence_needs_broadcast = xfails_pil(
+    "PIL kernel doesn't support sequences of length 1 for `fill` if the number of color channels is larger.",
     condition=fill_sequence_needs_broadcast,
 )
 
@@ -189,7 +193,7 @@ DISPATCHER_INFOS = [
         },
         pil_kernel_info=PILKernelInfo(F.affine_image_pil),
         test_marks=[
-            xfail_dispatch_pil_if_fill_sequence_needs_broadcast,
+            *xfails_pil_if_fill_sequence_needs_broadcast,
             xfail_jit_python_scalar_arg("shear"),
             xfail_jit_python_scalar_arg("fill"),
         ],
@@ -213,7 +217,10 @@ DISPATCHER_INFOS = [
             datapoints.Mask: F.rotate_mask,
         },
         pil_kernel_info=PILKernelInfo(F.rotate_image_pil),
-        test_marks=[xfail_jit_python_scalar_arg("fill")],
+        test_marks=[
+            xfail_jit_python_scalar_arg("fill"),
+            *xfails_pil_if_fill_sequence_needs_broadcast,
+        ],
     ),
     DispatcherInfo(
         F.crop,
@@ -245,17 +252,15 @@ DISPATCHER_INFOS = [
         },
         pil_kernel_info=PILKernelInfo(F.pad_image_pil, kernel_name="pad_image_pil"),
         test_marks=[
-            TestMark(
-                ("TestDispatchers", "test_dispatch_pil"),
-                pytest.mark.xfail(
-                    reason=(
-                        "PIL kernel doesn't support sequences of length 1 for argument `fill` and "
-                        "`padding_mode='constant'`, if the number of color channels is larger."
-                    )
+            *xfails_pil(
+                reason=(
+                    "PIL kernel doesn't support sequences of length 1 for argument `fill` and "
+                    "`padding_mode='constant'`, if the number of color channels is larger."
                 ),
                 condition=lambda args_kwargs: fill_sequence_needs_broadcast(args_kwargs)
                 and args_kwargs.kwargs.get("padding_mode", "constant") == "constant",
             ),
+            xfail_jit("F.pad only supports vector fills for list of floats", condition=pad_xfail_jit_fill_condition),
             xfail_jit_tuple_instead_of_list("padding"),
         ],
     ),
@@ -269,7 +274,7 @@ DISPATCHER_INFOS = [
         },
         pil_kernel_info=PILKernelInfo(F.perspective_image_pil),
         test_marks=[
-            xfail_dispatch_pil_if_fill_sequence_needs_broadcast,
+            *xfails_pil_if_fill_sequence_needs_broadcast,
             xfail_jit_python_scalar_arg("fill"),
         ],
     ),

--- a/test/prototype_transforms_kernel_infos.py
+++ b/test/prototype_transforms_kernel_infos.py
@@ -162,20 +162,6 @@ def xfail_jit_tuple_instead_of_list(name, *, reason=None):
     )
 
 
-def is_list_of_ints(args_kwargs):
-    # FIXME: why special case fill here?
-    fill = args_kwargs.kwargs.get("fill")
-    return isinstance(fill, list) and any(isinstance(scalar_fill, int) for scalar_fill in fill)
-
-
-# FIXME: maybe remove since it is only used once?
-def xfail_jit_list_of_ints(name, *, reason=None):
-    return xfail_jit(
-        reason or f"Passing a list of integers for `{name}` is not supported when scripting",
-        condition=is_list_of_ints,
-    )
-
-
 KERNEL_INFOS = []
 
 

--- a/test/prototype_transforms_kernel_infos.py
+++ b/test/prototype_transforms_kernel_infos.py
@@ -153,15 +153,6 @@ def xfail_jit_python_scalar_arg(name, *, reason=None):
     )
 
 
-# FIXME: does this also apply to padding???
-def xfail_jit_tuple_instead_of_list(name, *, reason=None):
-    reason = reason or f"Passing a tuple instead of a list for `{name}` is not supported when scripting"
-    return xfail_jit(
-        reason or f"Passing a tuple instead of a list for `{name}` is not supported when scripting",
-        condition=lambda args_kwargs: isinstance(args_kwargs.kwargs.get(name), tuple),
-    )
-
-
 KERNEL_INFOS = []
 
 
@@ -1149,7 +1140,7 @@ KERNEL_INFOS.extend(
             float32_vs_uint8=float32_vs_uint8_fill_adapter,
             closeness_kwargs=float32_vs_uint8_pixel_difference(),
             test_marks=[
-                xfail_jit_tuple_instead_of_list("padding"),
+                xfail_jit_python_scalar_arg("padding"),
                 xfail_jit(
                     "F.pad only supports vector fills for list of floats", condition=pad_xfail_jit_fill_condition
                 ),
@@ -1161,7 +1152,7 @@ KERNEL_INFOS.extend(
             reference_fn=reference_pad_bounding_box,
             reference_inputs_fn=reference_inputs_pad_bounding_box,
             test_marks=[
-                xfail_jit_tuple_instead_of_list("padding"),
+                xfail_jit_python_scalar_arg("padding"),
             ],
         ),
         KernelInfo(

--- a/test/prototype_transforms_kernel_infos.py
+++ b/test/prototype_transforms_kernel_infos.py
@@ -153,6 +153,7 @@ def xfail_jit_python_scalar_arg(name, *, reason=None):
     )
 
 
+# FIXME: does this also apply to padding???
 def xfail_jit_tuple_instead_of_list(name, *, reason=None):
     reason = reason or f"Passing a tuple instead of a list for `{name}` is not supported when scripting"
     return xfail_jit(
@@ -162,10 +163,12 @@ def xfail_jit_tuple_instead_of_list(name, *, reason=None):
 
 
 def is_list_of_ints(args_kwargs):
+    # FIXME: why special case fill here?
     fill = args_kwargs.kwargs.get("fill")
     return isinstance(fill, list) and any(isinstance(scalar_fill, int) for scalar_fill in fill)
 
 
+# FIXME: maybe remove since it is only used once?
 def xfail_jit_list_of_ints(name, *, reason=None):
     return xfail_jit(
         reason or f"Passing a list of integers for `{name}` is not supported when scripting",
@@ -633,9 +636,7 @@ KERNEL_INFOS.extend(
             closeness_kwargs=pil_reference_pixel_difference(10, mae=True),
             test_marks=[
                 xfail_jit_python_scalar_arg("shear"),
-                xfail_jit_tuple_instead_of_list("fill"),
-                # TODO: check if this is a regression since it seems that should be supported if `int` is ok
-                xfail_jit_list_of_ints("fill"),
+                xfail_jit_python_scalar_arg("fill"),
             ],
         ),
         KernelInfo(
@@ -826,9 +827,7 @@ KERNEL_INFOS.extend(
             float32_vs_uint8=True,
             closeness_kwargs=pil_reference_pixel_difference(1, mae=True),
             test_marks=[
-                xfail_jit_tuple_instead_of_list("fill"),
-                # TODO: check if this is a regression since it seems that should be supported if `int` is ok
-                xfail_jit_list_of_ints("fill"),
+                xfail_jit_python_scalar_arg("fill"),
             ],
         ),
         KernelInfo(
@@ -1151,6 +1150,7 @@ KERNEL_INFOS.extend(
             reference_inputs_fn=reference_inputs_pad_image_tensor,
             float32_vs_uint8=float32_vs_uint8_fill_adapter,
             closeness_kwargs=float32_vs_uint8_pixel_difference(),
+            # FIXME: pad is a little different
             test_marks=[
                 xfail_jit_tuple_instead_of_list("padding"),
                 xfail_jit_tuple_instead_of_list("fill"),
@@ -1272,6 +1272,7 @@ KERNEL_INFOS.extend(
                 **scripted_vs_eager_double_pixel_difference("cpu", atol=1e-5, rtol=1e-5),
                 **scripted_vs_eager_double_pixel_difference("cuda", atol=1e-5, rtol=1e-5),
             },
+            test_marks=[xfail_jit_python_scalar_arg("fill")],
         ),
         KernelInfo(
             F.perspective_bounding_box,
@@ -1358,6 +1359,7 @@ KERNEL_INFOS.extend(
                 **float32_vs_uint8_pixel_difference(6, mae=True),
                 **cuda_vs_cpu_pixel_difference(),
             },
+            test_marks=[xfail_jit_python_scalar_arg("fill")],
         ),
         KernelInfo(
             F.elastic_bounding_box,

--- a/test/test_prototype_transforms_functional.py
+++ b/test/test_prototype_transforms_functional.py
@@ -406,7 +406,7 @@ class TestDispatchers:
         [info for info in DISPATCHER_INFOS if info.pil_kernel_info is not None],
         args_kwargs_fn=lambda info: info.sample_inputs(datapoints.Image),
     )
-    def test_pil_output_type(self, request, info, args_kwargs):
+    def test_pil_output_type(self, info, args_kwargs):
         (image_datapoint, *other_args), kwargs = args_kwargs.load()
 
         if image_datapoint.ndim > 3:

--- a/test/test_prototype_transforms_functional.py
+++ b/test/test_prototype_transforms_functional.py
@@ -405,7 +405,7 @@ class TestDispatchers:
         [info for info in DISPATCHER_INFOS if info.pil_kernel_info is not None],
         args_kwargs_fn=lambda info: info.sample_inputs(datapoints.Image),
     )
-    def test_pil_output_type(self, info, args_kwargs):
+    def test_pil_output_type(self, request, info, args_kwargs):
         (image_datapoint, *other_args), kwargs = args_kwargs.load()
 
         if image_datapoint.ndim > 3:

--- a/torchvision/prototype/datapoints/_bounding_box.py
+++ b/torchvision/prototype/datapoints/_bounding_box.py
@@ -115,7 +115,7 @@ class BoundingBox(Datapoint):
     def pad(
         self,
         padding: Union[int, Sequence[int]],
-        fill: FillTypeJIT = None,
+        fill: Optional[Union[int, float, List[float]]] = None,
         padding_mode: str = "constant",
     ) -> BoundingBox:
         output, spatial_size = self._F.pad_bounding_box(

--- a/torchvision/prototype/datapoints/_datapoint.py
+++ b/torchvision/prototype/datapoints/_datapoint.py
@@ -169,7 +169,7 @@ class Datapoint(torch.Tensor):
 
     def pad(
         self,
-        padding: Union[int, List[int]],
+        padding: List[int],
         fill: Optional[Union[int, float, List[float]]] = None,
         padding_mode: str = "constant",
     ) -> Datapoint:

--- a/torchvision/prototype/datapoints/_datapoint.py
+++ b/torchvision/prototype/datapoints/_datapoint.py
@@ -12,7 +12,7 @@ from torchvision.transforms import InterpolationMode
 
 D = TypeVar("D", bound="Datapoint")
 FillType = Union[int, float, Sequence[int], Sequence[float], None]
-FillTypeJIT = Union[int, float, List[float], None]
+FillTypeJIT = Optional[List[float]]
 
 
 class Datapoint(torch.Tensor):
@@ -170,7 +170,7 @@ class Datapoint(torch.Tensor):
     def pad(
         self,
         padding: Union[int, List[int]],
-        fill: FillTypeJIT = None,
+        fill: Optional[Union[int, float, List[float]]] = None,
         padding_mode: str = "constant",
     ) -> Datapoint:
         return self

--- a/torchvision/prototype/datapoints/_image.py
+++ b/torchvision/prototype/datapoints/_image.py
@@ -104,7 +104,7 @@ class Image(Datapoint):
     def pad(
         self,
         padding: Union[int, List[int]],
-        fill: FillTypeJIT = None,
+        fill: Optional[Union[int, float, List[float]]] = None,
         padding_mode: str = "constant",
     ) -> Image:
         output = self._F.pad_image_tensor(self.as_subclass(torch.Tensor), padding, fill=fill, padding_mode=padding_mode)

--- a/torchvision/prototype/datapoints/_image.py
+++ b/torchvision/prototype/datapoints/_image.py
@@ -103,7 +103,7 @@ class Image(Datapoint):
 
     def pad(
         self,
-        padding: Union[int, List[int]],
+        padding: List[int],
         fill: Optional[Union[int, float, List[float]]] = None,
         padding_mode: str = "constant",
     ) -> Image:

--- a/torchvision/prototype/datapoints/_mask.py
+++ b/torchvision/prototype/datapoints/_mask.py
@@ -83,7 +83,7 @@ class Mask(Datapoint):
 
     def pad(
         self,
-        padding: Union[int, List[int]],
+        padding: List[int],
         fill: Optional[Union[int, float, List[float]]] = None,
         padding_mode: str = "constant",
     ) -> Mask:

--- a/torchvision/prototype/datapoints/_mask.py
+++ b/torchvision/prototype/datapoints/_mask.py
@@ -84,7 +84,7 @@ class Mask(Datapoint):
     def pad(
         self,
         padding: Union[int, List[int]],
-        fill: FillTypeJIT = None,
+        fill: Optional[Union[int, float, List[float]]] = None,
         padding_mode: str = "constant",
     ) -> Mask:
         output = self._F.pad_mask(self.as_subclass(torch.Tensor), padding, padding_mode=padding_mode, fill=fill)

--- a/torchvision/prototype/datapoints/_video.py
+++ b/torchvision/prototype/datapoints/_video.py
@@ -103,7 +103,7 @@ class Video(Datapoint):
     def pad(
         self,
         padding: Union[int, List[int]],
-        fill: FillTypeJIT = None,
+        fill: Optional[Union[int, float, List[float]]] = None,
         padding_mode: str = "constant",
     ) -> Video:
         output = self._F.pad_video(self.as_subclass(torch.Tensor), padding, fill=fill, padding_mode=padding_mode)

--- a/torchvision/prototype/datapoints/_video.py
+++ b/torchvision/prototype/datapoints/_video.py
@@ -102,7 +102,7 @@ class Video(Datapoint):
 
     def pad(
         self,
-        padding: Union[int, List[int]],
+        padding: List[int],
         fill: Optional[Union[int, float, List[float]]] = None,
         padding_mode: str = "constant",
     ) -> Video:

--- a/torchvision/prototype/transforms/_geometry.py
+++ b/torchvision/prototype/transforms/_geometry.py
@@ -270,7 +270,7 @@ class Pad(Transform):
 
     def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
         fill = self.fill[type(inpt)]
-        return F.pad(inpt, padding=self.padding, fill=fill, padding_mode=self.padding_mode)
+        return F.pad(inpt, padding=self.padding, fill=fill, padding_mode=self.padding_mode)  # type: ignore[arg-type]
 
 
 class RandomZoomOut(_RandomApplyTransform):

--- a/torchvision/prototype/transforms/_utils.py
+++ b/torchvision/prototype/transforms/_utils.py
@@ -60,10 +60,9 @@ def _convert_fill_arg(fill: datapoints.FillType) -> datapoints.FillTypeJIT:
     if fill is None:
         return fill
 
-    # This cast does Sequence -> List[float] to please mypy and torch.jit.script
     if not isinstance(fill, (int, float)):
         fill = [float(v) for v in list(fill)]
-    return fill
+    return fill  # type: ignore[return-value]
 
 
 def _setup_fill_arg(fill: Union[FillType, Dict[Type, FillType]]) -> Dict[Type, FillTypeJIT]:

--- a/torchvision/prototype/transforms/functional/_geometry.py
+++ b/torchvision/prototype/transforms/functional/_geometry.py
@@ -965,7 +965,7 @@ def _parse_pad_padding(padding: Union[int, List[int]]) -> List[int]:
 
 def pad_image_tensor(
     image: torch.Tensor,
-    padding: Union[int, List[int]],
+    padding: List[int],
     fill: Optional[Union[int, float, List[float]]] = None,
     padding_mode: str = "constant",
 ) -> torch.Tensor:
@@ -1070,7 +1070,7 @@ pad_image_pil = _FP.pad
 
 def pad_mask(
     mask: torch.Tensor,
-    padding: Union[int, List[int]],
+    padding: List[int],
     padding_mode: str = "constant",
     fill: datapoints.FillTypeJIT = None,
 ) -> torch.Tensor:
@@ -1095,7 +1095,7 @@ def pad_bounding_box(
     bounding_box: torch.Tensor,
     format: datapoints.BoundingBoxFormat,
     spatial_size: Tuple[int, int],
-    padding: Union[int, List[int]],
+    padding: List[int],
     padding_mode: str = "constant",
 ) -> Tuple[torch.Tensor, Tuple[int, int]]:
     if padding_mode not in ["constant"]:
@@ -1119,7 +1119,7 @@ def pad_bounding_box(
 
 def pad_video(
     video: torch.Tensor,
-    padding: Union[int, List[int]],
+    padding: List[int],
     fill: Optional[Union[int, float, List[float]]] = None,
     padding_mode: str = "constant",
 ) -> torch.Tensor:
@@ -1128,7 +1128,7 @@ def pad_video(
 
 def pad(
     inpt: datapoints.InputTypeJIT,
-    padding: Union[int, List[int]],
+    padding: List[int],
     fill: Optional[Union[int, float, List[float]]] = None,
     padding_mode: str = "constant",
 ) -> datapoints.InputTypeJIT:

--- a/torchvision/prototype/transforms/functional/_geometry.py
+++ b/torchvision/prototype/transforms/functional/_geometry.py
@@ -432,7 +432,7 @@ def _apply_grid_transform(
     if fill is not None:
         float_img, mask = torch.tensor_split(float_img, indices=(-1,), dim=-3)
         mask = mask.expand_as(float_img)
-        fill_list = fill if isinstance(fill, (tuple, list)) else [float(fill)]
+        fill_list = fill if isinstance(fill, (tuple, list)) else [float(fill)]  # type: ignore[arg-type]
         fill_img = torch.tensor(fill_list, dtype=float_img.dtype, device=float_img.device).view(1, -1, 1, 1)
         if mode == "nearest":
             bool_mask = mask < 0.5


### PR DESCRIPTION
TL;DR this reverts changes to the annotation of the `fill` and `padding` parameter that we made for v2, but turned out to not be compatible with the JIT behavior of v1.

---

We have three groups of transforms that take the `fill` parameter in v1:

- AA family:
  https://github.com/pytorch/vision/blob/f6b5b82efd0a89273f1a9274e7f1ce73c0f3971c/torchvision/transforms/autoaugment.py#L117-L118
- Affine family:
  https://github.com/pytorch/vision/blob/f6b5b82efd0a89273f1a9274e7f1ce73c0f3971c/torchvision/transforms/transforms.py#L1412-L1413
- `transforms.Pad`
  https://github.com/pytorch/vision/blob/f6b5b82efd0a89273f1a9274e7f1ce73c0f3971c/torchvision/transforms/transforms.py#L408-L412

In eager mode v1 and v2 behave the same and we enforce that in our consistency tests. However, for JIT they behave differently. The transforms aren't annotating the `fill` parameter, so we have to look at the functionals:

- AA family:
  https://github.com/pytorch/vision/blob/f6b5b82efd0a89273f1a9274e7f1ce73c0f3971c/torchvision/transforms/autoaugment.py#L14
- Affine family:
  https://github.com/pytorch/vision/blob/f6b5b82efd0a89273f1a9274e7f1ce73c0f3971c/torchvision/transforms/functional.py#L1148
- `F.pad`:
  https://github.com/pytorch/vision/blob/f6b5b82efd0a89273f1a9274e7f1ce73c0f3971c/torchvision/transforms/functional.py#L495

---

Let's start with the AA and affine family, since they use the same annotation:

```python
import torch
from torchvision.transforms import functional as F_v1
from torchvision.prototype.transforms import functional as F_v2

name = "rotate"
args = (torch.rand(3, 256, 256),)
kwargs = dict(angle=30)


for version, F in [
    ("v1", F_v1),
    ("v2", F_v2),
]:
    eager = getattr(F, name)
    scripted = torch.jit.script(eager)

    print(version, name)

    for fill in [None, 1, 0.5, [1], [0.5], (1,), (0.5,), [1, 0, 1], [0.1, 0.2, 0.3], (1, 0, 1), (0.1, 0.2, 0.3)]:
        try:
            eager(*args, **kwargs, fill=fill)
            eager_result = "PASS"
        except:
            eager_result = "FAIL"

        try:
            scripted(*args, **kwargs, fill=fill)
            scripted_result = "PASS"
        except:
            scripted_result = "FAIL"

        print(f"{str(fill):>15}: eager {eager_result}, scripted {scripted_result}")

    print("-" * 80)
```

On `main` this prints:

```
v1 rotate
           None: eager PASS, scripted PASS
              1: eager PASS, scripted FAIL
            0.5: eager PASS, scripted FAIL
            [1]: eager PASS, scripted PASS
          [0.5]: eager PASS, scripted PASS
           (1,): eager PASS, scripted PASS
         (0.5,): eager PASS, scripted PASS
      [1, 0, 1]: eager PASS, scripted PASS
[0.1, 0.2, 0.3]: eager PASS, scripted PASS
      (1, 0, 1): eager PASS, scripted PASS
(0.1, 0.2, 0.3): eager PASS, scripted PASS
--------------------------------------------------------------------------------
v2 rotate
           None: eager PASS, scripted PASS
              1: eager PASS, scripted PASS
            0.5: eager PASS, scripted PASS
            [1]: eager PASS, scripted FAIL
          [0.5]: eager PASS, scripted PASS
           (1,): eager PASS, scripted FAIL
         (0.5,): eager PASS, scripted FAIL
      [1, 0, 1]: eager PASS, scripted FAIL
[0.1, 0.2, 0.3]: eager PASS, scripted PASS
      (1, 0, 1): eager PASS, scripted FAIL
(0.1, 0.2, 0.3): eager PASS, scripted FAIL
--------------------------------------------------------------------------------
```

- v1 does not work with scalar ints or floats, but passes for everything else
- v2 does work for Python scalars, but doesn't for tuples or sequences of integers

So how did that happen? In v2 we changed the annotation to

https://github.com/pytorch/vision/blob/f6b5b82efd0a89273f1a9274e7f1ce73c0f3971c/torchvision/prototype/datapoints/_datapoint.py#L15

Meaning, failures for the list of integers are "expected" (we'll get to why later), but what happened to the tuples? v1 didn't annotate them either?

This is caused by some (undocumented) automagic of JIT. Annotating something with `List[int]` will automatically handle tuple inputs as well:

```python
@torch.jit.script
def foo(data: List[int]) -> torch.Tensor:
    if isinstance(data, int):
        data = [data]
    return torch.tensor(data)

foo((1, 2, 3))
```

However, if correct the annotation to `Union[int, List[int]]`, the automagic is no longer applied:

```python
@torch.jit.script
def bar(data: Union[int, List[int]]) -> torch.Tensor:
    if isinstance(data, int):
        data = [data]
    return torch.tensor(data)

bar((1, 2, 3))
```

```
RuntimeError: bar() Expected a value of type 'Union[List[int], int]' for argument 'data' but instead found type 'tuple'.
```
Well, we could just add `Tuple[int]` to the new annotation, right? Nope. `Tuple[int]` is not the equivalent to `List[int]`. That would be `Tuple[int, ...]`, but that is not supported by JIT. And since `fill` corresponds to the number of channels that will only be known at runtime, we cannot use `Tuple[int, int, int]` or any other fixed number. Meaning, we need to rely on the automagic for BC and need to revert our annotation changes.

---

So this is the end of the story? Nope again. As we saw above, `F.pad` uses different annotations. Let's run our script from above with

```python
name = "pad"
args = (torch.rand(3, 256, 256),)
kwargs = dict(padding=[2])
```

```
v1 pad
           None: eager PASS, scripted FAIL
              1: eager PASS, scripted PASS
            0.5: eager PASS, scripted PASS
            [1]: eager FAIL, scripted FAIL
          [0.5]: eager FAIL, scripted FAIL
           (1,): eager FAIL, scripted FAIL
         (0.5,): eager FAIL, scripted FAIL
      [1, 0, 1]: eager FAIL, scripted FAIL
[0.1, 0.2, 0.3]: eager FAIL, scripted FAIL
      (1, 0, 1): eager FAIL, scripted FAIL
(0.1, 0.2, 0.3): eager FAIL, scripted FAIL
--------------------------------------------------------------------------------
v2 pad
           None: eager PASS, scripted PASS
              1: eager PASS, scripted PASS
            0.5: eager PASS, scripted PASS
            [1]: eager PASS, scripted FAIL
          [0.5]: eager PASS, scripted PASS
           (1,): eager PASS, scripted FAIL
         (0.5,): eager PASS, scripted FAIL
      [1, 0, 1]: eager PASS, scripted FAIL
[0.1, 0.2, 0.3]: eager PASS, scripted PASS
      (1, 0, 1): eager PASS, scripted FAIL
(0.1, 0.2, 0.3): eager PASS, scripted FAIL
--------------------------------------------------------------------------------
```

- v1 only works with scalars even in eager mode (`None` does not work while scripting)
- v2 added support for multi-channel fills in eager mode and even passes on some of them during scripting

Meaning, we can keep our new annotation for `F.pad` since the v2 variant supports a superset of the values of v1 in eager as in scripted mode.

---

What's left is the `padding` argument on `F.pad`:

- v1:
  https://github.com/pytorch/vision/blob/f6b5b82efd0a89273f1a9274e7f1ce73c0f3971c/torchvision/transforms/functional.py#L495
- v2:
  https://github.com/pytorch/vision/blob/f6b5b82efd0a89273f1a9274e7f1ce73c0f3971c/torchvision/prototype/transforms/functional/_geometry.py#L1134

You can probably see where this is going. Changing the script from above to

```python
name = "pad"
args = (torch.rand(3, 256, 256),)
kwargs = dict()
```

and iterating over different `padding` values gives us:

```
v1 pad
           1: eager PASS, scripted FAIL
         [2]: eager PASS, scripted PASS
        (2,): eager PASS, scripted PASS
      [3, 4]: eager PASS, scripted PASS
      (3, 4): eager PASS, scripted PASS
[5, 6, 7, 8]: eager PASS, scripted PASS
(5, 6, 7, 8): eager PASS, scripted PASS
--------------------------------------------------------------------------------
v2 pad
           1: eager PASS, scripted PASS
         [2]: eager PASS, scripted PASS
        (2,): eager PASS, scripted FAIL
      [3, 4]: eager PASS, scripted PASS
      (3, 4): eager PASS, scripted FAIL
[5, 6, 7, 8]: eager PASS, scripted PASS
(5, 6, 7, 8): eager PASS, scripted FAIL
--------------------------------------------------------------------------------
```

Meaning, we need to revert the new annotation and rely on the automagic handling.

---

If this whole story wasn't so sad, this should probably should have been a blog post rather than a PR description. 

cc @vfdev-5 @bjuncek