### PR TITLE
Add new entry to .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -9,3 +9,5 @@ d367a01a18a3ae6bee13d8be3b63fd6a581ea46f
 6ca9c76adb6daf2695d603ad623a9cf1c4f4806f
 # Fix unnecessary exploded black formatting (#7709)
 a335d916db0694770e8152f41e19195de3134523
+# Renaming: `BoundingBox` -> `BoundingBoxes` (#7778)
+332bff937c6711666191880fab57fa2f23ae772e


### PR DESCRIPTION
To avoid blame noise from https://github.com/pytorch/vision/pull/7778