### PR TITLE
Restored beta warn checks

### DIFF
--- a/.github/workflows/test-linux-cpu.yml
+++ b/.github/workflows/test-linux-cpu.yml
@@ -60,4 +60,4 @@ jobs:
         # We keep them separate to avoid any side effects due to warnings / imports.
         # TODO: Remove this and add proper tests (possibly using a sub-process solution as described
         # in https://github.com/pytorch/vision/pull/7269).
-        python3 -m pytest -v test/check_v2_dataset_warnings.py
+        python3 test/check_v2_dataset_warnings.py

--- a/.github/workflows/test-linux-cpu.yml
+++ b/.github/workflows/test-linux-cpu.yml
@@ -55,3 +55,9 @@ jobs:
         # Run Tests
         python3 -m torch.utils.collect_env
         python3 -m pytest --junitxml=test-results/junit.xml -v --durations 20
+
+        # Specific test for warnings on "from torchvision.datasets import wrap_dataset_for_transforms_v2"
+        # We keep them separate to avoid any side effects due to warnings / imports.
+        # TODO: Remove this and add proper tests (possibly using a sub-process solution as described
+        # in https://github.com/pytorch/vision/pull/7269).
+        python3 -m pytest -v test/check_v2_dataset_warnings.py

--- a/test/check_v2_dataset_warnings.py
+++ b/test/check_v2_dataset_warnings.py
@@ -1,0 +1,19 @@
+import pytest
+
+
+def test_warns_if_imported_from_datasets(mocker):
+    mocker.patch("torchvision._WARN_ABOUT_BETA_TRANSFORMS", return_value=True)
+
+    import torchvision
+
+    with pytest.warns(UserWarning, match=torchvision._BETA_TRANSFORMS_WARNING):
+        from torchvision.datasets import wrap_dataset_for_transforms_v2
+
+        assert callable(wrap_dataset_for_transforms_v2)
+
+
+@pytest.mark.filterwarnings("error")
+def test_no_warns_if_imported_from_datasets():
+    from torchvision.datasets import wrap_dataset_for_transforms_v2
+
+    assert callable(wrap_dataset_for_transforms_v2)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -4,10 +4,9 @@ import numpy as np
 import pytest
 import torch
 import torchvision
-from common_utils import CUDA_NOT_AVAILABLE_MSG, IN_FBCODE, IN_OSS_CI, IN_RE_WORKER, OSS_CI_GPU_NO_CUDA_MSG
-
-
 torchvision.disable_beta_transforms_warning()
+
+from common_utils import CUDA_NOT_AVAILABLE_MSG, IN_FBCODE, IN_OSS_CI, IN_RE_WORKER, OSS_CI_GPU_NO_CUDA_MSG
 
 
 def pytest_configure(config):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 import torch
 import torchvision
+
 torchvision.disable_beta_transforms_warning()
 
 from common_utils import CUDA_NOT_AVAILABLE_MSG, IN_FBCODE, IN_OSS_CI, IN_RE_WORKER, OSS_CI_GPU_NO_CUDA_MSG


### PR DESCRIPTION
Context:
- https://github.com/pytorch/vision/commit/4774fe3afc61b40a56244e9411a7c3e64ae8147f broke warning check
- We can use `pytest --noconftest` and test is passing again, but I decided to get rid of pytest due to other possible side-effects.