### PR TITLE
Added a flag 'process_exif: bool = False' to 'read_image'

### DIFF
--- a/torchvision/io/image.py
+++ b/torchvision/io/image.py
@@ -3,11 +3,11 @@ from warnings import warn
 
 import torch
 
-from ..extension import _load_library
-from ..utils import _log_api_usage_once
-
 from PIL import Image
 from PIL.ExifTags import TAGS
+
+from ..extension import _load_library
+from ..utils import _log_api_usage_once
 
 try:
     _load_library("image")
@@ -267,11 +267,11 @@ def read_image(path: str, mode: ImageReadMode = ImageReadMode.UNCHANGED, process
 def process_exif_metadata(image_path):
     try:
         with Image.open(image_path) as img:
-            if hasattr(img, '_getexif'):
+            if hasattr(img, "_getexif"):
                 exif_data = img._getexif()
                 if exif_data:
-                    img_width = exif_data.get(256)  
-                    img_height = exif_data.get(257)  
+                    img_width = exif_data.get(256)
+                    img_height = exif_data.get(257)
                     if img_width is not None and img_height is not None:
                         print(f"Image Dimensions: Width={img_width}, Height={img_height}")
                     else:

--- a/torchvision/io/image.py
+++ b/torchvision/io/image.py
@@ -237,7 +237,7 @@ def decode_image(input: torch.Tensor, mode: ImageReadMode = ImageReadMode.UNCHAN
     return output
 
 
-def read_image(path: str, mode: ImageReadMode = ImageReadMode.UNCHANGED) -> torch.Tensor:
+def read_image(path: str, mode: ImageReadMode = ImageReadMode.UNCHANGED, process_exif: bool = False) -> torch.Tensor:
     """
     Reads a JPEG or PNG image into a 3 dimensional RGB or grayscale Tensor.
     Optionally converts the image to the desired format.
@@ -249,6 +249,7 @@ def read_image(path: str, mode: ImageReadMode = ImageReadMode.UNCHANGED) -> torc
             Default: ``ImageReadMode.UNCHANGED``.
             See ``ImageReadMode`` class for more information on various
             available modes.
+        process_exif(bool): Process the EXIF data of the image or not. Default: False
 
     Returns:
         output (Tensor[image_channels, image_height, image_width])


### PR DESCRIPTION

## Description

This pull request addresses issue #7977  by introducing a new feature to read and display EXIF metadata from images using the PyTorch Vision library.

- Solves Issue #7977 

## Changes Made

- I didn't know if Torch had any way to read the image's EXIF information, so I used `PIL` to do that
- I added a bool `process_exif`and set it's default value to `False`. 
- If it is set to `True`, then the user can see the EXIF details of the image, and that is present in the function `process_exif_metadata`.
- In the description of the function, I added what `process_exif` does.
- I have formatted the code using `ufmt`

## Reviewers

cc @pmeier  @NicolasHug 

## P.S. 
Sorry if this PR is written unprofessionally, and I didn't know if I had to add unit-tests for it, so I haven't added them here.

