### PR TITLE
prepare doc preview s3-prefix for future change

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -66,3 +66,16 @@ jobs:
           if-no-files-found: error
           path: html
           s3-prefix: pytorch/vision/${{ github.event.pull_request.number }}
+
+      # The upload below duplicates the upload from above, but to a different path. This is needed since we are in the
+      # process of changing the path, but want to keep the disruption to a minimum.
+      # See https://github.com/pytorch/test-infra/issues/3894
+      # After a grace period, we can delete this again
+      - name: Upload docs preview
+        uses: seemethere/upload-artifact-s3@v5
+        with:
+          retention-days: 14
+          s3-bucket: doc-previews
+          if-no-files-found: error
+          path: html
+          s3-prefix: pytorch/pytorch/vision/${{ github.event.pull_request.number }}


### PR DESCRIPTION
This patch is correct but somewhat confusing. Right now we are using the `$OWNER/$REPO` scheme at the start of the s3-prefix:

https://github.com/pytorch/vision/blob/2b25d67925df9741ba2a75a07bc3046302969e87/.github/workflows/docs.yml#L68

However, the CloudFront setup currently swallows a leading `pytorch/`. Thus, our docs are currently served under `https://docs-preview.pytorch.org/$REPO/$PR/index.html`, e.g. https://docs-preview.pytorch.org/vision/7453/index.html.

We want to get rid of this configuration in the future. To avoid disruption, this after this PR we will additionally upload to the future location and after a grace period disable the old path. 

This means that right now we need to upload with `s3-prefix: pytorch/pytorch/vision/` to counteract the CloudFront configuration. After the grace period we can go back to the current `pytorch/vision/` since that already uses the `$OWNER/$REPO` scheme we want. Meaning, after we change the CloudFront configuration, our current setup will upload to `https://docs-preview.pytorch.org/$OWNER/$REPO/$PR/index.html`

cc @seemethere