### PR TITLE
[ROCm] remove HCC references

### DIFF
--- a/torchvision/csrc/ops/cuda/deform_conv2d_kernel.cu
+++ b/torchvision/csrc/ops/cuda/deform_conv2d_kernel.cu
@@ -82,7 +82,7 @@ namespace {
 const int kMaxParallelImgs = 32;
 
 inline unsigned int GET_THREADS() {
-#ifdef __HIP_PLATFORM_HCC__
+#ifdef WITH_HIP
   return 256;
 #endif
   return 512;


### PR DESCRIPTION
rename `__HIP_PLATFORM_HCC__` to `WITH_ROCM`.

This symbol has had a long deprecation cycle and will finally be removed in ROCm 6.0. The WITH_ROCM preprocessor symbol was already defined by setup.py, so choosing to use it here instead to indicate the same thing.


cc @jithunnair-amd