### PR TITLE
Make _RandomApplyTransform public

### DIFF
--- a/torchvision/transforms/v2/__init__.py
+++ b/torchvision/transforms/v2/__init__.py
@@ -2,7 +2,7 @@ from torchvision.transforms import AutoAugmentPolicy, InterpolationMode  # usort
 
 from . import functional, utils  # usort: skip
 
-from ._transform import Transform  # usort: skip
+from ._transform import Transform, RandomApplyTransform  # usort: skip
 
 from ._augment import CutMix, MixUp, RandomErasing
 from ._auto_augment import AugMix, AutoAugment, RandAugment, TrivialAugmentWide
@@ -56,6 +56,7 @@ from ._type_conversion import PILToTensor, ToImagePIL, ToImageTensor, ToPILImage
 from ._deprecated import ToTensor  # usort: skip
 
 from torchvision import _BETA_TRANSFORMS_WARNING, _WARN_ABOUT_BETA_TRANSFORMS
+
 
 if _WARN_ABOUT_BETA_TRANSFORMS:
     import warnings

--- a/torchvision/transforms/v2/_augment.py
+++ b/torchvision/transforms/v2/_augment.py
@@ -8,14 +8,13 @@ import torch
 from torch.nn.functional import one_hot
 from torch.utils._pytree import tree_flatten, tree_unflatten
 from torchvision import datapoints, transforms as _transforms
-from torchvision.transforms.v2 import functional as F
+from torchvision.transforms.v2 import RandomApplyTransform, Transform, functional as F
 
-from ._transform import _RandomApplyTransform, Transform
 from ._utils import _parse_labels_getter
 from .utils import has_any, is_simple_tensor, query_chw, query_size
 
 
-class RandomErasing(_RandomApplyTransform):
+class RandomErasing(RandomApplyTransform):
     """[BETA] Randomly select a rectangle region in the input image or video and erase its pixels.
 
     .. v2betastatus:: RandomErasing transform

--- a/torchvision/transforms/v2/_augment.py
+++ b/torchvision/transforms/v2/_augment.py
@@ -8,7 +8,7 @@ import torch
 from torch.nn.functional import one_hot
 from torch.utils._pytree import tree_flatten, tree_unflatten
 from torchvision import datapoints, transforms as _transforms
-from torchvision.transforms.v2 import RandomApplyTransform, Transform, functional as F
+from torchvision.transforms.v2 import functional as F, RandomApplyTransform, Transform
 
 from ._utils import _parse_labels_getter
 from .utils import has_any, is_simple_tensor, query_chw, query_size

--- a/torchvision/transforms/v2/_color.py
+++ b/torchvision/transforms/v2/_color.py
@@ -4,9 +4,8 @@ from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 import PIL.Image
 import torch
 from torchvision import datapoints, transforms as _transforms
-from torchvision.transforms.v2 import functional as F, Transform
+from torchvision.transforms.v2 import functional as F, Transform, RandomApplyTransform
 
-from ._transform import _RandomApplyTransform
 from .utils import is_simple_tensor, query_chw
 
 
@@ -39,7 +38,7 @@ class Grayscale(Transform):
         return F.rgb_to_grayscale(inpt, num_output_channels=self.num_output_channels)
 
 
-class RandomGrayscale(_RandomApplyTransform):
+class RandomGrayscale(RandomApplyTransform):
     """[BETA] Randomly convert image or videos to grayscale with a probability of p (default 0.1).
 
     .. v2betastatus:: RandomGrayscale transform
@@ -274,7 +273,7 @@ class RandomPhotometricDistort(Transform):
         return inpt
 
 
-class RandomEqualize(_RandomApplyTransform):
+class RandomEqualize(RandomApplyTransform):
     """[BETA] Equalize the histogram of the given image or video with a given probability.
 
     .. v2betastatus:: RandomEqualize transform
@@ -293,7 +292,7 @@ class RandomEqualize(_RandomApplyTransform):
         return F.equalize(inpt)
 
 
-class RandomInvert(_RandomApplyTransform):
+class RandomInvert(RandomApplyTransform):
     """[BETA] Inverts the colors of the given image or video with a given probability.
 
     .. v2betastatus:: RandomInvert transform
@@ -312,7 +311,7 @@ class RandomInvert(_RandomApplyTransform):
         return F.invert(inpt)
 
 
-class RandomPosterize(_RandomApplyTransform):
+class RandomPosterize(RandomApplyTransform):
     """[BETA] Posterize the image or video with a given probability by reducing the
     number of bits for each color channel.
 
@@ -337,7 +336,7 @@ class RandomPosterize(_RandomApplyTransform):
         return F.posterize(inpt, bits=self.bits)
 
 
-class RandomSolarize(_RandomApplyTransform):
+class RandomSolarize(RandomApplyTransform):
     """[BETA] Solarize the image or video with a given probability by inverting all pixel
     values above a threshold.
 
@@ -362,7 +361,7 @@ class RandomSolarize(_RandomApplyTransform):
         return F.solarize(inpt, threshold=self.threshold)
 
 
-class RandomAutocontrast(_RandomApplyTransform):
+class RandomAutocontrast(RandomApplyTransform):
     """[BETA] Autocontrast the pixels of the given image or video with a given probability.
 
     .. v2betastatus:: RandomAutocontrast transform
@@ -381,7 +380,7 @@ class RandomAutocontrast(_RandomApplyTransform):
         return F.autocontrast(inpt)
 
 
-class RandomAdjustSharpness(_RandomApplyTransform):
+class RandomAdjustSharpness(RandomApplyTransform):
     """[BETA] Adjust the sharpness of the image or video with a given probability.
 
     .. v2betastatus:: RandomAdjustSharpness transform

--- a/torchvision/transforms/v2/_color.py
+++ b/torchvision/transforms/v2/_color.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 import PIL.Image
 import torch
 from torchvision import datapoints, transforms as _transforms
-from torchvision.transforms.v2 import functional as F, Transform, RandomApplyTransform
+from torchvision.transforms.v2 import functional as F, RandomApplyTransform, Transform
 
 from .utils import is_simple_tensor, query_chw
 

--- a/torchvision/transforms/v2/_geometry.py
+++ b/torchvision/transforms/v2/_geometry.py
@@ -9,10 +9,10 @@ import torch
 from torchvision import datapoints, transforms as _transforms
 from torchvision.ops.boxes import box_iou
 from torchvision.transforms.functional import _get_perspective_coeffs
-from torchvision.transforms.v2 import functional as F, InterpolationMode, Transform
+from torchvision.transforms.v2 import functional as F, InterpolationMode, Transform, RandomApplyTransform
 from torchvision.transforms.v2.functional._geometry import _check_interpolation
 
-from ._transform import _RandomApplyTransform
+#from ._transform import RandomApplyTransform
 from ._utils import (
     _check_padding_arg,
     _check_padding_mode_arg,
@@ -26,7 +26,7 @@ from ._utils import (
 from .utils import has_all, has_any, is_simple_tensor, query_bounding_boxes, query_size
 
 
-class RandomHorizontalFlip(_RandomApplyTransform):
+class RandomHorizontalFlip(RandomApplyTransform):
     """[BETA] Horizontally flip the input with a given probability.
 
     .. v2betastatus:: RandomHorizontalFlip transform
@@ -46,7 +46,7 @@ class RandomHorizontalFlip(_RandomApplyTransform):
         return F.horizontal_flip(inpt)
 
 
-class RandomVerticalFlip(_RandomApplyTransform):
+class RandomVerticalFlip(RandomApplyTransform):
     """[BETA] Vertically flip the input with a given probability.
 
     .. v2betastatus:: RandomVerticalFlip transform
@@ -480,7 +480,7 @@ class Pad(Transform):
         return F.pad(inpt, padding=self.padding, fill=fill, padding_mode=self.padding_mode)  # type: ignore[arg-type]
 
 
-class RandomZoomOut(_RandomApplyTransform):
+class RandomZoomOut(RandomApplyTransform):
     """[BETA] "Zoom out" transformation from
     `"SSD: Single Shot MultiBox Detector" <https://arxiv.org/abs/1512.02325>`_.
 
@@ -899,7 +899,7 @@ class RandomCrop(Transform):
         return inpt
 
 
-class RandomPerspective(_RandomApplyTransform):
+class RandomPerspective(RandomApplyTransform):
     """[BETA] Perform a random perspective transformation of the input with a given probability.
 
     .. v2betastatus:: RandomPerspective transform

--- a/torchvision/transforms/v2/_geometry.py
+++ b/torchvision/transforms/v2/_geometry.py
@@ -9,10 +9,9 @@ import torch
 from torchvision import datapoints, transforms as _transforms
 from torchvision.ops.boxes import box_iou
 from torchvision.transforms.functional import _get_perspective_coeffs
-from torchvision.transforms.v2 import functional as F, InterpolationMode, Transform, RandomApplyTransform
+from torchvision.transforms.v2 import functional as F, InterpolationMode, RandomApplyTransform, Transform
 from torchvision.transforms.v2.functional._geometry import _check_interpolation
 
-#from ._transform import RandomApplyTransform
 from ._utils import (
     _check_padding_arg,
     _check_padding_mode_arg,

--- a/torchvision/transforms/v2/_transform.py
+++ b/torchvision/transforms/v2/_transform.py
@@ -136,7 +136,7 @@ class Transform(nn.Module):
         return self._v1_transform_cls(**self._extract_params_for_v1_transform())
 
 
-class _RandomApplyTransform(Transform):
+class RandomApplyTransform(Transform):
     def __init__(self, p: float = 0.5) -> None:
         if not (0.0 <= p <= 1.0):
             raise ValueError("`p` should be a floating point value in the interval [0.0, 1.0].")


### PR DESCRIPTION
Renames `_RandomApplyTransform` to `RandomApplyTransform` and makes it public from `torchvision.transforms.v2`

This class will be beneficial for custom transformations that should have Random behaviour. 

This is discussed in issue https://github.com/pytorch/vision/issues/7799 