### PR TITLE
Revert "Pre-Script Update for Aarch64 (#7834)"

### DIFF
--- a/packaging/pre_build_script.sh
+++ b/packaging/pre_build_script.sh
@@ -11,7 +11,7 @@ if [[ "$(uname)" == Darwin ]]; then
   conda install -yq wget
 fi
 
-if [[ "$(uname)" == Darwin || "$OSTYPE" == "msys" || "$ARCH" == "aarch64" ]]; then
+if [[ "$(uname)" == Darwin || "$OSTYPE" == "msys" ]]; then
   # Install libpng from Anaconda (defaults)
   conda install libpng -yq
   conda install -yq ffmpeg=4.2 libjpeg-turbo -c pytorch


### PR DESCRIPTION
This reverts commit bda807d5a49cca8382a13a835ece2813e9c320ae / #7834.

See https://github.com/pytorch/vision/pull/7852#issuecomment-1686869324 for details. CI should be green after this, but something needs to be patched on the test-infra side.


cc @seemethere