### PR TITLE
Pass use_reentrant for checkpoint

### DIFF
--- a/torchvision/models/densenet.py
+++ b/torchvision/models/densenet.py
@@ -61,7 +61,7 @@ class _DenseLayer(nn.Module):
         def closure(*inputs):
             return self.bn_function(inputs)
 
-        return cp.checkpoint(closure, *input)
+        return cp.checkpoint(closure, *input, use_reentrant=False)
 
     @torch.jit._overload_method  # noqa: F811
     def forward(self, input: List[Tensor]) -> Tensor:  # noqa: F811


### PR DESCRIPTION
After https://github.com/pytorch/pytorch/pull/115868 `checkpoint` requires passing `use_reentrant`.
See https://dev-discuss.pytorch.org/t/bc-breaking-update-to-torch-utils-checkpoint-not-passing-in-use-reentrant-flag-will-raise-an-error/1745 for more info.

The tests are currently failing with unrelated
AttributeError: module 'expecttest' has no attribute 'ACCEPT'