### PR TITLE
fix mypy

### DIFF
--- a/torchvision/models/_api.py
+++ b/torchvision/models/_api.py
@@ -122,7 +122,9 @@ def get_weight(name: str) -> WeightsEnum:
     base_module_name = ".".join(sys.modules[__name__].__name__.split(".")[:-1])
     base_module = importlib.import_module(base_module_name)
     model_modules = [base_module] + [
-        x[1] for x in inspect.getmembers(base_module, inspect.ismodule) if x[1].__file__.endswith("__init__.py")
+        x[1]
+        for x in inspect.getmembers(base_module, inspect.ismodule)
+        if x[1].__file__.endswith("__init__.py")  # type: ignore[union-attr]
     ]
 
     weights_enum = None


### PR DESCRIPTION
This [error](https://github.com/pytorch/vision/actions/runs/5327631874/jobs/9651282417#step:10:1080) comes from a `mypy` update that includes python/typeshed#9891. Basically, now `mypy` knows that a module does not need to have a `__file__` attribute (esoteric, but you can create modules at runtime with [`types.ModuleType`](https://docs.python.org/3/library/types.html#types.ModuleType)). We can just silence it here, since we are sure that the modules we are working are always the real thing.
