### PR TITLE
Allow classification references to use the tensor backend

### DIFF
--- a/references/classification/presets.py
+++ b/references/classification/presets.py
@@ -16,8 +16,16 @@ class ClassificationPresetTrain:
         ra_magnitude=9,
         augmix_severity=3,
         random_erase_prob=0.0,
+        backend="pil",
     ):
-        trans = [transforms.RandomResizedCrop(crop_size, interpolation=interpolation)]
+        trans = []
+        backend = backend.lower()
+        if backend == "tensor":
+            trans.append(transforms.PILToTensor())
+        else:
+            assert backend == "pil"
+
+        trans.append(transforms.RandomResizedCrop(crop_size, interpolation=interpolation, antialias=True))
         if hflip_prob > 0:
             trans.append(transforms.RandomHorizontalFlip(hflip_prob))
         if auto_augment_policy is not None:
@@ -30,9 +38,13 @@ class ClassificationPresetTrain:
             else:
                 aa_policy = autoaugment.AutoAugmentPolicy(auto_augment_policy)
                 trans.append(autoaugment.AutoAugment(policy=aa_policy, interpolation=interpolation))
+
+        if backend == "pil":
+            # Note: we could also just use pure tensors?
+            trans.append(transforms.PILToTensor())
+
         trans.extend(
             [
-                transforms.PILToTensor(),
                 transforms.ConvertImageDtype(torch.float),
                 transforms.Normalize(mean=mean, std=std),
             ]
@@ -55,17 +67,30 @@ class ClassificationPresetEval:
         mean=(0.485, 0.456, 0.406),
         std=(0.229, 0.224, 0.225),
         interpolation=InterpolationMode.BILINEAR,
+        backend="pil",
     ):
+        trans = []
 
-        self.transforms = transforms.Compose(
-            [
-                transforms.Resize(resize_size, interpolation=interpolation),
-                transforms.CenterCrop(crop_size),
-                transforms.PILToTensor(),
-                transforms.ConvertImageDtype(torch.float),
-                transforms.Normalize(mean=mean, std=std),
-            ]
-        )
+        backend = backend.lower()
+        if backend == "tensor":
+            trans.append(transforms.PILToTensor())
+        else:
+            assert backend == "pil"
+
+        trans += [
+            transforms.Resize(resize_size, interpolation=interpolation, antialias=True),
+            transforms.CenterCrop(crop_size),
+        ]
+
+        if backend == "pil":
+            trans.append(transforms.PILToTensor())
+
+        trans += [
+            transforms.ConvertImageDtype(torch.float),
+            transforms.Normalize(mean=mean, std=std),
+        ]
+
+        self.transforms = transforms.Compose(trans)
 
     def __call__(self, img):
         return self.transforms(img)

--- a/references/classification/train.py
+++ b/references/classification/train.py
@@ -143,6 +143,7 @@ def load_data(traindir, valdir, args):
                 random_erase_prob=random_erase_prob,
                 ra_magnitude=ra_magnitude,
                 augmix_severity=augmix_severity,
+                backend=args.backend,
             ),
         )
         if args.cache_dataset:
@@ -160,10 +161,13 @@ def load_data(traindir, valdir, args):
     else:
         if args.weights and args.test_only:
             weights = torchvision.models.get_weight(args.weights)
-            preprocessing = weights.transforms()
+            preprocessing = weights.transforms(antialias=True, backend=args.backend)
         else:
             preprocessing = presets.ClassificationPresetEval(
-                crop_size=val_crop_size, resize_size=val_resize_size, interpolation=interpolation
+                crop_size=val_crop_size,
+                resize_size=val_resize_size,
+                interpolation=interpolation,
+                backend=args.backend,
             )
 
         dataset_test = torchvision.datasets.ImageFolder(
@@ -507,6 +511,7 @@ def get_args_parser(add_help=True):
         "--ra-reps", default=3, type=int, help="number of repetitions for Repeated Augmentation (default: 3)"
     )
     parser.add_argument("--weights", default=None, type=str, help="the weights enum name to load")
+    parser.add_argument("--backend", default="PIL", type=str, help="PIL or tensor - case insensitive")
     return parser
 
 


### PR DESCRIPTION
Results match between PIL and tensor with `--test-only`:

```
(pt) ➜  classification git:(main) ✗ torchrun --nproc_per_node=4 train.py --model resnet50 --data-path /datasets01_ontap/imagenet_full_size/061417 --test-only --weights ResNet50_Weights.IMAGENET1K_V1 --backend pil

Test:  Acc@1 76.130 Acc@5 92.856


(pt) ➜  classification git:(main) ✗ torchrun --nproc_per_node=4 train.py --model resnet50 --data-path /datasets01_ontap/imagenet_full_size/061417 --test-only --weights ResNet50_Weights.IMAGENET1K_V1 --backend tensor

Test:  Acc@1 76.138 Acc@5 92.866
```

I also verified that both `train_one_epoch()` and `evaluate()` run without errors for both backends. I didn't check the acc on those (that would require full training), but considering this PR is mostly a simplified version of https://github.com/pytorch/vision/pull/7220, everything should be fine. If there's any issue we'll know soon enough.