### PR TITLE
Explicitly ignore all video decoding tests

### DIFF
--- a/.github/scripts/setup-env.sh
+++ b/.github/scripts/setup-env.sh
@@ -46,6 +46,11 @@ conda activate ci
 conda install --quiet --yes libjpeg-turbo -c pytorch
 pip install --progress-bar=off --upgrade setuptools
 
+# See https://github.com/pytorch/vision/issues/6790
+if [[ "${PYTHON_VERSION}" != "3.11" ]]; then
+  pip install --progress-bar=off av!=10.0.0
+fi
+
 echo '::endgroup::'
 
 if [[ "${OS_TYPE}" == windows && "${GPU_ARCH_TYPE}" == cuda ]]; then

--- a/.github/scripts/setup-env.sh
+++ b/.github/scripts/setup-env.sh
@@ -46,11 +46,6 @@ conda activate ci
 conda install --quiet --yes libjpeg-turbo -c pytorch
 pip install --progress-bar=off --upgrade setuptools
 
-# See https://github.com/pytorch/vision/issues/6790
-if [[ "${PYTHON_VERSION}" != "3.11" ]]; then
-  pip install --progress-bar=off av!=10.0.0
-fi
-
 echo '::endgroup::'
 
 if [[ "${OS_TYPE}" == windows && "${GPU_ARCH_TYPE}" == cuda ]]; then

--- a/.github/scripts/unittest.sh
+++ b/.github/scripts/unittest.sh
@@ -13,4 +13,5 @@ echo '::endgroup::'
 
 python test/smoke_test.py
 
+# We explicitly ignore the video tests until we resolve https://github.com/pytorch/vision/issues/8162
 pytest --ignore-glob="*test_video*" --junit-xml="${RUNNER_TEST_RESULTS_DIR}/test-results.xml" -v --durations=25

--- a/.github/scripts/unittest.sh
+++ b/.github/scripts/unittest.sh
@@ -12,4 +12,5 @@ pip install --progress-bar=off pytest pytest-mock pytest-cov expecttest
 echo '::endgroup::'
 
 python test/smoke_test.py
-pytest --junit-xml="${RUNNER_TEST_RESULTS_DIR}/test-results.xml" -v --durations=25
+
+pytest --ignore-glob="*test_video*" --junit-xml="${RUNNER_TEST_RESULTS_DIR}/test-results.xml" -v --durations=25


### PR DESCRIPTION
This includes `read_video`, `VideoReader`, and the GPU decoder.