### PR TITLE
Trigger nightly build from GHA

### DIFF
--- a/.github/workflows/build-cmake.yml
+++ b/.github/workflows/build-cmake.yml
@@ -4,9 +4,11 @@ on:
   pull_request:
   push:
     branches:
-      - nightly
       - main
       - release/*
+    tags:
+        # Nightly builds look like: nightly-2022-06-03
+        - nightly-.[0-9]+-.[0-9]+-.[0-9]+
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build-cmake.yml
+++ b/.github/workflows/build-cmake.yml
@@ -7,7 +7,6 @@ on:
       - main
       - release/*
     tags:
-        # Nightly builds look like: nightly-2022-06-03
         - nightly-build
   workflow_dispatch:
 

--- a/.github/workflows/build-cmake.yml
+++ b/.github/workflows/build-cmake.yml
@@ -8,7 +8,7 @@ on:
       - release/*
     tags:
         # Nightly builds look like: nightly-2022-06-03
-        - nightly-.[0-9]+-.[0-9]+-.[0-9]+
+        - nightly-build
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build-conda-linux.yml
+++ b/.github/workflows/build-conda-linux.yml
@@ -4,13 +4,14 @@ on:
   pull_request:
   push:
     branches:
-      - nightly
       - main
       - release/*
     tags:
-        # NOTE: Binary build pipelines should only get triggered on release candidate builds
+        # NOTE: Binary build pipelines should only get triggered on release candidate or nightly builds
         # Release candidate tags look like: v1.11.0-rc1
+        # Nightly builds look like: nightly-2022-06-03
         - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
+        - nightly-.[0-9]+-.[0-9]+-.[0-9]+
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build-conda-linux.yml
+++ b/.github/workflows/build-conda-linux.yml
@@ -9,9 +9,8 @@ on:
     tags:
         # NOTE: Binary build pipelines should only get triggered on release candidate or nightly builds
         # Release candidate tags look like: v1.11.0-rc1
-        # Nightly builds look like: nightly-2022-06-03
         - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
-        - nightly-.[0-9]+-.[0-9]+-.[0-9]+
+        - nightly-build
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build-conda-m1.yml
+++ b/.github/workflows/build-conda-m1.yml
@@ -4,13 +4,14 @@ on:
   pull_request:
   push:
     branches:
-      - nightly
       - main
       - release/*
     tags:
-        # NOTE: Binary build pipelines should only get triggered on release candidate builds
+        # NOTE: Binary build pipelines should only get triggered on release candidate or nightly builds
         # Release candidate tags look like: v1.11.0-rc1
+        # Nightly builds look like: nightly-2022-06-03
         - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
+        - nightly-.[0-9]+-.[0-9]+-.[0-9]+
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build-conda-m1.yml
+++ b/.github/workflows/build-conda-m1.yml
@@ -9,9 +9,8 @@ on:
     tags:
         # NOTE: Binary build pipelines should only get triggered on release candidate or nightly builds
         # Release candidate tags look like: v1.11.0-rc1
-        # Nightly builds look like: nightly-2022-06-03
         - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
-        - nightly-.[0-9]+-.[0-9]+-.[0-9]+
+        - nightly-build
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build-conda-macos.yml
+++ b/.github/workflows/build-conda-macos.yml
@@ -4,13 +4,14 @@ on:
   pull_request:
   push:
     branches:
-      - nightly
       - main
       - release/*
     tags:
-        # NOTE: Binary build pipelines should only get triggered on release candidate builds
+        # NOTE: Binary build pipelines should only get triggered on release candidate or nightly builds
         # Release candidate tags look like: v1.11.0-rc1
+        # Nightly builds look like: nightly-2022-06-03
         - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
+        - nightly-.[0-9]+-.[0-9]+-.[0-9]+
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build-conda-macos.yml
+++ b/.github/workflows/build-conda-macos.yml
@@ -9,9 +9,8 @@ on:
     tags:
         # NOTE: Binary build pipelines should only get triggered on release candidate or nightly builds
         # Release candidate tags look like: v1.11.0-rc1
-        # Nightly builds look like: nightly-2022-06-03
         - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
-        - nightly-.[0-9]+-.[0-9]+-.[0-9]+
+        - nightly-build
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build-conda-windows.yml
+++ b/.github/workflows/build-conda-windows.yml
@@ -4,13 +4,14 @@ on:
   pull_request:
   push:
     branches:
-      - nightly
       - main
       - release/*
     tags:
-        # NOTE: Binary build pipelines should only get triggered on release candidate builds
+        # NOTE: Binary build pipelines should only get triggered on release candidate or nightly builds
         # Release candidate tags look like: v1.11.0-rc1
+        # Nightly builds look like: nightly-2022-06-03
         - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
+        - nightly-.[0-9]+-.[0-9]+-.[0-9]+
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build-conda-windows.yml
+++ b/.github/workflows/build-conda-windows.yml
@@ -9,9 +9,8 @@ on:
     tags:
         # NOTE: Binary build pipelines should only get triggered on release candidate or nightly builds
         # Release candidate tags look like: v1.11.0-rc1
-        # Nightly builds look like: nightly-2022-06-03
         - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
-        - nightly-.[0-9]+-.[0-9]+-.[0-9]+
+        - nightly-build
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build-wheels-linux.yml
+++ b/.github/workflows/build-wheels-linux.yml
@@ -4,13 +4,14 @@ on:
   pull_request:
   push:
     branches:
-      - nightly
       - main
       - release/*
     tags:
-        # NOTE: Binary build pipelines should only get triggered on release candidate builds
+        # NOTE: Binary build pipelines should only get triggered on release candidate or nightly builds
         # Release candidate tags look like: v1.11.0-rc1
+        # Nightly builds look like: nightly-2022-06-03
         - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
+        - nightly-.[0-9]+-.[0-9]+-.[0-9]+
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build-wheels-linux.yml
+++ b/.github/workflows/build-wheels-linux.yml
@@ -9,9 +9,8 @@ on:
     tags:
         # NOTE: Binary build pipelines should only get triggered on release candidate or nightly builds
         # Release candidate tags look like: v1.11.0-rc1
-        # Nightly builds look like: nightly-2022-06-03
         - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
-        - nightly-.[0-9]+-.[0-9]+-.[0-9]+
+        - nightly-build
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build-wheels-m1.yml
+++ b/.github/workflows/build-wheels-m1.yml
@@ -4,13 +4,14 @@ on:
   pull_request:
   push:
     branches:
-      - nightly
       - main
       - release/*
     tags:
-        # NOTE: Binary build pipelines should only get triggered on release candidate builds
+        # NOTE: Binary build pipelines should only get triggered on release candidate or nightly builds
         # Release candidate tags look like: v1.11.0-rc1
+        # Nightly builds look like: nightly-2022-06-03
         - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
+        - nightly-.[0-9]+-.[0-9]+-.[0-9]+
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build-wheels-m1.yml
+++ b/.github/workflows/build-wheels-m1.yml
@@ -9,9 +9,8 @@ on:
     tags:
         # NOTE: Binary build pipelines should only get triggered on release candidate or nightly builds
         # Release candidate tags look like: v1.11.0-rc1
-        # Nightly builds look like: nightly-2022-06-03
         - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
-        - nightly-.[0-9]+-.[0-9]+-.[0-9]+
+        - nightly-build
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build-wheels-macos.yml
+++ b/.github/workflows/build-wheels-macos.yml
@@ -4,13 +4,14 @@ on:
   pull_request:
   push:
     branches:
-      - nightly
       - main
       - release/*
     tags:
-        # NOTE: Binary build pipelines should only get triggered on release candidate builds
+        # NOTE: Binary build pipelines should only get triggered on release candidate or nightly builds
         # Release candidate tags look like: v1.11.0-rc1
+        # Nightly builds look like: nightly-2022-06-03
         - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
+        - nightly-.[0-9]+-.[0-9]+-.[0-9]+
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build-wheels-macos.yml
+++ b/.github/workflows/build-wheels-macos.yml
@@ -9,9 +9,8 @@ on:
     tags:
         # NOTE: Binary build pipelines should only get triggered on release candidate or nightly builds
         # Release candidate tags look like: v1.11.0-rc1
-        # Nightly builds look like: nightly-2022-06-03
         - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
-        - nightly-.[0-9]+-.[0-9]+-.[0-9]+
+        - nightly-build
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build-wheels-windows.yml
+++ b/.github/workflows/build-wheels-windows.yml
@@ -4,13 +4,14 @@ on:
   pull_request:
   push:
     branches:
-      - nightly
       - main
       - release/*
     tags:
-        # NOTE: Binary build pipelines should only get triggered on release candidate builds
+        # NOTE: Binary build pipelines should only get triggered on release candidate or nightly builds
         # Release candidate tags look like: v1.11.0-rc1
+        # Nightly builds look like: nightly-2022-06-03
         - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
+        - nightly-.[0-9]+-.[0-9]+-.[0-9]+
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build-wheels-windows.yml
+++ b/.github/workflows/build-wheels-windows.yml
@@ -9,9 +9,8 @@ on:
     tags:
         # NOTE: Binary build pipelines should only get triggered on release candidate or nightly builds
         # Release candidate tags look like: v1.11.0-rc1
-        # Nightly builds look like: nightly-2022-06-03
         - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
-        - nightly-.[0-9]+-.[0-9]+-.[0-9]+
+        - nightly-build
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,12 +4,12 @@ on:
   pull_request:
   push:
     branches:
-      - nightly
       - main
       - release/*
     tags:
       - v[0-9]+.[0-9]+.[0-9]
       - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
+      - nightly-.[0-9]+-.[0-9]+-.[0-9]+
   workflow_dispatch:
 
 jobs:
@@ -25,7 +25,7 @@ jobs:
         export GPU_ARCH_TYPE=cpu
         export GPU_ARCH_VERSION=''
         ./.github/scripts/setup-env.sh
-        
+
         # Prepare conda
         CONDA_PATH=$(which conda)
         eval "$(${CONDA_PATH} shell.bash hook)"
@@ -36,13 +36,13 @@ jobs:
         # Should we maybe always do this in `./.github/scripts/setup-env.sh` so that we don't
         # have to pay attention in all other workflows?
         export LD_LIBRARY_PATH="${CONDA_PREFIX}/lib:${LD_LIBRARY_PATH}"
-        
+
         cd docs
-        
+
         echo '::group::Install doc requirements'
         pip install --progress-bar=off -r requirements.txt
         echo '::endgroup::'
-        
+
         if [[ ${{ github.event_name }} == push && (${{ github.ref_type }} == tag || (${{ github.ref_type }} == branch && ${{ github.ref_name }} == release/*)) ]]; then
           echo '::group::Enable version string sanitization'
           # This environment variable just has to exist and must not be empty. The actual value is arbitrary.
@@ -55,9 +55,9 @@ jobs:
         # cores (`-j auto`). Thus, we limit to a single process (`-j 1`) here.
         sed -i -e 's/-j auto/-j 1/' Makefile
         make html
-        
+
         cp -r build/html "${RUNNER_ARTIFACT_DIR}"
-        
+
         # On PRs we also want to upload the docs into our S3 bucket for preview.
         if [[ ${{ github.event_name == 'pull_request' }} ]]; then
           cp -r build/html/* "${RUNNER_DOCS_DIR}"
@@ -65,7 +65,7 @@ jobs:
 
   upload:
     needs: build
-    if: github.repository == 'pytorch/vision' && github.event_name == 'push' && 
+    if: github.repository == 'pytorch/vision' && github.event_name == 'push' &&
         ((github.ref_type == 'branch' && github.ref_name == 'main') || github.ref_type == 'tag')
     permissions:
       contents: write
@@ -76,7 +76,7 @@ jobs:
       ref: gh-pages
       script: |
         set -euo pipefail
-        
+
         REF_TYPE=${{ github.ref_type }}
         REF_NAME=${{ github.ref_name }}
 
@@ -101,14 +101,14 @@ jobs:
         rm -rf "${TARGET_FOLDER}"/*
         mv "${RUNNER_ARTIFACT_DIR}"/html/* "${TARGET_FOLDER}"
         git add "${TARGET_FOLDER}" || true
-        
+
         if [[ "${TARGET_FOLDER}" == main ]]; then
           mkdir -p _static
           rm -rf _static/*
           cp -r "${TARGET_FOLDER}"/_static/* _static
           git add _static || true
         fi
-        
+
         git config user.name 'pytorchbot'
         git config user.email 'soumith+bot@pytorch.org'
         git commit -m "auto-generating sphinx docs" || true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,7 +9,7 @@ on:
     tags:
       - v[0-9]+.[0-9]+.[0-9]
       - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
-      - nightly-.[0-9]+-.[0-9]+-.[0-9]+
+      - nightly-build
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
   push:
     branches:
-      - nightly
       - main
       - release/*
     tags:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ on:
       - main
       - release/*
     tags:
-      - nightly-.[0-9]+-.[0-9]+-.[0-9]+
+      - nightly-build
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,8 @@ on:
       - nightly
       - main
       - release/*
+    tags:
+      - nightly-.[0-9]+-.[0-9]+-.[0-9]+
   workflow_dispatch:
 
 jobs:
@@ -41,7 +43,7 @@ jobs:
         export GPU_ARCH_VERSION=${{ matrix.gpu-arch-version }}
 
         ./.github/scripts/unittest.sh
-        
+
   unittests-macos:
     strategy:
       matrix:
@@ -102,7 +104,7 @@ jobs:
         export VSDEVCMD_ARGS=""
         export GPU_ARCH_TYPE=${{ matrix.gpu-arch-type }}
         export GPU_ARCH_VERSION=${{ matrix.gpu-arch-version }}
-        
+
         ./.github/scripts/unittest.sh
 
   onnx:
@@ -117,20 +119,20 @@ jobs:
         export GPU_ARCH_VERSION=''
 
         ./.github/scripts/setup-env.sh
-        
+
         # Prepare conda
         CONDA_PATH=$(which conda)
         eval "$(${CONDA_PATH} shell.bash hook)"
         conda activate ci
-        
+
         echo '::group::Install ONNX'
         pip install --progress-bar=off onnx onnxruntime
         echo '::endgroup::'
-        
+
         echo '::group::Install testing utilities'
         pip install --progress-bar=off pytest
         echo '::endgroup::'
-        
+
         echo '::group::Run ONNX tests'
         pytest --junit-xml="${RUNNER_TEST_RESULTS_DIR}/test-results.xml" -v --durations=25 test/test_onnx.py
         echo '::endgroup::'
@@ -147,21 +149,21 @@ jobs:
         export GPU_ARCH_VERSION=''
 
         ./.github/scripts/setup-env.sh
-        
+
         # Prepare conda
         CONDA_PATH=$(which conda)
         eval "$(${CONDA_PATH} shell.bash hook)"
         conda activate ci
-        
+
         echo '::group::Pre-download model weights'
         pip install --progress-bar=off aiohttp aiofiles tqdm
         python scripts/download_model_urls.py
         echo '::endgroup::'
-        
+
         echo '::group::Install testing utilities'
         pip install --progress-bar=off pytest
         echo '::endgroup::'
-        
+
         echo '::group::Run extended unittests'
         export PYTORCH_TEST_WITH_EXTENDED=1
         pytest --junit-xml="${RUNNER_TEST_RESULTS_DIR}/test-results.xml" -v --durations=25 test/test_extended_*.py

--- a/.github/workflows/trigger-nightly.yml
+++ b/.github/workflows/trigger-nightly.yml
@@ -1,0 +1,22 @@
+name: Trigger nightly builds
+
+on:
+  schedule:
+    # every night at 4:30AM
+    - cron: 30 4 * * *
+  workflow_dispatch:
+
+jobs:
+  tag_nightly:
+    if: ${{ github.repository == 'pytorch/vision' }}
+    name: Tag nightly from main
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: main
+          token: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
+      - name: Tag nightly from main
+        run: |
+          git tag -f nightly
+          git push origin -f nightly

--- a/.github/workflows/trigger-nightly.yml
+++ b/.github/workflows/trigger-nightly.yml
@@ -8,20 +8,16 @@ on:
   pull_request:
     paths:
       - .github/workflows/trigger-nightly.yml
-permissions:
-  contents: write
-
 jobs:
   tag_nightly:
     if: ${{ github.repository == 'pytorch/vision' }}
     name: Tag nightly from main
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: main
-          token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Tag nightly from main
-        run: |
+          token: ${{ secrets.VISION_GITHUB_DEPLOY_KEY }}
+      - run: |
           git tag -f nightly-build
           git push origin -f nightly-build

--- a/.github/workflows/trigger-nightly.yml
+++ b/.github/workflows/trigger-nightly.yml
@@ -8,6 +8,8 @@ on:
   pull_request:
     paths:
       - .github/workflows/trigger-nightly.yml
+permissions:
+  contents: write
 
 jobs:
   tag_nightly:

--- a/.github/workflows/trigger-nightly.yml
+++ b/.github/workflows/trigger-nightly.yml
@@ -5,9 +5,7 @@ on:
     # every night at 4:30AM
     - cron: 30 4 * * *
   workflow_dispatch:
-  pull_request:
-    paths:
-      - .github/workflows/trigger-nightly.yml
+
 jobs:
   tag_nightly:
     if: ${{ github.repository == 'pytorch/vision' }}

--- a/.github/workflows/trigger-nightly.yml
+++ b/.github/workflows/trigger-nightly.yml
@@ -19,6 +19,12 @@ jobs:
         with:
           ref: main
           token: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
+      - uses: dev-drprasad/delete-older-releases@v0.2
+        with:
+          keep_latest: 30
+          delete_tag_pattern: nightly
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
       - name: Tag nightly from main
         run: |
           git tag -f nightly-${{ steps.date.outputs.date }}

--- a/.github/workflows/trigger-nightly.yml
+++ b/.github/workflows/trigger-nightly.yml
@@ -5,6 +5,9 @@ on:
     # every night at 4:30AM
     - cron: 30 4 * * *
   workflow_dispatch:
+  pull_request:
+    paths:
+      - .github/workflows/trigger-nightly.yml
 
 jobs:
   tag_nightly:
@@ -21,7 +24,7 @@ jobs:
           token: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
       - uses: dev-drprasad/delete-older-releases@v0.2
         with:
-          keep_latest: 30
+          keep_latest: 500
           delete_tag_pattern: nightly
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PYTORCHBOT_TOKEN }}

--- a/.github/workflows/trigger-nightly.yml
+++ b/.github/workflows/trigger-nightly.yml
@@ -12,11 +12,14 @@ jobs:
     name: Tag nightly from main
     runs-on: ubuntu-latest
     steps:
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
       - uses: actions/checkout@v2
         with:
           ref: main
           token: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
       - name: Tag nightly from main
         run: |
-          git tag -f nightly
-          git push origin -f nightly
+          git tag -f nightly-${{ steps.date.outputs.date }}
+          git push origin -f nightly-${{ steps.date.outputs.date }}

--- a/.github/workflows/trigger-nightly.yml
+++ b/.github/workflows/trigger-nightly.yml
@@ -15,20 +15,11 @@ jobs:
     name: Tag nightly from main
     runs-on: ubuntu-latest
     steps:
-      - name: Get current date
-        id: date
-        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
       - uses: actions/checkout@v2
         with:
           ref: main
-          token: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
-      - uses: dev-drprasad/delete-older-releases@v0.2.1
-        with:
-          keep_latest: 100
-          delete_tag_pattern: nightly
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Tag nightly from main
         run: |
-          git tag -f nightly-${{ steps.date.outputs.date }}
-          git push origin -f nightly-${{ steps.date.outputs.date }}
+          git tag -f nightly-build
+          git push origin -f nightly-build

--- a/.github/workflows/trigger-nightly.yml
+++ b/.github/workflows/trigger-nightly.yml
@@ -22,9 +22,9 @@ jobs:
         with:
           ref: main
           token: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
-      - uses: dev-drprasad/delete-older-releases@v0.2
+      - uses: dev-drprasad/delete-older-releases@v0.2.1
         with:
-          keep_latest: 500
+          keep_latest: 100
           delete_tag_pattern: nightly
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PYTORCHBOT_TOKEN }}


### PR DESCRIPTION
Trigger nightly build from GHA. Deprecate cron job based on pytorch.warm package.
Deprecate : https://github.com/pytorch/vision/pull/1449
Tested: https://github.com/pytorch/pytorch-canary/actions/workflows/trigger-nightly.yml

Important Note: Github Token can't be used to push these tags since it will not trigger nightly workflows: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow


