### PR TITLE
ci: Limit macOS testing to one version of python

### DIFF
--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -13,10 +13,13 @@ jobs:
   unittests:
     strategy:
       matrix:
-        python-version:
+        include:
           # Test against the most popular version of Python (at the time of commit 40% of torch downloads use 3.8)
-          - "3.8"
-        runner: ["macos-12", "macos-m1-12"]
+          - python-version: "3.8"
+            runner: "macos-12"
+          # Minimum version available for Apple Silicon is 3.9, so just use that
+          - python-version: "3.9"
+            runner: "macos-m1-12"
       fail-fast: false
     uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
     with:


### PR DESCRIPTION
This limits macOS testing to one version of python since macOS unittests take a long time to run and are the most expensive runner type that we currently utilize

Long time follow up to:

* https://github.com/pytorch/vision/pull/5479

<!-- Before submitting a PR, please make sure to check our contributing guidelines regarding code formatting, tests, and documentation: https://github.com/pytorch/vision/blob/main/CONTRIBUTING.md -->
