### PR TITLE
fix color in draw_segmentation_masks

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -195,8 +195,8 @@ def test_draw_no_boxes():
         "blue",
         "#FF00FF",
         (1, 34, 122),
-        ["red", "blue"],
-        ["#FF00FF", (1, 34, 122)],
+        ["red", "#FF00FF"],
+        ["blue", (1, 34, 122)],
     ],
 )
 @pytest.mark.parametrize("alpha", (0, 0.5, 0.7, 1))
@@ -268,8 +268,6 @@ def test_draw_segmentation_masks_errors():
     with pytest.raises(ValueError, match="must have the same height and width"):
         masks_bad_shape = torch.randint(0, 2, size=(h + 4, w), dtype=torch.bool)
         utils.draw_segmentation_masks(image=img, masks=masks_bad_shape)
-    with pytest.raises(ValueError, match="There are more masks"):
-        utils.draw_segmentation_masks(image=img, masks=masks, colors=[])
     with pytest.raises(ValueError, match="colors must be a tuple or a string, or a list thereof"):
         bad_colors = np.array(["red", "blue"])  # should be a list
         utils.draw_segmentation_masks(image=img, masks=masks, colors=bad_colors)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -120,7 +120,7 @@ def test_draw_boxes_colors(colors):
     img = torch.full((3, 100, 100), 0, dtype=torch.uint8)
     utils.draw_bounding_boxes(img, boxes, fill=False, width=7, colors=colors)
 
-    with pytest.raises(ValueError, match=".*is less than the number of objects.*"):
+    with pytest.raises(ValueError, match="is less than the number of objects"):
         utils.draw_bounding_boxes(image=img, boxes=boxes, colors=[])
 
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -226,8 +226,7 @@ def test_draw_segmentation_masks(colors, alpha):
     assert_equal(img[:, ~masked_pixels], out[:, ~masked_pixels])
 
     if colors is None:
-        palette = torch.tensor([2**25 - 1, 2**15 - 1, 2**21 - 1])
-        colors = [tuple((i * palette) % 255) for i in range(num_masks)]
+        colors = utils._generate_color_palette(num_masks)
     elif isinstance(colors, str) or isinstance(colors, tuple):
         colors = [colors]
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -120,6 +120,9 @@ def test_draw_boxes_colors(colors):
     img = torch.full((3, 100, 100), 0, dtype=torch.uint8)
     utils.draw_bounding_boxes(img, boxes, fill=False, width=7, colors=colors)
 
+    with pytest.raises(ValueError, match=".*is less than the number of objects.*"):
+        utils.draw_bounding_boxes(image=img, boxes=boxes, colors=[])
+
 
 def test_draw_boxes_vanilla():
     img = torch.full((3, 100, 100), 0, dtype=torch.uint8)
@@ -268,6 +271,8 @@ def test_draw_segmentation_masks_errors():
     with pytest.raises(ValueError, match="must have the same height and width"):
         masks_bad_shape = torch.randint(0, 2, size=(h + 4, w), dtype=torch.bool)
         utils.draw_segmentation_masks(image=img, masks=masks_bad_shape)
+    with pytest.raises(ValueError, match=".*is less than the number of objects.*"):
+        utils.draw_segmentation_masks(image=img, masks=masks, colors=[])
     with pytest.raises(ValueError, match="colors must be a tuple or a string, or a list thereof"):
         bad_colors = np.array(["red", "blue"])  # should be a list
         utils.draw_segmentation_masks(image=img, masks=masks, colors=bad_colors)

--- a/torchvision/utils.py
+++ b/torchvision/utils.py
@@ -505,48 +505,6 @@ def _make_colorwheel() -> torch.Tensor:
     return colorwheel
 
 
-def _log_api_usage_once(obj: Any) -> None:
-
-    """
-    Logs API usage(module and name) within an organization.
-    In a large ecosystem, it's often useful to track the PyTorch and
-    TorchVision APIs usage. This API provides the similar functionality to the
-    logging module in the Python stdlib. It can be used for debugging purpose
-    to log which methods are used and by default it is inactive, unless the user
-    manually subscribes a logger via the `SetAPIUsageLogger method <https://github.com/pytorch/pytorch/blob/eb3b9fe719b21fae13c7a7cf3253f970290a573e/c10/util/Logging.cpp#L114>`_.
-    Please note it is triggered only once for the same API call within a process.
-    It does not collect any data from open-source users since it is no-op by default.
-    For more information, please refer to
-    * PyTorch note: https://pytorch.org/docs/stable/notes/large_scale_deployments.html#api-usage-logging;
-    * Logging policy: https://github.com/pytorch/vision/issues/5052;
-
-    Args:
-        obj (class instance or method): an object to extract info from.
-    """
-    module = obj.__module__
-    if not module.startswith("torchvision"):
-        module = f"torchvision.internal.{module}"
-    name = obj.__class__.__name__
-    if isinstance(obj, FunctionType):
-        name = obj.__name__
-    torch._C._log_api_usage_once(f"{module}.{name}")
-
-
-def _make_ntuple(x: Any, n: int) -> Tuple[Any, ...]:
-    """
-    Make n-tuple from input x. If x is an iterable, then we just convert it to tuple.
-    Otherwise, we will make a tuple of length n, all with value of x.
-    reference: https://github.com/pytorch/pytorch/blob/master/torch/nn/modules/utils.py#L8
-
-    Args:
-        x (Any): input value
-        n (int): length of the resulting tuple
-    """
-    if isinstance(x, collections.abc.Iterable):
-        return tuple(x)
-    return tuple(repeat(x, n))
-
-
 def _generate_color_palette(num_objects: int):
     palette = torch.tensor([2**25 - 1, 2**15 - 1, 2**21 - 1])
     return [tuple((i * palette) % 255) for i in range(num_objects)]
@@ -593,3 +551,45 @@ def _parse_colors(
         colors = [colors] * num_objects
 
     return [ImageColor.getrgb(color) if isinstance(color, str) else color for color in colors]
+
+
+def _log_api_usage_once(obj: Any) -> None:
+
+    """
+    Logs API usage(module and name) within an organization.
+    In a large ecosystem, it's often useful to track the PyTorch and
+    TorchVision APIs usage. This API provides the similar functionality to the
+    logging module in the Python stdlib. It can be used for debugging purpose
+    to log which methods are used and by default it is inactive, unless the user
+    manually subscribes a logger via the `SetAPIUsageLogger method <https://github.com/pytorch/pytorch/blob/eb3b9fe719b21fae13c7a7cf3253f970290a573e/c10/util/Logging.cpp#L114>`_.
+    Please note it is triggered only once for the same API call within a process.
+    It does not collect any data from open-source users since it is no-op by default.
+    For more information, please refer to
+    * PyTorch note: https://pytorch.org/docs/stable/notes/large_scale_deployments.html#api-usage-logging;
+    * Logging policy: https://github.com/pytorch/vision/issues/5052;
+
+    Args:
+        obj (class instance or method): an object to extract info from.
+    """
+    module = obj.__module__
+    if not module.startswith("torchvision"):
+        module = f"torchvision.internal.{module}"
+    name = obj.__class__.__name__
+    if isinstance(obj, FunctionType):
+        name = obj.__name__
+    torch._C._log_api_usage_once(f"{module}.{name}")
+
+
+def _make_ntuple(x: Any, n: int) -> Tuple[Any, ...]:
+    """
+    Make n-tuple from input x. If x is an iterable, then we just convert it to tuple.
+    Otherwise, we will make a tuple of length n, all with value of x.
+    reference: https://github.com/pytorch/pytorch/blob/master/torch/nn/modules/utils.py#L8
+
+    Args:
+        x (Any): input value
+        n (int): length of the resulting tuple
+    """
+    if isinstance(x, collections.abc.Iterable):
+        return tuple(x)
+    return tuple(repeat(x, n))

--- a/torchvision/utils.py
+++ b/torchvision/utils.py
@@ -313,7 +313,7 @@ def draw_segmentation_masks(
         img_to_draw[:, mask] = color[:, None]
 
     out = image * (1 - alpha) + img_to_draw * alpha
-    return out.to(dtype=out_dtype)
+    return out.to(out_dtype)
 
 
 @torch.no_grad()
@@ -589,6 +589,4 @@ def _parse_colors(
     else:  # colors specifies a single color for all objects
         colors = [colors] * num_objects
 
-    colors_ = [ImageColor.getrgb(color) if isinstance(color, str) else color for color in colors]
-
-    return colors_
+    return [ImageColor.getrgb(color) if isinstance(color, str) else color for color in colors]

--- a/torchvision/utils.py
+++ b/torchvision/utils.py
@@ -547,6 +547,11 @@ def _make_ntuple(x: Any, n: int) -> Tuple[Any, ...]:
     return tuple(repeat(x, n))
 
 
+def _generate_color_palette(num_objects: int):
+    palette = torch.tensor([2**25 - 1, 2**15 - 1, 2**21 - 1])
+    return [tuple((i * palette) % 255) for i in range(num_objects)]
+
+
 def _parse_colors(
     colors: Union[None, str, Tuple[int, int, int], List[Union[str, Tuple[int, int, int]]]],
     *,
@@ -575,8 +580,7 @@ def _parse_colors(
                     If `colors` is not a list, tuple, string or None.
     """
     if colors is None:
-        palette = torch.tensor([2**25 - 1, 2**15 - 1, 2**21 - 1])
-        colors = [tuple((i * palette) % 255) for i in range(num_objects)]
+        colors = _generate_color_palette(num_objects)
     elif isinstance(colors, list):
         if len(colors) < num_objects:
             raise ValueError(

--- a/torchvision/utils.py
+++ b/torchvision/utils.py
@@ -568,7 +568,6 @@ def _parse_colors(
 
             If `colors` is a tuple, it should be a 3-tuple specifying the RGB values of the color.
             If `colors` is a list, it should have at least as many elements as the number of objects to color.
-            If `colors` is None, a color palette will be generated automatically to have a distinct color for each object.
 
         num_objects (int): The number of objects to color.
 

--- a/torchvision/utils.py
+++ b/torchvision/utils.py
@@ -553,6 +553,7 @@ def _make_ntuple(x: Any, n: int) -> Tuple[Any, ...]:
 
 def _parse_colors(
     colors: Union[None, str, Tuple[int, int, int], List[Union[str, Tuple[int, int, int]]]],
+    *,
     num_objects: int,
     output_format: Optional[str] = "tensor",
 ) -> List[Union[torch.Tensor, Tuple[int, int, int]]]:

--- a/torchvision/utils.py
+++ b/torchvision/utils.py
@@ -304,7 +304,7 @@ def draw_segmentation_masks(
         warnings.warn("masks doesn't contain any mask. No mask was drawn")
         return image
 
-    colors = _parse_colors(colors=colors, num_objects=num_masks)
+    colors = _parse_colors(colors, num_objects=num_masks)
 
     img_to_draw = image.detach().clone()
     # TODO: There might be a way to vectorize this

--- a/torchvision/utils.py
+++ b/torchvision/utils.py
@@ -552,7 +552,7 @@ def _make_ntuple(x: Any, n: int) -> Tuple[Any, ...]:
 
 
 def _parse_colors(
-    colors: Optional[Union[List[Union[str, Tuple[int, int, int]]], str, Tuple[int, int, int], None]],
+    colors: Union[None, str, Tuple[int, int, int], List[Union[str, Tuple[int, int, int]]]],
     num_objects: int,
     output_format: Optional[str] = "tensor",
 ) -> List[Union[torch.Tensor, Tuple[int, int, int]]]:

--- a/torchvision/utils.py
+++ b/torchvision/utils.py
@@ -588,11 +588,11 @@ def _parse_colors(
         colors = _generate_color_palette(num_objects)
     elif isinstance(colors, list):
         if len(colors) < num_objects:
-            raise ValueError(f"Number of colors ({len(colors)}) is less than the number of objects ({num_objects}). ")
+            raise ValueError(f"Number of colors must be equal or larger than the number of objects, but got {len(colors)} < {num_objects}.")
     elif not isinstance(colors, (tuple, str)):
-        raise ValueError("colors must be a tuple or a string, or a list thereof")
+        raise ValueError("`colors` must be a tuple or a string, or a list thereof, but got {colors}.")
     elif isinstance(colors, tuple) and len(colors) != 3:
-        raise ValueError("It seems that you passed a tuple of colors instead of a list of colors")
+        raise ValueError("If passed as tuple, colors should be an RGB triplet, but got {colors}.")
     else:  # colors specifies a single color for all objects
         colors = [colors] * num_objects
 


### PR DESCRIPTION
**Reproduce bug:**
```python
import torch
import torchvision.utils as utils

num_masks, h, w = 4, 100, 100
img = torch.randint(0, 256, size=(3, h, w), dtype=torch.uint8)
masks = torch.randint(0, 2, (num_masks, h, w), dtype=torch.bool)

utils.draw_segmentation_masks(img, masks, colors="red")
```
which throws: 
> ValueError: There are more masks (4) than colors (3)

where the expected outcome is the drawing of all the segmentation masks in a single color ([as stated in the docs](https://pytorch.org/vision/main/generated/torchvision.utils.draw_segmentation_masks.html)).

Notice that, in the following settings the function works as intended;
- `num_masks=3` and `colors="red"`,
- `num_masks=4` and `colors="blue"`,
meaning, in the case of `num_masks=len(colors)`.

Currently, the respective tests pass even though the function does not work properly. This is because the test is checked in the presence of only 2 masks:
https://github.com/pytorch/vision/blob/b78d98bb152ffb9c0c0f5365f59f475c70b1784e/test/test_utils.py#L205
Therefore, for any input whose length is larger than 2, _i.e._ `"red"`, `"#FF00FF"`, `(240, 10, 157)`, the tests will pass.


**The Fix:**
I have adapted the code in `draw_segmentation_masks` such that it also accepts a string of colors. The code was adapted similarly to how it is handled in [`draw_bounding_boxes`](https://github.com/pytorch/vision/blob/b78d98bb152ffb9c0c0f5365f59f475c70b1784e/torchvision/utils.py#L220-L228), where the issue does not appear.
Specific tests passed with:
```python
pytest test/test_utils.py -vvv -k test_draw_segmentation_masks
```

