### PR TITLE
Assert Runtime Error for torch.compile on Python 3.11

### DIFF
--- a/test/smoke_test.py
+++ b/test/smoke_test.py
@@ -39,6 +39,8 @@ def smoke_test_compile() -> None:
     except RuntimeError:
         if platform == "win32":
             print("Successfully caught torch.compile RuntimeError on win")
+        elif sys.version_info >= (3, 11, 0):
+            print("Successfully caught torch.compile RuntimeError on Python 3.11")
         else:
             raise
 


### PR DESCRIPTION
`torch.compile` throws a RuntimError for Python 3.11. We add a smoke test to assert this behavior.