### PR TITLE
Include dlls required for wheel building

### DIFF
--- a/packaging/pre_build_script.sh
+++ b/packaging/pre_build_script.sh
@@ -15,7 +15,15 @@ if [[ "$(uname)" == Darwin || "$OSTYPE" == "msys" ]]; then
   # Install libpng from Anaconda (defaults)
   conda install ${CONDA_CHANNEL_FLAGS} libpng "jpeg<=9b" -y
   conda install -yq ffmpeg=4.2 -c pytorch
-else
+
+  # Copy binaries to be included in the wheel distribution
+  if [[ "$OSTYPE" == "msys" ]]; then
+      python_exec="$(which python)"
+      bin_path=$(dirname $python_exec)
+      cp "$bin_path/Library/bin/libpng16.dll" torchvision
+      cp "$bin_path/Library/bin/libjpeg.dll" torchvision
+  else
+
   # Install native CentOS libJPEG, freetype and GnuTLS
   yum install -y libjpeg-turbo-devel freetype gnutls
 

--- a/packaging/pre_build_script.sh
+++ b/packaging/pre_build_script.sh
@@ -20,9 +20,8 @@ if [[ "$(uname)" == Darwin || "$OSTYPE" == "msys" ]]; then
   if [[ "$OSTYPE" == "msys" ]]; then
       python_exec="$(which python)"
       bin_path=$(dirname $python_exec)
-      cp "$bin_path/Library/bin/libpng16.dll" torchvision
       cp "$bin_path/Library/bin/libjpeg.dll" torchvision
-  else
+  fi
 
   # Install native CentOS libJPEG, freetype and GnuTLS
   yum install -y libjpeg-turbo-devel freetype gnutls


### PR DESCRIPTION
Include dlls required for wheel building.
This step used to be here: https://github.com/pytorch/vision/blob/e012579d3dedfcd472e81ee7b7ba2cf30168afc8/packaging/build_wheel.sh#L25