### PR TITLE
[torchvision] replace if statement with assert for TRT compilation

### DIFF
--- a/torchvision/ops/deform_conv.py
+++ b/torchvision/ops/deform_conv.py
@@ -82,12 +82,11 @@ def deform_conv2d(
     n_offset_grps = offset.shape[1] // (2 * weights_h * weights_w)
     n_weight_grps = n_in_channels // weight.shape[1]
 
-    if n_offset_grps == 0:
-        raise RuntimeError(
+    torch._assert(offset.shape[1] // (2 * weights_h * weights_w) != 0,
             "the shape of the offset tensor at dimension 1 is not valid. It should "
             "be a multiple of 2 * weight.size[2] * weight.size[3].\n"
             f"Got offset.shape[1]={offset.shape[1]}, while 2 * weight.size[2] * weight.size[3]={2 * weights_h * weights_w}"
-        )
+    )
 
     return torch.ops.torchvision.deform_conv2d(
         input,


### PR DESCRIPTION
Summary:
Trying to use trt + deform_conv2d
```
return torchvision.ops.deform_conv2d(
            x,
            offset,
            self.weight,
            self.bias,
            self.stride,
            self.padding,
            self.dilation,
            mask,
        )
```
cause an error

```
torch.fx.proxy.TraceError: symbolically traced variables cannot be used as inputs to control flow
 File "/mnt/xarfuse/uid-29409/e2de88e3-seed-nspid4026534060_cgpid13798698-ns-4026534057/torchvision/ops/deform_conv.py", line 85, in deform_conv2d
    if n_offset_grps == 0:
```

Differential Revision: D46070158

