### PR TITLE
always install dependencies upfront with pip in CI

### DIFF
--- a/.github/scripts/setup-env.sh
+++ b/.github/scripts/setup-env.sh
@@ -71,19 +71,18 @@ if [[ $GPU_ARCH_TYPE == 'cuda' ]]; then
 fi
 echo '::endgroup::'
 
-if [[ "${OS_TYPE}" == "windows" ]]; then
-  echo '::group::Install third party dependencies prior to TorchVision install on Windows'
-  # `easy_install`, i.e. `python setup.py` has problems downloading the dependencies due to SSL.
-  # Thus, we install them upfront with `pip` to avoid that.
-  # Instead of fixing the SSL error, we can probably maintain this special case until we switch away from the deprecated
-  # `easy_install` anyway.
-  python setup.py egg_info
-  # The requires.txt cannot be used with `pip install -r` directly. The requirements are listed at the top and the
-  # optional dependencies come in non-standard syntax after a blank line. Thus, we just extract the header.
-  sed -e '/^$/,$d' *.egg-info/requires.txt > requirements.txt
-  pip install --progress-bar=off -r requirements.txt
-  echo '::endgroup::'
-fi
+echo '::group::Install third party dependencies prior to TorchVision install'
+# `easy_install`, i.e. `python setup.py`, has some quirks when installing third-party dependencies. For example:
+# - On Windows, we often hit an SSL error although `pip` can install just fine.
+# - `easy_install` happily pulls in pre-releases, which can lead to more problems down the line. `pip` does not unless
+#   explicitly told to do so.
+# Thus, we use `easy_install` to extract the third-party dependencies here and install them upfront with `pip`.
+python setup.py egg_info
+# The requires.txt cannot be used with `pip install -r` directly. The requirements are listed at the top and the
+# optional dependencies come in non-standard syntax after a blank line. Thus, we just extract the header.
+sed -e '/^$/,$d' *.egg-info/requires.txt > requirements.txt
+pip install --progress-bar=off -r requirements.txt
+echo '::endgroup::'
 
 echo '::group::Install TorchVision'
 python setup.py develop

--- a/.github/scripts/setup-env.sh
+++ b/.github/scripts/setup-env.sh
@@ -72,15 +72,16 @@ fi
 echo '::endgroup::'
 
 echo '::group::Install third party dependencies prior to TorchVision install'
-# `easy_install`, i.e. `python setup.py`, has some quirks when installing third-party dependencies. For example:
+# Installing with `easy_install`, e.g. `python setup.py install` or `python setup.py develop`, has some quirks when
+# when pulling in third-party dependencies. For example:
 # - On Windows, we often hit an SSL error although `pip` can install just fine.
-# - `easy_install` happily pulls in pre-releases, which can lead to more problems down the line. `pip` does not unless
-#   explicitly told to do so.
+# - It happily pulls in pre-releases, which can lead to more problems down the line.
+#   `pip` does not unless explicitly told to do so.
 # Thus, we use `easy_install` to extract the third-party dependencies here and install them upfront with `pip`.
 python setup.py egg_info
 # The requires.txt cannot be used with `pip install -r` directly. The requirements are listed at the top and the
 # optional dependencies come in non-standard syntax after a blank line. Thus, we just extract the header.
-sed -e '/^$/,$d' *.egg-info/requires.txt > requirements.txt
+sed -e '/^$/,$d' *.egg-info/requires.txt | tee requirements.txt
 pip install --progress-bar=off -r requirements.txt
 echo '::endgroup::'
 

--- a/setup.py
+++ b/setup.py
@@ -57,10 +57,8 @@ pytorch_dep = "torch"
 if os.getenv("PYTORCH_VERSION"):
     pytorch_dep += "==" + os.getenv("PYTORCH_VERSION")
 
-numpy_dep = "numpy" if sys.version_info[:2] >= (3, 9) else "numpy < 1.25"
-
 requirements = [
-    numpy_dep,
+    "numpy",
     "requests",
     pytorch_dep,
 ]


### PR DESCRIPTION
Instead of pinning `numpy` as done in #7639, this PR reuses the pre-install logic that we have in place for Windows for all workflows. Since `pip` does not suffer from the same issues as `easy_install` that should be more "future-proof". And take that with a grain of salt, since `easy_install` is deprecated anyway.


cc @seemethere