### PR TITLE
Add more tests for bounding boxes

### DIFF
--- a/test/test_prototype_transforms.py
+++ b/test/test_prototype_transforms.py
@@ -276,6 +276,7 @@ class TestSmoke:
 
         # Enforce that the transform does not turn a degenerate box marked by RandomIoUCrop (or any other future
         # transform that does this), back into a valid one.
+        # TODO: we should test that against all degenerate boxes above
         for format in list(datapoints.BoundingBoxFormat):
             sample = dict(
                 boxes=datapoints.BoundingBox([[0, 0, 0, 0]], format=format, spatial_size=(224, 244)),

--- a/test/test_prototype_transforms.py
+++ b/test/test_prototype_transforms.py
@@ -269,6 +269,11 @@ class TestSmoke:
             else:
                 assert output_item is input_item
 
+            if isinstance(input_item, datapoints.BoundingBox) and not isinstance(
+                transform, transforms.ConvertBoundingBoxFormat
+            ):
+                assert output_item.format == input_item.format
+
         # Enforce that the transform does not turn a degenerate box marked by RandomIoUCrop (or any other future
         # transform that does this), back into a valid one.
         for format in list(datapoints.BoundingBoxFormat):

--- a/test/test_prototype_transforms_functional.py
+++ b/test/test_prototype_transforms_functional.py
@@ -508,6 +508,22 @@ class TestDispatchers:
         with pytest.raises(TypeError, match=re.escape(str(type(unkown_input)))):
             info.dispatcher(unkown_input, *other_args, **kwargs)
 
+    @make_info_args_kwargs_parametrization(
+        [
+            info
+            for info in DISPATCHER_INFOS
+            if datapoints.BoundingBox in info.kernels and info.dispatcher is not F.convert_format_bounding_box
+        ],
+        args_kwargs_fn=lambda info: info.sample_inputs(datapoints.BoundingBox),
+    )
+    def test_bounding_box_format_consistency(self, info, args_kwargs):
+        (bounding_box, *other_args), kwargs = args_kwargs.load()
+        format = bounding_box.format
+
+        output = info.dispatcher(bounding_box, *other_args, **kwargs)
+
+        assert output.format == format
+
 
 @pytest.mark.parametrize(
     ("alias", "target"),


### PR DESCRIPTION
1. Add a test to our functional dispatchers that enforces that the `format` is not changed.
2. Expand the transforms smoke test to ensure that degenerate boxes stay degenerate.

cc @vfdev-5 @bjuncek