### PR TITLE
Make `disable_tf32` context manager handle exceptions

### DIFF
--- a/test/test_models.py
+++ b/test/test_models.py
@@ -29,8 +29,10 @@ SKIP_BIG_MODEL = os.getenv("SKIP_BIG_MODEL", "1") == "1"
 def disable_tf32():
     previous = torch.backends.cudnn.allow_tf32
     torch.backends.cudnn.allow_tf32 = False
-    yield
-    torch.backends.cudnn.allow_tf32 = previous
+    try:
+        yield
+    finally:
+        torch.backends.cudnn.allow_tf32 = previous
 
 
 def list_model_fns(module):


### PR DESCRIPTION
I.e. the pattern should always be:
```python
  intro()
  try:
    yield:
  finally:
     outro()
```

I.e. follow the pattern outlined in  I.e. follow pattern outlined in https://docs.python.org/3.8/library/contextlib.html#contextlib.contextmanager

<!-- Before submitting a PR, please make sure to check our contributing guidelines regarding code formatting, tests, and documentation: https://github.com/pytorch/vision/blob/main/CONTRIBUTING.md -->
