### PR TITLE
add ffmpeg to Linux CPU and GPU unittest workflows

### DIFF
--- a/.github/workflows/test-linux-cpu.yml
+++ b/.github/workflows/test-linux-cpu.yml
@@ -39,7 +39,7 @@ jobs:
         fi
 
         # Create Conda Env
-        conda create -yp ci_env python="${PYTHON_VERSION}" numpy libpng jpeg scipy
+        conda create -yp ci_env python="${PYTHON_VERSION}" numpy libpng jpeg scipy 'ffmpeg<4.3'
         conda activate /work/ci_env
 
         # Install PyTorch, Torchvision, and testing libraries

--- a/.github/workflows/test-linux-gpu.yml
+++ b/.github/workflows/test-linux-gpu.yml
@@ -43,7 +43,7 @@ jobs:
         fi
 
         # Create Conda Env
-        conda create -yp ci_env python="${PYTHON_VERSION}" numpy libpng jpeg scipy
+        conda create -yp ci_env python="${PYTHON_VERSION}" numpy libpng jpeg scipy 'ffmpeg<4.3'
         conda activate /work/ci_env
 
         # Install PyTorch, Torchvision, and testing libraries


### PR DESCRIPTION
Our current GHA workflows do not build against `ffmpeg` since it is not installed: https://github.com/pytorch/vision/actions/runs/4206146225/jobs/7299225421#step:10:1868

However, this was the case before when the workflows ran on CircleCI: https://app.circleci.com/pipelines/github/pytorch/vision/22145/workflows/dda25a3d-9c31-4d81-bc5e-c94fbc8d8566/jobs/1790112?invite=true#step-107-74

We specified it with

https://github.com/pytorch/vision/blob/474d87b8a942eb0d5f22f5d98120c6f8961c798e/.circleci/unittest/linux/scripts/setup_env.sh#L39-L44

but something similar is missing from the new GHA workflows. This PR adds it.

cc @seemethere