### PR TITLE
CI fix - Use pytest<8 in unittest jobs

### DIFF
--- a/.github/scripts/unittest.sh
+++ b/.github/scripts/unittest.sh
@@ -8,7 +8,8 @@ set -euo pipefail
 eval "$($(which conda) shell.bash hook)" && conda deactivate && conda activate ci
 
 echo '::group::Install testing utilities'
-pip install --progress-bar=off pytest pytest-mock pytest-cov expecttest!=0.2.0
+# TODO: remove the <8 constraint on pytest when https://github.com/pytorch/vision/issues/8238 is closed
+pip install --progress-bar=off "pytest<8" pytest-mock pytest-cov expecttest!=0.2.0
 echo '::endgroup::'
 
 python test/smoke_test.py

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -164,7 +164,8 @@ jobs:
         echo '::endgroup::'
 
         echo '::group::Install testing utilities'
-        pip install --progress-bar=off pytest
+        # TODO: remove the <8 constraint on pytest when https://github.com/pytorch/vision/issues/8238 is closed
+        pip install --progress-bar=off "pytest<8"
         echo '::endgroup::'
 
         echo '::group::Run extended unittests'


### PR DESCRIPTION
Related to https://github.com/pytorch/vision/issues/8238, this should help the CI be greener