### PR TITLE
[FBcode->GH] [codemod][highrisk] Fix shadowed variable in pytorch/vision/torchvision/csrc/io/decoder/decoder.cpp

### DIFF
--- a/torchvision/csrc/io/decoder/decoder.cpp
+++ b/torchvision/csrc/io/decoder/decoder.cpp
@@ -420,20 +420,20 @@ bool Decoder::openStreams(std::vector<DecoderMetadata>* metadata) {
     if (it->stream == -2 || // all streams of this type are welcome
         (!stream && (it->stream == -1 || it->stream == i))) { // new stream
       VLOG(1) << "Stream type: " << format.type << " found, at index: " << i;
-      auto stream = createStream(
+      auto stream_2 = createStream(
           format.type,
           inputCtx_,
           i,
           params_.convertPtsToWallTime,
           it->format,
           params_.loggingUuid);
-      CHECK(stream);
-      if (stream->openCodec(metadata, params_.numThreads) < 0) {
+      CHECK(stream_2);
+      if (stream_2->openCodec(metadata, params_.numThreads) < 0) {
         LOG(ERROR) << "uuid=" << params_.loggingUuid
                    << " open codec failed, stream_idx=" << i;
         return false;
       }
-      streams_.emplace(i, std::move(stream));
+      streams_.emplace(i, std::move(stream_2));
       inRange_.set(i, true);
     }
   }


### PR DESCRIPTION

Summary:
Our upcoming compiler upgrade will require us not to have shadowed variables. Such variables have a _high_ bug rate and reduce readability, so we would like to avoid them even if the compiler was not forcing us to do so.

This codemod attempts to fix an instance of a shadowed variable. Please review with care: if it's failed the result will be a silent bug.

**What's a shadowed variable?**

Shadowed variables are variables in an inner scope with the same name as another variable in an outer scope. Having the same name for both variables might be semantically correct, but it can make the code confusing to read! It can also hide subtle bugs.

This diff fixes such an issue by renaming the variable.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: palmje

Differential Revision: D52582795

fbshipit-source-id: 43df02107f8524ea94df18af2524b4a1ca3936b8

<!-- Before submitting a PR, please make sure to check our contributing guidelines regarding code formatting, tests, and documentation: https://github.com/pytorch/vision/blob/main/CONTRIBUTING.md -->
