### PR TITLE
Add missing model tracing step to cpp example readme, fixes #7952

### DIFF
--- a/examples/cpp/hello_world/README.rst
+++ b/examples/cpp/hello_world/README.rst
@@ -10,7 +10,7 @@ Once both dependencies are sorted, we can start the CMake fun:
 
 1) Create a ``build`` directory inside the current one.
 2) from within the ``build`` directory, run the following commands:
-    - ``python3 ../trace_model.py`` - To use a torchvision model in C++, you must first export it from the python version of torchvision. More information can be found on the corresponding documentation page (https://pytorch.org/tutorials/advanced/cpp_export.html#loading-a-torchscript-model-in-c)
+    - ``python ../trace_model.py`` To use a torchvision model in C++, you must first export it from the python version of torchvision. More information can be found on the corresponding `documentation page <https://pytorch.org/tutorials/advanced/cpp_export.html#loading-a-torchscript-model-in-c>`_.
     - | ``cmake -DCMAKE_PREFIX_PATH="<PATH_TO_LIBTORCH>;<PATH_TO_TORCHVISION>" ..``
       | where ``<PATH_TO_LIBTORCH>`` and ``<PATH_TO_TORCHVISION>`` are the paths to the libtorch and torchvision installations.
     - ``cmake --build .``

--- a/examples/cpp/hello_world/README.rst
+++ b/examples/cpp/hello_world/README.rst
@@ -10,6 +10,7 @@ Once both dependencies are sorted, we can start the CMake fun:
 
 1) Create a ``build`` directory inside the current one.
 2) from within the ``build`` directory, run the following commands:
+    - ``python3 ../trace_model.py`` (To use a torchvision model in C++, you must first export it from the python version of torchvision. More information can be found on [the corresponding documentation page](https://pytorch.org/tutorials/advanced/cpp_export.html#loading-a-torchscript-model-in-c))
     - | ``cmake -DCMAKE_PREFIX_PATH="<PATH_TO_LIBTORCH>;<PATH_TO_TORCHVISION>" ..``
       | where ``<PATH_TO_LIBTORCH>`` and ``<PATH_TO_TORCHVISION>`` are the paths to the libtorch and torchvision installations.
     - ``cmake --build .``

--- a/examples/cpp/hello_world/README.rst
+++ b/examples/cpp/hello_world/README.rst
@@ -10,7 +10,7 @@ Once both dependencies are sorted, we can start the CMake fun:
 
 1) Create a ``build`` directory inside the current one.
 2) from within the ``build`` directory, run the following commands:
-    - ``python3 ../trace_model.py`` (To use a torchvision model in C++, you must first export it from the python version of torchvision. More information can be found on [the corresponding documentation page](https://pytorch.org/tutorials/advanced/cpp_export.html#loading-a-torchscript-model-in-c))
+    - ``python3 ../trace_model.py`` - To use a torchvision model in C++, you must first export it from the python version of torchvision. More information can be found on the corresponding documentation page (https://pytorch.org/tutorials/advanced/cpp_export.html#loading-a-torchscript-model-in-c)
     - | ``cmake -DCMAKE_PREFIX_PATH="<PATH_TO_LIBTORCH>;<PATH_TO_TORCHVISION>" ..``
       | where ``<PATH_TO_LIBTORCH>`` and ``<PATH_TO_TORCHVISION>`` are the paths to the libtorch and torchvision installations.
     - ``cmake --build .``


### PR DESCRIPTION
<!-- Before submitting a PR, please make sure to check our contributing guidelines regarding code formatting, tests, and documentation: https://github.com/pytorch/vision/blob/main/CONTRIBUTING.md -->

When you follow [the instructions for building and running the c++ hello_world example project](https://github.com/pytorch/vision/blob/d84aaae1ccfae447b96b03d43793d97a11416431/examples/cpp/hello_world/README.rst), you will get the message error loading the model printed to the console.

This is because trace_model.py is never called, so the model file resnet18.pt is never created and also never copied over to the build folder where the compiled binary expects it to be.

In issue #7952, pmeier suggested that the tracing step shoud be added to the example projec's readme.md, which this PR does.