### PR TITLE
remove redundant typing casts

### DIFF
--- a/torchvision/prototype/tv_tensors/_label.py
+++ b/torchvision/prototype/tv_tensors/_label.py
@@ -48,7 +48,7 @@ class Label(_LabelBase):
         if self.categories is None:
             raise RuntimeError("Label does not have categories")
 
-        return tree_map(lambda idx: self.categories[idx], self.tolist())
+        return tree_map(lambda idx: self.categories[idx], self.tolist())  # type: ignore[index]
 
 
 class OneHotLabel(_LabelBase):

--- a/torchvision/transforms/v2/_geometry.py
+++ b/torchvision/transforms/v2/_geometry.py
@@ -1,7 +1,7 @@
 import math
 import numbers
 import warnings
-from typing import Any, Callable, cast, Dict, List, Literal, Optional, Sequence, Tuple, Type, Union
+from typing import Any, Callable, Dict, List, Literal, Optional, Sequence, Tuple, Type, Union
 
 import PIL.Image
 import torch
@@ -241,10 +241,8 @@ class RandomResizedCrop(Transform):
 
         if not isinstance(scale, Sequence):
             raise TypeError("Scale should be a sequence")
-        scale = cast(Tuple[float, float], scale)
         if not isinstance(ratio, Sequence):
             raise TypeError("Ratio should be a sequence")
-        ratio = cast(Tuple[float, float], ratio)
         if (scale[0] > scale[1]) or (ratio[0] > ratio[1]):
             warnings.warn("Scale and ratio should be of kind (min, max)")
 


### PR DESCRIPTION
They are no longer needed as of `mypy==1.7.1`. First failure on `main`: https://github.com/pytorch/vision/actions/runs/6973442404/job/18977451632. On the PR (#8134) we still installed `mypy==1.7.0` and thus this was not visible: https://github.com/pytorch/vision/actions/runs/6972043770/job/18973409450?pr=8134.