### PR TITLE
fix pr-labels workflow

### DIFF
--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -11,25 +11,28 @@ jobs:
 
     steps:
       - name: Set up python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
 
       - name: Install requests
         run: pip install requests
 
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Process commit and find merger responsible for labeling
         id: commit
-        run: echo "merger=$(python .github/process_commit.py ${{ github.sha }})" >> $GITHUB_OUTPUT
+        run: |
+          MERGER=$(python .github/process_commit.py ${{ github.sha }})
+          echo "merger=${MERGER}" | tee --append $GITHUB_OUTPUT
 
       - name: Ping merger responsible for labeling if necessary
         if: ${{ steps.commit.outputs.merger != '' }}
-        uses: mshick/add-pr-comment@v1
+        uses: mshick/add-pr-comment@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           message: |
             Hey ${{ steps.commit.outputs.merger }}!
 
-            You merged this PR, but no labels were added. The list of valid labels is available at https://github.com/pytorch/vision/blob/main/.github/process_commit.py
+            You merged this PR, but no labels were added.
+            The list of valid labels is available at https://github.com/pytorch/vision/blob/main/.github/process_commit.py

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   is-properly-labeled:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
 
     steps:
       - name: Set up python


### PR DESCRIPTION
This should fix #8224. Our process script is still running without issues. Looking at two examples

- :heavy_check_mark: https://github.com/pytorch/vision/actions/runs/7828303251/job/21357876487
- :x: https://github.com/pytorch/vision/actions/runs/7843097488/job/21402700234

it seems what is going wrong is the action that is supposed to create the comment on the PR. I've updated the permissions for this workflow to be able to write to PRs.

Plus, we are using ancient action versions here so I updated them.

cc @seemethere