### PR TITLE
Fix mac win unittests

### DIFF
--- a/.circleci/unittest/linux/scripts/environment.yml
+++ b/.circleci/unittest/linux/scripts/environment.yml
@@ -1,6 +1,7 @@
 channels:
   - pytorch
   - defaults
+  - malfet
 dependencies:
   - pytest
   - pytest-cov

--- a/.circleci/unittest/linux/scripts/setup_env.sh
+++ b/.circleci/unittest/linux/scripts/setup_env.sh
@@ -45,7 +45,8 @@ fi
 
 conda install -y -c pytorch "ffmpeg${FFMPEG_PIN}"
 if [[ "${PYTHON_VERSION}" = "3.11" ]]; then
-  pip install pytest pytest-cov pytest-mock libpng jpeg ca-certificates h5py future
+  conda install libpng jpeg ca-certificates
+  pip install pytest pytest-cov pytest-mock setuptools future dataclasses h5py
 else
   conda env update --file "${this_dir}/environment.yml" --prune
 fi

--- a/.circleci/unittest/linux/scripts/setup_env.sh
+++ b/.circleci/unittest/linux/scripts/setup_env.sh
@@ -44,4 +44,8 @@ if [[ "${PYTHON_VERSION}" = "3.9" ]]; then
 fi
 
 conda install -y -c pytorch "ffmpeg${FFMPEG_PIN}"
-conda env update --file "${this_dir}/environment.yml" --prune
+if [[ "${PYTHON_VERSION}" = "3.11" ]]; then
+  pip install pytest pytest-cov pytest-mock libpng jpeg ca-certificates h5py future
+else
+  conda env update --file "${this_dir}/environment.yml" --prune
+fi

--- a/.circleci/unittest/windows/scripts/environment.yml
+++ b/.circleci/unittest/windows/scripts/environment.yml
@@ -1,6 +1,7 @@
 channels:
   - pytorch
   - defaults
+  - malfet
 dependencies:
   - pytest
   - pytest-cov

--- a/.circleci/unittest/windows/scripts/setup_env.sh
+++ b/.circleci/unittest/windows/scripts/setup_env.sh
@@ -36,7 +36,11 @@ conda activate "${env_dir}"
 
 # 3. Install Conda dependencies
 printf "* Installing dependencies (except PyTorch)\n"
-conda env update --file "${this_dir}/environment.yml" --prune
+if [[ "${PYTHON_VERSION}" == '3.7' ]]; then
+  pip install pytest pytest-cov pytest-mock libpng jpeg ca-certificates hdf5 setuptools future dataclasses h5py
+else
+  conda env update --file "${this_dir}/environment.yml" --prune
+fi
 
 # 4. Downgrade setuptools on Python 3.7.
 #    See https://github.com/pytorch/vision/pull/5868

--- a/.circleci/unittest/windows/scripts/setup_env.sh
+++ b/.circleci/unittest/windows/scripts/setup_env.sh
@@ -37,7 +37,8 @@ conda activate "${env_dir}"
 # 3. Install Conda dependencies
 printf "* Installing dependencies (except PyTorch)\n"
 if [[ "${PYTHON_VERSION}" == '3.7' ]]; then
-  pip install pytest pytest-cov pytest-mock libpng jpeg ca-certificates hdf5 setuptools future dataclasses h5py
+  conda install libpng jpeg hdf5 ca-certificates
+  pip install pytest pytest-cov pytest-mock setuptools future dataclasses h5py
 else
   conda env update --file "${this_dir}/environment.yml" --prune
 fi


### PR DESCRIPTION
Trying to address [unittest_windows_cpu_py3.11](https://circleci.com/gh/pytorch/vision/1836203?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link&utm_content=summary) and [unittest_macos_cpu_py3.11](https://circleci.com/gh/pytorch/vision/1836187?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link&utm_content=summary), which both fail with dependency satisfaction errors on Python 3.11