### PR TITLE
Fix CutMix and MixUp arguments in transforms.py

### DIFF
--- a/references/classification/transforms.py
+++ b/references/classification/transforms.py
@@ -13,13 +13,13 @@ def get_mixup_cutmix(*, mixup_alpha, cutmix_alpha, num_categories, use_v2):
     mixup_cutmix = []
     if mixup_alpha > 0:
         mixup_cutmix.append(
-            transforms_module.MixUp(alpha=mixup_alpha, num_categories=num_categories)
+            transforms_module.MixUp(alpha=mixup_alpha, num_classes=num_categories)
             if use_v2
             else RandomMixUp(num_classes=num_categories, p=1.0, alpha=mixup_alpha)
         )
     if cutmix_alpha > 0:
         mixup_cutmix.append(
-            transforms_module.CutMix(alpha=mixup_alpha, num_categories=num_categories)
+            transforms_module.CutMix(alpha=mixup_alpha, num_classes=num_categories)
             if use_v2
             else RandomCutMix(num_classes=num_categories, p=1.0, alpha=mixup_alpha)
         )


### PR DESCRIPTION
both torchvision.transforms.v2.CutMix and torchvision.transforms.v2.MixUp uses num_classes instead of num_categories as arguments.

<!-- Before submitting a PR, please make sure to check our contributing guidelines regarding code formatting, tests, and documentation: https://github.com/pytorch/vision/blob/main/CONTRIBUTING.md -->
