### PR TITLE
Fix Resize() documentation

### DIFF
--- a/torchvision/transforms/functional.py
+++ b/torchvision/transforms/functional.py
@@ -423,13 +423,11 @@ def resize(
             supported.
             The corresponding Pillow integer constants, e.g. ``PIL.Image.BILINEAR`` are accepted as well.
         max_size (int, optional): The maximum allowed for the longer edge of
-            the resized image: if the longer edge of the image is greater
-            than ``max_size`` after being resized according to ``size``, then
-            the image is resized again so that the longer edge is equal to
-            ``max_size``. As a result, ``size`` might be overruled, i.e. the
-            smaller edge may be shorter than ``size``. This is only supported
-            if ``size`` is an int (or a sequence of length 1 in torchscript
-            mode).
+            the resized image. If the longer edge of the image is greater
+            than ``max_size`` after being resized according to ``size``, 
+            ``size`` will be overruled. As a result, the smaller edge may be 
+            shorter than ``size``. This is only supported if ``size`` is an int
+            (or a sequence of length 1 in torchscript mode).
         antialias (bool, optional): Whether to apply antialiasing.
             It only affects **tensors** with bilinear or bicubic modes and it is
             ignored otherwise: on PIL images, antialiasing is always applied on

--- a/torchvision/transforms/functional.py
+++ b/torchvision/transforms/functional.py
@@ -427,9 +427,9 @@ def resize(
             than ``max_size`` after being resized according to ``size``, 
             ``size`` will be overruled so that the longer edge is equal to
             ``max_size``.
-            As a result, the smaller edge may be 
-            shorter than ``size``. This is only supported if ``size`` is an int
-            (or a sequence of length 1 in torchscript mode).
+            As a result, the smaller edge may be shorter than ``size``. This 
+            is only supported if ``size`` is an int (or a sequence of length
+            1 in torchscript mode).
         antialias (bool, optional): Whether to apply antialiasing.
             It only affects **tensors** with bilinear or bicubic modes and it is
             ignored otherwise: on PIL images, antialiasing is always applied on

--- a/torchvision/transforms/functional.py
+++ b/torchvision/transforms/functional.py
@@ -425,7 +425,9 @@ def resize(
         max_size (int, optional): The maximum allowed for the longer edge of
             the resized image. If the longer edge of the image is greater
             than ``max_size`` after being resized according to ``size``, 
-            ``size`` will be overruled. As a result, the smaller edge may be 
+            ``size`` will be overruled so that the longer edge is equal to
+            ``max_size``.
+            As a result, the smaller edge may be 
             shorter than ``size``. This is only supported if ``size`` is an int
             (or a sequence of length 1 in torchscript mode).
         antialias (bool, optional): Whether to apply antialiasing.

--- a/torchvision/transforms/transforms.py
+++ b/torchvision/transforms/transforms.py
@@ -311,9 +311,9 @@ class Resize(torch.nn.Module):
             than ``max_size`` after being resized according to ``size``, 
             ``size`` will be overruled so that the longer edge is equal to
             ``max_size``.
-            As a result, the smaller edge may be 
-            shorter than ``size``. This is only supported if ``size`` is an int
-            (or a sequence of length 1 in torchscript mode).
+            As a result, the smaller edge may be shorter than ``size``. This 
+            is only supported if ``size`` is an int (or a sequence of length
+            1 in torchscript mode).
         antialias (bool, optional): Whether to apply antialiasing.
             It only affects **tensors** with bilinear or bicubic modes and it is
             ignored otherwise: on PIL images, antialiasing is always applied on

--- a/torchvision/transforms/transforms.py
+++ b/torchvision/transforms/transforms.py
@@ -307,13 +307,11 @@ class Resize(torch.nn.Module):
             ``InterpolationMode.BILINEAR`` and ``InterpolationMode.BICUBIC`` are supported.
             The corresponding Pillow integer constants, e.g. ``PIL.Image.BILINEAR`` are accepted as well.
         max_size (int, optional): The maximum allowed for the longer edge of
-            the resized image: if the longer edge of the image is greater
-            than ``max_size`` after being resized according to ``size``, then
-            the image is resized again so that the longer edge is equal to
-            ``max_size``. As a result, ``size`` might be overruled, i.e. the
-            smaller edge may be shorter than ``size``. This is only supported
-            if ``size`` is an int (or a sequence of length 1 in torchscript
-            mode).
+            the resized image. If the longer edge of the image is greater
+            than ``max_size`` after being resized according to ``size``, 
+            ``size`` will be overruled. As a result, the smaller edge may be 
+            shorter than ``size``. This is only supported if ``size`` is an int
+            (or a sequence of length 1 in torchscript mode).
         antialias (bool, optional): Whether to apply antialiasing.
             It only affects **tensors** with bilinear or bicubic modes and it is
             ignored otherwise: on PIL images, antialiasing is always applied on

--- a/torchvision/transforms/transforms.py
+++ b/torchvision/transforms/transforms.py
@@ -309,7 +309,9 @@ class Resize(torch.nn.Module):
         max_size (int, optional): The maximum allowed for the longer edge of
             the resized image. If the longer edge of the image is greater
             than ``max_size`` after being resized according to ``size``, 
-            ``size`` will be overruled. As a result, the smaller edge may be 
+            ``size`` will be overruled so that the longer edge is equal to
+            ``max_size``.
+            As a result, the smaller edge may be 
             shorter than ``size``. This is only supported if ``size`` is an int
             (or a sequence of length 1 in torchscript mode).
         antialias (bool, optional): Whether to apply antialiasing.

--- a/torchvision/transforms/v2/_geometry.py
+++ b/torchvision/transforms/v2/_geometry.py
@@ -97,13 +97,13 @@ class Resize(Transform):
             ``InterpolationMode.BILINEAR`` and ``InterpolationMode.BICUBIC`` are supported.
             The corresponding Pillow integer constants, e.g. ``PIL.Image.BILINEAR`` are accepted as well.
         max_size (int, optional): The maximum allowed for the longer edge of
-            the resized image: if the longer edge of the image is greater
-            than ``max_size`` after being resized according to ``size``, then
-            the image is resized again so that the longer edge is equal to
-            ``max_size``. As a result, ``size`` might be overruled, i.e. the
-            smaller edge may be shorter than ``size``. This is only supported
-            if ``size`` is an int (or a sequence of length 1 in torchscript
-            mode).
+            the resized image. If the longer edge of the image is greater
+            than ``max_size`` after being resized according to ``size``, 
+            ``size`` will be overruled so that the longer edge is equal to
+            ``max_size``.
+            As a result, the smaller edge may be shorter than ``size``. This 
+            is only supported if ``size`` is an int (or a sequence of length
+            1 in torchscript mode).
         antialias (bool, optional): Whether to apply antialiasing.
             It only affects **tensors** with bilinear or bicubic modes and it is
             ignored otherwise: on PIL images, antialiasing is always applied on


### PR DESCRIPTION
The current documentation implies that the computation of Resize() is performed twice in some cases related to the ``max_size`` parameter. This is not the case in the code. 
This PR fixes the issue.