### PR TITLE
Remove old TODO about using `_log_api_usage_once()`

### DIFF
--- a/torchvision/transforms/v2/functional/__init__.py
+++ b/torchvision/transforms/v2/functional/__init__.py
@@ -1,5 +1,3 @@
-# TODO: Add _log_api_usage_once() in all mid-level kernels. If they remain not jit-scriptable we can use decorators
-
 from torchvision.transforms import InterpolationMode  # usort: skip
 
 from ._utils import is_simple_tensor  # usort: skip


### PR DESCRIPTION
I believe this TODO is now outdated as `_log_api_usage_once()` is called in the dispatcher kernels.

cc @vfdev-5