### PR TITLE
allow dispatch to PIL image subclasses

### DIFF
--- a/torchvision/transforms/v2/functional/_utils.py
+++ b/torchvision/transforms/v2/functional/_utils.py
@@ -103,7 +103,7 @@ def _get_kernel(functional, input_type, *, allow_passthrough=False):
     for cls in input_type.__mro__:
         if cls in registry:
             return registry[cls]
-        elif issubclass(input_type, datapoints.Datapoint) and cls is datapoints.Datapoint:
+        elif cls is datapoints.Datapoint:
             # We don't want user-defined datapoints to dispatch to the pure Tensor kernels, so we explicit stop the
             # MRO traversal before hitting torch.Tensor. We can even stop at datapoints.Datapoint, since we don't
             # allow kernels to be registered for datapoints.Datapoint anyway.


### PR DESCRIPTION
Bug that was spotted by @vfdev-5:

```python
opened_image = PIL.Image.open("test/assets/encode_jpeg/grace_hopper_517x606.jpg")
loaded_image = opened_image.convert("RGB")

assert isinstance(opened_image, PIL.Image.Image)
assert type(opened_image) is not PIL.Image.Image

assert type(loaded_image) is PIL.Image.Image

F.resize(loaded_image, (17, 11))  # ok
F.resize(opened_image, (17, 11))  # raises TypeError, since we currently only allow exact matches for PIL.Image.Image
```

This PR removes the restriction that we only walk up the MRO for `datapoints.Datapoint` and thus enabling an "`isinstance`" check for `PIL.Image.Image`.

That also means that _we_ can now also register kernels for subclasses of `PIL.Image.Image` or `torch.Tensor`. However, since we don't plan on doing that and users are not allowed to do so

https://github.com/pytorch/vision/blob/498b9c8662e2322615748aafc321ad4a5bc02afb/torchvision/transforms/v2/functional/_utils.py#L86-L90

this has no other side-effect. It actually simplifies the code.


cc @vfdev-5