### PR TITLE
increase timeout for Linux unittest CI on CPU

### DIFF
--- a/.github/workflows/test-linux-cpu.yml
+++ b/.github/workflows/test-linux-cpu.yml
@@ -22,6 +22,7 @@ jobs:
     with:
       runner: linux.12xlarge
       repository: pytorch/vision
+      timeout: 120
       script: |
         # Mark Build Directory Safe
         git config --global --add safe.directory /__w/vision/vision


### PR DESCRIPTION
Without specifying anything, timeout will be 30 minutes:

https://github.com/pytorch/test-infra/blob/09a6ae7404ad6628b21c079fdc499dd9ba6c8005/.github/workflows/linux_job.yml#L10-L13

It seems we barely were under that before: https://github.com/pytorch/vision/actions/runs/4286797892/jobs/7466846704

However, starting today, I saw a workflows cancelled, e.g. https://github.com/pytorch/vision/actions/runs/4304331778/jobs/7505214648

GPU already uses 120 minutes so we just align the two:

https://github.com/pytorch/vision/blob/924d373cc234bb837f09c9be0ca18fd138453d52/.github/workflows/test-linux-gpu.yml#L28

cc @seemethere