### PR TITLE
decrease log level in android workflows

### DIFF
--- a/.circleci/unittest/android/scripts/binary_android_build.sh
+++ b/.circleci/unittest/android/scripts/binary_android_build.sh
@@ -20,7 +20,7 @@ echo "ndk.dir=${ANDROID_NDK_HOME}" >> $GRADLE_LOCAL_PROPERTIES
 echo "GRADLE_PATH $GRADLE_PATH"
 echo "GRADLE_HOME $GRADLE_HOME"
 
-${GRADLE_PATH} --scan --stacktrace --debug --no-daemon -p ${VISION_ANDROID} assemble || true
+${GRADLE_PATH} --no-daemon -p ${VISION_ANDROID} assemble || true
 
 mkdir -p ~/workspace/artifacts
 find . -type f -name *aar -print | xargs tar cfvz ~/workspace/artifacts/artifacts-aars.tgz

--- a/.circleci/unittest/android/scripts/binary_android_upload.sh
+++ b/.circleci/unittest/android/scripts/binary_android_upload.sh
@@ -28,7 +28,7 @@ echo "signing.password=${ANDROID_SIGN_PASS}" >> $GRADLE_PROPERTIES
 
 cat /home/circleci/project/android/gradle.properties | grep VERSION
 
-${GRADLE_PATH} --scan --stacktrace --debug --no-daemon -p ${VISION_ANDROID} ops:uploadArchives
+${GRADLE_PATH} --no-daemon -p ${VISION_ANDROID} ops:uploadArchives
 
 mkdir -p ~/workspace/artifacts
 find . -type f -name *aar -print | xargs tar cfvz ~/workspace/artifacts/artifacts-aars.tgz


### PR DESCRIPTION
We are currently running with `--debug` log level, which obfuscates any useful information for 99% of the cases: https://app.circleci.com/pipelines/github/pytorch/vision/23946/workflows/f0af7f08-da38-40e0-9ec7-97dfc76caa15/jobs/1851891

Compare that to the log output from #7410, which includes the same path as this PR: https://app.circleci.com/pipelines/github/pytorch/vision/23985/workflows/93c08d16-4776-4ace-aa14-89dec0998364/jobs/1852841?invite=true#step-103-7

There you can actually comprehend what is going on. I propose we reduce the log level to something normal by default and only use `--debug` if we actually want to debug the workflow.