### PR TITLE
Fix RandomZoomOut doc string

### DIFF
--- a/torchvision/transforms/v2/_geometry.py
+++ b/torchvision/transforms/v2/_geometry.py
@@ -537,7 +537,7 @@ class RandomZoomOut(_RandomApplyTransform):
             ``Mask`` will be filled with 0.
         side_range (sequence of floats, optional): tuple of two floats defines minimum and maximum factors to
             scale the input size.
-        p (float, optional): probability of the input being flipped. Default value is 0.5
+        p (float, optional): probability that the zoom operation will be performed.
     """
 
     def __init__(


### PR DESCRIPTION
Looks like a copy-paste error to me. Changed the wording to match `RandomErasing`:
https://github.com/pytorch/vision/blob/3966f9558bfc8443fc4fe16538b33805dd42812d/torchvision/transforms/v2/_augment.py#L27C13-L27C13