### PR TITLE
Allow register_kernel() to take dispatcher name as input

### DIFF
--- a/torchvision/transforms/v2/functional/_utils.py
+++ b/torchvision/transforms/v2/functional/_utils.py
@@ -37,7 +37,22 @@ def _register_kernel_internal(dispatcher, datapoint_cls, *, datapoint_wrapper=Tr
     return decorator
 
 
+def _name_to_dispatcher(name):
+    import torchvision.transforms.v2.functional  # noqa
+
+    try:
+        return next(
+            obj
+            for obj in torchvision.transforms.v2.functional.__dict__.values()
+            if getattr(obj, "__name__", "") == name
+        )
+    except StopIteration:
+        raise ValueError(f"Could not find dispatcher with name '{name}'.")
+
+
 def register_kernel(dispatcher, datapoint_cls):
+    if isinstance(dispatcher, str):
+        dispatcher = _name_to_dispatcher(name=dispatcher)
     return _register_kernel_internal(dispatcher, datapoint_cls, datapoint_wrapper=False)
 
 

--- a/torchvision/transforms/v2/functional/_utils.py
+++ b/torchvision/transforms/v2/functional/_utils.py
@@ -41,13 +41,9 @@ def _name_to_dispatcher(name):
     import torchvision.transforms.v2.functional  # noqa
 
     try:
-        return next(
-            obj
-            for obj in torchvision.transforms.v2.functional.__dict__.values()
-            if getattr(obj, "__name__", "") == name
-        )
-    except StopIteration:
-        raise ValueError(f"Could not find dispatcher with name '{name}'.")
+        return getattr(torchvision.transforms.v2.functional, name)
+    except AttributeError:
+        raise ValueError(f"Could not find dispatcher with name '{name}'.") from None
 
 
 def register_kernel(dispatcher, datapoint_cls):


### PR DESCRIPTION
plus  some minor tests for `register_kernel`.

Writing the tutorials in https://github.com/pytorch/vision/pull/7795 I thought that we should allow to register kernels by name, not just by callables. Typically if I'm a dev and I just care about `Resize()` (the **transform class**), I should just be able to register my kernel with `@register_kernel("resize", MyDatapoint)` instead of having to do  `@register_kernel(resize, MyDatapoint)` which forces me to import the functional dispatcher for no obvious reason.

Side note: I thought about allowing the transform name as well e.g. ``@register_kernel("Resize", MyDatapoint)``, but I don't think we should do that because that won't work in general anyway, as some transforms rely on more than one dispatcher.