### PR TITLE
add ffmpeg version pin to video backend in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Torchvision currently supports the following video backends:
   conflicting version of ffmpeg installed. Currently, this is only supported on Linux.
 
 ```
-conda install -c conda-forge ffmpeg
+conda install -c conda-forge 'ffmpeg<4.3'
 python setup.py install
 ```
 


### PR DESCRIPTION
We are currently stuck on `ffmpeg<4.3`:

https://github.com/pytorch/vision/blob/1a9ff0d728787df66a372283328158879805dcad/.github/scripts/setup-env.sh#L44

See #7296.
