### PR TITLE
Update docstring of Resize with shape constraint

### DIFF
--- a/torchvision/transforms/transforms.py
+++ b/torchvision/transforms/transforms.py
@@ -283,7 +283,7 @@ class Normalize(torch.nn.Module):
 class Resize(torch.nn.Module):
     """Resize the input image to the given size.
     If the image is torch Tensor, it is expected
-    to have [..., H, W] shape, where ... means an arbitrary number of leading dimensions
+    to have [..., H, W] shape, where ... means a maximum of two leading dimensions
 
     .. warning::
         The output image might be different depending on its type: when downsampling, the interpolation of PIL images


### PR DESCRIPTION
Update the docstring of transforms.Resize with explicit shape constraint: Input Tensor dimensions have to be <= 4

See: https://github.com/pytorch/vision/issues/7476

<!-- Before submitting a PR, please make sure to check our contributing guidelines regarding code formatting, tests, and documentation: https://github.com/pytorch/vision/blob/main/CONTRIBUTING.md -->
