### PR TITLE
Remove unnecessary dependency from macOS/Conda binaries

### DIFF
--- a/packaging/torchvision/meta.yaml
+++ b/packaging/torchvision/meta.yaml
@@ -11,8 +11,7 @@ requirements:
     - {{ compiler('c') }} # [win]
     - libpng
     - libjpeg-turbo
-    # NOTE: The only ffmpeg version that we build is actually 4.2
-    - ffmpeg >=4.2  # [not win]
+    - pytorch::ffmpeg >=4.2  # [linux]
 
   host:
     - python
@@ -27,7 +26,7 @@ requirements:
     - numpy >=1.23.5 # [py >= 311]
     - requests
     - libpng
-    - ffmpeg >=4.2  # [not win]
+    - ffmpeg >=4.2  # [linux]
     - libjpeg-turbo
     - pillow >=5.3.0, !=8.3.*
     - pytorch-mutex 1.0 {{ build_variant }}  # [not osx ]

--- a/packaging/torchvision/meta.yaml
+++ b/packaging/torchvision/meta.yaml
@@ -11,7 +11,7 @@ requirements:
     - {{ compiler('c') }} # [win]
     - libpng
     - libjpeg-turbo
-    - pytorch::ffmpeg >=4.2  # [linux]
+    - ffmpeg >=4.2  # [linux]
 
   host:
     - python


### PR DESCRIPTION
This commit updates the dependency description on Conda package,
so that FFmpeg is installed only on platforms on which torchvision comes with the corresponding extension.

- Currently, FFmpeg integration is enabled only for Linux.

https://github.com/pytorch/vision/blob/a8ebd0b3e69407e06ad4e8a4f2ade5147dda6628/setup.py#L366-L367

- For binary packaging, even for Linux, it is excluded in wheel. (due to the lack of build-time dependency in CI)

https://github.com/pytorch/vision/actions/runs/6678010959/job/18148611653#step:14:106

- The Linux/Conda package is still built with FFmpeg after this commit

https://github.com/pytorch/vision/actions/runs/6695315792/job/18190638421?pr=8077#step:9:199

