### PR TITLE
Pin expecttest to restore CI

### DIFF
--- a/.github/scripts/unittest.sh
+++ b/.github/scripts/unittest.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 eval "$($(which conda) shell.bash hook)" && conda deactivate && conda activate ci
 
 echo '::group::Install testing utilities'
-pip install --progress-bar=off pytest pytest-mock pytest-cov expecttest
+pip install --progress-bar=off pytest pytest-mock pytest-cov expecttest==0.1.6
 echo '::endgroup::'
 
 python test/smoke_test.py


### PR DESCRIPTION
Everything is red now because of new expecttest release with new API. A related issue - https://github.com/pytorch/pytorch/issues/116208
