### PR TITLE
test_prototype_datasets_builtin: Properly close all streams

### DIFF
--- a/test/test_prototype_datasets_builtin.py
+++ b/test/test_prototype_datasets_builtin.py
@@ -123,7 +123,7 @@ class TestCommon:
     def test_stream_closing(self, log_session_streams, dataset_mock, config):
         def make_msg_and_close(head):
             unclosed_streams = []
-            for stream in StreamWrapper.session_streams.keys():
+            for stream in list(StreamWrapper.session_streams.keys()):
                 unclosed_streams.append(repr(stream.file_obj))
                 stream.close()
             unclosed_streams = "\n".join(unclosed_streams)


### PR DESCRIPTION
In https://github.com/pytorch/data/pull/1016 I noticed that if a test fails subsequent tests will also fail as not all streams are being closed correctly due to:

```
for stream in StreamWrapper.session_streams.keys():
RuntimeError: dictionary changed size during iteration
```
This addresses this issue so that only the "necessary" tests fail.
In theory we should also be able to remove l.135-136 but to be safe I have kept them.
```python
if StreamWrapper.session_streams:
    raise pytest.UsageError(make_msg_and_close("A previous test did not close the following streams:"))
```