### PR TITLE
fix error test for F.pad_mask

### DIFF
--- a/test/test_transforms_v2.py
+++ b/test/test_transforms_v2.py
@@ -3641,7 +3641,7 @@ class TestPad:
     @pytest.mark.parametrize("fill", [[1], (0,), [1, 0, 1], (0, 1, 0)])
     def test_kernel_mask_errors(self, fill):
         with pytest.raises(ValueError, match="Non-scalar fill value is not supported"):
-            check_kernel(F.pad_mask, make_segmentation_mask(), padding=[1], fill=fill)
+            F.pad_mask(make_segmentation_mask(), padding=[1], fill=fill)
 
     def test_kernel_video(self):
         check_kernel(F.pad_video, make_video(), padding=[1])


### PR DESCRIPTION
Spotted in #8127 / https://github.com/pytorch/vision/actions/runs/6971354622/attempts/1#summary-18971247416, because it failed to `torch.compile` test.

Since we only want to trigger the error and we have checked the kernel above already, we can just call it directly here.

cc @vfdev-5