### PR TITLE
fix make_image

### DIFF
--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -503,12 +503,13 @@ def make_image(
     device="cpu",
     memory_format=torch.contiguous_format,
 ):
+    dtype = dtype or torch.uint8
     max_value = get_max_value(dtype)
     data = torch.testing.make_tensor(
         (*batch_dims, get_num_channels(color_space), *size),
         low=0,
         high=max_value,
-        dtype=dtype or torch.uint8,
+        dtype=dtype,
         device=device,
         memory_format=memory_format,
     )


### PR DESCRIPTION
I botched this in #7717 when moving from `dtype=torch.float32` to `dtype=None` as default value. When passing `dtype=None` (or more likely don't pass `dtype` at all), without this fix we also pass `None`  to `get_max_value` and get back

https://github.com/pytorch/vision/blob/1402eb8ee0cb21f44cbdde5745677d4bce4a35e5/torchvision/transforms/_functional_tensor.py#L52-L55

This would be the right maximum value for floating point images, but since we have also switched to `torch.uint8` as default dtype, we now request an integer tensor with bounds [0, 1) aka a full zero tensor.