### PR TITLE
Making root parameter optional for Vision Dataset

### DIFF
--- a/torchvision/datasets/vision.py
+++ b/torchvision/datasets/vision.py
@@ -12,7 +12,7 @@ class VisionDataset(data.Dataset):
     It is necessary to override the ``__getitem__`` and ``__len__`` method.
 
     Args:
-        root (string): Root directory of dataset.
+        root (string, optional): Root directory of dataset.
         transforms (callable, optional): A function/transforms that takes in
             an image and a label and returns the transformed versions of both.
         transform (callable, optional): A function/transform that  takes in an PIL image
@@ -29,7 +29,7 @@ class VisionDataset(data.Dataset):
 
     def __init__(
         self,
-        root: str,
+        root: Optional[str] = None,
         transforms: Optional[Callable] = None,
         transform: Optional[Callable] = None,
         target_transform: Optional[Callable] = None,


### PR DESCRIPTION
This resolves #8123 while maintaining backward compatibility