### PR TITLE
Revert "[ROCm] remove HCC references (#8070)"

### DIFF
--- a/torchvision/csrc/ops/cuda/deform_conv2d_kernel.cu
+++ b/torchvision/csrc/ops/cuda/deform_conv2d_kernel.cu
@@ -82,7 +82,7 @@ namespace {
 const int kMaxParallelImgs = 32;
 
 inline unsigned int GET_THREADS() {
-#ifdef WITH_HIP
+#ifdef __HIP_PLATFORM_HCC__
   return 256;
 #endif
   return 512;


### PR DESCRIPTION
This reverts commit a63f98add5d67f85a5eac6ede8ca850d3b2bbfd3.

Let's  see if it changes anything to https://github.com/pytorch/vision/issues/8079

cc @jeffdaily @jithunnair-amd