### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Process commit and find merger responsible for labeling
         id: commit
-        run: echo "::set-output name=merger::$(python .github/process_commit.py ${{ github.sha }})"
+        run: echo "merger=$(python .github/process_commit.py ${{ github.sha }})" >> $GITHUB_OUTPUT
 
       - name: Ping merger responsible for labeling if necessary
         if: ${{ steps.commit.outputs.merger != '' }}


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter