### PR TITLE
try the new macos-12-xl runners

### DIFF
--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -18,7 +18,7 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
-        runner: ["macos-12"]
+        runner: ["macos-12-xl"]
         include:
           - python-version: "3.8"
             runner: macos-m1-12
@@ -26,9 +26,7 @@ jobs:
     uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
     with:
       repository: pytorch/vision
-      # We need an increased timeout here, since the macos-12 runner is the free one from GH
-      # and needs roughly 2 hours to just run the test suite
-      timeout: 240
+      timeout: 120
       runner: ${{ matrix.runner }}
       script: |
         set -euo pipefail


### PR DESCRIPTION
As mentioned in https://github.com/pytorch/vision/pull/7507#issuecomment-1505761959, the regular `macos-12` runners hosted by GitHub Actions are underspecced for our needs. They recently introduced [XL variants](https://github.blog/2023-03-01-github-actions-introducing-faster-github-hosted-x64-macos-runners/). PyTorch core is explicitly mentioned in the blog post with cutting down runtime from 1.5 hours to 0.5.

The XL runners are 4 times as expensive as the regular ones. Thus, in the light of the cost discussion in #7507, it is only uncontroversial to use them if we achieve roughly a 4x speed-up and thus keeping the cost equal.