### PR TITLE
[RELEASE-ONLY CHANGES] [Cherry-pick for 0.17] CI fix - Use pytest<8 in unittest jobs

### DIFF
--- a/.github/scripts/unittest.sh
+++ b/.github/scripts/unittest.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 eval "$($(which conda) shell.bash hook)" && conda deactivate && conda activate ci
 
 echo '::group::Install testing utilities'
-pip install --progress-bar=off pytest pytest-mock pytest-cov expecttest
+pip install --progress-bar=off "pytest<8" pytest-mock pytest-cov expecttest
 echo '::endgroup::'
 
 python test/smoke_test.py

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -164,7 +164,7 @@ jobs:
         echo '::endgroup::'
 
         echo '::group::Install testing utilities'
-        pip install --progress-bar=off pytest
+        pip install --progress-bar=off "pytest<8"
         echo '::endgroup::'
 
         echo '::group::Run extended unittests'


### PR DESCRIPTION
Cherry pick of https://github.com/pytorch/vision/pull/8239. We need to use pytest7 as pytest8 (released this weekend) is causing issues.