### PR TITLE
Add masks to boundaries

### DIFF
--- a/docs/source/ops.rst
+++ b/docs/source/ops.rst
@@ -22,6 +22,7 @@ The below operators perform pre-processing as well as post-processing required i
 
     batched_nms
     masks_to_boxes
+    masks_to_boundaries
     nms
     roi_align
     roi_pool

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -2302,6 +2302,85 @@ class TestMasksToBoxes:
         torch.testing.assert_close(boxes, expected, rtol=0.0, atol=0.0)
 
 
+def reference_masks_to_boundaries(masks, kernel_size):
+    masks_bool = masks.bool()
+    padding = kernel_size // 2
+    padded_masks = F.pad(masks_bool, [padding, padding, padding, padding])
+    eroded_masks = torch.zeros_like(masks_bool)
+
+    _, height, width = masks_bool.shape
+    for y in range(height):
+        for x in range(width):
+            neighborhood = padded_masks[:, y : y + kernel_size, x : x + kernel_size]
+            eroded_masks[:, y, x] = neighborhood.flatten(1).all(dim=1)
+
+    return torch.logical_xor(masks_bool, eroded_masks)
+
+
+class TestMasksToBoundaries:
+    @pytest.mark.parametrize("device", cpu_and_cuda())
+    @pytest.mark.parametrize("kernel_size", [3, 5])
+    def test_masks_to_boundaries(self, device, kernel_size):
+        masks = torch.zeros((4, 12, 14), dtype=torch.bool, device=device)
+        masks[0, 1:5, 1:5] = True
+        masks[0, 7:11, 9:13] = True
+        masks[1, 2:8, 3:11] = True
+        masks[1, 4:6, 5:8] = False
+        masks[2, 0:4, 0:4] = True
+        masks[3, 6, 1:12] = True
+
+        boundaries = ops.masks_to_boundaries(masks, kernel_size=kernel_size)
+        expected = reference_masks_to_boundaries(masks, kernel_size=kernel_size)
+
+        assert boundaries.dtype == torch.bool
+        torch.testing.assert_close(boundaries, expected)
+
+    def test_numeric_masks(self):
+        masks = torch.zeros((1, 5, 5), dtype=torch.float32)
+        masks[:, 1:4, 1:4] = 2
+
+        boundaries = ops.masks_to_boundaries(masks)
+        expected = torch.tensor(
+            [
+                [
+                    [False, False, False, False, False],
+                    [False, True, True, True, False],
+                    [False, True, False, True, False],
+                    [False, True, True, True, False],
+                    [False, False, False, False, False],
+                ]
+            ]
+        )
+
+        assert boundaries.dtype == torch.bool
+        torch.testing.assert_close(boundaries, expected)
+
+    def test_empty_masks(self):
+        masks = torch.empty((0, 8, 8), dtype=torch.uint8)
+        boundaries = ops.masks_to_boundaries(masks)
+
+        assert boundaries.shape == masks.shape
+        assert boundaries.dtype == torch.bool
+
+    @pytest.mark.parametrize("kernel_size", [0, 2, -1])
+    def test_invalid_kernel_size(self, kernel_size):
+        masks = torch.zeros((1, 5, 5), dtype=torch.bool)
+        with pytest.raises(ValueError, match="positive odd integer"):
+            ops.masks_to_boundaries(masks, kernel_size=kernel_size)
+
+    def test_invalid_shape(self):
+        masks = torch.zeros((5, 5), dtype=torch.bool)
+        with pytest.raises(ValueError, match="shape"):
+            ops.masks_to_boundaries(masks)
+
+    def test_script(self):
+        masks = torch.zeros((1, 5, 5), dtype=torch.bool)
+        masks[:, 1:4, 1:4] = True
+
+        scripted = torch.jit.script(ops.masks_to_boundaries)
+        torch.testing.assert_close(scripted(masks, 3), ops.masks_to_boundaries(masks, 3))
+
+
 class TestStochasticDepth:
     @pytest.mark.parametrize("seed", range(10))
     @pytest.mark.parametrize("p", [0.2, 0.5, 0.8])

--- a/torchvision/ops/__init__.py
+++ b/torchvision/ops/__init__.py
@@ -1,3 +1,4 @@
+from ._masks import masks_to_boundaries
 from ._register_onnx_ops import _register_custom_op
 from .boxes import (
     batched_nms,
@@ -32,6 +33,7 @@ _register_custom_op()
 
 __all__ = [
     "masks_to_boxes",
+    "masks_to_boundaries",
     "deform_conv2d",
     "DeformConv2d",
     "nms",

--- a/torchvision/ops/_masks.py
+++ b/torchvision/ops/_masks.py
@@ -1,0 +1,38 @@
+import torch
+import torch.nn.functional as F
+from torch import Tensor
+
+from ..utils import _log_api_usage_once
+
+
+def masks_to_boundaries(masks: Tensor, kernel_size: int = 3) -> Tensor:
+    """
+    Compute the boundaries around the provided binary masks.
+
+    The boundary of each mask is computed as the difference between the mask and
+    its morphological erosion with a square structuring element.
+
+    Args:
+        masks (Tensor[N, H, W]): binary masks where N is the number of masks and
+            (H, W) are the spatial dimensions.
+        kernel_size (int, optional): size of the square structuring element used
+            for erosion. It must be a positive odd integer. Default: 3.
+
+    Returns:
+        Tensor[N, H, W]: boolean boundary masks.
+    """
+    if not torch.jit.is_scripting() and not torch.jit.is_tracing():
+        _log_api_usage_once(masks_to_boundaries)
+    if masks.dim() != 3:
+        raise ValueError("masks must have shape [N, H, W]")
+    if kernel_size <= 0 or kernel_size % 2 == 0:
+        raise ValueError("kernel_size must be a positive odd integer")
+    if masks.numel() == 0:
+        return torch.zeros_like(masks, dtype=torch.bool)
+
+    masks_bool = masks.to(dtype=torch.bool)
+    masks_float = masks_bool.float().unsqueeze(1)
+    weight = torch.ones((1, 1, kernel_size, kernel_size), dtype=masks_float.dtype, device=masks.device)
+
+    eroded_masks = F.conv2d(masks_float, weight, padding=kernel_size // 2).squeeze(1) == kernel_size * kernel_size
+    return torch.logical_xor(masks_bool, eroded_masks)


### PR DESCRIPTION
Fixes:  https://github.com/pytorch/vision/issues/7537

How do you would impl the test against:
 https://github.com/bowenc0221/boundary-iou-api/blob/master/boundary_iou/utils/boundary_utils.py#L12-L30
 
 I suppose we don't want to add python OpenCV as a test dependecy.