### PR TITLE
Fix import torchvision after https://github.com/pytorch/pytorch/pull/113182

### DIFF
--- a/torchvision/_meta_registrations.py
+++ b/torchvision/_meta_registrations.py
@@ -1,7 +1,6 @@
 import functools
 
 import torch
-import torch._custom_ops
 import torch.library
 
 # Ensure that torch.ops.torchvision is visible
@@ -160,7 +159,7 @@ def meta_ps_roi_pool_backward(
     return grad.new_empty((batch_size, channels, height, width))
 
 
-@torch._custom_ops.impl_abstract("torchvision::nms")
+@torch.library.impl_abstract("torchvision::nms")
 def meta_nms(dets, scores, iou_threshold):
     torch._check(dets.dim() == 2, lambda: f"boxes should be a 2d tensor, got {dets.dim()}D")
     torch._check(dets.size(1) == 4, lambda: f"boxes should have 4 elements in dimension 1, got {dets.size(1)}")
@@ -169,7 +168,7 @@ def meta_nms(dets, scores, iou_threshold):
         dets.size(0) == scores.size(0),
         lambda: f"boxes and scores should have same number of elements in dimension 0, got {dets.size(0)} and {scores.size(0)}",
     )
-    ctx = torch._custom_ops.get_ctx()
+    ctx = torch.library.get_ctx()
     num_to_keep = ctx.create_unbacked_symint()
     return dets.new_empty(num_to_keep, dtype=torch.long)
 


### PR DESCRIPTION
Fixes https://github.com/pytorch/vision/issues/8101

After https://github.com/pytorch/pytorch/pull/113182, if I build torch and torchvision from source, I end up with the following error `RuntimeError: operator torchvision::nms does not exist` as described in https://github.com/pytorch/vision/issues/8101

It's a puzzle on why nightly builds work though, but at least this updates vision to uses the correct syntax as used in https://github.com/pytorch/pytorch/pull/113182

### Testing
Build torch and torchvision locally from the latest main commits, `import torchvison` successfully.  The issue can also be reproduced on this WIP PR https://github.com/pytorch/pytorch/actions/runs/6832974336/job/18584450379#step:16:5329