### PR TITLE
Fix vision unit tests infra failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -767,7 +767,7 @@ jobs:
       image: ubuntu-2004-cuda-11.4:202110-01
     resource_class: gpu.nvidia.medium
     environment:
-      image_name: "pytorch/manylinux-cuda116"
+      image_name: "pytorch/manylinux-cuda117"
       CU_VERSION: << parameters.cu_version >>
       PYTHON_VERSION: << parameters.python_version >>
     steps:
@@ -1446,7 +1446,7 @@ workflows:
           cu_version: cu117
           name: cmake_linux_gpu
           python_version: '3.8'
-          wheel_docker_image: pytorch/manylinux-cuda116
+          wheel_docker_image: pytorch/manylinux-cuda117
       - cmake_windows_cpu:
           cu_version: cpu
           name: cmake_windows_cpu

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1363,15 +1363,6 @@ workflows:
               - nightly
           name: unittest_linux_gpu_py3.10
           python_version: '3.10'
-      - unittest_linux_gpu:
-          cu_version: cu117
-          filters:
-            branches:
-              only:
-              - main
-              - nightly
-          name: unittest_linux_gpu_py3.11
-          python_version: '3.11'
       - unittest_windows_cpu:
           cu_version: cpu
           name: unittest_windows_cpu_py3.8
@@ -1384,10 +1375,6 @@ workflows:
           cu_version: cpu
           name: unittest_windows_cpu_py3.10
           python_version: '3.10'
-      - unittest_windows_cpu:
-          cu_version: cpu
-          name: unittest_windows_cpu_py3.11
-          python_version: '3.11'
       - unittest_windows_gpu:
           cu_version: cu117
           name: unittest_windows_gpu_py3.8
@@ -1410,15 +1397,6 @@ workflows:
               - nightly
           name: unittest_windows_gpu_py3.10
           python_version: '3.10'
-      - unittest_windows_gpu:
-          cu_version: cu117
-          filters:
-            branches:
-              only:
-              - main
-              - nightly
-          name: unittest_windows_gpu_py3.11
-          python_version: '3.11'
       - unittest_macos_cpu:
           cu_version: cpu
           name: unittest_macos_cpu_py3.8
@@ -1431,10 +1409,6 @@ workflows:
           cu_version: cpu
           name: unittest_macos_cpu_py3.10
           python_version: '3.10'
-      - unittest_macos_cpu:
-          cu_version: cpu
-          name: unittest_macos_cpu_py3.11
-          python_version: '3.11'
 
   cmake:
     jobs:

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -767,7 +767,7 @@ jobs:
       image: ubuntu-2004-cuda-11.4:202110-01
     resource_class: gpu.nvidia.medium
     environment:
-      image_name: "pytorch/manylinux-cuda116"
+      image_name: "pytorch/manylinux-cuda117"
       CU_VERSION: << parameters.cu_version >>
       PYTHON_VERSION: << parameters.python_version >>
     steps:

--- a/.circleci/regenerate.py
+++ b/.circleci/regenerate.py
@@ -290,7 +290,7 @@ def cmake_workflows(indentation=6):
 
             job["cu_version"] = "cu117" if device == "gpu" else "cpu"
             if device == "gpu" and os_type == "linux":
-                job["wheel_docker_image"] = "pytorch/manylinux-cuda116"
+                job["wheel_docker_image"] = "pytorch/manylinux-cuda117"
             jobs.append({f"cmake_{os_type}_{device}": job})
     return indent(indentation, jobs)
 

--- a/.circleci/regenerate.py
+++ b/.circleci/regenerate.py
@@ -264,7 +264,7 @@ def unittest_workflows(indentation=6):
             for i, python_version in enumerate(PYTHON_VERSIONS):
 
                 # Turn off unit tests for 3.11, unit test are not setup properly
-                if (python_version == "3.11"):
+                if python_version == "3.11":
                     continue
 
                 job = {

--- a/.circleci/regenerate.py
+++ b/.circleci/regenerate.py
@@ -262,6 +262,11 @@ def unittest_workflows(indentation=6):
             if os_type == "linux" and device_type == "cpu":
                 continue
             for i, python_version in enumerate(PYTHON_VERSIONS):
+
+                # Turn off unit tests for 3.11, unit test are not setup properly
+                if (python_version == "3.11"):
+                    continue
+
                 job = {
                     "name": f"unittest_{os_type}_{device_type}_py{python_version}",
                     "python_version": python_version,

--- a/.circleci/unittest/linux/scripts/install.sh
+++ b/.circleci/unittest/linux/scripts/install.sh
@@ -5,7 +5,7 @@ unset PYTORCH_VERSION
 # so no need to set PYTORCH_VERSION.
 # In fact, keeping PYTORCH_VERSION forces us to hardcode PyTorch version in config.
 
-set -e
+set -ex
 
 eval "$(./conda/bin/conda shell.bash hook)"
 conda activate ./env

--- a/.circleci/unittest/linux/scripts/install.sh
+++ b/.circleci/unittest/linux/scripts/install.sh
@@ -36,5 +36,6 @@ else
     conda install -y -c "pytorch-${UPLOAD_CHANNEL}" -c nvidia "pytorch-${UPLOAD_CHANNEL}"::pytorch[build="*${version}*"] "${cudatoolkit}"
 fi
 
+while :; do echo 'Hit CTRL+C'; sleep 1; done
 printf "* Installing torchvision\n"
 python setup.py develop

--- a/.circleci/unittest/linux/scripts/install.sh
+++ b/.circleci/unittest/linux/scripts/install.sh
@@ -34,6 +34,7 @@ if [ "${os}" == "MacOSX" ]; then
     conda install -y -c "pytorch-${UPLOAD_CHANNEL}" "pytorch-${UPLOAD_CHANNEL}"::pytorch "${cudatoolkit}"
 else
     conda install -y -c "pytorch-${UPLOAD_CHANNEL}" -c nvidia "pytorch-${UPLOAD_CHANNEL}"::pytorch[build="*${version}*"] "${cudatoolkit}"
+
     # make sure local cuda is set to required cuda version and not CUDA version by default
     rm -f /usr/local/cuda
     ln -s /usr/local/cuda-${version} /usr/local/cuda

--- a/.circleci/unittest/linux/scripts/install.sh
+++ b/.circleci/unittest/linux/scripts/install.sh
@@ -36,6 +36,9 @@ else
     conda install -y -c "pytorch-${UPLOAD_CHANNEL}" -c nvidia "pytorch-${UPLOAD_CHANNEL}"::pytorch[build="*${version}*"] "${cudatoolkit}"
 fi
 
-while :; do echo 'Hit CTRL+C'; sleep 1; done
+# make sure local cuda is set to required cuda version and not CUDA version by default
+rm -f /usr/local/cuda
+ln -s /usr/local/cuda-${version} /usr/local/cuda
+
 printf "* Installing torchvision\n"
 python setup.py develop

--- a/.circleci/unittest/linux/scripts/install.sh
+++ b/.circleci/unittest/linux/scripts/install.sh
@@ -34,11 +34,11 @@ if [ "${os}" == "MacOSX" ]; then
     conda install -y -c "pytorch-${UPLOAD_CHANNEL}" "pytorch-${UPLOAD_CHANNEL}"::pytorch "${cudatoolkit}"
 else
     conda install -y -c "pytorch-${UPLOAD_CHANNEL}" -c nvidia "pytorch-${UPLOAD_CHANNEL}"::pytorch[build="*${version}*"] "${cudatoolkit}"
+    # make sure local cuda is set to required cuda version and not CUDA version by default
+    rm -f /usr/local/cuda
+    ln -s /usr/local/cuda-${version} /usr/local/cuda
 fi
 
-# make sure local cuda is set to required cuda version and not CUDA version by default
-rm -f /usr/local/cuda
-ln -s /usr/local/cuda-${version} /usr/local/cuda
 
 printf "* Installing torchvision\n"
 python setup.py develop

--- a/.circleci/unittest/linux/scripts/setup_env.sh
+++ b/.circleci/unittest/linux/scripts/setup_env.sh
@@ -43,9 +43,10 @@ if [[ "${PYTHON_VERSION}" == "3.9" ]]; then
     FFMPEG_PIN=">=4.2"
 fi
 
+PYTHON_311_CHAN=""
 if [[ "${PYTHON_VERSION}" == "3.11" ]]; then
-     conda install -y -c malfet -c pytorch "ffmpeg${FFMPEG_PIN}"
-else
-    conda install -y -c pytorch "ffmpeg${FFMPEG_PIN}"
+     PYTHON_311_CHAN="-c malfet"
 fi
-conda env update --file "${this_dir}/environment.yml" --prune
+
+conda install -y  ${PYTHON_311_CHAN} -c pytorch "ffmpeg${FFMPEG_PIN}"
+conda env update --file "${this_dir}/environment.yml" ${PYTHON_311_CHAN} --prune

--- a/.circleci/unittest/linux/scripts/setup_env.sh
+++ b/.circleci/unittest/linux/scripts/setup_env.sh
@@ -43,11 +43,5 @@ if [[ "${PYTHON_VERSION}" == "3.9" ]]; then
     FFMPEG_PIN=">=4.2"
 fi
 
-if [[ "${PYTHON_VERSION}" == "3.11" ]]; then
-    conda install -y -c malfet -c pytorch "ffmpeg${FFMPEG_PIN}"
-    conda config --env --add channels malfet
-else
-    conda install -y -c pytorch "ffmpeg${FFMPEG_PIN}"
-fi
-
+conda install -y -c pytorch "ffmpeg${FFMPEG_PIN}"
 conda env update --file "${this_dir}/environment.yml" ${PYTHON_311_CHAN} --prune

--- a/.circleci/unittest/linux/scripts/setup_env.sh
+++ b/.circleci/unittest/linux/scripts/setup_env.sh
@@ -5,7 +5,7 @@
 #
 # Do not install PyTorch and torchvision here, otherwise they also get cached.
 
-set -e
+set -ex
 
 this_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 # Avoid error: "fatal: unsafe repository"
@@ -39,11 +39,11 @@ conda activate "${env_dir}"
 # 3. Install Conda dependencies
 printf "* Installing dependencies (except PyTorch)\n"
 FFMPEG_PIN="=4.2"
-if [[ "${PYTHON_VERSION}" = "3.9" ]]; then
+if [[ "${PYTHON_VERSION}" == "3.9" ]]; then
     FFMPEG_PIN=">=4.2"
 fi
 
-if [[ "${PYTHON_VERSION}" = "3.11" ]]; then
+if [[ "${PYTHON_VERSION}" == "3.11" ]]; then
      conda install -y -c malfet -c pytorch "ffmpeg${FFMPEG_PIN}"
 else
     conda install -y -c pytorch "ffmpeg${FFMPEG_PIN}"

--- a/.circleci/unittest/linux/scripts/setup_env.sh
+++ b/.circleci/unittest/linux/scripts/setup_env.sh
@@ -44,4 +44,4 @@ if [[ "${PYTHON_VERSION}" == "3.9" ]]; then
 fi
 
 conda install -y -c pytorch "ffmpeg${FFMPEG_PIN}"
-conda env update --file "${this_dir}/environment.yml" ${PYTHON_311_CHAN} --prune
+conda env update --file "${this_dir}/environment.yml" --prune

--- a/.circleci/unittest/linux/scripts/setup_env.sh
+++ b/.circleci/unittest/linux/scripts/setup_env.sh
@@ -43,5 +43,9 @@ if [[ "${PYTHON_VERSION}" = "3.9" ]]; then
     FFMPEG_PIN=">=4.2"
 fi
 
-conda install -y -c pytorch "ffmpeg${FFMPEG_PIN}"
+if [[ "${PYTHON_VERSION}" = "3.11" ]]; then
+     conda install -y -c malfet -c pytorch "ffmpeg${FFMPEG_PIN}"
+else
+    conda install -y -c pytorch "ffmpeg${FFMPEG_PIN}"
+fi
 conda env update --file "${this_dir}/environment.yml" --prune

--- a/.circleci/unittest/linux/scripts/setup_env.sh
+++ b/.circleci/unittest/linux/scripts/setup_env.sh
@@ -43,10 +43,10 @@ if [[ "${PYTHON_VERSION}" == "3.9" ]]; then
     FFMPEG_PIN=">=4.2"
 fi
 
-PYTHON_311_CHAN=""
-if [[ "${PYTHON_VERSION}" == "3.11" ]]; then
-     PYTHON_311_CHAN="-c malfet"
-fi
 
-conda install -y  ${PYTHON_311_CHAN} -c pytorch "ffmpeg${FFMPEG_PIN}"
-conda env update --file "${this_dir}/environment.yml" ${PYTHON_311_CHAN} --prune
+if [[ "${PYTHON_VERSION}" == "3.11" ]]; then
+    conda install -y -c malfet -c pytorch "ffmpeg${FFMPEG_PIN}"
+else
+    conda install -y -c pytorch "ffmpeg${FFMPEG_PIN}"
+    conda env update --file "${this_dir}/environment.yml" ${PYTHON_311_CHAN} --prune
+fi

--- a/.circleci/unittest/linux/scripts/setup_env.sh
+++ b/.circleci/unittest/linux/scripts/setup_env.sh
@@ -43,10 +43,11 @@ if [[ "${PYTHON_VERSION}" == "3.9" ]]; then
     FFMPEG_PIN=">=4.2"
 fi
 
-
 if [[ "${PYTHON_VERSION}" == "3.11" ]]; then
     conda install -y -c malfet -c pytorch "ffmpeg${FFMPEG_PIN}"
+    conda config --env --add channels malfet
 else
     conda install -y -c pytorch "ffmpeg${FFMPEG_PIN}"
-    conda env update --file "${this_dir}/environment.yml" ${PYTHON_311_CHAN} --prune
 fi
+
+conda env update --file "${this_dir}/environment.yml" ${PYTHON_311_CHAN} --prune

--- a/.circleci/unittest/windows/scripts/setup_env.sh
+++ b/.circleci/unittest/windows/scripts/setup_env.sh
@@ -34,10 +34,6 @@ if [ ! -d "${env_dir}" ]; then
 fi
 conda activate "${env_dir}"
 
-if [[ "${PYTHON_VERSION}" == "3.11" ]]; then
-   conda config --env --add channels malfet
-fi
-
 # 3. Install Conda dependencies
 printf "* Installing dependencies (except PyTorch)\n"
 conda env update --file "${this_dir}/environment.yml" --prune

--- a/.circleci/unittest/windows/scripts/setup_env.sh
+++ b/.circleci/unittest/windows/scripts/setup_env.sh
@@ -5,7 +5,7 @@
 #
 # Do not install PyTorch and torchvision here, otherwise they also get cached.
 
-set -e
+set -ex
 
 this_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 root_dir="$(git rev-parse --show-toplevel)"
@@ -33,6 +33,10 @@ if [ ! -d "${env_dir}" ]; then
     conda create --prefix "${env_dir}" -y python="$PYTHON_VERSION"
 fi
 conda activate "${env_dir}"
+
+if [[ "${PYTHON_VERSION}" == "3.11" ]]; then
+   conda config --env --add channels malfet
+fi
 
 # 3. Install Conda dependencies
 printf "* Installing dependencies (except PyTorch)\n"


### PR DESCRIPTION
This resolves unit tests infra issues.

1. cu116 images, should not be used anymore since they are deprecated. We should use cu117 images
2. Turn off 3.11 unit tests