### PR TITLE
[FBcode->GH] Bump SoLoader and Allow building torchvision operators statically

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -14,7 +14,7 @@ allprojects {
 
             androidSupportAppCompatV7Version = "28.0.0"
             fbjniJavaOnlyVersion = "0.0.3"
-            soLoaderNativeLoaderVersion = "0.10.4"
+            soLoaderNativeLoaderVersion = "0.10.5"
             pytorchAndroidVersion = "1.12"
         }
 

--- a/torchvision/csrc/macros.h
+++ b/torchvision/csrc/macros.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(TORCHVISION_BUILD_STATIC_LIBS)
 #if defined(torchvision_EXPORTS)
 #define VISION_API __declspec(dllexport)
 #else


### PR DESCRIPTION
Some recent cherry-picks onto `main` for the Fbcode-> GH sync.

Closes https://github.com/pytorch/vision/pull/7188
Closes https://github.com/pytorch/vision/pull/7337