### PR TITLE
Ignore some flake8 codes

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ max-line-length = 120
 [flake8]
 # note: we ignore all 501s (line too long) anyway as they're taken care of by black
 max-line-length = 120
-ignore = E203, E402, W503, W504, F821, E501
+ignore = E203, E402, W503, W504, F821, E501, B, C4, EXE
 per-file-ignores =
     __init__.py: F401, F403, F405
     ./hubconf.py: F401


### PR DESCRIPTION
These plugins are used by pytorch/pytorch, but make direct
use of flake8 unusable for vision.  Disable these warnings
so that flake8 is clean.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

<!-- Before submitting a PR, please make sure to check our contributing guidelines regarding code formatting, tests, and documentation: https://github.com/pytorch/vision/blob/main/CONTRIBUTING.md -->
