### PR TITLE
MovingMNIST split fix

### DIFF
--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -278,6 +278,7 @@ class CityScapesTestCase(datasets_utils.ImageDatasetTestCase):
     FEATURE_TYPES = (PIL.Image.Image, (dict, PIL.Image.Image))
 
     def inject_fake_data(self, tmpdir, config):
+
         tmpdir = pathlib.Path(tmpdir)
 
         mode_to_splits = {
@@ -1512,7 +1513,7 @@ class MovingMNISTTestCase(datasets_utils.DatasetTestCase):
         data = np.concatenate(
             [
                 np.zeros((config["split_ratio"], num_samples, 64, 64)),
-                np.ones((self._N_FRAMES - config["split_ratio"], num_samples, 64, 64)),
+                np.ones((self._NUM_FRAMES - config["split_ratio"], num_samples, 64, 64)),
             ]
         )
         np.save(os.path.join(base_folder, "mnist_test_seq.npy"), data)
@@ -1526,7 +1527,7 @@ class MovingMNISTTestCase(datasets_utils.DatasetTestCase):
             elif config["split"] == "test":
                 assert (dataset.data == 1).all()
             else:
-                assert dataset.data.size()[1] == self._N_FRAMES
+                assert dataset.data.size()[1] == self._NUM_FRAMES
 
 
 class DatasetFolderTestCase(datasets_utils.ImageDatasetTestCase):
@@ -1941,6 +1942,7 @@ class KittiFlowTestCase(datasets_utils.ImageDatasetTestCase):
     FEATURE_TYPES = (PIL.Image.Image, PIL.Image.Image, (np.ndarray, type(None)), (np.ndarray, type(None)))
 
     def inject_fake_data(self, tmpdir, config):
+
         root = pathlib.Path(tmpdir) / "KittiFlow"
 
         num_examples = 2 if config["split"] == "train" else 3

--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -278,7 +278,6 @@ class CityScapesTestCase(datasets_utils.ImageDatasetTestCase):
     FEATURE_TYPES = (PIL.Image.Image, (dict, PIL.Image.Image))
 
     def inject_fake_data(self, tmpdir, config):
-
         tmpdir = pathlib.Path(tmpdir)
 
         mode_to_splits = {
@@ -1504,14 +1503,16 @@ class MovingMNISTTestCase(datasets_utils.DatasetTestCase):
 
     ADDITIONAL_CONFIGS = combinations_grid(split=(None, "train", "test"), split_ratio=(10, 1, 19))
 
+    _N_FRAMES = 20
+
     def inject_fake_data(self, tmpdir, config):
         base_folder = os.path.join(tmpdir, self.DATASET_CLASS.__name__)
         os.makedirs(base_folder, exist_ok=True)
-        num_samples = 20
+        num_samples = 5
         data = np.concatenate(
             [
                 np.zeros((config["split_ratio"], num_samples, 64, 64)),
-                np.ones((20 - config["split_ratio"], num_samples, 64, 64)),
+                np.ones((_N_FRAMES - config["split_ratio"], num_samples, 64, 64)),
             ]
         )
         np.save(os.path.join(base_folder, "mnist_test_seq.npy"), data)
@@ -1519,14 +1520,13 @@ class MovingMNISTTestCase(datasets_utils.DatasetTestCase):
 
     @datasets_utils.test_all_configs
     def test_split(self, config):
-        if config["split"] is None:
-            return
-
-        with self.create_dataset(config) as (dataset, info):
+        with self.create_dataset(config) as (dataset, _):
             if config["split"] == "train":
                 assert (dataset.data == 0).all()
-            else:
+            elif config["split"] == "test":
                 assert (dataset.data == 1).all()
+            else:
+                assert dataset.data.size[1] == _N_FRAMES
 
 
 class DatasetFolderTestCase(datasets_utils.ImageDatasetTestCase):
@@ -1945,7 +1945,6 @@ class KittiFlowTestCase(datasets_utils.ImageDatasetTestCase):
 
         num_examples = 2 if config["split"] == "train" else 3
         for split_dir in ("training", "testing"):
-
             datasets_utils.create_image_folder(
                 root / split_dir,
                 name="image_2",

--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -1512,7 +1512,7 @@ class MovingMNISTTestCase(datasets_utils.DatasetTestCase):
         data = np.concatenate(
             [
                 np.zeros((config["split_ratio"], num_samples, 64, 64)),
-                np.ones((_N_FRAMES - config["split_ratio"], num_samples, 64, 64)),
+                np.ones((self._N_FRAMES - config["split_ratio"], num_samples, 64, 64)),
             ]
         )
         np.save(os.path.join(base_folder, "mnist_test_seq.npy"), data)
@@ -1526,7 +1526,7 @@ class MovingMNISTTestCase(datasets_utils.DatasetTestCase):
             elif config["split"] == "test":
                 assert (dataset.data == 1).all()
             else:
-                assert dataset.data.size[1] == _N_FRAMES
+                assert dataset.data.size()[1] == self._N_FRAMES
 
 
 class DatasetFolderTestCase(datasets_utils.ImageDatasetTestCase):

--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -1942,11 +1942,11 @@ class KittiFlowTestCase(datasets_utils.ImageDatasetTestCase):
     FEATURE_TYPES = (PIL.Image.Image, PIL.Image.Image, (np.ndarray, type(None)), (np.ndarray, type(None)))
 
     def inject_fake_data(self, tmpdir, config):
-
         root = pathlib.Path(tmpdir) / "KittiFlow"
 
         num_examples = 2 if config["split"] == "train" else 3
         for split_dir in ("training", "testing"):
+
             datasets_utils.create_image_folder(
                 root / split_dir,
                 name="image_2",

--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -1503,7 +1503,7 @@ class MovingMNISTTestCase(datasets_utils.DatasetTestCase):
 
     ADDITIONAL_CONFIGS = combinations_grid(split=(None, "train", "test"), split_ratio=(10, 1, 19))
 
-    _N_FRAMES = 20
+    _NUM_FRAMES = 20
 
     def inject_fake_data(self, tmpdir, config):
         base_folder = os.path.join(tmpdir, self.DATASET_CLASS.__name__)

--- a/torchvision/datasets/moving_mnist.py
+++ b/torchvision/datasets/moving_mnist.py
@@ -58,7 +58,7 @@ class MovingMNIST(VisionDataset):
         data = torch.from_numpy(np.load(os.path.join(self._base_folder, self._filename)))
         if self.split == "train":
             data = data[: self.split_ratio]
-        else:
+        elif self.split == "test":
             data = data[self.split_ratio :]
         self.data = data.transpose(0, 1).unsqueeze(2).contiguous()
 


### PR DESCRIPTION
Describe the fix

1. `torchvision/datasets/moving_mnist.py`: Separate handling of `split="test"` condition
2. `test/test_datasets.py`: Test `split=None` condition and verify that the second dimension equals `_N_FRAMES`


Check list

- [x] Code formatting
- [x] Unit test

Fix #7439 


cc @pmeier