### PR TITLE
exclude onnxruntime==1.16.0 in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -124,7 +124,7 @@ jobs:
         conda activate ci
         
         echo '::group::Install ONNX'
-        pip install --progress-bar=off onnx onnxruntime
+        pip install --progress-bar=off onnx onnxruntime!=1.16.0
         echo '::endgroup::'
         
         echo '::group::Install testing utilities'


### PR DESCRIPTION
Acts on https://github.com/pytorch/vision/issues/7980#issuecomment-1729260734.

cc @neginraoof @justinchuby @seemethere