### PR TITLE
Added allowed_workflows to pytorch probot

### DIFF
--- a/.github/pytorch-probot.yml
+++ b/.github/pytorch-probot.yml
@@ -1,6 +1,7 @@
 tracking_issue: 2447
 
 # List of workflows that will be re-run in case of failures
+# https://github.com/pytorch/test-infra/blob/main/torchci/lib/bot/retryBot.ts
 allowed_workflows:
 - Build Linux
 - Build Macos

--- a/.github/pytorch-probot.yml
+++ b/.github/pytorch-probot.yml
@@ -1,1 +1,8 @@
 tracking_issue: 2447
+allowed_workflows:
+- lint
+- Build Linux
+- Build Macos
+- Build M1
+- Tests on Linux
+- Tests on macOS

--- a/.github/pytorch-probot.yml
+++ b/.github/pytorch-probot.yml
@@ -1,6 +1,7 @@
 tracking_issue: 2447
+
+# List of workflows that will be re-run in case of failures
 allowed_workflows:
-- lint
 - Build Linux
 - Build Macos
 - Build M1


### PR DESCRIPTION
Added allowed_workflows to pytorch probot. This is a follow up PR [regarding the retry bot](https://github.com/pytorch/test-infra/pull/3942/files#diff-ee5e4f1e1fa962c6f62e5dcebde6e0bab573e74474601bf5749ccb668fd9c900R14-R16).