### PR TITLE
Change default pytest traceback from native to short

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -3,7 +3,7 @@ addopts =
     # show tests that (f)ailed, (E)rror, or (X)passed in the summary
     -rfEX
     # Make tracebacks shorter
-    --tb=native
+    --tb=short
     # enable all warnings
     -Wd
     --ignore=test/test_datasets_download.py


### PR DESCRIPTION
IDK why but `short` looks much better on my terminal (and it's the same size)

native:
![native](https://github.com/pytorch/vision/assets/1190450/0479255d-f7b9-4f25-8883-05c0fec43fbd)

short:
![short](https://github.com/pytorch/vision/assets/1190450/c0262b44-4bbb-46a8-b984-3ddae4215d3e)

