### PR TITLE
Remove import-time warning for v2 namespaces

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -34,9 +34,6 @@ from tabulate import tabulate
 
 sys.path.append(os.path.abspath("."))
 
-torchvision.disable_beta_transforms_warning()
-import torchvision.datapoints  # Don't remove, otherwise the docs for datapoints aren't linked properly
-
 # -- General configuration ------------------------------------------------
 
 # Required version of sphinx is set from docs/requirements.txt

--- a/gallery/v2_transforms/plot_custom_datapoints.py
+++ b/gallery/v2_transforms/plot_custom_datapoints.py
@@ -11,12 +11,6 @@ Torchvision v2 transforms. Before continuing, make sure you have read
 
 # %%
 import torch
-import torchvision
-
-# We are using BETA APIs, so we deactivate the associated warning, thereby acknowledging that
-# some APIs may slightly change in the future
-torchvision.disable_beta_transforms_warning()
-
 from torchvision import datapoints
 from torchvision.transforms import v2
 

--- a/gallery/v2_transforms/plot_custom_transforms.py
+++ b/gallery/v2_transforms/plot_custom_transforms.py
@@ -9,12 +9,6 @@ torchvision transforms V2 API.
 
 # %%
 import torch
-import torchvision
-
-# We are using BETA APIs, so we deactivate the associated warning, thereby acknowledging that
-# some APIs may slightly change in the future
-torchvision.disable_beta_transforms_warning()
-
 from torchvision import datapoints
 from torchvision.transforms import v2
 

--- a/gallery/v2_transforms/plot_cutmix_mixup.py
+++ b/gallery/v2_transforms/plot_cutmix_mixup.py
@@ -17,13 +17,7 @@ function.
 
 # %%
 import torch
-import torchvision
 from torchvision.datasets import FakeData
-
-# We are using BETA APIs, so we deactivate the associated warning, thereby acknowledging that
-# some APIs may slightly change in the future
-torchvision.disable_beta_transforms_warning()
-
 from torchvision.transforms import v2
 
 

--- a/gallery/v2_transforms/plot_datapoints.py
+++ b/gallery/v2_transforms/plot_datapoints.py
@@ -24,12 +24,6 @@ and how they behave.
 import PIL.Image
 
 import torch
-import torchvision
-
-# We are using BETA APIs, so we deactivate the associated warning, thereby acknowledging that
-# some APIs may slightly change in the future
-torchvision.disable_beta_transforms_warning()
-
 from torchvision import datapoints
 from torchvision.transforms.v2 import functional as F
 

--- a/gallery/v2_transforms/plot_transforms_v2.py
+++ b/gallery/v2_transforms/plot_transforms_v2.py
@@ -11,7 +11,6 @@ example showcases the core functionality of the new ``torchvision.transforms.v2`
 import pathlib
 
 import torch
-import torchvision
 
 
 def load_data():
@@ -42,9 +41,6 @@ def load_data():
 # detection or instance and semantic segmentation. Still, the interface is the same, making
 # :mod:`torchvision.transforms.v2` a drop-in replacement for the existing :mod:`torchvision.transforms` API, aka v1.
 
-# We are using BETA APIs, so we deactivate the associated warning, thereby acknowledging that
-# some APIs may slightly change in the future
-torchvision.disable_beta_transforms_warning()
 import torchvision.transforms.v2 as transforms
 
 transform = transforms.Compose(

--- a/gallery/v2_transforms/plot_transforms_v2_e2e.py
+++ b/gallery/v2_transforms/plot_transforms_v2_e2e.py
@@ -16,7 +16,8 @@ import PIL.Image
 import torch
 import torch.utils.data
 
-import torchvision
+from torchvision import models, datasets
+import torchvision.transforms.v2 as transforms
 
 
 def show(sample):
@@ -39,18 +40,9 @@ def show(sample):
     fig.show()
 
 
-# We are using BETA APIs, so we deactivate the associated warning, thereby acknowledging that
-# some APIs may slightly change in the future
-torchvision.disable_beta_transforms_warning()
-
-from torchvision import models, datasets
-import torchvision.transforms.v2 as transforms
-
-
 # %%
 # We start off by loading the :class:`~torchvision.datasets.CocoDetection` dataset to have a look at what it currently
 # returns, and we'll see how to convert it to a format that is compatible with our new transforms.
-
 
 def load_example_coco_detection_dataset(**kwargs):
     # This loads fake data for illustration purposes of this example. In practice, you'll have

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -3,10 +3,6 @@ import random
 import numpy as np
 import pytest
 import torch
-import torchvision
-
-
-torchvision.disable_beta_transforms_warning()
 
 from common_utils import (
     CUDA_NOT_AVAILABLE_MSG,

--- a/test/test_transforms_v2.py
+++ b/test/test_transforms_v2.py
@@ -1,7 +1,6 @@
 import itertools
 import pathlib
 import random
-import textwrap
 import warnings
 
 import numpy as np
@@ -11,7 +10,7 @@ import pytest
 import torch
 import torchvision.transforms.v2 as transforms
 
-from common_utils import assert_equal, assert_run_python_script, cpu_and_cuda
+from common_utils import assert_equal, cpu_and_cuda
 from torch.utils._pytree import tree_flatten, tree_unflatten
 from torchvision import datapoints
 from torchvision.ops.boxes import box_iou
@@ -1277,55 +1276,6 @@ def test_sanitize_bounding_boxes_errors():
     with pytest.raises(ValueError, match="Number of boxes"):
         different_sizes = {"bbox": good_bbox, "labels": torch.arange(good_bbox.shape[0] + 3)}
         transforms.SanitizeBoundingBoxes()(different_sizes)
-
-
-@pytest.mark.parametrize(
-    "import_statement",
-    (
-        "from torchvision.transforms import v2",
-        "import torchvision.transforms.v2",
-        "from torchvision.transforms.v2 import Resize",
-        "import torchvision.transforms.v2.functional",
-        "from torchvision.transforms.v2.functional import resize",
-        "from torchvision import datapoints",
-        "from torchvision.datapoints import Image",
-        "from torchvision.datasets import wrap_dataset_for_transforms_v2",
-    ),
-)
-@pytest.mark.parametrize("call_disable_warning", (True, False))
-def test_warnings_v2_namespaces(import_statement, call_disable_warning):
-    if call_disable_warning:
-        source = f"""
-        import warnings
-        import torchvision
-        torchvision.disable_beta_transforms_warning()
-        with warnings.catch_warnings():
-            warnings.simplefilter("error")
-            {import_statement}
-        """
-    else:
-        source = f"""
-        import pytest
-        with pytest.warns(UserWarning, match="v2 namespaces are still Beta"):
-            {import_statement}
-        """
-    assert_run_python_script(textwrap.dedent(source))
-
-
-def test_no_warnings_v1_namespace():
-    source = """
-    import warnings
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
-        import torchvision.transforms
-        from torchvision import transforms
-        import torchvision.transforms.functional
-        from torchvision.transforms import Resize
-        from torchvision.transforms.functional import resize
-        from torchvision import datasets
-        from torchvision.datasets import ImageNet
-    """
-    assert_run_python_script(textwrap.dedent(source))
 
 
 class TestLambda:

--- a/torchvision/__init__.py
+++ b/torchvision/__init__.py
@@ -95,20 +95,3 @@ def get_video_backend():
 
 def _is_tracing():
     return torch._C._get_tracing_state()
-
-
-_WARN_ABOUT_BETA_TRANSFORMS = True
-_BETA_TRANSFORMS_WARNING = (
-    "The torchvision.datapoints and torchvision.transforms.v2 namespaces are still Beta. "
-    "While we do not expect major breaking changes, some APIs may still change "
-    "according to user feedback. Please submit any feedback you may have in "
-    "this issue: https://github.com/pytorch/vision/issues/6753, and you can also "
-    "check out https://github.com/pytorch/vision/issues/7319 to learn more about "
-    "the APIs that we suspect might involve future changes. "
-    "You can silence this warning by calling torchvision.disable_beta_transforms_warning()."
-)
-
-
-def disable_beta_transforms_warning():
-    global _WARN_ABOUT_BETA_TRANSFORMS
-    _WARN_ABOUT_BETA_TRANSFORMS = False

--- a/torchvision/datapoints/__init__.py
+++ b/torchvision/datapoints/__init__.py
@@ -1,5 +1,4 @@
 import torch
-from torchvision import _BETA_TRANSFORMS_WARNING, _WARN_ABOUT_BETA_TRANSFORMS
 
 from ._bounding_box import BoundingBoxes, BoundingBoxFormat
 from ._datapoint import Datapoint
@@ -7,11 +6,6 @@ from ._image import Image
 from ._mask import Mask
 from ._torch_function_helpers import set_return_type
 from ._video import Video
-
-if _WARN_ABOUT_BETA_TRANSFORMS:
-    import warnings
-
-    warnings.warn(_BETA_TRANSFORMS_WARNING)
 
 
 def wrap(wrappee, *, like, **kwargs):

--- a/torchvision/datasets/__init__.py
+++ b/torchvision/datasets/__init__.py
@@ -1,5 +1,3 @@
-from torchvision.datapoints._dataset_wrapper import wrap_dataset_for_transforms_v2
-
 from ._optical_flow import FlyingChairs, FlyingThings3D, HD1K, KittiFlow, Sintel
 from ._stereo_matching import (
     CarlaStereo,
@@ -131,3 +129,16 @@ __all__ = (
     "ETH3DStereo",
     "wrap_dataset_for_transforms_v2",
 )
+
+
+# We override current module's attributes to handle the import:
+# from torchvision.datasets import wrap_dataset_for_transforms_v2
+# without a cyclic error.
+# Ref: https://peps.python.org/pep-0562/
+def __getattr__(name):
+    if name in ("wrap_dataset_for_transforms_v2",):
+        from torchvision.datapoints._dataset_wrapper import wrap_dataset_for_transforms_v2
+
+        return wrap_dataset_for_transforms_v2
+
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/torchvision/datasets/__init__.py
+++ b/torchvision/datasets/__init__.py
@@ -1,3 +1,5 @@
+from torchvision.datapoints._dataset_wrapper import wrap_dataset_for_transforms_v2
+
 from ._optical_flow import FlyingChairs, FlyingThings3D, HD1K, KittiFlow, Sintel
 from ._stereo_matching import (
     CarlaStereo,
@@ -127,19 +129,5 @@ __all__ = (
     "SintelStereo",
     "InStereo2k",
     "ETH3DStereo",
+    "wrap_dataset_for_transforms_v2",
 )
-
-
-# We override current module's attributes to handle the import:
-# from torchvision.datasets import wrap_dataset_for_transforms_v2
-# with beta state v2 warning from torchvision.datapoints
-# We also want to avoid raising the warning when importing other attributes
-# from torchvision.datasets
-# Ref: https://peps.python.org/pep-0562/
-def __getattr__(name):
-    if name in ("wrap_dataset_for_transforms_v2",):
-        from torchvision.datapoints._dataset_wrapper import wrap_dataset_for_transforms_v2
-
-        return wrap_dataset_for_transforms_v2
-
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/torchvision/transforms/v2/__init__.py
+++ b/torchvision/transforms/v2/__init__.py
@@ -55,10 +55,3 @@ from ._temporal import UniformTemporalSubsample
 from ._type_conversion import PILToTensor, ToImage, ToPILImage, ToPureTensor
 
 from ._deprecated import ToTensor  # usort: skip
-
-from torchvision import _BETA_TRANSFORMS_WARNING, _WARN_ABOUT_BETA_TRANSFORMS
-
-if _WARN_ABOUT_BETA_TRANSFORMS:
-    import warnings
-
-    warnings.warn(_BETA_TRANSFORMS_WARNING)


### PR DESCRIPTION
We have addressed a lot of things we were uncertain about (I'll udpate https://github.com/pytorch/vision/issues/7319 soon), and today we're fairly confident that there will not be future disruptive public changes to the v2 APIs.

We're still keeping them as Beta for the next release, but we don't think the import-time warnings are warranted anymore. This will allow us to promote and encourage v2 APIs more smoothly.