### PR TITLE
replace c10::stoi with std::stoi

### DIFF
--- a/torchvision/csrc/io/video/video.cpp
+++ b/torchvision/csrc/io/video/video.cpp
@@ -77,7 +77,7 @@ std::tuple<std::string, long> _parseStream(const std::string& streamString) {
   long index_ = -1;
   if (match[2].matched) {
     try {
-      index_ = c10::stoi(match[2].str());
+      index_ = std::stoi(match[2].str());
     } catch (const std::exception&) {
       TORCH_CHECK(
           false,


### PR DESCRIPTION
`c10::stoi` was removed in pytorch/pytorch#109179 in favor of `std::stoi`.

cc @cyyever