### PR TITLE
fix assert_run_python_script on Windows

### DIFF
--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -844,17 +844,20 @@ class InfoBase:
 
 def assert_run_python_script(source_code):
     """Utility to check assertions in an independent Python subprocess.
-    The script provided in the source code should return 0 and not print
-    anything on stderr or stdout. Taken from scikit-learn test utils.
-    source_code (str): The Python source code to execute.
-    """
-    with tempfile.NamedTemporaryFile(mode="wb") as f:
-        f.write(source_code.encode())
-        f.flush()
 
-        cmd = [sys.executable, f.name]
+    The script provided in the source code should return 0 and not print
+    anything on stderr or stdout. Modified from scikit-learn test utils.
+
+    Args:
+        source_code (str): The Python source code to execute.
+    """
+    with get_tmp_dir() as root:
+        path = pathlib.Path(root) / "main.py"
+        with open(path, "w") as file:
+            file.write(source_code)
+
         try:
-            out = check_output(cmd, stderr=STDOUT)
+            out = check_output([sys.executable, str(path)], stderr=STDOUT)
         except CalledProcessError as e:
             raise RuntimeError(f"script errored with output:\n{e.output.decode()}")
         if out != b"":

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -2,7 +2,6 @@ import math
 import os
 import random
 import re
-import sys
 import textwrap
 import warnings
 from functools import partial
@@ -2279,10 +2278,6 @@ def test_random_grayscale_with_grayscale_input():
     ),
 )
 @pytest.mark.parametrize("from_private", (True, False))
-@pytest.mark.skipif(
-    sys.platform in ("win32", "cygwin"),
-    reason="assert_run_python_script is broken on Windows. Possible fix in https://github.com/pytorch/vision/pull/7346",
-)
 def test_functional_deprecation_warning(import_statement, from_private):
     if from_private:
         import_statement = import_statement.replace("functional", "_functional")

--- a/test/test_transforms_v2.py
+++ b/test/test_transforms_v2.py
@@ -2,7 +2,6 @@ import itertools
 import pathlib
 import random
 import re
-import sys
 import textwrap
 import warnings
 from collections import defaultdict
@@ -2102,10 +2101,6 @@ def test_sanitize_bounding_boxes_errors():
     ),
 )
 @pytest.mark.parametrize("call_disable_warning", (True, False))
-@pytest.mark.skipif(
-    sys.platform in ("win32", "cygwin"),
-    reason="assert_run_python_script is broken on Windows. Possible fix in https://github.com/pytorch/vision/pull/7346",
-)
 def test_warnings_v2_namespaces(import_statement, call_disable_warning):
     if call_disable_warning:
         source = f"""
@@ -2125,10 +2120,6 @@ def test_warnings_v2_namespaces(import_statement, call_disable_warning):
     assert_run_python_script(textwrap.dedent(source))
 
 
-@pytest.mark.skipif(
-    sys.platform in ("win32", "cygwin"),
-    reason="assert_run_python_script is broken on Windows. Possible fix in https://github.com/pytorch/vision/pull/7346",
-)
 def test_no_warnings_v1_namespace():
     source = """
     import warnings


### PR DESCRIPTION
All tests that use `assert_run_python_script`, fail on Windows. For example: https://app.circleci.com/pipelines/github/pytorch/vision/23631/workflows/9af6160b-70a4-480e-9593-0800b2c67547/jobs/1842615

I think the issue is that Windows does not allow to access a file from a another process while it is still opened. Instead of a temporary file that deletes itself after closing it, this PR adds a temporary directory that does the same. Inside the directory we can write to a regular file and close that before we start the subprocess.