### PR TITLE
[ROCm] Use CI env variable instead of Githubactions and CircleCI.

### DIFF
--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -28,7 +28,7 @@ from torchvision.transforms._functional_tensor import _max_value as get_max_valu
 from torchvision.transforms.v2.functional import convert_dtype_image_tensor, to_image_tensor
 
 
-IN_OSS_CI = any(os.getenv(var) == "true" for var in ["CIRCLECI", "GITHUB_ACTIONS"])
+IN_OSS_CI = bool(os.getenv('CI'))
 IN_RE_WORKER = os.environ.get("INSIDE_RE_WORKER") is not None
 IN_FBCODE = os.environ.get("IN_FBCODE_TORCHVISION") == "1"
 CUDA_NOT_AVAILABLE_MSG = "CUDA device not available"


### PR DESCRIPTION
This PR fixes the ROCm CI to run same tests as CUDA CI. 

Summary:
Both the Circle CI environment and Github enviornment uses "CI" env variable set to true, as per the documentation below:
The same has been already used in PyTorch CI as well. 

https://circleci.com/docs/variables/
https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables

cc: @jithunnair-amd 

cc @jeffdaily @jithunnair-amd