### PR TITLE
add smoke test for prototype namespace on release versions

### DIFF
--- a/test/smoke_test.py
+++ b/test/smoke_test.py
@@ -1,5 +1,6 @@
 """Run smoke tests"""
 
+import re
 import sys
 from pathlib import Path
 
@@ -78,6 +79,18 @@ def smoke_test_torchvision_resnet50_classify(device: str = "cpu") -> None:
 def main() -> None:
     print(f"torchvision: {torchvision.__version__}")
     print(f"torch.cuda.is_available: {torch.cuda.is_available()}")
+
+    if re.match(r"\d+\.\d+\.\d+(?!a0)", torchvision.__version__):
+        try:
+            import torchvision.prototype as _
+        except ModuleNotFoundError:
+            pass
+        else:
+            raise AssertionError(
+                "torchvision.prototype available on a release version. "
+                "Run\n\n"
+                "rm -rf torchvision/prototype test/test_prototype* .github/workflows/prototype*"
+            )
 
     # Turn 1.11.0aHASH into 1.11 (major.minor only)
     version = ".".join(torchvision.__version__.split(".")[:2])


### PR DESCRIPTION
We use our version format as indicator for a release branch. On `main` we have

https://github.com/pytorch/vision/blob/997384cf7276303725265ab1401bf2297ca54446/version.txt#L1

while on a release branch this is

https://github.com/pytorch/vision/blob/fbb4cc54ed521ba912f50f180dc16a213775bf5c/version.txt#L1

Meaning, we only run the check if we find a `a0` after the regular semantic versioning.

This should prevent #7983 in the future.