### PR TITLE
add same size shortcut for resize in transforms v2

### DIFF
--- a/test/transforms_v2_kernel_infos.py
+++ b/test/transforms_v2_kernel_infos.py
@@ -321,6 +321,9 @@ def reference_resize_bounding_box(bounding_box, *, spatial_size, size, max_size=
     old_height, old_width = spatial_size
     new_height, new_width = F._geometry._compute_resized_output_size(spatial_size, size=size, max_size=max_size)
 
+    if (old_height, old_width) == (new_height, new_width):
+        return bounding_box, (old_height, old_width)
+
     affine_matrix = np.array(
         [
             [new_width / old_width, 0, 0],

--- a/torchvision/transforms/v2/functional/_geometry.py
+++ b/torchvision/transforms/v2/functional/_geometry.py
@@ -215,8 +215,8 @@ def resize_image_pil(
     old_height, old_width = image.height, image.width
     new_height, new_width = _compute_resized_output_size(
         (old_height, old_width),
-        size=size,
-        max_size=max_size,  # type: ignore[arg-type]
+        size=size,  # type: ignore[arg-type]
+        max_size=max_size,
     )
 
     interpolation = _check_interpolation(interpolation)


### PR DESCRIPTION
While reviewing #7519, I realized we don't have this shortcut in v2 at all. Since it was intentionally put into v1 and I currently see no downside, I added it for v2 as well.

cc @vfdev-5