### PR TITLE
Remove limitation for torch.compile and python 3.11

### DIFF
--- a/test/smoke_test.py
+++ b/test/smoke_test.py
@@ -44,8 +44,6 @@ def smoke_test_compile() -> None:
     except RuntimeError:
         if sys.platform == "win32":
             print("Successfully caught torch.compile RuntimeError on win")
-        elif sys.version_info >= (3, 11, 0):
-            print("Successfully caught torch.compile RuntimeError on Python 3.11")
         else:
             raise
 


### PR DESCRIPTION
Since 2.1.0 we no longer have this limitation. Hence no reason to keep it in the test.
