### PR TITLE
Fixes documentation typo from semantic segmentation reference

### DIFF
--- a/references/segmentation/README.md
+++ b/references/segmentation/README.md
@@ -1,7 +1,7 @@
 # Semantic segmentation reference training scripts
 
 This folder contains reference training scripts for semantic segmentation.
-They serve as a log of how to train specific models, as provide baseline
+They serve as a log of how to train specific models and provide baseline
 training and evaluation scripts to quickly bootstrap research.
 
 All models have been trained on 8x V100 GPUs.


### PR DESCRIPTION
<!-- Before submitting a PR, please make sure to check our contributing guidelines regarding code formatting, tests, and documentation: https://github.com/pytorch/vision/blob/main/CONTRIBUTING.md -->

Was checking out segmentation reference training scripts and this line had a typo.