### PR TITLE
only return small set of targets by default from dataset wrapper

### DIFF
--- a/gallery/plot_transforms_v2_e2e.py
+++ b/gallery/plot_transforms_v2_e2e.py
@@ -75,7 +75,8 @@ print(type(target), type(target[0]), list(target[0].keys()))
 # :func:`~torchvision.datasets.wrap_dataset_for_transforms_v2` function. For
 # :class:`~torchvision.datasets.CocoDetection`, this changes the target structure to a single dictionary of lists. It
 # also adds the key-value-pairs ``"boxes"``, ``"masks"``, and ``"labels"`` wrapped in the corresponding
-# ``torchvision.datapoints``.
+# ``torchvision.datapoints``. By default, it only returns ``"boxes"`` and ``"labels"`` to avoid transforming unnecessary
+# items down the line, but you can pass the ``target_type`` parameter for fine-grained control.
 
 dataset = datasets.wrap_dataset_for_transforms_v2(dataset)
 
@@ -83,7 +84,7 @@ sample = dataset[0]
 image, target = sample
 print(type(image))
 print(type(target), list(target.keys()))
-print(type(target["boxes"]), type(target["masks"]), type(target["labels"]))
+print(type(target["boxes"]), type(target["labels"]))
 
 ########################################################################################################################
 # As baseline, let's have a look at a sample without transformations:

--- a/test/datasets_utils.py
+++ b/test/datasets_utils.py
@@ -25,7 +25,7 @@ import torch
 import torchvision.datasets
 import torchvision.io
 from common_utils import disable_console_output, get_tmp_dir
-from torch.utils._pytree import tree_any
+from torch.utils._pytree import tree_flatten
 from torchvision.transforms.functional import get_dimensions
 
 
@@ -572,9 +572,22 @@ class DatasetTestCase(unittest.TestCase):
 
         try:
             with self.create_dataset(config) as (dataset, _):
-                wrapped_dataset = wrap_dataset_for_transforms_v2(dataset)
-                wrapped_sample = wrapped_dataset[0]
-                assert tree_any(lambda item: isinstance(item, (Datapoint, PIL.Image.Image)), wrapped_sample)
+                for target_keys in [None, "all"]:
+                    wrapped_dataset = wrap_dataset_for_transforms_v2(dataset, target_keys=target_keys)
+                    wrapped_sample = wrapped_dataset[0]
+
+                    flat_sample, _ = tree_flatten(wrapped_sample)
+
+                    for item in flat_sample:
+                        if isinstance(item, (Datapoint, PIL.Image.Image)):
+                            break
+                        elif isinstance(item, torch.Tensor):
+                            raise AssertionError(
+                                "Found a plain tensor before an explicit image or video. "
+                                "This is not compatible with the tensor fallback heuristic."
+                            )
+                    else:
+                        raise AssertionError("Found no image or video in sample.")
         except TypeError as error:
             msg = f"No wrapper exists for dataset class {type(dataset).__name__}"
             if str(error).startswith(msg):

--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -771,6 +771,8 @@ class CocoDetectionTestCase(datasets_utils.ImageDatasetTestCase):
                     bbox=torch.rand(4).tolist(),
                     segmentation=[torch.rand(8).tolist()],
                     category_id=int(torch.randint(91, ())),
+                    area=float(torch.rand(1)),
+                    iscrowd=int(torch.randint(2, size=(1,))),
                 )
             )
             annotion_id += 1

--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -3338,7 +3338,7 @@ class TestDatasetWrapper:
         mocker.patch.dict(
             datapoints._dataset_wrapper.WRAPPER_FACTORIES,
             clear=False,
-            values={datasets.FakeData: lambda dataset: lambda idx, sample: sentinel},
+            values={datasets.FakeData: lambda dataset, target_keys: lambda idx, sample: sentinel},
         )
 
         class MyFakeData(datasets.FakeData):


### PR DESCRIPTION
From benchmarking, it seems that the detection references with v2 are quite a bit slower than v1 for two reasons:

1. The input sample for COCO is fairly large with roughly > 50 items. The largest part come from the `"segmentations"` key, which stores the vertex coordinates of polygons in nested lists. Recursing through them every time with `pytree` is slow.
2. The `"segmentations"` key will be decoded into a `datapoints.Mask` and later on transformed although for regular object detection, this is not needed.

This PR introduces the `target_keys` parameter that let's users select which keys they actually want.

ToDo:

- [x] add support for `"all"` if users want everything
- [x] document this
- [x] honor `target_keys` in all irregular datasets besides `CocoDetection`

cc @vfdev-5