### PR TITLE
install packaging as part of the regular dev requirements

### DIFF
--- a/.github/scripts/setup-env.sh
+++ b/.github/scripts/setup-env.sh
@@ -44,9 +44,7 @@ conda create \
   'ffmpeg<4.3'
 conda activate ci
 conda install --quiet --yes libjpeg-turbo -c pytorch
-pip install --progress-bar=off --upgrade setuptools
-# FIXME: remove this when https://github.com/pytorch/pytorch/pull/113154 is resolved
-pip install --progress-bar=off packaging
+pip install --progress-bar=off --upgrade setuptools packaging
 
 # See https://github.com/pytorch/vision/issues/6790
 if [[ "${PYTHON_VERSION}" != "3.11" ]]; then


### PR DESCRIPTION
This addresses #8100. The offending PR was reverted: The offending PR was reverted: https://github.com/pytorch/pytorch/pull/113023#issuecomment-1802723128. However, one of `pkg_resources` (deprecated package that comes with `setuptools`) or `packaging` is still required: https://github.com/pytorch/pytorch/blame/a1e3c501652101e8b37baac62216db7ca22c9923/torch/torch_version.py#L22-L29

Thus, let's just install `packaging` as part of the regular dev requirements to avoid the warning.