### PR TITLE
exclude expecttest==0.2.0

### DIFF
--- a/.github/scripts/unittest.sh
+++ b/.github/scripts/unittest.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 eval "$($(which conda) shell.bash hook)" && conda deactivate && conda activate ci
 
 echo '::group::Install testing utilities'
-pip install --progress-bar=off pytest pytest-mock pytest-cov expecttest==0.1.6
+pip install --progress-bar=off pytest pytest-mock pytest-cov expecttest!=0.2.0
 echo '::endgroup::'
 
 python test/smoke_test.py


### PR DESCRIPTION
Follow-up to #8181. `expecttest==0.2.1` was released that restores the old behavior that was broken in `0.2.0`. Thus, instead of pinning to an outdated version, i.e. `0.1.6`, we simply exclude the broken one.

cc @seemethere