### PR TITLE
skip tests that use assert_run_python_script on windows

### DIFF
--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -2,6 +2,7 @@ import math
 import os
 import random
 import re
+import sys
 import textwrap
 import warnings
 from functools import partial
@@ -2278,6 +2279,10 @@ def test_random_grayscale_with_grayscale_input():
     ),
 )
 @pytest.mark.parametrize("from_private", (True, False))
+@pytest.mark.skipif(
+    sys.platform in ("win32", "cygwin"),
+    reason="assert_run_python_script is broken on Windows. Possible fix in https://github.com/pytorch/vision/pull/7346",
+)
 def test_functional_deprecation_warning(import_statement, from_private):
     if from_private:
         import_statement = import_statement.replace("functional", "_functional")

--- a/test/test_transforms_v2.py
+++ b/test/test_transforms_v2.py
@@ -2,6 +2,7 @@ import itertools
 import pathlib
 import random
 import re
+import sys
 import textwrap
 import warnings
 from collections import defaultdict
@@ -2101,6 +2102,10 @@ def test_sanitize_bounding_boxes_errors():
     ),
 )
 @pytest.mark.parametrize("call_disable_warning", (True, False))
+@pytest.mark.skipif(
+    sys.platform in ("win32", "cygwin"),
+    reason="assert_run_python_script is broken on Windows. Possible fix in https://github.com/pytorch/vision/pull/7346",
+)
 def test_warnings_v2_namespaces(import_statement, call_disable_warning):
     if call_disable_warning:
         source = f"""
@@ -2120,6 +2125,10 @@ def test_warnings_v2_namespaces(import_statement, call_disable_warning):
     assert_run_python_script(textwrap.dedent(source))
 
 
+@pytest.mark.skipif(
+    sys.platform in ("win32", "cygwin"),
+    reason="assert_run_python_script is broken on Windows. Possible fix in https://github.com/pytorch/vision/pull/7346",
+)
 def test_no_warnings_v1_namespace():
     source = """
     import warnings


### PR DESCRIPTION
Parallel to #7346 for speed. I took the condition from 

https://github.com/pytorch/vision/blob/547dd1d05a83e1f9d04da891c73aff146b6c0316/test/test_image.py#L35

since I don't have a Windows box to test it myself.

cc @vfdev-5