### PR TITLE
fix atol in resize_image kernel test

### DIFF
--- a/test/test_transforms_v2.py
+++ b/test/test_transforms_v2.py
@@ -599,7 +599,7 @@ class TestResize:
 
         # In contrast to CPU, there is no native `InterpolationMode.BICUBIC` implementation for uint8 images on CUDA.
         # Internally, it uses the float path. Thus, we need to test with an enormous tolerance here to account for that.
-        atol = 30 if transforms.InterpolationMode.BICUBIC and dtype is torch.uint8 else 1
+        atol = 30 if (interpolation is transforms.InterpolationMode.BICUBIC and dtype is torch.uint8) else 1
         check_cuda_vs_cpu_tolerances = dict(rtol=0, atol=atol / 255 if dtype.is_floating_point else atol)
 
         check_kernel(


### PR DESCRIPTION
Since `assert bool(transforms.InterpolationMode.BICUBIC)` without this PR we are testing all interpolation modes against `atol=30` although we want `atol=1` for all modes besides bicubic.


cc @vfdev-5