### PR TITLE
Split Mask into SegmentationMask and DetectionMasks

### DIFF
--- a/references/detection/presets.py
+++ b/references/detection/presets.py
@@ -54,7 +54,7 @@ class DetectionPresetTrain:
                 T.RandomHorizontalFlip(p=hflip_prob),
             ]
         elif data_augmentation == "ssd":
-            fill = defaultdict(lambda: mean, {tv_tensors.Mask: 0}) if use_v2 else list(mean)
+            fill = defaultdict(lambda: mean, {tv_tensors.DetectionMasks: 0}) if use_v2 else list(mean)
             transforms += [
                 T.RandomPhotometricDistort(),
                 T.RandomZoomOut(fill=fill),

--- a/references/segmentation/presets.py
+++ b/references/segmentation/presets.py
@@ -46,7 +46,7 @@ class SegmentationPresetTrain:
         if use_v2:
             # We need a custom pad transform here, since the padding we want to perform here is fundamentally
             # different from the padding in `RandomCrop` if `pad_if_needed=True`.
-            transforms += [v2_extras.PadIfSmaller(crop_size, fill={tv_tensors.Mask: 255, "others": 0})]
+            transforms += [v2_extras.PadIfSmaller(crop_size, fill={tv_tensors.SegmentationMask: 255, "others": 0})]
 
         transforms += [T.RandomCrop(crop_size)]
 
@@ -56,7 +56,10 @@ class SegmentationPresetTrain:
         if use_v2:
             img_type = tv_tensors.Image if backend == "tv_tensor" else torch.Tensor
             transforms += [
-                T.ToDtype(dtype={img_type: torch.float32, tv_tensors.Mask: torch.int64, "others": None}, scale=True)
+                T.ToDtype(
+                    dtype={img_type: torch.float32, tv_tensors.SegmentationMask: torch.int64, "others": None},
+                    scale=True,
+                )
             ]
         else:
             # No need to explicitly convert masks as they're magically int64 already

--- a/references/segmentation/v2_extras.py
+++ b/references/segmentation/v2_extras.py
@@ -80,4 +80,4 @@ class CocoDetectionToVOCSegmentation(v2.Transform):
         if segmentation_mask is None:
             segmentation_mask = torch.zeros(v2.functional.get_size(image), dtype=torch.uint8)
 
-        return image, tv_tensors.Mask(segmentation_mask)
+        return image, tv_tensors.SegmentationMask(segmentation_mask)

--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -446,7 +446,7 @@ def make_bounding_boxes(
 def make_detection_mask(size=DEFAULT_SIZE, *, dtype=None, device="cpu"):
     """Make a "detection" mask, i.e. (*, N, H, W), where each object is encoded as one of N boolean masks"""
     num_objects = 1
-    return tv_tensors.Mask(
+    return tv_tensors.DetectionMasks(
         torch.testing.make_tensor(
             (num_objects, *size),
             low=0,
@@ -459,7 +459,7 @@ def make_detection_mask(size=DEFAULT_SIZE, *, dtype=None, device="cpu"):
 
 def make_segmentation_mask(size=DEFAULT_SIZE, *, num_categories=10, batch_dims=(), dtype=None, device="cpu"):
     """Make a "segmentation" mask, i.e. (*, H, W), where the category is encoded as pixel value"""
-    return tv_tensors.Mask(
+    return tv_tensors.SegmentationMask(
         torch.testing.make_tensor(
             (*batch_dims, *size),
             low=0,

--- a/test/test_transforms_v2_refactored.py
+++ b/test/test_transforms_v2_refactored.py
@@ -536,7 +536,8 @@ class TestResize:
             (F._resize_image_pil, PIL.Image.Image),
             (F.resize_image, tv_tensors.Image),
             (F.resize_bounding_boxes, tv_tensors.BoundingBoxes),
-            (F.resize_mask, tv_tensors.Mask),
+            (F.resize_mask, tv_tensors.SegmentationMask),
+            (F.resize_mask, tv_tensors.DetectionMasks),
             (F.resize_video, tv_tensors.Video),
         ],
     )
@@ -871,7 +872,8 @@ class TestHorizontalFlip:
             (F._horizontal_flip_image_pil, PIL.Image.Image),
             (F.horizontal_flip_image, tv_tensors.Image),
             (F.horizontal_flip_bounding_boxes, tv_tensors.BoundingBoxes),
-            (F.horizontal_flip_mask, tv_tensors.Mask),
+            (F.horizontal_flip_mask, tv_tensors.SegmentationMask),
+            (F.horizontal_flip_mask, tv_tensors.DetectionMasks),
             (F.horizontal_flip_video, tv_tensors.Video),
         ],
     )
@@ -1039,7 +1041,8 @@ class TestAffine:
             (F._affine_image_pil, PIL.Image.Image),
             (F.affine_image, tv_tensors.Image),
             (F.affine_bounding_boxes, tv_tensors.BoundingBoxes),
-            (F.affine_mask, tv_tensors.Mask),
+            (F.affine_mask, tv_tensors.SegmentationMask),
+            (F.affine_mask, tv_tensors.DetectionMasks),
             (F.affine_video, tv_tensors.Video),
         ],
     )
@@ -1321,7 +1324,8 @@ class TestVerticalFlip:
             (F._vertical_flip_image_pil, PIL.Image.Image),
             (F.vertical_flip_image, tv_tensors.Image),
             (F.vertical_flip_bounding_boxes, tv_tensors.BoundingBoxes),
-            (F.vertical_flip_mask, tv_tensors.Mask),
+            (F.vertical_flip_mask, tv_tensors.SegmentationMask),
+            (F.vertical_flip_mask, tv_tensors.DetectionMasks),
             (F.vertical_flip_video, tv_tensors.Video),
         ],
     )
@@ -1464,7 +1468,8 @@ class TestRotate:
             (F._rotate_image_pil, PIL.Image.Image),
             (F.rotate_image, tv_tensors.Image),
             (F.rotate_bounding_boxes, tv_tensors.BoundingBoxes),
-            (F.rotate_mask, tv_tensors.Mask),
+            (F.rotate_mask, tv_tensors.SegmentationMask),
+            (F.rotate_mask, tv_tensors.DetectionMasks),
             (F.rotate_video, tv_tensors.Video),
         ],
     )
@@ -1867,7 +1872,7 @@ class TestToDtype:
         # make sure "others" works as a catch-all and that None means no conversion
 
         sample, inpt_dtype, bbox_dtype, mask_dtype = self.make_inpt_with_bbox_and_mask(make_input)
-        out = transforms.ToDtype(dtype={tv_tensors.Mask: torch.int64, "others": None})(sample)
+        out = transforms.ToDtype(dtype={tv_tensors.DetectionMasks: torch.int64, "others": None})(sample)
         assert out["inpt"].dtype == inpt_dtype
         assert out["bbox"].dtype == bbox_dtype
         assert out["mask"].dtype != mask_dtype
@@ -1880,7 +1885,8 @@ class TestToDtype:
 
         sample, inpt_dtype, bbox_dtype, mask_dtype = self.make_inpt_with_bbox_and_mask(make_input)
         out = transforms.ToDtype(
-            dtype={type(sample["inpt"]): torch.float32, tv_tensors.Mask: torch.int64, "others": None}, scale=True
+            dtype={type(sample["inpt"]): torch.float32, tv_tensors.DetectionMasks: torch.int64, "others": None},
+            scale=True,
         )(sample)
         assert out["inpt"].dtype != inpt_dtype
         assert out["inpt"].dtype == torch.float32
@@ -2034,8 +2040,8 @@ class TestCutMixMixUp:
 
         for input_with_bad_type in (
             F.to_pil_image(imgs[0]),
-            tv_tensors.Mask(torch.rand(12, 12)),
-            tv_tensors.BoundingBoxes(torch.rand(2, 4), format="XYXY", canvas_size=12),
+            tv_tensors.DetectionMasks(torch.rand(12, 12)),
+            tv_tensors.BoundingBoxes(torch.rand(2, 4), format="XYXY", canvas_size=(12, 12)),
         ):
             with pytest.raises(ValueError, match="does not support PIL images, "):
                 cutmix_mixup(input_with_bad_type)
@@ -2233,6 +2239,8 @@ class TestGetKernel:
         PIL.Image.Image: F._resize_image_pil,
         tv_tensors.Image: F.resize_image,
         tv_tensors.BoundingBoxes: F.resize_bounding_boxes,
+        tv_tensors.SegmentationMask: F.resize_mask,
+        tv_tensors.DetectionMasks: F.resize_mask,
         tv_tensors.Mask: F.resize_mask,
         tv_tensors.Video: F.resize_video,
     }
@@ -2436,7 +2444,8 @@ class TestElastic:
             (F._elastic_image_pil, PIL.Image.Image),
             (F.elastic_image, tv_tensors.Image),
             (F.elastic_bounding_boxes, tv_tensors.BoundingBoxes),
-            (F.elastic_mask, tv_tensors.Mask),
+            (F.elastic_mask, tv_tensors.SegmentationMask),
+            (F.elastic_mask, tv_tensors.DetectionMasks),
             (F.elastic_video, tv_tensors.Video),
         ],
     )
@@ -2478,7 +2487,8 @@ class TestToPureTensor:
             "img": make_image(),
             "img_tensor": make_image_tensor(),
             "img_pil": make_image_pil(),
-            "mask": make_detection_mask(),
+            "segmentation_mask": make_segmentation_mask(),
+            "detection_masks": make_detection_mask(),
             "video": make_video(),
             "bbox": make_bounding_boxes(),
             "str": "str",
@@ -2549,7 +2559,8 @@ class TestCrop:
             (F._crop_image_pil, PIL.Image.Image),
             (F.crop_image, tv_tensors.Image),
             (F.crop_bounding_boxes, tv_tensors.BoundingBoxes),
-            (F.crop_mask, tv_tensors.Mask),
+            (F.crop_mask, tv_tensors.SegmentationMask),
+            (F.crop_mask, tv_tensors.DetectionMasks),
             (F.crop_video, tv_tensors.Video),
         ],
     )
@@ -2571,7 +2582,15 @@ class TestCrop:
     )
     @pytest.mark.parametrize(
         "make_input",
-        [make_image_tensor, make_image_pil, make_image, make_bounding_boxes, make_segmentation_mask, make_video],
+        [
+            make_image_tensor,
+            make_image_pil,
+            make_image,
+            make_bounding_boxes,
+            make_segmentation_mask,
+            make_detection_mask,
+            make_video,
+        ],
     )
     def test_transform(self, param, value, make_input):
         input = make_input(self.INPUT_SIZE)

--- a/test/test_transforms_v2_refactored.py
+++ b/test/test_transforms_v2_refactored.py
@@ -185,7 +185,7 @@ def check_functional(functional, input, *args, check_scripted_smoke=True, **kwar
 
         spy.assert_any_call(f"{functional.__module__}.{functional.__name__}")
 
-    assert type(output) is type(input)
+    assert isinstance(output, type(input))
 
     if isinstance(input, tv_tensors.BoundingBoxes):
         assert output.format == input.format

--- a/test/test_transforms_v2_refactored.py
+++ b/test/test_transforms_v2_refactored.py
@@ -185,7 +185,7 @@ def check_functional(functional, input, *args, check_scripted_smoke=True, **kwar
 
         spy.assert_any_call(f"{functional.__module__}.{functional.__name__}")
 
-    assert isinstance(output, type(input))
+    assert type(output) is type(input)
 
     if isinstance(input, tv_tensors.BoundingBoxes):
         assert output.format == input.format

--- a/torchvision/transforms/v2/_geometry.py
+++ b/torchvision/transforms/v2/_geometry.py
@@ -447,8 +447,8 @@ class Pad(Transform):
         fill (number or tuple or dict, optional): Pixel fill value used when the  ``padding_mode`` is constant.
             Default is 0. If a tuple of length 3, it is used to fill R, G, B channels respectively.
             Fill value can be also a dictionary mapping data type to the fill value, e.g.
-            ``fill={tv_tensors.Image: 127, tv_tensors.Mask: 0}`` where ``Image`` will be filled with 127 and
-            ``Mask`` will be filled with 0.
+            ``fill={tv_tensors.Image: 127, tv_tensors.SegmentationMask: 0}`` where ``Image`` will be filled with 127 and
+            ``SegmentationMask`` will be filled with 0.
         padding_mode (str, optional): Type of padding. Should be: constant, edge, reflect or symmetric.
             Default is "constant".
 
@@ -524,8 +524,8 @@ class RandomZoomOut(_RandomApplyTransform):
         fill (number or tuple or dict, optional): Pixel fill value used when the  ``padding_mode`` is constant.
             Default is 0. If a tuple of length 3, it is used to fill R, G, B channels respectively.
             Fill value can be also a dictionary mapping data type to the fill value, e.g.
-            ``fill={tv_tensors.Image: 127, tv_tensors.Mask: 0}`` where ``Image`` will be filled with 127 and
-            ``Mask`` will be filled with 0.
+            ``fill={tv_tensors.Image: 127, tv_tensors.SegmentationMask: 0}`` where ``Image`` will be filled with 127 and
+            ``SegmentationMask`` will be filled with 0.
         side_range (sequence of floats, optional): tuple of two floats defines minimum and maximum factors to
             scale the input size.
         p (float, optional): probability that the zoom operation will be performed.
@@ -596,8 +596,8 @@ class RandomRotation(Transform):
         fill (number or tuple or dict, optional): Pixel fill value used when the  ``padding_mode`` is constant.
             Default is 0. If a tuple of length 3, it is used to fill R, G, B channels respectively.
             Fill value can be also a dictionary mapping data type to the fill value, e.g.
-            ``fill={tv_tensors.Image: 127, tv_tensors.Mask: 0}`` where ``Image`` will be filled with 127 and
-            ``Mask`` will be filled with 0.
+            ``fill={tv_tensors.Image: 127, tv_tensors.SegmentationMask: 0}`` where ``Image`` will be filled with 127 and
+            ``SegmentationMask`` will be filled with 0.
 
     .. _filters: https://pillow.readthedocs.io/en/latest/handbook/concepts.html#filters
 
@@ -676,8 +676,8 @@ class RandomAffine(Transform):
         fill (number or tuple or dict, optional): Pixel fill value used when the  ``padding_mode`` is constant.
             Default is 0. If a tuple of length 3, it is used to fill R, G, B channels respectively.
             Fill value can be also a dictionary mapping data type to the fill value, e.g.
-            ``fill={tv_tensors.Image: 127, tv_tensors.Mask: 0}`` where ``Image`` will be filled with 127 and
-            ``Mask`` will be filled with 0.
+            ``fill={tv_tensors.Image: 127, tv_tensors.SegmentationMask: 0}`` where ``Image`` will be filled with 127 and
+            ``SegmentationMask`` will be filled with 0.
         center (sequence, optional): Optional center of rotation, (x, y). Origin is the upper left corner.
             Default is the center of the image.
 
@@ -794,8 +794,8 @@ class RandomCrop(Transform):
         fill (number or tuple or dict, optional): Pixel fill value used when the  ``padding_mode`` is constant.
             Default is 0. If a tuple of length 3, it is used to fill R, G, B channels respectively.
             Fill value can be also a dictionary mapping data type to the fill value, e.g.
-            ``fill={tv_tensors.Image: 127, tv_tensors.Mask: 0}`` where ``Image`` will be filled with 127 and
-            ``Mask`` will be filled with 0.
+            ``fill={tv_tensors.Image: 127, tv_tensors.SegmentationMask: 0}`` where ``Image`` will be filled with 127 and
+            ``SegmentationMask`` will be filled with 0.
         padding_mode (str, optional): Type of padding. Should be: constant, edge, reflect or symmetric.
             Default is constant.
 
@@ -943,8 +943,8 @@ class RandomPerspective(_RandomApplyTransform):
         fill (number or tuple or dict, optional): Pixel fill value used when the  ``padding_mode`` is constant.
             Default is 0. If a tuple of length 3, it is used to fill R, G, B channels respectively.
             Fill value can be also a dictionary mapping data type to the fill value, e.g.
-            ``fill={tv_tensors.Image: 127, tv_tensors.Mask: 0}`` where ``Image`` will be filled with 127 and
-            ``Mask`` will be filled with 0.
+            ``fill={tv_tensors.Image: 127, tv_tensors.SegmentationMask: 0}`` where ``Image`` will be filled with 127 and
+            ``SegmentationMask`` will be filled with 0.
     """
 
     _v1_transform_cls = _transforms.RandomPerspective
@@ -1046,8 +1046,8 @@ class ElasticTransform(Transform):
         fill (number or tuple or dict, optional): Pixel fill value used when the  ``padding_mode`` is constant.
             Default is 0. If a tuple of length 3, it is used to fill R, G, B channels respectively.
             Fill value can be also a dictionary mapping data type to the fill value, e.g.
-            ``fill={tv_tensors.Image: 127, tv_tensors.Mask: 0}`` where ``Image`` will be filled with 127 and
-            ``Mask`` will be filled with 0.
+            ``fill={tv_tensors.Image: 127, tv_tensors.SegmentationMask: 0}`` where ``Image`` will be filled with 127 and
+            ``SegmentationMask`` will be filled with 0.
     """
 
     _v1_transform_cls = _transforms.ElasticTransform

--- a/torchvision/transforms/v2/_misc.py
+++ b/torchvision/transforms/v2/_misc.py
@@ -231,8 +231,8 @@ class ToDtype(Transform):
             If a ``torch.dtype`` is passed, e.g. ``torch.float32``, only images and videos will be converted
             to that dtype: this is for compatibility with :class:`~torchvision.transforms.v2.ConvertImageDtype`.
             A dict can be passed to specify per-tv_tensor conversions, e.g.
-            ``dtype={tv_tensors.Image: torch.float32, tv_tensors.Mask: torch.int64, "others":None}``. The "others"
-            key can be used as a catch-all for any other tv_tensor type, and ``None`` means no conversion.
+            ``dtype={tv_tensors.Image: torch.float32, tv_tensors.SegmentationMask: torch.int64, "others":None}``. The
+            "others" key can be used as a catch-all for any other tv_tensor type, and ``None`` means no conversion.
         scale (bool, optional): Whether to scale the values for images or videos. See :ref:`range_and_dtype`.
             Default: ``False``.
     """
@@ -277,8 +277,9 @@ class ToDtype(Transform):
                 f"No dtype was specified for type {type(inpt)}. "
                 "If you only need to convert the dtype of images or videos, you can just pass e.g. dtype=torch.float32. "
                 "If you're passing a dict as dtype, "
-                'you can use "others" as a catch-all key '
-                'e.g. dtype={tv_tensors.Mask: torch.int64, "others": None} to pass-through the rest of the inputs.'
+                'you can use "others" as a catch-all key, '
+                'e.g. dtype={tv_tensors.SegmentationMask: torch.int64, "others": None} '
+                "to pass-through the rest of the inputs."
             )
 
         supports_scaling = is_pure_tensor(inpt) or isinstance(inpt, (tv_tensors.Image, tv_tensors.Video))

--- a/torchvision/transforms/v2/_misc.py
+++ b/torchvision/transforms/v2/_misc.py
@@ -415,7 +415,7 @@ class SanitizeBoundingBoxes(Transform):
 
     def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
         is_label = inpt is not None and inpt is params["labels"]
-        is_bounding_boxes_or_mask = isinstance(inpt, (tv_tensors.BoundingBoxes, tv_tensors.Mask))
+        is_bounding_boxes_or_mask = isinstance(inpt, (tv_tensors.BoundingBoxes, tv_tensors.DetectionMasks))
 
         if not (is_label or is_bounding_boxes_or_mask):
             return inpt

--- a/torchvision/tv_tensors/__init__.py
+++ b/torchvision/tv_tensors/__init__.py
@@ -1,8 +1,6 @@
-import torch
-
 from ._bounding_box import BoundingBoxes, BoundingBoxFormat
 from ._image import Image
-from ._mask import Mask
+from ._mask import DetectionMasks, Mask, SegmentationMask
 from ._torch_function_helpers import set_return_type
 from ._tv_tensor import TVTensor
 from ._video import Video

--- a/torchvision/tv_tensors/_mask.py
+++ b/torchvision/tv_tensors/_mask.py
@@ -37,3 +37,34 @@ class Mask(TVTensor):
 
         tensor = cls._to_tensor(data, dtype=dtype, device=device, requires_grad=requires_grad)
         return tensor.as_subclass(cls)
+
+
+class SegmentationMask(Mask):
+    def __new__(
+        cls,
+        data: Any,
+        *,
+        dtype: Optional[torch.dtype] = None,
+        device: Optional[Union[torch.device, str, int]] = None,
+        requires_grad: Optional[bool] = None,
+    ) -> Mask:
+        if isinstance(data, PIL.Image.Image):
+            from torchvision.transforms.v2 import functional as F
+
+            data = F.pil_to_tensor(data)
+
+        tensor = cls._to_tensor(data, dtype=dtype, device=device, requires_grad=requires_grad)
+        return tensor.as_subclass(cls)
+
+
+class DetectionMasks(Mask):
+    def __new__(
+        cls,
+        data: Any,
+        *,
+        dtype: Optional[torch.dtype] = None,
+        device: Optional[Union[torch.device, str, int]] = None,
+        requires_grad: Optional[bool] = None,
+    ) -> Mask:
+        tensor = cls._to_tensor(data, dtype=dtype, device=device, requires_grad=requires_grad)
+        return tensor.as_subclass(cls)


### PR DESCRIPTION
`SegmentationMask` in singular similar to `Image`, since it can easily be batched. `DetectionMasks` in plural similar to `BoundingBoxes`, since the shape should always be `(N, H, W)` corresponding to the `(N, 4)` of `BoundingBoxes`.

All mask kernels continue to work, since we support subclasses, i.e. both `F.resize(tv_tensors.SegmentationMask(...), ...)` and `F.resize(tv_tensors.DetectionMasks(...), ...)` dispatch to `F.resize_mask`.

Some decisions I made that are up to discussion:

- Only `SegmentationMask` can be instantiated from a PIL image, since multiple detection masks cannot be stored in a single image
- `SanitizeBoundingBoxes` only sanitizes `DetectionMasks`, since there is no coupling of a potential existing `SegmentationMask` in the sample and the `BoundingBoxes` that we operate on

Documentation is TBD.