### PR TITLE
improve UX for v2 Compose

### DIFF
--- a/test/test_transforms_v2_refactored.py
+++ b/test/test_transforms_v2_refactored.py
@@ -1669,8 +1669,12 @@ class TestCompose:
     )
     @pytest.mark.parametrize("unpack", [True, False])
     def test_packed_unpacked(self, transform_clss, unpack):
-        if (unpack and any(issubclass(cls, self.PackedInputTransform) for cls in transform_clss)) or (
-            not unpack and any(issubclass(cls, self.UnpackedInputTransform) for cls in transform_clss)
+        if any(
+            unpack
+            and issubclass(cls, self.PackedInputTransform)
+            or not unpack
+            and issubclass(cls, self.UnpackedInputTransform)
+            for cls in transform_clss
         ):
             return
 

--- a/test/test_transforms_v2_refactored.py
+++ b/test/test_transforms_v2_refactored.py
@@ -1645,8 +1645,8 @@ class TestCompose:
 
     class PackedInputTransform(nn.Module):
         def forward(self, sample):
-            image, label = sample
-            return image, label
+            assert len(sample) == 2
+            return sample
 
     class UnpackedInputTransform(nn.Module):
         def forward(self, image, label):

--- a/torchvision/transforms/v2/_container.py
+++ b/torchvision/transforms/v2/_container.py
@@ -46,10 +46,15 @@ class Compose(Transform):
         self.transforms = transforms
 
     def forward(self, *inputs: Any) -> Any:
-        sample = inputs if len(inputs) > 1 else inputs[0]
+        needs_unpacking = len(inputs) > 1
+
+        if not self.transforms:
+            return inputs if needs_unpacking else inputs[0]
+
         for transform in self.transforms:
-            sample = transform(sample)
-        return sample
+            outputs = transform(*inputs)
+            inputs = outputs if needs_unpacking else (outputs,)
+        return outputs
 
     def extra_repr(self) -> str:
         format_string = []

--- a/torchvision/transforms/v2/_container.py
+++ b/torchvision/transforms/v2/_container.py
@@ -43,14 +43,12 @@ class Compose(Transform):
         super().__init__()
         if not isinstance(transforms, Sequence):
             raise TypeError("Argument transforms should be a sequence of callables")
+        elif not transforms:
+            raise ValueError("Pass at least one transform")
         self.transforms = transforms
 
     def forward(self, *inputs: Any) -> Any:
         needs_unpacking = len(inputs) > 1
-
-        if not self.transforms:
-            return inputs if needs_unpacking else inputs[0]
-
         for transform in self.transforms:
             outputs = transform(*inputs)
             inputs = outputs if needs_unpacking else (outputs,)


### PR DESCRIPTION
The way `Compose` is currently implemented always passes the input "packed" t the individual transforms. Meaning, if one passes `Compose([...])(image, label)` individually (on "unpacked"), the transforms inside the `Compose` receive `(image, label)`, i.e. the individual inputs packed into a tuple. 

For our builtin transforms this makes no difference, since we operate on arbitrary input structures anyway. However, this becomes relevant as soon as a user wants to add a custom transform into the same pipeline. Assuming the user doesn't want to bother with our whole protocol and knows the sample structure exactly, they like want to write something like

```python
class MyTransform(nn.Module):
    def forward(self, image, label):
        ...
```

However, dropping this into a `Compose` would not work when passing `image` and `label` individually, due to the packing behavior described above. Instead the user would have to write

```python
class MyTransform(nn.Module):
    def forward(self, sample):
        image, label = sample
        ...
```

This is somewhat awkward, since the input of the individual transform no longer conforms to the input of the `Compose`.

This transform fixes this behavior. This means, if the inputs to the `Compose` are unpacked, they also have to be unpacked in the signature of the individual transform. Same is true for the other way around: if the input to the `Compose` is packed, the individual transform also needs to take a packed input.

cc @vfdev-5