### PR TITLE
fix lint c workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -49,8 +49,9 @@ jobs:
         CONDA_PATH=$(which conda)
         eval "$(${CONDA_PATH} shell.bash hook)"
         # clang-format needs some shared libraries that conflict with the system ones. Thus, we install them from conda
-        # and prepend the libraries to linker path to prioritize them
-        conda create --name ci --quiet --yes python=3.8 ncurses=5 libgcc
+        # and prepend the libraries to linker path to prioritize them. `ncurses=5` is only available on the conda-forge
+        # channel. Since we are not building or testing here, this is fine.
+        conda create --name ci --quiet --yes -c conda-forge python=3.8 ncurses=5 libgcc
         conda activate ci
         export LD_LIBRARY_PATH="${CONDA_PREFIX}/lib:${LD_LIBRARY_PATH}"
         echo '::endgroup::'


### PR DESCRIPTION
I messed up in #7401. `ncurses=5`, which is implicitly needed for the `clang-format` binary we are running, is not available on the conda defaults channel: https://github.com/pytorch/vision/actions/runs/4383741408/jobs/7674435301#step:10:110

Thus, we have to install from conda-forge here.

cc @seemethere