### PR TITLE
Add warnings checks for v2 namespaces

### DIFF
--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -8,8 +8,10 @@ import os
 import pathlib
 import random
 import shutil
+import sys
 import tempfile
 from collections import defaultdict
+from subprocess import CalledProcessError, check_output, STDOUT
 from typing import Callable, Sequence, Tuple, Union
 
 import numpy as np
@@ -838,3 +840,22 @@ class InfoBase:
         if isinstance(device, torch.device):
             device = device.type
         return self.closeness_kwargs.get((test_id, dtype, device), dict())
+
+
+def assert_run_python_script(source_code):
+    """Utility to check assertions in an independent Python subprocess.
+    The script provided in the source code should return 0 and not print
+    anything on stderr or stdout. Taken from scikit-learn test utils.
+    source_code (str): The Python source code to execute.
+    """
+    with tempfile.NamedTemporaryFile(mode="wb") as f:
+        f.write(source_code.encode())
+        f.flush()
+
+        cmd = [sys.executable, f.name]
+        try:
+            out = check_output(cmd, stderr=STDOUT)
+        except CalledProcessError as e:
+            raise RuntimeError("script errored with output:\n%s" % e.output.decode())
+        if out != b"":
+            raise AssertionError(out.decode())

--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -856,6 +856,6 @@ def assert_run_python_script(source_code):
         try:
             out = check_output(cmd, stderr=STDOUT)
         except CalledProcessError as e:
-            raise RuntimeError("script errored with output:\n%s" % e.output.decode())
+            raise RuntimeError(f"script errored with output:\n{e.output.decode()}")
         if out != b"":
             raise AssertionError(out.decode())

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -4,10 +4,11 @@ import numpy as np
 import pytest
 import torch
 import torchvision
-from common_utils import CUDA_NOT_AVAILABLE_MSG, IN_FBCODE, IN_OSS_CI, IN_RE_WORKER, OSS_CI_GPU_NO_CUDA_MSG
 
 
 torchvision.disable_beta_transforms_warning()
+
+from common_utils import CUDA_NOT_AVAILABLE_MSG, IN_FBCODE, IN_OSS_CI, IN_RE_WORKER, OSS_CI_GPU_NO_CUDA_MSG
 
 
 def pytest_configure(config):

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -2297,7 +2297,6 @@ def test_functional_deprecation_warning(import_statement, from_private):
         import_statement = import_statement.replace("functional", "_functional")
         prelude = """
         import warnings
-        import torchvision
 
         with warnings.catch_warnings():
             warnings.simplefilter("error")

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -2281,19 +2281,19 @@ def test_random_grayscale_with_grayscale_input():
 def test_functional_deprecation_warning(import_statement, from_private):
     if from_private:
         import_statement = import_statement.replace("functional", "_functional")
-        prelude = """
+        source = f"""
         import warnings
 
         with warnings.catch_warnings():
             warnings.simplefilter("error")
+            {import_statement}
         """
     else:
-        prelude = """
+        source = f"""
         import pytest
         with pytest.warns(UserWarning, match="removed in 0.17"):
+            {import_statement}
         """
-
-    source = prelude + " " * 4 + import_statement
     assert_run_python_script(textwrap.dedent(source))
 
 

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -2267,20 +2267,6 @@ def test_random_grayscale_with_grayscale_input():
     torch.testing.assert_close(F.pil_to_tensor(output_pil), image_tensor)
 
 
-def test_no_warnings_v1_namespace():
-    source = """
-    import warnings
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
-        import torchvision.transforms
-        from torchvision import transforms
-        import torchvision.transforms.functional
-        from torchvision.transforms import Resize
-        from torchvision.transforms.functional import resize
-    """
-    assert_run_python_script(textwrap.dedent(source))
-
-
 # TODO: remove in 0.17 when we can delete functional_pil.py and functional_tensor.py
 @pytest.mark.parametrize(
     "import_statement",

--- a/test/test_transforms_v2.py
+++ b/test/test_transforms_v2.py
@@ -2065,20 +2065,20 @@ def test_sanitize_bounding_boxes_errors():
 @pytest.mark.parametrize("call_disable_warning", (True, False))
 def test_warnings_v2_namespaces(import_statement, call_disable_warning):
     if call_disable_warning:
-        prelude = """
+        source = f"""
         import warnings
         import torchvision
         torchvision.disable_beta_transforms_warning()
         with warnings.catch_warnings():
             warnings.simplefilter("error")
-
+            {import_statement}
         """
     else:
-        prelude = """
+        source = f"""
         import pytest
         with pytest.warns(UserWarning, match="v2 namespaces are still Beta"):
+            {import_statement}
         """
-    source = prelude + " " * 4 + import_statement
     assert_run_python_script(textwrap.dedent(source))
 
 

--- a/test/test_transforms_v2.py
+++ b/test/test_transforms_v2.py
@@ -2059,16 +2059,19 @@ def test_sanitize_bounding_boxes_errors():
         "from torchvision.transforms.v2.functional import resize",
         "from torchvision import datapoints",
         "from torchvision.datapoints import Image",
+        "from torchvision.datasets import wrap_dataset_for_transforms_v2",
     ),
 )
 @pytest.mark.parametrize("call_disable_warning", (True, False))
-def test_warnings(import_statement, call_disable_warning):
+def test_warnings_v2_namespaces(import_statement, call_disable_warning):
     if call_disable_warning:
         prelude = """
         import warnings
         import torchvision
         torchvision.disable_beta_transforms_warning()
         with warnings.catch_warnings():
+            warnings.simplefilter("error")
+
         """
     else:
         prelude = """
@@ -2078,15 +2081,18 @@ def test_warnings(import_statement, call_disable_warning):
     source = prelude + " " * 4 + import_statement
     assert_run_python_script(textwrap.dedent(source))
 
-    # TODO: Also do these below + the depreacted functional_pil.py and functional_ tensor.py + dataset wrapper
-    # source = """
-    # import warnings
-    # with warnings.catch_warnings():
-    #     warnings.simplefilter("error")
-    #     import torchvision.transforms
-    #     from torchvision import transforms
-    #     import torchvision.transforms.functional
-    #     from torchvision.transforms import Resize
-    #     from torchvision.transforms.functional import resize
-    # """
-    # assert_run_python_script(textwrap.dedent(source))
+
+def test_no_warnings_v1_namespace():
+    source = """
+    import warnings
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        import torchvision.transforms
+        from torchvision import transforms
+        import torchvision.transforms.functional
+        from torchvision.transforms import Resize
+        from torchvision.transforms.functional import resize
+        from torchvision import datasets
+        from torchvision.datasets import ImageNet
+    """
+    assert_run_python_script(textwrap.dedent(source))


### PR DESCRIPTION
This PR adds tests related to warnings we raise in the v2 namespaces (transforms, datapoints, dataset wrapper). Also added import tests related to the deprecated `function_pil` and `functiona_tensor` modules