### PR TITLE
Add notes about BoundingBoxes transform utils in ops/boxes docstrings

### DIFF
--- a/torchvision/ops/boxes.py
+++ b/torchvision/ops/boxes.py
@@ -118,7 +118,7 @@ def remove_small_boxes(boxes: Tensor, min_size: float) -> Tensor:
     that is smaller than :attr:`min_size`.
 
     .. warning::
-        For sanitizing a :class:`~tv_tensors.BoundingBoxes` object, consider using 
+        For sanitizing a :class:`~tv_tensors.BoundingBoxes` object, consider using
         the transform :func:`~torchvision.transforms.v2.SanitizeBoundingBoxes` instead.
 
     Args:
@@ -143,7 +143,7 @@ def clip_boxes_to_image(boxes: Tensor, size: Tuple[int, int]) -> Tensor:
     Clip boxes so that they lie inside an image of size :attr:`size`.
 
     .. warning::
-        For clipping a :class:`~tv_tensors.BoundingBoxes` object, consider using 
+        For clipping a :class:`~tv_tensors.BoundingBoxes` object, consider using
         the transform :func:`~torchvision.transforms.v2.ClampBoundingBoxes` instead.
 
     Args:
@@ -175,15 +175,15 @@ def clip_boxes_to_image(boxes: Tensor, size: Tuple[int, int]) -> Tensor:
 
 
 def box_convert(boxes: Tensor, in_fmt: str, out_fmt: str) -> Tensor:
-    """    
+    """
     Converts :class:`torch.Tensor` boxes from a given :attr:`in_fmt` to :attr:`out_fmt`.
 
     .. warning::
-        For converting a :class:`torch.Tensor` or a :class:`~tv_tensors.BoundingBoxes` object 
+        For converting a :class:`torch.Tensor` or a :class:`~tv_tensors.BoundingBoxes` object
         between different :class:`~torchvision.tv_tensors.BoundingBoxFormat`s,
-        consider using :func:`~torchvision.transforms.v2.functional.convert_bounding_box_format` instead. 
+        consider using :func:`~torchvision.transforms.v2.functional.convert_bounding_box_format` instead.
         Or see the corresponding transform :func:`~torchvision.transforms.v2.ConvertBoundingBoxFormat`.
-    
+
     Supported :attr:`in_fmt` and :attr:`out_fmt` strings are:
 
     ``'xyxy'``: boxes are represented via corners, x1, y1 being top left and x2, y2 being bottom right.
@@ -193,7 +193,7 @@ def box_convert(boxes: Tensor, in_fmt: str, out_fmt: str) -> Tensor:
 
     ``'cxcywh'``: boxes are represented via centre, width and height, cx, cy being center of box, w, h
     being width and height.
-    
+
     Args:
         boxes (Tensor[N, 4]): boxes which will be converted.
         in_fmt (str): Input format of given boxes. Supported formats are ['xyxy', 'xywh', 'cxcywh'].
@@ -238,7 +238,7 @@ def box_area(boxes: Tensor) -> Tensor:
     (x1, y1, x2, y2) coordinates.
 
     .. warning::
-        For computing the area of a :class:`~tv_tensors.BoundingBoxes` object 
+        For computing the area of a :class:`~tv_tensors.BoundingBoxes` object
         consider using :func:`~torchvision.transforms.v2.functional.get_size` instead.
 
     Args:

--- a/torchvision/ops/boxes.py
+++ b/torchvision/ops/boxes.py
@@ -16,7 +16,7 @@ def nms(boxes: Tensor, scores: Tensor, iou_threshold: float) -> Tensor:
     to their intersection-over-union (IoU).
 
     NMS iteratively removes lower scoring boxes which have an
-    IoU greater than :attr:`iou_threshold` with another (higher scoring)
+    IoU greater than ``iou_threshold`` with another (higher scoring)
     box.
 
     If multiple boxes have the exact same score and satisfy the IoU
@@ -114,11 +114,11 @@ def _batched_nms_vanilla(
 
 def remove_small_boxes(boxes: Tensor, min_size: float) -> Tensor:
     """
-    Remove every box from :attr:`boxes` which contains at least one side length
-    that is smaller than :attr:`min_size`.
+    Remove every box from ``boxes`` which contains at least one side length
+    that is smaller than ``min_size``.
 
     .. warning::
-        For sanitizing a :class:`~tv_tensors.BoundingBoxes` object, consider using
+        For sanitizing a :class:`~torchvision.tv_tensors.BoundingBoxes` object, consider using
         the transform :func:`~torchvision.transforms.v2.SanitizeBoundingBoxes` instead.
 
     Args:
@@ -128,7 +128,7 @@ def remove_small_boxes(boxes: Tensor, min_size: float) -> Tensor:
 
     Returns:
         Tensor[K]: indices of the boxes that have both sides
-        larger than :attr:`min_size`
+        larger than ``min_size``
     """
     if not torch.jit.is_scripting() and not torch.jit.is_tracing():
         _log_api_usage_once(remove_small_boxes)

--- a/torchvision/ops/boxes.py
+++ b/torchvision/ops/boxes.py
@@ -166,18 +166,25 @@ def clip_boxes_to_image(boxes: Tensor, size: Tuple[int, int]) -> Tensor:
 
 
 def box_convert(boxes: Tensor, in_fmt: str, out_fmt: str) -> Tensor:
-    """
-    Converts boxes from given in_fmt to out_fmt.
-    Supported in_fmt and out_fmt are:
+    """    
+    Converts :class:`torch.Tensor` boxes from given in_fmt to out_fmt.
+
+    .. warning::
+        For converting a :class:`torch.Tensor` or a :class:`~tv_tensors.BoundingBoxes` object 
+        between different :class:`~torchvision.tv_tensors.BoundingBoxFormat`s,
+        consider using :func:`~torchvision.transforms.v2.functional.convert_bounding_box_format` instead. 
+        Or see the corresponding transform :func:`~torchvision.transforms.v2.ConvertBoundingBoxFormat`.
+    
+    Supported in_fmt and out_fmt strings are:
 
     'xyxy': boxes are represented via corners, x1, y1 being top left and x2, y2 being bottom right.
     This is the format that torchvision utilities expect.
 
-    'xywh' : boxes are represented via corner, width and height, x1, y2 being top left, w, h being width and height.
+    'xywh': boxes are represented via corner, width and height, x1, y2 being top left, w, h being width and height.
 
-    'cxcywh' : boxes are represented via centre, width and height, cx, cy being center of box, w, h
+    'cxcywh': boxes are represented via centre, width and height, cx, cy being center of box, w, h
     being width and height.
-
+    
     Args:
         boxes (Tensor[N, 4]): boxes which will be converted.
         in_fmt (str): Input format of given boxes. Supported formats are ['xyxy', 'xywh', 'cxcywh'].

--- a/torchvision/ops/boxes.py
+++ b/torchvision/ops/boxes.py
@@ -16,7 +16,7 @@ def nms(boxes: Tensor, scores: Tensor, iou_threshold: float) -> Tensor:
     to their intersection-over-union (IoU).
 
     NMS iteratively removes lower scoring boxes which have an
-    IoU greater than iou_threshold with another (higher scoring)
+    IoU greater than :attr:`iou_threshold` with another (higher scoring)
     box.
 
     If multiple boxes have the exact same score and satisfy the IoU
@@ -114,7 +114,12 @@ def _batched_nms_vanilla(
 
 def remove_small_boxes(boxes: Tensor, min_size: float) -> Tensor:
     """
-    Remove boxes which contains at least one side smaller than min_size.
+    Remove every box from :attr:`boxes` which contains at least one side length
+    that is smaller than :attr:`min_size`.
+
+    .. warning::
+        For sanitizing a :class:`~tv_tensors.BoundingBoxes` object, consider using 
+        the transform :func:`~torchvision.transforms.v2.SanitizeBoundingBoxes` instead.
 
     Args:
         boxes (Tensor[N, 4]): boxes in ``(x1, y1, x2, y2)`` format
@@ -123,7 +128,7 @@ def remove_small_boxes(boxes: Tensor, min_size: float) -> Tensor:
 
     Returns:
         Tensor[K]: indices of the boxes that have both sides
-        larger than min_size
+        larger than :attr:`min_size`
     """
     if not torch.jit.is_scripting() and not torch.jit.is_tracing():
         _log_api_usage_once(remove_small_boxes)
@@ -135,7 +140,11 @@ def remove_small_boxes(boxes: Tensor, min_size: float) -> Tensor:
 
 def clip_boxes_to_image(boxes: Tensor, size: Tuple[int, int]) -> Tensor:
     """
-    Clip boxes so that they lie inside an image of size `size`.
+    Clip boxes so that they lie inside an image of size :attr:`size`.
+
+    .. warning::
+        For clipping a :class:`~tv_tensors.BoundingBoxes` object, consider using 
+        the transform :func:`~torchvision.transforms.v2.ClampBoundingBoxes` instead.
 
     Args:
         boxes (Tensor[N, 4]): boxes in ``(x1, y1, x2, y2)`` format
@@ -167,7 +176,7 @@ def clip_boxes_to_image(boxes: Tensor, size: Tuple[int, int]) -> Tensor:
 
 def box_convert(boxes: Tensor, in_fmt: str, out_fmt: str) -> Tensor:
     """    
-    Converts :class:`torch.Tensor` boxes from given in_fmt to out_fmt.
+    Converts :class:`torch.Tensor` boxes from a given :attr:`in_fmt` to :attr:`out_fmt`.
 
     .. warning::
         For converting a :class:`torch.Tensor` or a :class:`~tv_tensors.BoundingBoxes` object 
@@ -175,14 +184,14 @@ def box_convert(boxes: Tensor, in_fmt: str, out_fmt: str) -> Tensor:
         consider using :func:`~torchvision.transforms.v2.functional.convert_bounding_box_format` instead. 
         Or see the corresponding transform :func:`~torchvision.transforms.v2.ConvertBoundingBoxFormat`.
     
-    Supported in_fmt and out_fmt strings are:
+    Supported :attr:`in_fmt` and :attr:`out_fmt` strings are:
 
-    'xyxy': boxes are represented via corners, x1, y1 being top left and x2, y2 being bottom right.
+    ``'xyxy'``: boxes are represented via corners, x1, y1 being top left and x2, y2 being bottom right.
     This is the format that torchvision utilities expect.
 
-    'xywh': boxes are represented via corner, width and height, x1, y2 being top left, w, h being width and height.
+    ``'xywh'``: boxes are represented via corner, width and height, x1, y2 being top left, w, h being width and height.
 
-    'cxcywh': boxes are represented via centre, width and height, cx, cy being center of box, w, h
+    ``'cxcywh'``: boxes are represented via centre, width and height, cx, cy being center of box, w, h
     being width and height.
     
     Args:
@@ -227,6 +236,10 @@ def box_area(boxes: Tensor) -> Tensor:
     """
     Computes the area of a set of bounding boxes, which are specified by their
     (x1, y1, x2, y2) coordinates.
+
+    .. warning::
+        For computing the area of a :class:`~tv_tensors.BoundingBoxes` object 
+        consider using :func:`~torchvision.transforms.v2.functional.get_size` instead.
 
     Args:
         boxes (Tensor[N, 4]): boxes for which the area will be computed. They

--- a/torchvision/ops/boxes.py
+++ b/torchvision/ops/boxes.py
@@ -180,7 +180,7 @@ def box_convert(boxes: Tensor, in_fmt: str, out_fmt: str) -> Tensor:
 
     .. note::
         For converting a :class:`torch.Tensor` or a :class:`~torchvision.tv_tensors.BoundingBoxes` object
-        between different :class:`~torchvision.tv_tensors.BoundingBoxFormat`s,
+        between different formats,
         consider using :func:`~torchvision.transforms.v2.functional.convert_bounding_box_format` instead.
         Or see the corresponding transform :func:`~torchvision.transforms.v2.ConvertBoundingBoxFormat`.
 

--- a/torchvision/ops/boxes.py
+++ b/torchvision/ops/boxes.py
@@ -117,7 +117,7 @@ def remove_small_boxes(boxes: Tensor, min_size: float) -> Tensor:
     Remove every box from ``boxes`` which contains at least one side length
     that is smaller than ``min_size``.
 
-    .. warning::
+    .. note::
         For sanitizing a :class:`~torchvision.tv_tensors.BoundingBoxes` object, consider using
         the transform :func:`~torchvision.transforms.v2.SanitizeBoundingBoxes` instead.
 
@@ -140,10 +140,10 @@ def remove_small_boxes(boxes: Tensor, min_size: float) -> Tensor:
 
 def clip_boxes_to_image(boxes: Tensor, size: Tuple[int, int]) -> Tensor:
     """
-    Clip boxes so that they lie inside an image of size :attr:`size`.
+    Clip boxes so that they lie inside an image of size ``size``.
 
-    .. warning::
-        For clipping a :class:`~tv_tensors.BoundingBoxes` object, consider using
+    .. note::
+        For clipping a :class:`~torchvision.tv_tensors.BoundingBoxes` object, consider using
         the transform :func:`~torchvision.transforms.v2.ClampBoundingBoxes` instead.
 
     Args:
@@ -176,15 +176,15 @@ def clip_boxes_to_image(boxes: Tensor, size: Tuple[int, int]) -> Tensor:
 
 def box_convert(boxes: Tensor, in_fmt: str, out_fmt: str) -> Tensor:
     """
-    Converts :class:`torch.Tensor` boxes from a given :attr:`in_fmt` to :attr:`out_fmt`.
+    Converts :class:`torch.Tensor` boxes from a given ``in_fmt`` to ``out_fmt``.
 
-    .. warning::
-        For converting a :class:`torch.Tensor` or a :class:`~tv_tensors.BoundingBoxes` object
+    .. note::
+        For converting a :class:`torch.Tensor` or a :class:`~torchvision.tv_tensors.BoundingBoxes` object
         between different :class:`~torchvision.tv_tensors.BoundingBoxFormat`s,
         consider using :func:`~torchvision.transforms.v2.functional.convert_bounding_box_format` instead.
         Or see the corresponding transform :func:`~torchvision.transforms.v2.ConvertBoundingBoxFormat`.
 
-    Supported :attr:`in_fmt` and :attr:`out_fmt` strings are:
+    Supported ``in_fmt`` and ``out_fmt`` strings are:
 
     ``'xyxy'``: boxes are represented via corners, x1, y1 being top left and x2, y2 being bottom right.
     This is the format that torchvision utilities expect.
@@ -236,10 +236,6 @@ def box_area(boxes: Tensor) -> Tensor:
     """
     Computes the area of a set of bounding boxes, which are specified by their
     (x1, y1, x2, y2) coordinates.
-
-    .. warning::
-        For computing the area of a :class:`~tv_tensors.BoundingBoxes` object
-        consider using :func:`~torchvision.transforms.v2.functional.get_size` instead.
 
     Args:
         boxes (Tensor[N, 4]): boxes for which the area will be computed. They


### PR DESCRIPTION
Added documentation to multiple functions in `torchvision.ops.boxes` as proposed by https://github.com/pytorch/vision/issues/8190 .
