### PR TITLE
remove obsolete pre Pyhton3.8 compat

### DIFF
--- a/torchvision/_internally_replaced_utils.py
+++ b/torchvision/_internally_replaced_utils.py
@@ -28,7 +28,6 @@ def _get_extension_path(lib_name):
     if os.name == "nt":
         # Register the main torchvision library location on the default DLL path
         import ctypes
-        import sys
 
         kernel32 = ctypes.WinDLL("kernel32.dll", use_last_error=True)
         with_load_library_flags = hasattr(kernel32, "AddDllDirectory")
@@ -37,14 +36,7 @@ def _get_extension_path(lib_name):
         if with_load_library_flags:
             kernel32.AddDllDirectory.restype = ctypes.c_void_p
 
-        if sys.version_info >= (3, 8):
-            os.add_dll_directory(lib_dir)
-        elif with_load_library_flags:
-            res = kernel32.AddDllDirectory(lib_dir)
-            if res is None:
-                err = ctypes.WinError(ctypes.get_last_error())
-                err.strerror += f' Error adding "{lib_dir}" to the DLL directories.'
-                raise err
+        os.add_dll_directory(lib_dir)
 
         kernel32.SetErrorMode(prev_error_mode)
 

--- a/torchvision/extension.py
+++ b/torchvision/extension.py
@@ -1,7 +1,5 @@
-import ctypes
 import os
 import sys
-from warnings import warn
 
 import torch
 
@@ -22,7 +20,7 @@ try:
     # conda environment/bin path is configured Please take a look:
     # https://stackoverflow.com/questions/59330863/cant-import-dll-module-in-python
     # Please note: if some path can't be added using add_dll_directory we simply ignore this path
-    if os.name == "nt" and sys.version_info >= (3, 8) and sys.version_info < (3, 9):
+    if os.name == "nt" and sys.version_info < (3, 9):
         env_path = os.environ["PATH"]
         path_arr = env_path.split(";")
         for path in path_arr:
@@ -88,19 +86,6 @@ def _check_cuda_version():
 
 def _load_library(lib_name):
     lib_path = _get_extension_path(lib_name)
-    # On Windows Python-3.8+ has `os.add_dll_directory` call,
-    # which is called from _get_extension_path to configure dll search path
-    # Condition below adds a workaround for older versions by
-    # explicitly calling `LoadLibraryExW` with the following flags:
-    #  - LOAD_LIBRARY_SEARCH_DEFAULT_DIRS (0x1000)
-    #  - LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR (0x100)
-    if os.name == "nt" and sys.version_info < (3, 8):
-        _kernel32 = ctypes.WinDLL("kernel32.dll", use_last_error=True)
-        if hasattr(_kernel32, "LoadLibraryExW"):
-            _kernel32.LoadLibraryExW(lib_path, None, 0x00001100)
-        else:
-            warn("LoadLibraryExW is missing in kernel32.dll")
-
     torch.ops.load_library(lib_path)
 
 


### PR DESCRIPTION
We hard-depend on Python >= 3.8, so this is dead code.