### PR TITLE
Add google collab link for gallery examples

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -55,6 +55,13 @@ jobs:
         # cores (`-j auto`). Thus, we limit to a single process (`-j 1`) here.
         sed -i -e 's/-j auto/-j 1/' Makefile
         make html
+
+        mkdir build/html/_generated_ipynb_notebooks
+        for file in `find build/html/_downloads`; do
+          if [[ $file == *.ipynb ]]; then
+            cp $file build/html/_generated_ipynb_notebooks/
+          fi
+        done
         
         cp -r build/html "${RUNNER_ARTIFACT_DIR}"
         

--- a/gallery/plot_datapoints.py
+++ b/gallery/plot_datapoints.py
@@ -3,6 +3,8 @@
 Datapoints FAQ
 ==============
 
+https://colab.research.google.com/github/pytorch/vision/blob/gh-pages/_generated_ipynb_notebooks/plot_datapoints.ipynb
+
 Datapoints are Tensor subclasses introduced together with
 ``torchvision.transforms.v2``. This example showcases what these datapoints are
 and how they behave.


### PR DESCRIPTION
Addresses https://github.com/pytorch/vision/issues/7794

This isn't perfect but this should hopefully do the trick. We'll need to merge this PR before we can assess whether this works or not. If it does, I'll add a nicer link and do the same for the rest of the gallery examples