### PR TITLE
Fix typo in docs

### DIFF
--- a/docs/source/models/ssdlite.rst
+++ b/docs/source/models/ssdlite.rst
@@ -6,7 +6,7 @@ SSDlite
 The SSDLite model is based on the `SSD: Single Shot MultiBox Detector
 <https://arxiv.org/abs/1512.02325>`__, `Searching for MobileNetV3
 <https://arxiv.org/abs/1905.02244>`__ and `MobileNetV2: Inverted Residuals and Linear
-Bottlenecks <https://arxiv.org/abs/1801.04381>__` papers.
+Bottlenecks <https://arxiv.org/abs/1801.04381>`__ papers.
 
 .. betastatus:: detection module
 


### PR DESCRIPTION
Fixed a link by moving a backtick.