### PR TITLE
remove obsolete transforms tests

### DIFF
--- a/test/test_functional_tensor.py
+++ b/test/test_functional_tensor.py
@@ -67,6 +67,7 @@ def test_scale_channel():
 
 
 class TestRotate:
+
     ALL_DTYPES = [None, torch.float32, torch.float64, torch.float16]
     scripted_rotate = torch.jit.script(F.rotate)
     IMG_W = 26
@@ -152,6 +153,7 @@ class TestRotate:
 
 
 class TestAffine:
+
     ALL_DTYPES = [None, torch.float32, torch.float64, torch.float16]
     scripted_affine = torch.jit.script(F.affine)
 
@@ -405,6 +407,7 @@ def _get_data_dims_and_points_for_perspective():
 )
 @pytest.mark.parametrize("fn", [F.perspective, torch.jit.script(F.perspective)])
 def test_perspective_pil_vs_tensor(device, dims_and_points, dt, fill, fn):
+
     if dt == torch.float16 and device == "cpu":
         # skip float16 on CPU case
         return
@@ -436,6 +439,7 @@ def test_perspective_pil_vs_tensor(device, dims_and_points, dt, fill, fn):
 @pytest.mark.parametrize("dims_and_points", _get_data_dims_and_points_for_perspective())
 @pytest.mark.parametrize("dt", [None, torch.float32, torch.float64, torch.float16])
 def test_perspective_batch(device, dims_and_points, dt):
+
     if dt == torch.float16 and device == "cpu":
         # skip float16 on CPU case
         return
@@ -487,6 +491,7 @@ def test_perspective_interpolation_type():
 @pytest.mark.parametrize("max_size", [None, 34, 40, 1000])
 @pytest.mark.parametrize("interpolation", [BILINEAR, BICUBIC, NEAREST, NEAREST_EXACT])
 def test_resize(device, dt, size, max_size, interpolation):
+
     if dt == torch.float16 and device == "cpu":
         # skip float16 on CPU case
         return
@@ -536,6 +541,7 @@ def test_resize(device, dt, size, max_size, interpolation):
 
 @pytest.mark.parametrize("device", cpu_and_gpu())
 def test_resize_asserts(device):
+
     tensor, pil_img = _create_data(26, 36, device=device)
 
     res1 = F.resize(tensor, size=32, interpolation=PIL.Image.BILINEAR)
@@ -555,6 +561,7 @@ def test_resize_asserts(device):
 @pytest.mark.parametrize("size", [[96, 72], [96, 420], [420, 72]])
 @pytest.mark.parametrize("interpolation", [BILINEAR, BICUBIC])
 def test_resize_antialias(device, dt, size, interpolation):
+
     if dt == torch.float16 and device == "cpu":
         # skip float16 on CPU case
         return
@@ -603,6 +610,7 @@ def test_resize_antialias(device, dt, size, interpolation):
 
 
 def test_resize_antialias_default_warning():
+
     img = torch.randint(0, 256, size=(3, 44, 56), dtype=torch.uint8)
 
     match = "The default value of the antialias"
@@ -621,6 +629,7 @@ def test_resize_antialias_default_warning():
 def check_functional_vs_PIL_vs_scripted(
     fn, fn_pil, fn_t, config, device, dtype, channels=3, tol=2.0 + 1e-10, agg_method="max"
 ):
+
     script_fn = torch.jit.script(fn)
     torch.manual_seed(15)
     tensor, pil_img = _create_data(26, 34, channels=channels, device=device)
@@ -1057,6 +1066,7 @@ def test_crop(device, top, left, height, width):
 @pytest.mark.parametrize("sigma", [[0.5, 0.5], (0.5, 0.5), (0.8, 0.8), (1.7, 1.7)])
 @pytest.mark.parametrize("fn", [F.gaussian_blur, torch.jit.script(F.gaussian_blur)])
 def test_gaussian_blur(device, image_size, dt, ksize, sigma, fn):
+
     # true_cv2_results = {
     #     # np_img = np.arange(3 * 10 * 12, dtype="uint8").reshape((10, 12, 3))
     #     # cv2.GaussianBlur(np_img, ksize=(3, 3), sigmaX=0.8)

--- a/test/test_functional_tensor.py
+++ b/test/test_functional_tensor.py
@@ -67,7 +67,6 @@ def test_scale_channel():
 
 
 class TestRotate:
-
     ALL_DTYPES = [None, torch.float32, torch.float64, torch.float16]
     scripted_rotate = torch.jit.script(F.rotate)
     IMG_W = 26
@@ -153,7 +152,6 @@ class TestRotate:
 
 
 class TestAffine:
-
     ALL_DTYPES = [None, torch.float32, torch.float64, torch.float16]
     scripted_affine = torch.jit.script(F.affine)
 
@@ -407,7 +405,6 @@ def _get_data_dims_and_points_for_perspective():
 )
 @pytest.mark.parametrize("fn", [F.perspective, torch.jit.script(F.perspective)])
 def test_perspective_pil_vs_tensor(device, dims_and_points, dt, fill, fn):
-
     if dt == torch.float16 and device == "cpu":
         # skip float16 on CPU case
         return
@@ -439,7 +436,6 @@ def test_perspective_pil_vs_tensor(device, dims_and_points, dt, fill, fn):
 @pytest.mark.parametrize("dims_and_points", _get_data_dims_and_points_for_perspective())
 @pytest.mark.parametrize("dt", [None, torch.float32, torch.float64, torch.float16])
 def test_perspective_batch(device, dims_and_points, dt):
-
     if dt == torch.float16 and device == "cpu":
         # skip float16 on CPU case
         return
@@ -491,7 +487,6 @@ def test_perspective_interpolation_type():
 @pytest.mark.parametrize("max_size", [None, 34, 40, 1000])
 @pytest.mark.parametrize("interpolation", [BILINEAR, BICUBIC, NEAREST, NEAREST_EXACT])
 def test_resize(device, dt, size, max_size, interpolation):
-
     if dt == torch.float16 and device == "cpu":
         # skip float16 on CPU case
         return
@@ -541,7 +536,6 @@ def test_resize(device, dt, size, max_size, interpolation):
 
 @pytest.mark.parametrize("device", cpu_and_gpu())
 def test_resize_asserts(device):
-
     tensor, pil_img = _create_data(26, 36, device=device)
 
     res1 = F.resize(tensor, size=32, interpolation=PIL.Image.BILINEAR)
@@ -561,7 +555,6 @@ def test_resize_asserts(device):
 @pytest.mark.parametrize("size", [[96, 72], [96, 420], [420, 72]])
 @pytest.mark.parametrize("interpolation", [BILINEAR, BICUBIC])
 def test_resize_antialias(device, dt, size, interpolation):
-
     if dt == torch.float16 and device == "cpu":
         # skip float16 on CPU case
         return
@@ -609,23 +602,7 @@ def test_resize_antialias(device, dt, size, interpolation):
     assert_equal(resized_tensor, resize_result)
 
 
-@needs_cuda
-@pytest.mark.parametrize("interpolation", [BILINEAR, BICUBIC])
-def test_assert_resize_antialias(interpolation):
-
-    # Checks implementation on very large scales
-    # and catch TORCH_CHECK inside PyTorch implementation
-    torch.manual_seed(12)
-    tensor, _ = _create_data(1000, 1000, device="cuda")
-
-    # Error message is not yet updated in pytorch nightly
-    # with pytest.raises(RuntimeError, match=r"Provided interpolation parameters can not be handled"):
-    with pytest.raises(RuntimeError, match=r"Too much shared memory required"):
-        F.resize(tensor, size=(5, 5), interpolation=interpolation, antialias=True)
-
-
 def test_resize_antialias_default_warning():
-
     img = torch.randint(0, 256, size=(3, 44, 56), dtype=torch.uint8)
 
     match = "The default value of the antialias"
@@ -641,29 +618,9 @@ def test_resize_antialias_default_warning():
         F.resized_crop(img, 0, 0, 10, 10, size=(20, 20), interpolation=NEAREST)
 
 
-@pytest.mark.parametrize("device", cpu_and_gpu())
-@pytest.mark.parametrize("dt", [torch.float32, torch.float64, torch.float16])
-@pytest.mark.parametrize("size", [[10, 7], [10, 42], [42, 7]])
-@pytest.mark.parametrize("interpolation", [BILINEAR, BICUBIC])
-def test_interpolate_antialias_backward(device, dt, size, interpolation):
-
-    if dt == torch.float16 and device == "cpu":
-        # skip float16 on CPU case
-        return
-
-    torch.manual_seed(12)
-    x = (torch.rand(1, 32, 29, 3, dtype=torch.double, device=device).permute(0, 3, 1, 2).requires_grad_(True),)
-    resize = partial(F.resize, size=size, interpolation=interpolation, antialias=True)
-    assert torch.autograd.gradcheck(resize, x, eps=1e-8, atol=1e-6, rtol=1e-6, fast_mode=False)
-
-    x = (torch.rand(1, 3, 32, 29, dtype=torch.double, device=device, requires_grad=True),)
-    assert torch.autograd.gradcheck(resize, x, eps=1e-8, atol=1e-6, rtol=1e-6, fast_mode=False)
-
-
 def check_functional_vs_PIL_vs_scripted(
     fn, fn_pil, fn_t, config, device, dtype, channels=3, tol=2.0 + 1e-10, agg_method="max"
 ):
-
     script_fn = torch.jit.script(fn)
     torch.manual_seed(15)
     tensor, pil_img = _create_data(26, 34, channels=channels, device=device)
@@ -1100,7 +1057,6 @@ def test_crop(device, top, left, height, width):
 @pytest.mark.parametrize("sigma", [[0.5, 0.5], (0.5, 0.5), (0.8, 0.8), (1.7, 1.7)])
 @pytest.mark.parametrize("fn", [F.gaussian_blur, torch.jit.script(F.gaussian_blur)])
 def test_gaussian_blur(device, image_size, dt, ksize, sigma, fn):
-
     # true_cv2_results = {
     #     # np_img = np.arange(3 * 10 * 12, dtype="uint8").reshape((10, 12, 3))
     #     # cv2.GaussianBlur(np_img, ksize=(3, 3), sigmaX=0.8)


### PR DESCRIPTION
As mentioned in https://github.com/pytorch/vision/pull/7562#issuecomment-1597176486 and confirmed in https://github.com/pytorch/vision/pull/7562#issuecomment-1597258784, both tests deleted in this PR come from a time when we had our custom `interpolate` kernels, since PyTorch core didn't support antialiasing. This is no longer the case and thus the tests are obsolete.


cc @vfdev-5