### PR TITLE
Add a removable warning in torchvision.transforms.v2 and torchvision.datapoints

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -3,7 +3,11 @@ import random
 import numpy as np
 import pytest
 import torch
+import torchvision
 from common_utils import CUDA_NOT_AVAILABLE_MSG, IN_FBCODE, IN_OSS_CI, IN_RE_WORKER, OSS_CI_GPU_NO_CUDA_MSG
+
+
+torchvision.disable_beta_transforms_warning()
 
 
 def pytest_configure(config):

--- a/torchvision/__init__.py
+++ b/torchvision/__init__.py
@@ -98,6 +98,14 @@ def _is_tracing():
 
 
 _WARN_ABOUT_BETA_TRANSFORMS = True
+_BETA_TRANSFORMS_WARNING = (
+    "The torchvision.datapoints and torchvision.transforms.v2 namespaces are still Beta. "
+    "While we will try our best to maintain backward compatibility, "
+    "some APIs or behaviors might change without a deprecation cycle. "
+    "To help us improve these new features, please provide your feedback "
+    "here: https://github.com/pytorch/vision/issues/6753."
+    "You can silence this warning by calling torchvision.disable_beta_transform_warning()."
+)
 
 
 def disable_beta_transforms_warning():

--- a/torchvision/__init__.py
+++ b/torchvision/__init__.py
@@ -95,3 +95,11 @@ def get_video_backend():
 
 def _is_tracing():
     return torch._C._get_tracing_state()
+
+
+_WARN_ABOUT_BETA_TRANSFORMS = True
+
+
+def disable_beta_transforms_warning():
+    global _WARN_ABOUT_BETA_TRANSFORMS
+    _WARN_ABOUT_BETA_TRANSFORMS = False

--- a/torchvision/datapoints/__init__.py
+++ b/torchvision/datapoints/__init__.py
@@ -5,3 +5,10 @@ from ._mask import Mask
 from ._video import TensorVideoType, TensorVideoTypeJIT, Video, VideoType, VideoTypeJIT
 
 from ._dataset_wrapper import wrap_dataset_for_transforms_v2  # type: ignore[attr-defined]  # usort: skip
+
+from torchvision import _WARN_ABOUT_BETA_TRANSFORMS
+
+if _WARN_ABOUT_BETA_TRANSFORMS:
+    import warnings
+
+    warnings.warn("THE WARNING")

--- a/torchvision/datapoints/__init__.py
+++ b/torchvision/datapoints/__init__.py
@@ -6,9 +6,9 @@ from ._video import _TensorVideoType, _TensorVideoTypeJIT, _VideoType, _VideoTyp
 
 from ._dataset_wrapper import wrap_dataset_for_transforms_v2  # type: ignore[attr-defined]  # usort: skip
 
-from torchvision import _WARN_ABOUT_BETA_TRANSFORMS
+from torchvision import _BETA_TRANSFORMS_WARNING, _WARN_ABOUT_BETA_TRANSFORMS
 
 if _WARN_ABOUT_BETA_TRANSFORMS:
     import warnings
 
-    warnings.warn("THE WARNING")
+    warnings.warn(_BETA_TRANSFORMS_WARNING)

--- a/torchvision/transforms/v2/__init__.py
+++ b/torchvision/transforms/v2/__init__.py
@@ -46,9 +46,9 @@ from ._type_conversion import PILToTensor, ToImagePIL, ToImageTensor, ToPILImage
 
 from ._deprecated import ToTensor  # usort: skip
 
-from torchvision import _WARN_ABOUT_BETA_TRANSFORMS
+from torchvision import _BETA_TRANSFORMS_WARNING, _WARN_ABOUT_BETA_TRANSFORMS
 
 if _WARN_ABOUT_BETA_TRANSFORMS:
     import warnings
 
-    warnings.warn("THE WARNING")
+    warnings.warn(_BETA_TRANSFORMS_WARNING)

--- a/torchvision/transforms/v2/__init__.py
+++ b/torchvision/transforms/v2/__init__.py
@@ -45,3 +45,10 @@ from ._temporal import UniformTemporalSubsample
 from ._type_conversion import PILToTensor, ToImagePIL, ToImageTensor, ToPILImage
 
 from ._deprecated import ToTensor  # usort: skip
+
+from torchvision import _WARN_ABOUT_BETA_TRANSFORMS
+
+if _WARN_ABOUT_BETA_TRANSFORMS:
+    import warnings
+
+    warnings.warn("THE WARNING")


### PR DESCRIPTION
EDIT:

here's how it works as of [1d58209](https://github.com/pytorch/vision/pull/7270/commits/1d5820976ba330b21e4b9799c41247f598d57501):

```py
# No warning on any of those
import torchvision
from torchvision import transforms
import torchvision.transforms.functional
from torchvision.transforms import Resize
```

```py
# Warning on any of those (it actually warns twice because v2 and datapoints call each-others. Do we care?)
from torchvision.transforms import v2
from torchvision import datapoints
```

```py
# No warning
import torchvision
torchvision.disable_beta_transforms_warning()
from torchvision.transforms import v2
from torchvision import datapoints
```

------

Before moving forward with such a solution we need to understand that this mean we cannot add `datapoints`  here

https://github.com/pytorch/vision/blob/8f198e533e5832caeb16ef80132c5270c75d6080/torchvision/__init__.py#L6

nor can we add `v2` here

https://github.com/pytorch/vision/blob/8f198e533e5832caeb16ef80132c5270c75d6080/torchvision/transforms/__init__.py#L1-L2

So far every import has been working as expected, so I'm not sure whether we actually would need to do so.

If I can have your green light on this @pmeier @vfdev-5 I'll polish the warning message and address the tests