### PR TITLE
temporarily add packaging as CI requirement

### DIFF
--- a/.github/scripts/setup-env.sh
+++ b/.github/scripts/setup-env.sh
@@ -45,6 +45,8 @@ conda create \
 conda activate ci
 conda install --quiet --yes libjpeg-turbo -c pytorch
 pip install --progress-bar=off --upgrade setuptools
+# FIXME: remove this when https://github.com/pytorch/pytorch/pull/113154 is resolved
+pip install --progress-bar=off packaging
 
 # See https://github.com/pytorch/vision/issues/6790
 if [[ "${PYTHON_VERSION}" != "3.11" ]]; then


### PR DESCRIPTION
This can be reverted when pytorch/pytorch#113154 is merged or the underlying issue is fixed upstream.

cc @seemethere