### PR TITLE
Fixed mypy issue in VideoClips

### DIFF
--- a/torchvision/datasets/video_utils.py
+++ b/torchvision/datasets/video_utils.py
@@ -136,7 +136,7 @@ class VideoClips:
 
     def _compute_frame_pts(self) -> None:
         self.video_pts = []
-        self.video_fps = []
+        self.video_fps: List[int] = []
 
         # strategy: use a DataLoader to parallelize read_video_timestamps
         # so need to create a dummy dataset first


### PR DESCRIPTION
Fixing CI error: https://github.com/pytorch/vision/actions/runs/6826668235/job/18620326828?pr=8110
```
  torchvision/datasets/video_utils.py:139: error: Need type annotation for
  "video_fps" (hint: "video_fps: List[<type>] = ...")  [var-annotated]
              self.video_fps = []
              ^~~~~~~~~~~~~~
  Found 1 error in 1 file (checked 236 source files)
```