### PR TITLE
Pin openssl to 3.0.9

### DIFF
--- a/.github/scripts/setup-env.sh
+++ b/.github/scripts/setup-env.sh
@@ -41,6 +41,7 @@ conda create \
   python="${PYTHON_VERSION}" pip \
   ninja cmake \
   libpng \
+  openssl=3.0.9 \
   'ffmpeg<4.3'
 conda activate ci
 conda install --quiet --yes libjpeg-turbo -c pytorch

--- a/.github/scripts/setup-env.sh
+++ b/.github/scripts/setup-env.sh
@@ -41,6 +41,7 @@ conda create \
   python="${PYTHON_VERSION}" pip \
   ninja cmake \
   libpng \
+  openssl=3.0.9 \
   'ffmpeg<4.3'
 conda activate ci
 conda install --quiet --yes libjpeg-turbo openssl=3.0.9 -c pytorch

--- a/.github/scripts/setup-env.sh
+++ b/.github/scripts/setup-env.sh
@@ -41,10 +41,9 @@ conda create \
   python="${PYTHON_VERSION}" pip \
   ninja cmake \
   libpng \
-  openssl=3.0.9 \
   'ffmpeg<4.3'
 conda activate ci
-conda install --quiet --yes libjpeg-turbo -c pytorch
+conda install --quiet --yes libjpeg-turbo openssl=3.0.9 -c pytorch
 pip install --progress-bar=off --upgrade setuptools
 
 # See https://github.com/pytorch/vision/issues/6790


### PR DESCRIPTION
To resolve windows failure here: https://github.com/pytorch/vision/actions/runs/5963157567/job/16175769668
due to openssl update to 3.0.10
