### PR TITLE
fix ImagePair MAE comparison

### DIFF
--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -292,7 +292,8 @@ class ImagePair(TensorLikePair):
         actual, expected = self._equalize_attributes(actual, expected)
 
         if self.mae:
-            actual, expected = self._promote_for_comparison(actual, expected)
+            if actual.dtype is torch.uint8:
+                actual, expected = actual.to(torch.int), expected.to(torch.int)
             mae = float(torch.abs(actual - expected).float().mean())
             if mae > self.atol:
                 self._fail(


### PR DESCRIPTION
The `_promote_for_comparison` method was removed in pytorch/pytorch#96131.