### PR TITLE
Update InferenceSession call to latest format

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -124,7 +124,7 @@ jobs:
         conda activate ci
         
         echo '::group::Install ONNX'
-        pip install --progress-bar=off onnx onnxruntime!=1.16.0
+        pip install --progress-bar=off onnx onnxruntime
         echo '::endgroup::'
         
         echo '::group::Install testing utilities'

--- a/test/test_onnx.py
+++ b/test/test_onnx.py
@@ -79,8 +79,7 @@ class TestONNXExporter:
         inputs = list(map(to_numpy, inputs))
         outputs = list(map(to_numpy, outputs))
 
-        ort_session = onnxruntime.InferenceSession(onnx_io.getvalue(),
-                                                   providers=onnxruntime.get_available_providers())
+        ort_session = onnxruntime.InferenceSession(onnx_io.getvalue(), providers=onnxruntime.get_available_providers())
         # compute onnxruntime output prediction
         ort_inputs = {ort_session.get_inputs()[i].name: inpt for i, inpt in enumerate(inputs)}
         ort_outs = ort_session.run(None, ort_inputs)

--- a/test/test_onnx.py
+++ b/test/test_onnx.py
@@ -79,7 +79,8 @@ class TestONNXExporter:
         inputs = list(map(to_numpy, inputs))
         outputs = list(map(to_numpy, outputs))
 
-        ort_session = onnxruntime.InferenceSession(onnx_io.getvalue())
+        ort_session = onnxruntime.InferenceSession(onnx_io.getvalue(),
+                                                   providers=onnxruntime.get_available_providers())
         # compute onnxruntime output prediction
         ort_inputs = {ort_session.get_inputs()[i].name: inpt for i, inpt in enumerate(inputs)}
         ort_outs = ort_session.run(None, ort_inputs)


### PR DESCRIPTION
Fixes: #7980 
Reverts: #7981

The actual fix is a simple update call convention for onnxruntime. No need to skip latest ORT version

@vfdev-5 @seemethere @pmeier 

cc @pmeier @neginraoof @justinchuby