### PR TITLE
Put pytestmark at top of file

### DIFF
--- a/test/test_transforms_v2.py
+++ b/test/test_transforms_v2.py
@@ -52,6 +52,10 @@ from torchvision.transforms.v2.functional._geometry import _get_perspective_coef
 from torchvision.transforms.v2.functional._utils import _get_kernel, _register_kernel_internal
 
 
+# turns all warnings into errors for this module
+pytestmark = pytest.mark.filterwarnings("error")
+
+
 @pytest.fixture(autouse=True)
 def fix_rng_seed():
     set_rng_seed(0)
@@ -537,10 +541,6 @@ def reference_affine_bounding_boxes_helper(bounding_boxes, *, affine_matrix, new
         format=format,
         canvas_size=canvas_size,
     )
-
-
-# turns all warnings into errors for this module
-pytestmark = pytest.mark.filterwarnings("error")
 
 
 class TestResize:


### PR DESCRIPTION
Right now it's hidden in the middle of the file and it's hard to find

cc @vfdev-5 @pmeier