### PR TITLE
port AA tests

### DIFF
--- a/test/test_transforms_v2_consistency.py
+++ b/test/test_transforms_v2_consistency.py
@@ -749,30 +749,6 @@ class TestAATransforms:
             assert_close(expected_output, output, atol=1, rtol=0.1)
 
     @pytest.mark.parametrize(
-        "interpolation",
-        [
-            v2_transforms.InterpolationMode.NEAREST,
-            v2_transforms.InterpolationMode.BILINEAR,
-        ],
-    )
-    @pytest.mark.parametrize("fill", [None, 85, (10, -10, 10), 0.7, [0.0, 0.0, 0.0], [1], 1])
-    def test_randaug_jit(self, interpolation, fill):
-        inpt = torch.randint(0, 256, size=(1, 3, 256, 256), dtype=torch.uint8)
-        t_ref = legacy_transforms.RandAugment(interpolation=interpolation, num_ops=1, fill=fill)
-        t = v2_transforms.RandAugment(interpolation=interpolation, num_ops=1, fill=fill)
-
-        tt_ref = torch.jit.script(t_ref)
-        tt = torch.jit.script(t)
-
-        torch.manual_seed(12)
-        expected_output = tt_ref(inpt)
-
-        torch.manual_seed(12)
-        scripted_output = tt(inpt)
-
-        assert_equal(scripted_output, expected_output)
-
-    @pytest.mark.parametrize(
         "inpt",
         [
             torch.randint(0, 256, size=(1, 3, 256, 256), dtype=torch.uint8),
@@ -823,30 +799,6 @@ class TestAATransforms:
             output = t(inpt)
 
             assert_close(expected_output, output, atol=1, rtol=0.1)
-
-    @pytest.mark.parametrize(
-        "interpolation",
-        [
-            v2_transforms.InterpolationMode.NEAREST,
-            v2_transforms.InterpolationMode.BILINEAR,
-        ],
-    )
-    @pytest.mark.parametrize("fill", [None, 85, (10, -10, 10), 0.7, [0.0, 0.0, 0.0], [1], 1])
-    def test_trivial_aug_jit(self, interpolation, fill):
-        inpt = torch.randint(0, 256, size=(1, 3, 256, 256), dtype=torch.uint8)
-        t_ref = legacy_transforms.TrivialAugmentWide(interpolation=interpolation, fill=fill)
-        t = v2_transforms.TrivialAugmentWide(interpolation=interpolation, fill=fill)
-
-        tt_ref = torch.jit.script(t_ref)
-        tt = torch.jit.script(t)
-
-        torch.manual_seed(12)
-        expected_output = tt_ref(inpt)
-
-        torch.manual_seed(12)
-        scripted_output = tt(inpt)
-
-        assert_equal(scripted_output, expected_output)
 
     @pytest.mark.parametrize(
         "inpt",
@@ -902,31 +854,6 @@ class TestAATransforms:
         assert_equal(expected_output, output)
 
     @pytest.mark.parametrize(
-        "interpolation",
-        [
-            v2_transforms.InterpolationMode.NEAREST,
-            v2_transforms.InterpolationMode.BILINEAR,
-        ],
-    )
-    @pytest.mark.parametrize("fill", [None, 85, (10, -10, 10), 0.7, [0.0, 0.0, 0.0], [1], 1])
-    def test_augmix_jit(self, interpolation, fill):
-        inpt = torch.randint(0, 256, size=(1, 3, 256, 256), dtype=torch.uint8)
-
-        t_ref = legacy_transforms.AugMix(interpolation=interpolation, mixture_width=1, chain_depth=1, fill=fill)
-        t = v2_transforms.AugMix(interpolation=interpolation, mixture_width=1, chain_depth=1, fill=fill)
-
-        tt_ref = torch.jit.script(t_ref)
-        tt = torch.jit.script(t)
-
-        torch.manual_seed(12)
-        expected_output = tt_ref(inpt)
-
-        torch.manual_seed(12)
-        scripted_output = tt(inpt)
-
-        assert_equal(scripted_output, expected_output)
-
-    @pytest.mark.parametrize(
         "inpt",
         [
             torch.randint(0, 256, size=(1, 3, 256, 256), dtype=torch.uint8),
@@ -954,30 +881,6 @@ class TestAATransforms:
         output = t(inpt)
 
         assert_equal(expected_output, output)
-
-    @pytest.mark.parametrize(
-        "interpolation",
-        [
-            v2_transforms.InterpolationMode.NEAREST,
-            v2_transforms.InterpolationMode.BILINEAR,
-        ],
-    )
-    def test_aa_jit(self, interpolation):
-        inpt = torch.randint(0, 256, size=(1, 3, 256, 256), dtype=torch.uint8)
-        aa_policy = legacy_transforms.AutoAugmentPolicy("imagenet")
-        t_ref = legacy_transforms.AutoAugment(aa_policy, interpolation=interpolation)
-        t = v2_transforms.AutoAugment(aa_policy, interpolation=interpolation)
-
-        tt_ref = torch.jit.script(t_ref)
-        tt = torch.jit.script(t)
-
-        torch.manual_seed(12)
-        expected_output = tt_ref(inpt)
-
-        torch.manual_seed(12)
-        scripted_output = tt(inpt)
-
-        assert_equal(scripted_output, expected_output)
 
 
 def import_transforms_from_references(reference):


### PR DESCRIPTION
Follow up to https://github.com/pytorch/vision/pull/7839#discussion_r1296858951.

Some questions that are up for discussion:

1. Since we have changed the random sampling in v2, we cannot easily compare the AA transforms to their v1 equivalent. It is doable, but leads to complicated monkeypatching / mocking, e.g.

   https://github.com/pytorch/vision/blob/fb115c2295b6bc2f2ed7689e1ace00f25d882777/test/test_transforms_v2_consistency.py#L729-L743

   IMO, it was a good thing that we implemented this thorough check when we were actively working on implementing the AA transforms for v2 to avoid accidental breakages. However, now that they are ported and checked, we can probably drop them. We do not guarantee BC for randomly sampled parameters and thus, these test offer little value. Worse they might break in the future if we change something about the random sampling.
2. The checks for the v1 transforms call the transform multiple times:

   - https://github.com/pytorch/vision/blob/fb115c2295b6bc2f2ed7689e1ace00f25d882777/test/test_transforms.py#L1570-L1571
   - https://github.com/pytorch/vision/blob/fb115c2295b6bc2f2ed7689e1ace00f25d882777/test/test_transforms_tensor.py#L590-L592

   I presume this is to get a better coverage of the randomly sampled ops. However, this also leads to quite long test times, e.g.

   ```bash
   ❯ time pytest test/test_transforms.py::test_augmix &> /dev/null
   pytest test/test_transforms.py::test_augmix &> /dev/null  1143,96s user 71,33s system 1156% cpu 1:45,11 total
   ```

   Since we have a frozen RNG seed, different parametrization will not increase coverage of the sampled ops. One option could be to reproducibly set the seed based on the parametrization, i.e. `seed = hash(("interpolation", InterpolationMode.NEAREST))`. Since we run multiple parametrizations for each transform, that should give us good coverage without the need to run the transform multiple times for each parametrization.

Thoughts?