### PR TITLE
fix test_detection_preset for ssd data augmentation

### DIFF
--- a/test/test_transforms_v2.py
+++ b/test/test_transforms_v2.py
@@ -1875,7 +1875,7 @@ def test_detection_preset(image_type, data_augmentation, to_tensor, sanitize):
     elif data_augmentation == "ssd":
         t = [
             transforms.RandomPhotometricDistort(p=1),
-            transforms.RandomZoomOut(fill=defaultdict(lambda: (123.0, 117.0, 104.0), {datapoints.Mask: 0})),
+            transforms.RandomZoomOut(fill=defaultdict(lambda: (123.0, 117.0, 104.0), {datapoints.Mask: 0}), p=1),
             transforms.RandomIoUCrop(),
             transforms.RandomHorizontalFlip(p=1),
             to_tensor,
@@ -1934,7 +1934,7 @@ def test_detection_preset(image_type, data_augmentation, to_tensor, sanitize):
         # param is True.
         # Note that the values below are probably specific to the random seed
         # set above (which is fine).
-        (True, "ssd"): 4,
+        (True, "ssd"): 5,
         (True, "ssdlite"): 4,
     }.get((sanitize, data_augmentation), num_boxes)
 


### PR DESCRIPTION
#7442 broke this test. However, this is not a bug in the PR, but rather an oversight in the test setup. #7442 changed the random sampling strategy (see https://github.com/pytorch/vision/pull/7442#discussion_r1144799717), which ultimately leads to a different number of boxes in the final output. As expected, only keeping `RandomPhotometricDistort` in the pipeline yields exactly the same results prior and after #7442.

cc @vfdev-5