### PR TITLE
Add missing bracket

### DIFF
--- a/torchvision/transforms/v2/_color.py
+++ b/torchvision/transforms/v2/_color.py
@@ -178,7 +178,7 @@ class RandomPhotometricDistort(Transform):
     Args:
         brightness (tuple of float (min, max), optional): How much to jitter brightness.
             brightness_factor is chosen uniformly from [min, max]. Should be non negative numbers.
-        contrast tuple of float (min, max), optional): How much to jitter contrast.
+        contrast (tuple of float (min, max), optional): How much to jitter contrast.
             contrast_factor is chosen uniformly from [min, max]. Should be non-negative numbers.
         saturation (tuple of float (min, max), optional): How much to jitter saturation.
             saturation_factor is chosen uniformly from [min, max]. Should be non negative numbers.


### PR DESCRIPTION
I've added a missing bracket to the docstring.

However, I was actually looking for the docs for [this page](https://pytorch.org/vision/stable/generated/torchvision.transforms.v2.RandomPhotometricDistort.html#torchvision.transforms.v2.RandomPhotometricDistort), where it says in the parameters:
`float (contrast tuple of) – How much to jitter contrast. contrast_factor is chosen uniformly from [min, max]. Should be non-negative numbers.`
Obviously, there has been a mix-up.

I haven't been able to find the source for that page, maybe someone here knows how (or rather, where) to fix that.