### PR TITLE
Fix segfault in DeformConv2d when `mask` is None

### DIFF
--- a/torchvision/ops/deform_conv.py
+++ b/torchvision/ops/deform_conv.py
@@ -68,7 +68,7 @@ def deform_conv2d(
     use_mask = mask is not None
 
     if mask is None:
-        mask = torch.zeros((input.shape[0], 0), device=input.device, dtype=input.dtype)
+        mask = torch.zeros((input.shape[0], 1), device=input.device, dtype=input.dtype)
 
     if bias is None:
         bias = torch.zeros(out_channels, device=input.device, dtype=input.dtype)


### PR DESCRIPTION
There's a segfault internally on this line:

https://github.com/pytorch/vision/blob/4a51822ca20027b6e03ec4fb582c31cc9545ba4e/torchvision/csrc/ops/cpu/deform_conv2d_kernel.cpp#L224:L224

caused in our tests by this line, i.e. calling the op without a `mask`:

https://github.com/pytorch/vision/blob/4a51822ca20027b6e03ec4fb582c31cc9545ba4e/test/test_ops.py#L923:L923

I'm not 100% sure whether this sefgault is expected and whether this fix is the "right" one. But it does remove the segfault, and it can't affect the results because of the `use_mask` flag which is always False in those calls.