### PR TITLE
Add scale option to ToDtype. Remove ConvertDtype.

### DIFF
--- a/docs/source/transforms.rst
+++ b/docs/source/transforms.rst
@@ -234,7 +234,6 @@ Conversion
     v2.PILToTensor
     v2.ToImageTensor
     ConvertImageDtype
-    v2.ConvertDtype
     v2.ConvertImageDtype
     v2.ToDtype
     v2.ConvertBoundingBoxFormat

--- a/gallery/plot_transforms_v2_e2e.py
+++ b/gallery/plot_transforms_v2_e2e.py
@@ -29,7 +29,7 @@ def show(sample):
     image, target = sample
     if isinstance(image, PIL.Image.Image):
         image = F.to_image_tensor(image)
-    image = F.convert_dtype(image, torch.uint8)
+    image = F.to_dtype(image, torch.uint8, scale=True)
     annotated_image = draw_bounding_boxes(image, target["boxes"], colors="yellow", width=3)
 
     fig, ax = plt.subplots()

--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -27,7 +27,7 @@ from PIL import Image
 from torch.testing._comparison import BooleanPair, NonePair, not_close_error_metas, NumberPair, TensorLikePair
 from torchvision import datapoints, io
 from torchvision.transforms._functional_tensor import _max_value as get_max_value
-from torchvision.transforms.v2.functional import convert_dtype_image_tensor, to_image_pil, to_image_tensor
+from torchvision.transforms.v2.functional import to_dtype_image_tensor, to_image_pil, to_image_tensor
 
 
 IN_OSS_CI = any(os.getenv(var) == "true" for var in ["CIRCLECI", "GITHUB_ACTIONS"])
@@ -601,7 +601,7 @@ def make_image_loader_for_interpolation(
             image_tensor = image_tensor.to(device=device, memory_format=memory_format, copy=True)
         else:
             image_tensor = image_tensor.to(device=device)
-        image_tensor = convert_dtype_image_tensor(image_tensor, dtype=dtype)
+        image_tensor = to_dtype_image_tensor(image_tensor, dtype=dtype, scale=True)
 
         return datapoints.Image(image_tensor)
 

--- a/test/test_transforms_v2.py
+++ b/test/test_transforms_v2.py
@@ -1,7 +1,6 @@
 import itertools
 import pathlib
 import random
-import re
 import textwrap
 import warnings
 from collections import defaultdict

--- a/test/test_transforms_v2.py
+++ b/test/test_transforms_v2.py
@@ -1326,61 +1326,6 @@ class TestRandomResize:
         )
 
 
-class TestToDtype:
-    @pytest.mark.parametrize(
-        ("dtype", "expected_dtypes"),
-        [
-            (
-                torch.float64,
-                {
-                    datapoints.Video: torch.float64,
-                    datapoints.Image: torch.float64,
-                    datapoints.BoundingBox: torch.float64,
-                },
-            ),
-            (
-                {datapoints.Video: torch.int32, datapoints.Image: torch.float32, datapoints.BoundingBox: torch.float64},
-                {datapoints.Video: torch.int32, datapoints.Image: torch.float32, datapoints.BoundingBox: torch.float64},
-            ),
-        ],
-    )
-    def test_call(self, dtype, expected_dtypes):
-        sample = dict(
-            video=make_video(dtype=torch.int64),
-            image=make_image(dtype=torch.uint8),
-            bounding_box=make_bounding_box(format=datapoints.BoundingBoxFormat.XYXY, dtype=torch.float32),
-            str="str",
-            int=0,
-        )
-
-        transform = transforms.ToDtype(dtype)
-        transformed_sample = transform(sample)
-
-        for key, value in sample.items():
-            value_type = type(value)
-            transformed_value = transformed_sample[key]
-
-            # make sure the transformation retains the type
-            assert isinstance(transformed_value, value_type)
-
-            if isinstance(value, torch.Tensor):
-                assert transformed_value.dtype is expected_dtypes[value_type]
-            else:
-                assert transformed_value is value
-
-    @pytest.mark.filterwarnings("error")
-    def test_plain_tensor_call(self):
-        tensor = torch.empty((), dtype=torch.float32)
-        transform = transforms.ToDtype({torch.Tensor: torch.float64})
-
-        assert transform(tensor).dtype is torch.float64
-
-    @pytest.mark.parametrize("other_type", [datapoints.Image, datapoints.Video])
-    def test_plain_tensor_warning(self, other_type):
-        with pytest.warns(UserWarning, match=re.escape("`torch.Tensor` will *not* be transformed")):
-            transforms.ToDtype(dtype={torch.Tensor: torch.float32, other_type: torch.float64})
-
-
 class TestUniformTemporalSubsample:
     @pytest.mark.parametrize(
         "inpt",

--- a/test/test_transforms_v2.py
+++ b/test/test_transforms_v2.py
@@ -105,7 +105,7 @@ def normalize_adapter(transform, input, device):
             continue
         elif check_type(value, (datapoints.Image, datapoints.Video, is_simple_tensor)):
             # normalize doesn't support integer images
-            value = F.convert_dtype(value, torch.float32)
+            value = F.to_dtype(value, torch.float32, scale=True)
         adapted_input[key] = value
     return adapted_input
 
@@ -146,7 +146,7 @@ class TestSmoke:
             (transforms.ScaleJitter((16, 16), scale_range=(0.8, 1.2), antialias=True), None),
             (transforms.ClampBoundingBox(), None),
             (transforms.ConvertBoundingBoxFormat(datapoints.BoundingBoxFormat.CXCYWH), None),
-            (transforms.ConvertDtype(), None),
+            (transforms.ConvertImageDtype(), None),
             (transforms.GaussianBlur(kernel_size=3), None),
             (
                 transforms.LinearTransformation(

--- a/test/test_transforms_v2_consistency.py
+++ b/test/test_transforms_v2_consistency.py
@@ -191,7 +191,7 @@ CONSISTENCY_CONFIGS = [
         closeness_kwargs=dict(rtol=None, atol=None),
     ),
     ConsistencyConfig(
-        v2_transforms.ConvertDtype,
+        v2_transforms.ConvertImageDtype,
         legacy_transforms.ConvertImageDtype,
         [
             ArgsKwargs(torch.float16),

--- a/test/test_transforms_v2_functional.py
+++ b/test/test_transforms_v2_functional.py
@@ -283,12 +283,12 @@ class TestKernels:
         adapted_other_args, adapted_kwargs = info.float32_vs_uint8(other_args, kwargs)
 
         actual = info.kernel(
-            F.convert_dtype_image_tensor(input, dtype=torch.float32),
+            F.to_dtype_image_tensor(input, dtype=torch.float32, scale=True),
             *adapted_other_args,
             **adapted_kwargs,
         )
 
-        expected = F.convert_dtype_image_tensor(info.kernel(input, *other_args, **kwargs), dtype=torch.float32)
+        expected = F.to_dtype_image_tensor(info.kernel(input, *other_args, **kwargs), dtype=torch.float32, scale=True)
 
         assert_close(
             actual,
@@ -538,31 +538,12 @@ class TestDispatchers:
             (F.get_image_num_channels, F.get_num_channels),
             (F.to_pil_image, F.to_image_pil),
             (F.elastic_transform, F.elastic),
-            (F.convert_image_dtype, F.convert_dtype_image_tensor),
             (F.to_grayscale, F.rgb_to_grayscale),
         ]
     ],
 )
 def test_alias(alias, target):
     assert alias is target
-
-
-@pytest.mark.parametrize(
-    ("info", "args_kwargs"),
-    make_info_args_kwargs_params(
-        KERNEL_INFOS_MAP[F.convert_dtype_image_tensor],
-        args_kwargs_fn=lambda info: info.sample_inputs_fn(),
-    ),
-)
-@pytest.mark.parametrize("device", cpu_and_cuda())
-def test_convert_dtype_image_tensor_dtype_and_device(info, args_kwargs, device):
-    (input, *other_args), kwargs = args_kwargs.load(device)
-    dtype = other_args[0] if other_args else kwargs.get("dtype", torch.float32)
-
-    output = info.kernel(input, dtype)
-
-    assert output.dtype == dtype
-    assert output.device == input.device
 
 
 @pytest.mark.parametrize("device", cpu_and_cuda())

--- a/test/test_transforms_v2_refactored.py
+++ b/test/test_transforms_v2_refactored.py
@@ -1813,7 +1813,7 @@ class TestToDtype:
         out = F.to_dtype(input, dtype=output_dtype, scale=scale)
         expected = self.reference_convert_dtype_image_tensor(input, dtype=output_dtype, scale=scale)
 
-        if input_dtype.is_floating_point and output_dtype is torch.uint8 and scale:
+        if input_dtype.is_floating_point and not output_dtype.is_floating_point and scale:
             torch.testing.assert_close(out, expected, atol=1, rtol=0)
         else:
             torch.testing.assert_close(out, expected)

--- a/test/test_transforms_v2_refactored.py
+++ b/test/test_transforms_v2_refactored.py
@@ -1798,10 +1798,10 @@ class TestToDtype:
                         factor = (output_max_value + 1) // (input_max_value + 1)
                         return value * factor
 
-        return torch.tensor(tree_map(fn, image.tolist()), dtype=dtype)
+        return torch.tensor(tree_map(fn, image.tolist()), dtype=dtype, device=image.device)
 
-    @pytest.mark.parametrize("input_dtype", [torch.float32, torch.float64, torch.uint8, torch.int64])
-    @pytest.mark.parametrize("output_dtype", [torch.float32, torch.float64, torch.uint8, torch.int64])
+    @pytest.mark.parametrize("input_dtype", [torch.float32, torch.float64, torch.uint8])
+    @pytest.mark.parametrize("output_dtype", [torch.float32, torch.float64, torch.uint8])
     @pytest.mark.parametrize("device", cpu_and_cuda())
     @pytest.mark.parametrize("scale", (True, False))
     def test_image_correctness(self, input_dtype, output_dtype, device, scale):

--- a/test/test_transforms_v2_refactored.py
+++ b/test/test_transforms_v2_refactored.py
@@ -1832,19 +1832,15 @@ class TestToDtype:
             return inpt.max() <= 1
 
         H, W = 10, 10
+        img_dtype = torch.uint8
+        bbox_dtype = torch.float32
+        mask_dtype = torch.bool
         sample = {
-            "img": make_input(size=(H, W), dtype=torch.uint8),
-            "bbox": make_bounding_box(size=(H, W)),
-            "mask": make_detection_mask(size=(H, W)),
+            "img": make_input(size=(H, W), dtype=img_dtype),
+            "bbox": make_bounding_box(size=(H, W), dtype=bbox_dtype),
+            "mask": make_detection_mask(size=(H, W), dtype=mask_dtype),
         }
 
-        img_dtype = sample["img"].dtype
-
-        bbox_dtype = sample["bbox"].dtype
-        assert bbox_dtype == torch.float32
-
-        mask_dtype = sample["mask"].dtype
-        assert mask_dtype == torch.bool
 
         # only img gets transformed when dtype isn't a dict
         for scale in (True, False):

--- a/test/test_transforms_v2_refactored.py
+++ b/test/test_transforms_v2_refactored.py
@@ -1642,6 +1642,7 @@ class TestRotate:
         with pytest.raises(TypeError, match="Got inappropriate fill arg"):
             transforms.RandomAffine(degrees=0, fill="fill")
 
+
 class TestCompose:
     class BuiltinTransform(transforms.Transform):
         def _transform(self, inpt, params):
@@ -1701,6 +1702,7 @@ class TestCompose:
             assert isinstance(output, tuple) and len(output) == 2
             assert output[0] is image
             assert output[1] is label
+
 
 class TestToDtype:
     @pytest.mark.parametrize(

--- a/test/transforms_v2_dispatcher_infos.py
+++ b/test/transforms_v2_dispatcher_infos.py
@@ -365,16 +365,6 @@ DISPATCHER_INFOS = [
         ],
     ),
     DispatcherInfo(
-        F.convert_dtype,
-        kernels={
-            datapoints.Image: F.convert_dtype_image_tensor,
-            datapoints.Video: F.convert_dtype_video,
-        },
-        test_marks=[
-            skip_dispatch_datapoint,
-        ],
-    ),
-    DispatcherInfo(
         F.uniform_temporal_subsample,
         kernels={
             datapoints.Video: F.uniform_temporal_subsample_video,

--- a/test/transforms_v2_kernel_infos.py
+++ b/test/transforms_v2_kernel_infos.py
@@ -1,4 +1,3 @@
-import decimal
 import functools
 import itertools
 
@@ -27,7 +26,6 @@ from common_utils import (
     mark_framework_limitation,
     TestMark,
 )
-from torch.utils._pytree import tree_map
 from torchvision import datapoints
 from torchvision.transforms._functional_tensor import _max_value as get_max_value, _parse_pad_padding
 
@@ -1566,7 +1564,7 @@ def multi_crop_pil_reference_wrapper(pil_kernel):
     def wrapper(input_tensor, *other_args, **kwargs):
         output = pil_reference_wrapper(pil_kernel)(input_tensor, *other_args, **kwargs)
         return type(output)(
-            F.convert_dtype_image_tensor(F.to_image_tensor(output_pil), dtype=input_tensor.dtype)
+            F.to_dtype_image_tensor(F.to_image_tensor(output_pil), dtype=input_tensor.dtype, scale=True)
             for output_pil in output
         )
 
@@ -1662,125 +1660,6 @@ KERNEL_INFOS.extend(
         KernelInfo(
             F.normalize_video,
             sample_inputs_fn=sample_inputs_normalize_video,
-        ),
-    ]
-)
-
-
-def sample_inputs_convert_dtype_image_tensor():
-    for input_dtype, output_dtype in itertools.product(
-        [torch.uint8, torch.int64, torch.float32, torch.float64], repeat=2
-    ):
-        if input_dtype.is_floating_point and output_dtype == torch.int64:
-            # conversion cannot be performed safely
-            continue
-
-        for image_loader in make_image_loaders(
-            sizes=[DEFAULT_PORTRAIT_SPATIAL_SIZE], color_spaces=["RGB"], dtypes=[input_dtype]
-        ):
-            yield ArgsKwargs(image_loader, dtype=output_dtype)
-
-
-def reference_convert_dtype_image_tensor(image, dtype=torch.float):
-    input_dtype = image.dtype
-    output_dtype = dtype
-
-    if output_dtype == input_dtype:
-        return image
-
-    def fn(value):
-        if input_dtype.is_floating_point:
-            if output_dtype.is_floating_point:
-                return value
-            else:
-                return int(decimal.Decimal(value) * torch.iinfo(output_dtype).max)
-        else:
-            input_max_value = torch.iinfo(input_dtype).max
-
-            if output_dtype.is_floating_point:
-                return float(decimal.Decimal(value) / input_max_value)
-            else:
-                output_max_value = torch.iinfo(output_dtype).max
-
-                if input_max_value > output_max_value:
-                    factor = (input_max_value + 1) // (output_max_value + 1)
-                    return value // factor
-                else:
-                    factor = (output_max_value + 1) // (input_max_value + 1)
-                    return value * factor
-
-    return torch.tensor(tree_map(fn, image.tolist()), dtype=dtype)
-
-
-def reference_inputs_convert_dtype_image_tensor():
-    for input_dtype, output_dtype in itertools.product(
-        [
-            torch.uint8,
-            torch.int16,
-            torch.int32,
-            torch.int64,
-            torch.float16,
-            torch.float32,
-            torch.float64,
-            torch.bfloat16,
-        ],
-        repeat=2,
-    ):
-        if (input_dtype == torch.float32 and output_dtype in {torch.int32, torch.int64}) or (
-            input_dtype == torch.float64 and output_dtype == torch.int64
-        ):
-            continue
-
-        if input_dtype.is_floating_point:
-            data = [0.0, 0.5, 1.0]
-        else:
-            max_value = torch.iinfo(input_dtype).max
-            data = [0, max_value // 2, max_value]
-        image = torch.tensor(data, dtype=input_dtype)
-
-        yield ArgsKwargs(image, dtype=output_dtype)
-
-
-def sample_inputs_convert_dtype_video():
-    for video_loader in make_video_loaders(sizes=[DEFAULT_PORTRAIT_SPATIAL_SIZE], num_frames=[3]):
-        yield ArgsKwargs(video_loader)
-
-
-skip_dtype_consistency = TestMark(
-    ("TestKernels", "test_dtype_and_device_consistency"),
-    pytest.mark.skip(reason="`convert_dtype_*` kernels convert the dtype by design"),
-    condition=lambda args_kwargs: args_kwargs.args[0].dtype != args_kwargs.kwargs.get("dtype", torch.float32),
-)
-
-KERNEL_INFOS.extend(
-    [
-        KernelInfo(
-            F.convert_dtype_image_tensor,
-            sample_inputs_fn=sample_inputs_convert_dtype_image_tensor,
-            reference_fn=reference_convert_dtype_image_tensor,
-            reference_inputs_fn=reference_inputs_convert_dtype_image_tensor,
-            test_marks=[
-                skip_dtype_consistency,
-                TestMark(
-                    ("TestKernels", "test_against_reference"),
-                    pytest.mark.xfail(reason="Conversion overflows"),
-                    condition=lambda args_kwargs: (
-                        args_kwargs.args[0].dtype in {torch.float16, torch.bfloat16}
-                        and not args_kwargs.kwargs["dtype"].is_floating_point
-                    )
-                    or (
-                        args_kwargs.args[0].dtype in {torch.int32, torch.int64}
-                        and args_kwargs.kwargs["dtype"] == torch.float16
-                    ),
-                ),
-            ],
-        ),
-        KernelInfo(
-            F.convert_dtype_video,
-            sample_inputs_fn=sample_inputs_convert_dtype_video,
-            test_marks=[
-                skip_dtype_consistency,
-            ],
         ),
     ]
 )

--- a/torchvision/transforms/v2/__init__.py
+++ b/torchvision/transforms/v2/__init__.py
@@ -39,7 +39,7 @@ from ._geometry import (
     ScaleJitter,
     TenCrop,
 )
-from ._meta import ClampBoundingBox, ConvertBoundingBoxFormat, ConvertDtype, ConvertImageDtype
+from ._meta import ClampBoundingBox, ConvertBoundingBoxFormat, ConvertImageDtype
 from ._misc import GaussianBlur, Identity, Lambda, LinearTransformation, Normalize, SanitizeBoundingBox, ToDtype
 from ._temporal import UniformTemporalSubsample
 from ._type_conversion import PILToTensor, ToImagePIL, ToImageTensor, ToPILImage

--- a/torchvision/transforms/v2/_meta.py
+++ b/torchvision/transforms/v2/_meta.py
@@ -37,7 +37,7 @@ class ConvertImageDtype(Transform):
     .. v2betastatus:: ConvertImageDtype transform
 
     .. warning::
-        Consider using ToDtype(dtype, scale=True) instead.
+        Consider using ``ToDtype(dtype, scale=True)`` instead. See :class:`~torchvision.transforms.v2.ToDtype`.
 
     This function does not support PIL Image.
 

--- a/torchvision/transforms/v2/_meta.py
+++ b/torchvision/transforms/v2/_meta.py
@@ -64,9 +64,8 @@ class ConvertImageDtype(Transform):
         super().__init__()
         self.dtype = dtype
 
-    def _transform(self, inpt: datapoints._TensorImageType, params: Dict[str, Any]) -> datapoints._TensorImageType:
-        output = F.to_dtype_image_tensor(inpt.as_subclass(torch.Tensor), self.dtype, scale=True)
-        return datapoints.Image.wrap_like(inpt, output)
+    def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
+        return F.to_dtype(inpt, dtype=self.dtype, scale=True)
 
 
 class ClampBoundingBox(Transform):

--- a/torchvision/transforms/v2/_misc.py
+++ b/torchvision/transforms/v2/_misc.py
@@ -244,7 +244,9 @@ class ToDtype(Transform):
 
     _transformed_types = (torch.Tensor,)
 
-    def __init__(self, dtype: Union[torch.dtype, Dict[Type, Optional[torch.dtype]]], scale: bool = False) -> None:
+    def __init__(
+        self, dtype: Union[torch.dtype, Dict[Union[Type, str], Optional[torch.dtype]]], scale: bool = False
+    ) -> None:
         super().__init__()
 
         if not isinstance(dtype, (dict, torch.dtype)):
@@ -265,11 +267,12 @@ class ToDtype(Transform):
 
     def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
         if isinstance(self.dtype, torch.dtype):
-            # For consistency / BC with ConvertImageDtype, we only care about images or videos when dtype is a simple torch.dtype
+            # For consistency / BC with ConvertImageDtype, we only care about images or videos when dtype
+            # is a simple torch.dtype
             if not is_simple_tensor(inpt) and not isinstance(inpt, (datapoints.Image, datapoints.Video)):
                 return inpt
 
-            dtype = self.dtype
+            dtype: Optional[torch.dtype] = self.dtype
         elif type(inpt) in self.dtype:
             dtype = self.dtype[type(inpt)]
         elif "others" in self.dtype:

--- a/torchvision/transforms/v2/_misc.py
+++ b/torchvision/transforms/v2/_misc.py
@@ -225,17 +225,21 @@ class GaussianBlur(Transform):
 
 
 class ToDtype(Transform):
-    # TODO FINISH DOCS  !!!
-    """[BETA] Converts the input to a specific dtype.
+    """[BETA] Converts the input to a specific dtype, optionally scaling the values for images or videos.
 
     .. v2betastatus:: ToDtype transform
 
+    .. note::
+        ``ToDtype(dtype, scale=True)`` is the recommended replacement for ``ConvertImageDtype(dtype)``.
+
     Args:
         dtype (``torch.dtype`` or dict of ``Datapoint`` -> ``torch.dtype``): The dtype to convert to.
+            If a ``torch.dtype`` is passed, e.g. ``torch.float32``, only images and videos will be converted
+            to that dtype: this is for compatibility with :class:`~torchvision.transforms.v2.ConvertImageDtype`.
             A dict can be passed to specify per-datapoint conversions, e.g.
-            ``dtype={datapoints.Image: torch.float32, datapoints.Video:
-            torch.float64}``.
-        scale:
+            ``dtype={datapoints.Image: torch.float32, datapoints.Mask: torch.int64, "others":None}``. The "others"
+            key can be used as a catch-all for any other datapoint type, and ``None`` means no conversion.
+        scale (bool, optional): Whether to scale the values for images or videos. Default: ``False``.
     """
 
     _transformed_types = (torch.Tensor,)

--- a/torchvision/transforms/v2/functional/__init__.py
+++ b/torchvision/transforms/v2/functional/__init__.py
@@ -5,6 +5,7 @@ from ._utils import is_simple_tensor  # usort: skip
 from ._meta import (
     clamp_bounding_box,
     convert_format_bounding_box,
+    convert_image_dtype,
     to_dtype,
     to_dtype_image_tensor,
     to_dtype_video,

--- a/torchvision/transforms/v2/functional/__init__.py
+++ b/torchvision/transforms/v2/functional/__init__.py
@@ -5,10 +5,9 @@ from ._utils import is_simple_tensor  # usort: skip
 from ._meta import (
     clamp_bounding_box,
     convert_format_bounding_box,
-    convert_dtype_image_tensor,
-    convert_dtype,
-    convert_dtype_video,
-    convert_image_dtype,
+    to_dtype,
+    to_dtype_image_tensor,
+    to_dtype_video,
     get_dimensions_image_tensor,
     get_dimensions_image_pil,
     get_dimensions,

--- a/torchvision/transforms/v2/functional/_color.py
+++ b/torchvision/transforms/v2/functional/_color.py
@@ -9,7 +9,7 @@ from torchvision.transforms._functional_tensor import _max_value
 
 from torchvision.utils import _log_api_usage_once
 
-from ._meta import _num_value_bits, convert_dtype_image_tensor
+from ._meta import _num_value_bits, to_dtype_image_tensor
 from ._utils import is_simple_tensor
 
 
@@ -351,7 +351,7 @@ def adjust_hue_image_tensor(image: torch.Tensor, hue_factor: float) -> torch.Ten
         return image
 
     orig_dtype = image.dtype
-    image = convert_dtype_image_tensor(image, torch.float32)
+    image = to_dtype_image_tensor(image, torch.float32, scale=True)
 
     image = _rgb_to_hsv(image)
     h, s, v = image.unbind(dim=-3)
@@ -359,7 +359,7 @@ def adjust_hue_image_tensor(image: torch.Tensor, hue_factor: float) -> torch.Ten
     image = torch.stack((h, s, v), dim=-3)
     image_hue_adj = _hsv_to_rgb(image)
 
-    return convert_dtype_image_tensor(image_hue_adj, orig_dtype)
+    return to_dtype_image_tensor(image_hue_adj, orig_dtype, scale=True)
 
 
 adjust_hue_image_pil = _FP.adjust_hue
@@ -393,7 +393,7 @@ def adjust_gamma_image_tensor(image: torch.Tensor, gamma: float, gain: float = 1
     # The input image is either assumed to be at [0, 1] scale (if float) or is converted to that scale (if integer).
     # Since the gamma is non-negative, the output remains at [0, 1] scale.
     if not torch.is_floating_point(image):
-        output = convert_dtype_image_tensor(image, torch.float32).pow_(gamma)
+        output = to_dtype_image_tensor(image, torch.float32, scale=True).pow_(gamma)
     else:
         output = image.pow(gamma)
 
@@ -402,7 +402,7 @@ def adjust_gamma_image_tensor(image: torch.Tensor, gamma: float, gain: float = 1
         # of the output can go beyond [0, 1].
         output = output.mul_(gain).clamp_(0.0, 1.0)
 
-    return convert_dtype_image_tensor(output, image.dtype)
+    return to_dtype_image_tensor(output, image.dtype, scale=True)
 
 
 adjust_gamma_image_pil = _FP.adjust_gamma
@@ -565,7 +565,7 @@ def equalize_image_tensor(image: torch.Tensor) -> torch.Tensor:
     # Since we need to convert in most cases anyway and out of the acceptable dtypes mentioned in 1. `torch.uint8` is
     # by far the most common, we choose it as base.
     output_dtype = image.dtype
-    image = convert_dtype_image_tensor(image, torch.uint8)
+    image = to_dtype_image_tensor(image, torch.uint8, scale=True)
 
     # The histogram is computed by using the flattened image as index. For example, a pixel value of 127 in the image
     # corresponds to adding 1 to index 127 in the histogram.
@@ -616,7 +616,7 @@ def equalize_image_tensor(image: torch.Tensor) -> torch.Tensor:
     equalized_image = lut.gather(dim=-1, index=flat_image).view_as(image)
 
     output = torch.where(valid_equalization, equalized_image, image)
-    return convert_dtype_image_tensor(output, output_dtype)
+    return to_dtype_image_tensor(output, output_dtype, scale=True)
 
 
 equalize_image_pil = _FP.equalize

--- a/torchvision/transforms/v2/functional/_meta.py
+++ b/torchvision/transforms/v2/functional/_meta.py
@@ -372,4 +372,4 @@ def to_dtype(inpt: datapoints._InputTypeJIT, dtype: torch.dtype = torch.float, s
     elif isinstance(inpt, datapoints._datapoint.Datapoint):
         return inpt.to(dtype)
     else:
-        raise TypeError("Input can either be a plain tensor or a datapoint, " f"but got {type(inpt)} instead. ")
+        raise TypeError(f"Input can either be a plain tensor or a datapoint, but got {type(inpt)} instead.")

--- a/torchvision/transforms/v2/functional/_meta.py
+++ b/torchvision/transforms/v2/functional/_meta.py
@@ -348,6 +348,7 @@ def to_dtype_image_tensor(image: torch.Tensor, dtype: torch.dtype = torch.float,
             return image.to(dtype).bitwise_left_shift_(num_value_bits_output - num_value_bits_input)
 
 
+# We encourage users to use to_dtype() instead but we keep this for BC
 def convert_image_dtype(image: torch.Tensor, dtype: torch.dtype = torch.float32) -> torch.Tensor:
     return to_dtype_image_tensor(image, dtype=dtype, scale=True)
 


### PR DESCRIPTION
Closes https://github.com/pytorch/vision/issues/7756

this PR:

- adds a `scale` parameter to ToDtype, which only affects images or videos
- removes ConvetDtype to keep ConvertImageDtype. ConvertImageDtype now only supports images, not videos.
- removes all  dispatchers / kernels associated with `convert_.*`  and replace with `to_dtype*` dispatchers / kernels.
- When passing `ToDtype(torch.float32)` i.e. the `dtype` parameter is just a dtype, not a dict, we only convert images and videos - this is for BC with ConvertImageDtype and reduces adoption friction

(I may have removed too much stuff on the existing tests, we'll see with the CI)