### PR TITLE
NOMRG POC for docs

### DIFF
--- a/docs/source/transforms.rst
+++ b/docs/source/transforms.rst
@@ -107,6 +107,7 @@ Transforms on PIL Image and torch.\*Tensor
     :template: class.rst
 
     CenterCrop
+    v2.CenterCrop
     ColorJitter
     FiveCrop
     Grayscale

--- a/torchvision/transforms/v2/_geometry.py
+++ b/torchvision/transforms/v2/_geometry.py
@@ -76,6 +76,7 @@ class Resize(Transform):
 
 
 class CenterCrop(Transform):
+    """[BETA] Crops the given image at the center."""
     _v1_transform_cls = _transforms.CenterCrop
 
     def __init__(self, size: Union[int, Sequence[int]]):


### PR DESCRIPTION
Just a very short illustration of one way we could add docs (there are various other options we can explore):

![image](https://user-images.githubusercontent.com/1190450/220110681-332d3c78-2dfe-400a-bff6-73403b288e6b.png)
