### PR TITLE
Add non-TS'able _resize_image_and_masks variant with less tensor ops

### DIFF
--- a/torchvision/models/detection/transform.py
+++ b/torchvision/models/detection/transform.py
@@ -24,8 +24,8 @@ def _fake_cast_onnx(v: Tensor) -> float:
 
 def _resize_image_and_masks(
     image: Tensor,
-    self_min_size: float,
-    self_max_size: float,
+    self_min_size: int,
+    self_max_size: int,
     target: Optional[Dict[str, Tensor]] = None,
     fixed_size: Optional[Tuple[int, int]] = None,
 ) -> Tuple[Tensor, Optional[Dict[str, Tensor]]]:
@@ -40,55 +40,24 @@ def _resize_image_and_masks(
     if fixed_size is not None:
         size = [fixed_size[1], fixed_size[0]]
     else:
-        min_size = torch.min(im_shape).to(dtype=torch.float32)
-        max_size = torch.max(im_shape).to(dtype=torch.float32)
-        scale = torch.min(self_min_size / min_size, self_max_size / max_size)
+        if torch.jit.is_scripting():
+            min_size = torch.min(im_shape).to(dtype=torch.float32)
+            max_size = torch.max(im_shape).to(dtype=torch.float32)
+            self_min_size_f = float(self_min_size)
+            self_max_size_f = float(self_max_size)
+            scale = torch.min(self_min_size_f / min_size, self_max_size_f / max_size)
 
-        if torchvision._is_tracing():
-            scale_factor = _fake_cast_onnx(scale)
+            if torchvision._is_tracing():
+                scale_factor = _fake_cast_onnx(scale)
+            else:
+                scale_factor = scale.item()
+
         else:
-            scale_factor = scale.item()
-        recompute_scale_factor = True
+            # Do it the normal way
+            min_size = min(im_shape)
+            max_size = max(im_shape)
+            scale_factor = min(self_min_size / min_size, self_max_size / max_size)
 
-    image = torch.nn.functional.interpolate(
-        image[None],
-        size=size,
-        scale_factor=scale_factor,
-        mode="bilinear",
-        recompute_scale_factor=recompute_scale_factor,
-        align_corners=False,
-    )[0]
-
-    if target is None:
-        return image, target
-
-    if "masks" in target:
-        mask = target["masks"]
-        mask = torch.nn.functional.interpolate(
-            mask[:, None].float(), size=size, scale_factor=scale_factor, recompute_scale_factor=recompute_scale_factor
-        )[:, 0].byte()
-        target["masks"] = mask
-    return image, target
-
-
-def _resize_image_and_masks_simple(
-    image: Tensor,
-    self_min_size: int,
-    self_max_size: int,
-    target: Optional[Dict[str, Tensor]] = None,
-    fixed_size: Optional[Tuple[int, int]] = None,
-) -> Tuple[Tensor, Optional[Dict[str, Tensor]]]:
-    im_shape = image.shape[-2:]
-
-    size: Optional[List[int]] = None
-    scale_factor: Optional[float] = None
-    recompute_scale_factor: Optional[bool] = None
-    if fixed_size is not None:
-        size = [fixed_size[1], fixed_size[0]]
-    else:
-        min_size = min(im_shape)
-        max_size = max(im_shape)
-        scale_factor = min(self_min_size / min_size, self_max_size / max_size)
         recompute_scale_factor = True
 
     image = torch.nn.functional.interpolate(
@@ -200,8 +169,7 @@ class GeneralizedRCNNTransform(nn.Module):
     def torch_choice(self, k: List[int]) -> int:
         """
         Implements `random.choice` via torch ops, so it can be compiled with
-        TorchScript. Remove if https://github.com/pytorch/pytorch/issues/25803
-        is fixed.
+        TorchScript and we use PyTorch's RNG (not native RNG)
         """
         index = int(torch.empty(1).uniform_(0.0, float(len(k))).item())
         return k[index]
@@ -212,23 +180,13 @@ class GeneralizedRCNNTransform(nn.Module):
         target: Optional[Dict[str, Tensor]] = None,
     ) -> Tuple[Tensor, Optional[Dict[str, Tensor]]]:
         h, w = image.shape[-2:]
-        if not torch.jit.is_scripting():
-            if self.training:
-                if self._skip_resize:
-                    return image, target
-                size = random.choice(self.min_size)
-            else:
-                size = self.min_size[-1]
-            image, target = _resize_image_and_masks_simple(image, size, self.max_size, target, self.fixed_size)
+        if self.training:
+            if self._skip_resize:
+                return image, target
+            size = self.torch_choice(self.min_size)
         else:
-            if self.training:
-                if self._skip_resize:
-                    return image, target
-                size = float(self.torch_choice(self.min_size))
-            else:
-                # FIXME assume for now that testing uses the largest scale
-                size = float(self.min_size[-1])
-            image, target = _resize_image_and_masks(image, size, float(self.max_size), target, self.fixed_size)
+            size = self.min_size[-1]
+        image, target = _resize_image_and_masks(image, size, self.max_size, target, self.fixed_size)
 
         if target is None:
             return image, target

--- a/torchvision/models/detection/transform.py
+++ b/torchvision/models/detection/transform.py
@@ -40,7 +40,7 @@ def _resize_image_and_masks(
     if fixed_size is not None:
         size = [fixed_size[1], fixed_size[0]]
     else:
-        if torch.jit.is_scripting():
+        if torch.jit.is_scripting() or torchvision._is_tracing():
             min_size = torch.min(im_shape).to(dtype=torch.float32)
             max_size = torch.max(im_shape).to(dtype=torch.float32)
             self_min_size_f = float(self_min_size)


### PR DESCRIPTION
We did some horrible things to _resize_image_and_masks
to make it TorchScriptable, and those horrible things cause
weird divergences when you send the float computation
to a real compiler that is willing to do fastmath optimizations
to floating point, see https://github.com/pytorch/pytorch/issues/93598

This PR adds a non TS-goopified version of the operator which doesn't
have this problem, since it does the size compute the "normal way"
(and consequently, doesn't get fastmath'ified).

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

<!-- Before submitting a PR, please make sure to check our contributing guidelines regarding code formatting, tests, and documentation: https://github.com/pytorch/vision/blob/main/CONTRIBUTING.md -->
