### PR TITLE
allow len 1 sequences for fill with PIL

### DIFF
--- a/test/test_transforms_v2_refactored.py
+++ b/test/test_transforms_v2_refactored.py
@@ -2581,9 +2581,6 @@ class TestCrop:
             # 2. the fill parameter only has an affect if we need padding
             kwargs["size"] = [s + 4 for s in self.INPUT_SIZE]
 
-            if isinstance(input, PIL.Image.Image) and isinstance(value, (tuple, list)) and len(value) == 1:
-                pytest.xfail("F._pad_image_pil does not support sequences of length 1 for fill.")
-
             if isinstance(input, tv_tensors.Mask) and isinstance(value, (tuple, list)):
                 pytest.skip("F.pad_mask doesn't support non-scalar fill.")
 

--- a/torchvision/transforms/_functional_pil.py
+++ b/torchvision/transforms/_functional_pil.py
@@ -270,7 +270,7 @@ def _parse_fill(
             msg = "The number of elements in 'fill' does not match the number of channels of the image ({} != {})"
             raise ValueError(msg.format(len(fill), num_channels))
 
-        fill = tuple(fill)
+        fill = tuple(fill)  # type: ignore[arg-type]
 
     if img.mode != "F":
         if isinstance(fill, (list, tuple)):

--- a/torchvision/transforms/_functional_pil.py
+++ b/torchvision/transforms/_functional_pil.py
@@ -264,7 +264,9 @@ def _parse_fill(
     if isinstance(fill, (int, float)) and num_channels > 1:
         fill = tuple([fill] * num_channels)
     if isinstance(fill, (list, tuple)):
-        if len(fill) != num_channels:
+        if len(fill) == 1:
+            fill = fill * num_channels
+        elif len(fill) != num_channels:
             msg = "The number of elements in 'fill' does not match the number of channels of the image ({} != {})"
             raise ValueError(msg.format(len(fill), num_channels))
 


### PR DESCRIPTION
The length 1 sequences for `fill` were just a workaround back when JIT didn't support `Union`. Since PIL is not restricted by JIT, we never added support for it.

This means however, that for example `F.rotate(img_tensor, fill=[127])` works, while `F.rotate(img_pil, fill=[127])` doesn't.

That makes parametrized tests harder, e.g.

- https://github.com/pytorch/vision/blob/a3ba01a87e111ce6a33005db15e69931e3b5e126/test/transforms_v2_dispatcher_infos.py#L135-L138
- https://github.com/pytorch/vision/blob/a3ba01a87e111ce6a33005db15e69931e3b5e126/test/test_transforms_v2_refactored.py#L2584-L2585

This PR adds support for length 1 sequences of `fill` for the PIL backend. Note, that I've implemented the fix in v1, since all our v2 PIL ops with a `fill` parameter are thin wrappers around the v1 kernel. LMK if that is ok. Otherwise we can also do it in a more verbose way in v2.

cc @vfdev-5