### PR TITLE
Fix torchvision test for release

### DIFF
--- a/test/smoke_test.py
+++ b/test/smoke_test.py
@@ -80,8 +80,8 @@ def main() -> None:
     print(f"torch.cuda.is_available: {torch.cuda.is_available()}")
 
     # Turn 1.11.0aHASH into 1.11 (major.minor only)
-    version = release = ".".join(torchvision.__version__.split(".")[:2])
-    if(version >= "0.16"):
+    version = ".".join(torchvision.__version__.split(".")[:2])
+    if version >= "0.16":
         print(f"{torch.ops.image._jpeg_version() = }")
         assert torch.ops.image._is_compiled_against_turbo()
 


### PR DESCRIPTION
We are running these test for release monitoring in pytorch/builder repo.

This is currently failing since Release 2.0.1 do not have libjpeg-turbo yet: https://github.com/pytorch/builder/actions/runs/5863131234