### PR TITLE
improve geometry image kernels to support 2d mask inputs

### DIFF
--- a/torchvision/transforms/v2/functional/_geometry.py
+++ b/torchvision/transforms/v2/functional/_geometry.py
@@ -221,7 +221,7 @@ def resize_image(
         output_shape = image.shape[:-3] + (num_channels, new_height, new_width)
     else:
         num_channels = 1
-        output_shape = [new_height, new_width]
+        output_shape = [new_height, new_width]  # type: ignore[assignment]
 
     numel = image.numel()
     if numel == 0:
@@ -561,7 +561,7 @@ def _apply_grid_transform(img: torch.Tensor, grid: torch.Tensor, mode: str, fill
     else:
         num_channels = 1
         input_height, input_width = input_shape
-        output_shape = [output_height, output_width]
+        output_shape = [output_height, output_width]  # type: ignore[assignment]
 
     if img.numel() == 0:
         return img.reshape(output_shape)
@@ -1170,7 +1170,7 @@ def _pad_with_scalar_fill(
         output_shape = image.shape[:-3] + (num_channels, new_height, new_width)
     else:
         num_channels = 1
-        output_shape = [new_height, new_width]
+        output_shape = [new_height, new_width]  # type: ignore[assignment]
 
     if image.numel() == 0:
         return image.reshape(output_shape)

--- a/torchvision/transforms/v2/functional/_geometry.py
+++ b/torchvision/transforms/v2/functional/_geometry.py
@@ -977,7 +977,6 @@ def rotate_image(
     output_width, output_height = (
         _compute_affine_output_size(matrix, input_width, input_height) if expand else (input_width, input_height)
     )
-
     dtype = image.dtype if torch.is_floating_point(image) else torch.float32
     theta = torch.tensor(matrix, dtype=dtype, device=image.device).reshape(1, 2, 3)
     grid = _affine_grid(

--- a/torchvision/transforms/v2/functional/_geometry.py
+++ b/torchvision/transforms/v2/functional/_geometry.py
@@ -227,54 +227,56 @@ def resize_image(
     if numel == 0:
         return image.reshape(output_shape)
 
-    image = image.reshape(-1, num_channels, old_height, old_width)
+    # FIXME: remove this before merge. This is just here to get a proper diff view
+    if True:
+        image = image.reshape(-1, num_channels, old_height, old_width)
 
-    dtype = image.dtype
-    acceptable_dtypes = [torch.float32, torch.float64]
-    if interpolation == InterpolationMode.NEAREST or interpolation == InterpolationMode.NEAREST_EXACT:
-        # uint8 dtype can be included for cpu and cuda input if nearest mode
-        acceptable_dtypes.append(torch.uint8)
-    elif image.device.type == "cpu":
-        # uint8 dtype support for bilinear and bicubic is limited to cpu and
-        # according to our benchmarks, non-AVX CPUs should still prefer u8->f32->interpolate->u8 path for bilinear
-        if (interpolation == InterpolationMode.BILINEAR and "AVX2" in torch.backends.cpu.get_cpu_capability()) or (
-            interpolation == InterpolationMode.BICUBIC
-        ):
+        dtype = image.dtype
+        acceptable_dtypes = [torch.float32, torch.float64]
+        if interpolation == InterpolationMode.NEAREST or interpolation == InterpolationMode.NEAREST_EXACT:
+            # uint8 dtype can be included for cpu and cuda input if nearest mode
             acceptable_dtypes.append(torch.uint8)
+        elif image.device.type == "cpu":
+            # uint8 dtype support for bilinear and bicubic is limited to cpu and
+            # according to our benchmarks, non-AVX CPUs should still prefer u8->f32->interpolate->u8 path for bilinear
+            if (interpolation == InterpolationMode.BILINEAR and "AVX2" in torch.backends.cpu.get_cpu_capability()) or (
+                interpolation == InterpolationMode.BICUBIC
+            ):
+                acceptable_dtypes.append(torch.uint8)
 
-    strides = image.stride()
-    if image.is_contiguous(memory_format=torch.channels_last) and image.shape[0] == 1 and numel != strides[0]:
-        # There is a weird behaviour in torch core where the output tensor of `interpolate()` can be allocated as
-        # contiguous even though the input is un-ambiguously channels_last (https://github.com/pytorch/pytorch/issues/68430).
-        # In particular this happens for the typical torchvision use-case of single CHW images where we fake the batch dim
-        # to become 1CHW. Below, we restride those tensors to trick torch core into properly allocating the output as
-        # channels_last, thus preserving the memory format of the input. This is not just for format consistency:
-        # for uint8 bilinear images, this also avoids an extra copy (re-packing) of the output and saves time.
-        # TODO: when https://github.com/pytorch/pytorch/issues/68430 is fixed (possibly by https://github.com/pytorch/pytorch/pull/100373),
-        # we should be able to remove this hack.
-        new_strides = list(strides)
-        new_strides[0] = numel
-        image = image.as_strided((1, num_channels, old_height, old_width), new_strides)
+        strides = image.stride()
+        if image.is_contiguous(memory_format=torch.channels_last) and image.shape[0] == 1 and numel != strides[0]:
+            # There is a weird behaviour in torch core where the output tensor of `interpolate()` can be allocated as
+            # contiguous even though the input is un-ambiguously channels_last (https://github.com/pytorch/pytorch/issues/68430).
+            # In particular this happens for the typical torchvision use-case of single CHW images where we fake the batch dim
+            # to become 1CHW. Below, we restride those tensors to trick torch core into properly allocating the output as
+            # channels_last, thus preserving the memory format of the input. This is not just for format consistency:
+            # for uint8 bilinear images, this also avoids an extra copy (re-packing) of the output and saves time.
+            # TODO: when https://github.com/pytorch/pytorch/issues/68430 is fixed (possibly by https://github.com/pytorch/pytorch/pull/100373),
+            # we should be able to remove this hack.
+            new_strides = list(strides)
+            new_strides[0] = numel
+            image = image.as_strided((1, num_channels, old_height, old_width), new_strides)
 
-    need_cast = dtype not in acceptable_dtypes
-    if need_cast:
-        image = image.to(dtype=torch.float32)
+        need_cast = dtype not in acceptable_dtypes
+        if need_cast:
+            image = image.to(dtype=torch.float32)
 
-    image = interpolate(
-        image,
-        size=[new_height, new_width],
-        mode=interpolation.value,
-        align_corners=align_corners,
-        antialias=antialias,
-    )
+        image = interpolate(
+            image,
+            size=[new_height, new_width],
+            mode=interpolation.value,
+            align_corners=align_corners,
+            antialias=antialias,
+        )
 
-    if need_cast:
-        if interpolation == InterpolationMode.BICUBIC and dtype == torch.uint8:
-            # This path is hit on non-AVX archs, or on GPU.
-            image = image.clamp_(min=0, max=255)
-        if dtype in (torch.uint8, torch.int8, torch.int16, torch.int32, torch.int64):
-            image = image.round_()
-        image = image.to(dtype=dtype)
+        if need_cast:
+            if interpolation == InterpolationMode.BICUBIC and dtype == torch.uint8:
+                # This path is hit on non-AVX archs, or on GPU.
+                image = image.clamp_(min=0, max=255)
+            if dtype in (torch.uint8, torch.int8, torch.int16, torch.int32, torch.int64):
+                image = image.round_()
+            image = image.to(dtype=dtype)
 
     return image.reshape(output_shape)
 

--- a/torchvision/transforms/v2/functional/_geometry.py
+++ b/torchvision/transforms/v2/functional/_geometry.py
@@ -974,21 +974,25 @@ def rotate_image(
     # we need to set -angle.
     matrix = _get_inverse_affine_matrix(center_f, -angle, [0.0, 0.0], 1.0, [0.0, 0.0])
 
-    _assert_grid_transform_inputs(image, matrix, interpolation.value, fill, ["nearest", "bilinear"])
+    # FIXME: revert before merge
+    if True:
+        _assert_grid_transform_inputs(image, matrix, interpolation.value, fill, ["nearest", "bilinear"])
 
-    output_width, output_height = (
-        _compute_affine_output_size(matrix, input_width, input_height) if expand else (input_width, input_height)
-    )
-    dtype = image.dtype if torch.is_floating_point(image) else torch.float32
-    theta = torch.tensor(matrix, dtype=dtype, device=image.device).reshape(1, 2, 3)
-    grid = _affine_grid(
-        theta,
-        input_width=input_width,
-        input_height=input_height,
-        output_width=output_width,
-        output_height=output_height,
-    )
-    return _apply_grid_transform(image, grid, interpolation.value, fill=fill)
+        output_width, output_height = (
+            _compute_affine_output_size(matrix, input_width, input_height) if expand else (input_width, input_height)
+        )
+        dtype = image.dtype if torch.is_floating_point(image) else torch.float32
+        theta = torch.tensor(matrix, dtype=dtype, device=image.device).reshape(1, 2, 3)
+        grid = _affine_grid(
+            theta,
+            input_width=input_width,
+            input_height=input_height,
+            output_width=output_width,
+            output_height=output_height,
+        )
+        output = _apply_grid_transform(image, grid, interpolation.value, fill=fill)
+
+    return output
 
 
 @_register_kernel_internal(rotate, PIL.Image.Image)


### PR DESCRIPTION
In #6574, we realized that we can have 2d segmentation masks, i.e. `(H, W)`, and thus we cannot simply call the image kernel in case that accesses the number of channels, i.e. `C` in `C, H, W`. As a workaround we added (un-)squeezing logic to the mask kernels, e.g.

https://github.com/pytorch/vision/blob/4af683107f967d4d435be4180020989dd8c3019c/torchvision/transforms/v2/functional/_geometry.py#L307-L319

Since our kernels support arbitrary batch sizes, but the PyTorch kernels we call internally often require 4D inputs, we have additional reshaping logic inside the image kernels, e.g.

https://github.com/pytorch/vision/blob/4af683107f967d4d435be4180020989dd8c3019c/torchvision/transforms/v2/functional/_geometry.py#L221

However, this alone is not sufficient. 3d detection masks, i.e. `(N, H, W)`, can have `N==0`. This might for example happen after `SanitizeBoundingBoxes`. For that case our image kernels have additional checks, e.g.

https://github.com/pytorch/vision/blob/4af683107f967d4d435be4180020989dd8c3019c/torchvision/transforms/v2/functional/_geometry.py#L220

This PR simplifies this by merging all this logic inside the image kernel.

cc @vfdev-5