### PR TITLE
allow size to be generic Sequence

### DIFF
--- a/test/test_transforms_v2_refactored.py
+++ b/test/test_transforms_v2_refactored.py
@@ -699,7 +699,7 @@ class TestResize:
         assert_equal(actual, expected)
 
     def test_transform_unknown_size_error(self):
-        with pytest.raises(ValueError, match="size can either be an integer or a list or tuple of one or two integers"):
+        with pytest.raises(ValueError, match="size can either be an integer or a sequence of one or two integers"):
             transforms.Resize(size=object())
 
     @pytest.mark.parametrize(

--- a/torchvision/transforms/v2/_geometry.py
+++ b/torchvision/transforms/v2/_geometry.py
@@ -139,7 +139,7 @@ class Resize(Transform):
             size = list(size)
         else:
             raise ValueError(
-                f"size can either be an integer or a list or tuple of one or two integers, " f"but got {size} instead."
+                f"size can either be an integer or a sequence of one or two integers, but got {size} instead."
             )
         self.size = size
 

--- a/torchvision/transforms/v2/_geometry.py
+++ b/torchvision/transforms/v2/_geometry.py
@@ -135,7 +135,7 @@ class Resize(Transform):
 
         if isinstance(size, int):
             size = [size]
-        elif isinstance(size, (list, tuple)) and len(size) in {1, 2}:
+        elif isinstance(size, (list, tuple, Sequence)) and len(size) in {1, 2}:
             size = list(size)
         else:
             raise ValueError(

--- a/torchvision/transforms/v2/_geometry.py
+++ b/torchvision/transforms/v2/_geometry.py
@@ -135,7 +135,7 @@ class Resize(Transform):
 
         if isinstance(size, int):
             size = [size]
-        elif isinstance(size, (list, tuple, Sequence)) and len(size) in {1, 2}:
+        elif isinstance(size, Sequence) and len(size) in {1, 2}:
             size = list(size)
         else:
             raise ValueError(


### PR DESCRIPTION
For example, when we pass a `size` arg in a config created by omegaconf, only allowing `list, tuple` will raise an error.

<!-- Before submitting a PR, please make sure to check our contributing guidelines regarding code formatting, tests, and documentation: https://github.com/pytorch/vision/blob/main/CONTRIBUTING.md -->
