### PR TITLE
[PoC] simplify simple tensor fallback heuristic

### DIFF
--- a/torchvision/transforms/v2/_transform.py
+++ b/torchvision/transforms/v2/_transform.py
@@ -1,14 +1,15 @@
 from __future__ import annotations
 
 import enum
-from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
+from typing import Any, Dict, List, Optional, Tuple, Type
 
 import PIL.Image
 import torch
 from torch import nn
 from torch.utils._pytree import tree_flatten, tree_unflatten
 from torchvision import datapoints
-from torchvision.transforms.v2.utils import check_type, has_any, is_simple_tensor
+from torchvision.datapoints._datapoint import Datapoint
+from torchvision.transforms.v2.utils import is_simple_tensor
 from torchvision.utils import _log_api_usage_once
 
 
@@ -16,7 +17,7 @@ class Transform(nn.Module):
 
     # Class attribute defining transformed types. Other types are passed-through without any transformation
     # We support both Types and callables that are able to do further checks on the type of the input.
-    _transformed_types: Tuple[Union[Type, Callable[[Any], bool]], ...] = (torch.Tensor, PIL.Image.Image)
+    _transformed_types: Tuple[Type, ...] = (Datapoint, PIL.Image.Image)
 
     def __init__(self) -> None:
         super().__init__()
@@ -32,53 +33,29 @@ class Transform(nn.Module):
         raise NotImplementedError
 
     def forward(self, *inputs: Any) -> Any:
-        flat_inputs, spec = tree_flatten(inputs if len(inputs) > 1 else inputs[0])
+        sample = inputs if len(inputs) > 1 else inputs[0]
+        if is_simple_tensor(sample):
+            sample = datapoints.Image(sample)
+            simple_tensor_image_fallback = True
+        else:
+            simple_tensor_image_fallback = False
+
+        flat_inputs, spec = tree_flatten(sample)
 
         self._check_inputs(flat_inputs)
 
-        needs_transform_list = self._needs_transform_list(flat_inputs)
-        params = self._get_params(
-            [inpt for (inpt, needs_transform) in zip(flat_inputs, needs_transform_list) if needs_transform]
-        )
+        params = self._get_params(flat_inputs)
 
         flat_outputs = [
-            self._transform(inpt, params) if needs_transform else inpt
-            for (inpt, needs_transform) in zip(flat_inputs, needs_transform_list)
+            self._transform(inpt, params) if isinstance(inpt, self._transformed_types) else inpt for inpt in flat_inputs
         ]
 
-        return tree_unflatten(flat_outputs, spec)
+        outputs = tree_unflatten(flat_outputs, spec)
 
-    def _needs_transform_list(self, flat_inputs: List[Any]) -> List[bool]:
-        # Below is a heuristic on how to deal with simple tensor inputs:
-        # 1. Simple tensors, i.e. tensors that are not a datapoint, are passed through if there is an explicit image
-        #    (`datapoints.Image` or `PIL.Image.Image`) or video (`datapoints.Video`) in the sample.
-        # 2. If there is no explicit image or video in the sample, only the first encountered simple tensor is
-        #    transformed as image, while the rest is passed through. The order is defined by the returned `flat_inputs`
-        #    of `tree_flatten`, which recurses depth-first through the input.
-        #
-        # This heuristic stems from two requirements:
-        # 1. We need to keep BC for single input simple tensors and treat them as images.
-        # 2. We don't want to treat all simple tensors as images, because some datasets like `CelebA` or `Widerface`
-        #    return supplemental numerical data as tensors that cannot be transformed as images.
-        #
-        # The heuristic should work well for most people in practice. The only case where it doesn't is if someone
-        # tries to transform multiple simple tensors at the same time, expecting them all to be treated as images.
-        # However, this case wasn't supported by transforms v1 either, so there is no BC concern.
+        if simple_tensor_image_fallback:
+            outputs = outputs.as_subclass(torch.Tensor)
 
-        needs_transform_list = []
-        transform_simple_tensor = not has_any(flat_inputs, datapoints.Image, datapoints.Video, PIL.Image.Image)
-        for inpt in flat_inputs:
-            needs_transform = True
-
-            if not check_type(inpt, self._transformed_types):
-                needs_transform = False
-            elif is_simple_tensor(inpt):
-                if transform_simple_tensor:
-                    transform_simple_tensor = False
-                else:
-                    needs_transform = False
-            needs_transform_list.append(needs_transform)
-        return needs_transform_list
+        return outputs
 
     def extra_repr(self) -> str:
         extra = []


### PR DESCRIPTION
Since we had some internal discussions about the heuristic before and it came up again in https://github.com/pytorch/vision/pull/7331#discussion_r1117264774, this PR is an attempt to simplify it while adhering to the original goals. Let's start with a little bit of context:

When transforms v2 was conceived, one major design goal was to make it BC to v1. Part of that is that we need to treat simple `torch.Tensor`'s as images and don't require users to wrap them into a `datapoints.Image` or similar. To achieve that the functional API internally just dispatches to the `*_image_tensor` kernel, e.g.

https://github.com/pytorch/vision/blob/01ef0a68b6ec00452391251fc16c38e58b92bf07/torchvision/transforms/v2/functional/_geometry.py#L78-L79

By not adding any logic other than allowing simple tensors to be transformed, the transforms inherited this behavior. However, this proved detrimental for two reasons:

1. After the decision was made that we'll leave `datapoints.Label` and `datapoints.OneHotLabel` in the prototype area for now, we wanted to represent them as simple tensors
2. Some datasets like [`CelebA`](https://github.com/pytorch/vision/blob/01ef0a68b6ec00452391251fc16c38e58b92bf07/torchvision/datasets/celeba.py#L22-L32) return simple tensors as part of their annotations.

To support these use cases, the initial idea was to introduce a no-op datapoint ():

```py
class DontTouchMe(Datapoint):
    pass
```

This could be easily filtered out by the transforms. However this again had two issues:

1. Users are forced to address this situation by wrapping their simple tensor inputs that aren't images.
2. We increase our API surface.

To overcome this, #7170 added a heuristic that currently behaves as follows:

https://github.com/pytorch/vision/blob/01ef0a68b6ec00452391251fc16c38e58b92bf07/gallery/plot_transforms_v2.py#L92-L95

This solves the issues above. However, it goes beyond the original goal of keeping BC: v1 does not support joint transformations and thus allowing simple tensors to act as images in a joint context is *not* needed for BC. And this is the part that makes the current heuristic more complicated than it has to be since it introduces stuff like order into the picture.

The heuristic this PR proposed goes a more pragmatic approach regarding BC:

1. If the input is a single simple tensor, it will be transformed as image as it was done in v1.
2. Otherwise, simple tensors will not be transformed, but rather be passed through.

The only thing we are losing by going for this simplification is the ability to intentionally use simple tensors as images in a joint setting. IMHO, it isn't a big ask of users to wrap into a `datapoints.Image` there, since they will have to wrap into `datapoints.Mask`'s and `datapoints.BoundingBox`'es anyway in a joint context.
