### PR TITLE
Use python 3.9 conda environment for cmake circleci workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -995,6 +995,8 @@ jobs:
           command: |
             set -ex
             source packaging/windows/internal/vc_install_helper.sh
+            eval "$('/C/tools/miniconda3/Scripts/conda.exe' 'shell.bash' 'hook')"
+            conda activate base
             conda create -yn python39 python=3.9
             conda activate python39
             packaging/build_cmake.sh
@@ -1014,6 +1016,8 @@ jobs:
             set -ex
             source packaging/windows/internal/vc_install_helper.sh
             packaging/windows/internal/cuda_install.bat
+            eval "$('/C/tools/miniconda3/Scripts/conda.exe' 'shell.bash' 'hook')"
+            conda activate base
             conda create -yn python39 python=3.9
             conda activate python39
             packaging/build_cmake.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1017,7 +1017,8 @@ jobs:
             source packaging/windows/internal/vc_install_helper.sh
             packaging/windows/internal/cuda_install.bat
             eval "$('/C/tools/miniconda3/Scripts/conda.exe' 'shell.bash' 'hook')"
-            conda activate base
+            conda activate
+            conda update -y conda
             conda create -yn python39 python=3.9
             conda activate python39
             packaging/build_cmake.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -995,6 +995,8 @@ jobs:
           command: |
             set -ex
             source packaging/windows/internal/vc_install_helper.sh
+            conda create -yn python39 python=3.9
+            conda activate python39
             packaging/build_cmake.sh
 
   cmake_windows_gpu:
@@ -1012,6 +1014,8 @@ jobs:
             set -ex
             source packaging/windows/internal/vc_install_helper.sh
             packaging/windows/internal/cuda_install.bat
+            conda create -yn python39 python=3.9
+            conda activate python39
             packaging/build_cmake.sh
 
   build_docs:

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -995,6 +995,8 @@ jobs:
           command: |
             set -ex
             source packaging/windows/internal/vc_install_helper.sh
+            eval "$('/C/tools/miniconda3/Scripts/conda.exe' 'shell.bash' 'hook')"
+            conda activate base
             conda create -yn python39 python=3.9
             conda activate python39
             packaging/build_cmake.sh
@@ -1014,6 +1016,8 @@ jobs:
             set -ex
             source packaging/windows/internal/vc_install_helper.sh
             packaging/windows/internal/cuda_install.bat
+            eval "$('/C/tools/miniconda3/Scripts/conda.exe' 'shell.bash' 'hook')"
+            conda activate base
             conda create -yn python39 python=3.9
             conda activate python39
             packaging/build_cmake.sh

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -1017,7 +1017,8 @@ jobs:
             source packaging/windows/internal/vc_install_helper.sh
             packaging/windows/internal/cuda_install.bat
             eval "$('/C/tools/miniconda3/Scripts/conda.exe' 'shell.bash' 'hook')"
-            conda activate base
+            conda activate
+            conda update -y conda
             conda create -yn python39 python=3.9
             conda activate python39
             packaging/build_cmake.sh

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -995,6 +995,8 @@ jobs:
           command: |
             set -ex
             source packaging/windows/internal/vc_install_helper.sh
+            conda create -yn python39 python=3.9
+            conda activate python39
             packaging/build_cmake.sh
 
   cmake_windows_gpu:
@@ -1012,6 +1014,8 @@ jobs:
             set -ex
             source packaging/windows/internal/vc_install_helper.sh
             packaging/windows/internal/cuda_install.bat
+            conda create -yn python39 python=3.9
+            conda activate python39
             packaging/build_cmake.sh
 
   build_docs:


### PR DESCRIPTION
Use python 3.9 conda environment for cmake circleci workflows