### PR TITLE
Added an "s" to match the function name

### DIFF
--- a/torchvision/__init__.py
+++ b/torchvision/__init__.py
@@ -105,7 +105,7 @@ _BETA_TRANSFORMS_WARNING = (
     "this issue: https://github.com/pytorch/vision/issues/6753, and you can also "
     "check out https://github.com/pytorch/vision/issues/7319 to learn more about "
     "the APIs that we suspect might involve future changes. "
-    "You can silence this warning by calling torchvision.disable_beta_transform_warning()."
+    "You can silence this warning by calling torchvision.disable_beta_transforms_warning()."
 )
 
 


### PR DESCRIPTION
Update the _BETA_TRANSFORMS_WARNING string that currently prints a function that does not exist. An "s" is added. From torchvision.disable_beta_transform_warning() to torchvision.disable_beta_transforms_warning()

<!-- Before submitting a PR, please make sure to check our contributing guidelines regarding code formatting, tests, and documentation: https://github.com/pytorch/vision/blob/main/CONTRIBUTING.md -->
