### PR TITLE
remove double doc upload after CloudFront fix

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -66,16 +66,3 @@ jobs:
           if-no-files-found: error
           path: html
           s3-prefix: pytorch/vision/${{ github.event.pull_request.number }}
-
-      # The upload below duplicates the upload from above, but to a different path. This is needed since we are in the
-      # process of changing the path, but want to keep the disruption to a minimum.
-      # See https://github.com/pytorch/test-infra/issues/3894
-      # After a grace period, we can delete this again
-      - name: Upload docs preview
-        uses: seemethere/upload-artifact-s3@v5
-        with:
-          retention-days: 14
-          s3-bucket: doc-previews
-          if-no-files-found: error
-          path: html
-          s3-prefix: pytorch/pytorch/vision/${{ github.event.pull_request.number }}


### PR DESCRIPTION
Grace period is over. See pytorch/test-infra#3894 for details. This needs to be merged simultaneously with the CloudFront update to avoid disruption.

After this, I'll migrate our current doc upload workflow to the new builtin functionality from pytorch/test-infra#4013.

cc @seemethere