### PR TITLE
Fix negative size issue in vector allocation

### DIFF
--- a/torchvision/csrc/ops/cpu/roi_align_kernel.cpp
+++ b/torchvision/csrc/ops/cpu/roi_align_kernel.cpp
@@ -62,6 +62,8 @@ void roi_align_forward_kernel_impl(
 
     // we want to precalculate indices and weights shared by all channels,
     // this is the key point of optimization
+    roi_bin_grid_h = std::max(roi_bin_grid_h, 0);
+    roi_bin_grid_w = std::max(roi_bin_grid_w, 0);
     std::vector<detail::PreCalc<T>> pre_calc(
         roi_bin_grid_h * roi_bin_grid_w * pooled_width * pooled_height);
     detail::pre_calc_for_bilinear_interpolate(


### PR DESCRIPTION
<!-- Before submitting a PR, please make sure to check our contributing guidelines regarding code formatting, tests, and documentation: https://github.com/pytorch/vision/blob/main/CONTRIBUTING.md -->
Ensure roi_bin_grid_h and roi_bin_grid_w are non-negative before calculating the size for vector allocation. This prevents undefined behavior by using std::max to set any negative values to 0. This change is critical to avoid potential crashes or excessive memory allocation when negative dimensions are provided.