### PR TITLE
Remove cmake for update viable/strict

### DIFF
--- a/.github/workflows/update-viablestrict.yml
+++ b/.github/workflows/update-viablestrict.yml
@@ -17,7 +17,7 @@ jobs:
     uses: pytorch/test-infra/.github/workflows/update-viablestrict.yml@main
     with:
       repository: pytorch/vision
-      required_checks: "cmake,lint,Build Linux,Build M1,Build Macos,Tests on Linux,Tests on macOS,Docs,Lint"
+      required_checks: "Build Linux,Build M1,Build Macos,Tests on Linux,Tests on macOS,Docs,Lint"
     secrets:
       ROCKSET_API_KEY: ${{ secrets.ROCKSET_API_KEY }}
       GITHUB_DEPLOY_KEY : ${{ secrets.VISION_GITHUB_DEPLOY_KEY }}


### PR DESCRIPTION
Skip the CircleCI workflows from the list of required workflows for update viable/strict branch.

cc @seemethere