### PR TITLE
Migrate the macOS runners label from macos-m1-12 to macos-m1-stable

### DIFF
--- a/.github/workflows/build-cmake.yml
+++ b/.github/workflows/build-cmake.yml
@@ -41,7 +41,7 @@ jobs:
       matrix:
         include:
           - runner: macos-12
-          - runner: macos-m1-12
+          - runner: macos-m1-stable
       fail-fast: false
     uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
     with:

--- a/.github/workflows/build-conda-m1.yml
+++ b/.github/workflows/build-conda-m1.yml
@@ -46,7 +46,7 @@ jobs:
       post-script: ${{ matrix.post-script }}
       package-name: ${{ matrix.package-name }}
       smoke-test-script: ${{ matrix.smoke-test-script }}
-      runner-type: macos-m1-12
+      runner-type: macos-m1-stable
       trigger-event: ${{ github.event_name }}
     secrets:
       CONDA_PYTORCHBOT_TOKEN: ${{ secrets.CONDA_PYTORCHBOT_TOKEN }}

--- a/.github/workflows/build-wheels-m1.yml
+++ b/.github/workflows/build-wheels-m1.yml
@@ -47,6 +47,6 @@ jobs:
       pre-script: ${{ matrix.pre-script }}
       post-script: ${{ matrix.post-script }}
       package-name: ${{ matrix.package-name }}
-      runner-type: macos-m1-12
+      runner-type: macos-m1-stable
       smoke-test-script: ${{ matrix.smoke-test-script }}
       trigger-event: ${{ github.event_name }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,7 +54,7 @@ jobs:
         runner: ["macos-12"]
         include:
           - python-version: "3.8"
-            runner: macos-m1-12
+            runner: macos-m1-stable
       fail-fast: false
     uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
     with:


### PR DESCRIPTION
There is a new label for our macOS runners: "macos-m1-stable". All runners labeled "macos-m1-12" should be switched to "macos-m1-stable". [Here](https://fb.workplace.com/groups/pytorch.dev.perf.infra.teams/permalink/7546708885348237/) you can find more detailed info.