### PR TITLE
Avoid segfault in VideoClip test

### DIFF
--- a/test/test_datasets_video_utils.py
+++ b/test/test_datasets_video_utils.py
@@ -60,7 +60,7 @@ class TestVideo:
         video_list = get_list_of_videos(tmpdir, num_videos=3, sizes=[12, 12, 12], fps=[3, 4, 6])
         num_frames = 4
         for fps in [1, 3, 4, 10]:
-            video_clips = VideoClips(video_list, num_frames, num_frames, fps, num_workers=2)
+            video_clips = VideoClips(video_list, num_frames, num_frames, fps)
             for i in range(video_clips.num_clips()):
                 video, audio, info, video_idx = video_clips.get_clip(i)
                 assert video.shape[0] == num_frames


### PR DESCRIPTION
Closes https://github.com/pytorch/vision/issues/8147

I couldn't trace the problem back to a change in the `DataLoader` from torch core.

Considering:

- this popped randomly (without an obvious upstream change)
- this only happens on 3.8
- this only happens when `num_workers > 0`
- `num_workers>0` works fine in `test_video_clips()`

*If* there's an actual legit issue/bug somewhere, it's unlikely that it comes  directly from torchvision. I'm just going to set `num_workers=0` here to silence the issue. 