### PR TITLE
Document that datasets support pathlib.Path

### DIFF
--- a/torchvision/datasets/_optical_flow.py
+++ b/torchvision/datasets/_optical_flow.py
@@ -113,7 +113,7 @@ class Sintel(FlowDataset):
                         ...
 
     Args:
-        root (string): Root directory of the Sintel Dataset.
+        root (str or ``pathlib.Path``): Root directory of the Sintel Dataset.
         split (string, optional): The dataset split, either "train" (default) or "test"
         pass_name (string, optional): The pass to use, either "clean" (default), "final", or "both". See link above for
             details on the different passes.
@@ -183,7 +183,7 @@ class KittiFlow(FlowDataset):
                     flow_occ
 
     Args:
-        root (string): Root directory of the KittiFlow Dataset.
+        root (str or ``pathlib.Path``): Root directory of the KittiFlow Dataset.
         split (string, optional): The dataset split, either "train" (default) or "test"
         transforms (callable, optional): A function/transform that takes in
             ``img1, img2, flow, valid_flow_mask`` and returns a transformed version.
@@ -248,7 +248,7 @@ class FlyingChairs(FlowDataset):
 
 
     Args:
-        root (string): Root directory of the FlyingChairs Dataset.
+        root (str or ``pathlib.Path``): Root directory of the FlyingChairs Dataset.
         split (string, optional): The dataset split, either "train" (default) or "val"
         transforms (callable, optional): A function/transform that takes in
             ``img1, img2, flow, valid_flow_mask`` and returns a transformed version.
@@ -316,7 +316,7 @@ class FlyingThings3D(FlowDataset):
                     TRAIN
 
     Args:
-        root (string): Root directory of the intel FlyingThings3D Dataset.
+        root (str or ``pathlib.Path``): Root directory of the intel FlyingThings3D Dataset.
         split (string, optional): The dataset split, either "train" (default) or "test"
         pass_name (string, optional): The pass to use, either "clean" (default) or "final" or "both". See link above for
             details on the different passes.
@@ -411,7 +411,7 @@ class HD1K(FlowDataset):
                     image_2
 
     Args:
-        root (string): Root directory of the HD1K Dataset.
+        root (str or ``pathlib.Path``): Root directory of the HD1K Dataset.
         split (string, optional): The dataset split, either "train" (default) or "test"
         transforms (callable, optional): A function/transform that takes in
             ``img1, img2, flow, valid_flow_mask`` and returns a transformed version.

--- a/torchvision/datasets/_optical_flow.py
+++ b/torchvision/datasets/_optical_flow.py
@@ -13,7 +13,6 @@ from ..io.image import _read_png_16
 from .utils import _read_pfm, verify_str_arg
 from .vision import VisionDataset
 
-
 T1 = Tuple[Image.Image, Image.Image, Optional[np.ndarray], Optional[np.ndarray]]
 T2 = Tuple[Image.Image, Image.Image, Optional[np.ndarray]]
 
@@ -33,7 +32,7 @@ class FlowDataset(ABC, VisionDataset):
     # and it's up to whatever consumes the dataset to decide what valid_flow_mask should be.
     _has_builtin_flow_mask = False
 
-    def __init__(self, root: str, transforms: Optional[Callable] = None) -> None:
+    def __init__(self, root: Union[str, Path], transforms: Optional[Callable] = None) -> None:
 
         super().__init__(root=root)
         self.transforms = transforms
@@ -125,7 +124,7 @@ class Sintel(FlowDataset):
 
     def __init__(
         self,
-        root: str,
+        root: Union[str, Path],
         split: str = "train",
         pass_name: str = "clean",
         transforms: Optional[Callable] = None,
@@ -191,7 +190,7 @@ class KittiFlow(FlowDataset):
 
     _has_builtin_flow_mask = True
 
-    def __init__(self, root: str, split: str = "train", transforms: Optional[Callable] = None) -> None:
+    def __init__(self, root: Union[str, Path], split: str = "train", transforms: Optional[Callable] = None) -> None:
         super().__init__(root=root, transforms=transforms)
 
         verify_str_arg(split, "split", valid_values=("train", "test"))
@@ -256,7 +255,7 @@ class FlyingChairs(FlowDataset):
             return a built-in valid mask, such as :class:`~torchvision.datasets.KittiFlow`.
     """
 
-    def __init__(self, root: str, split: str = "train", transforms: Optional[Callable] = None) -> None:
+    def __init__(self, root: Union[str, Path], split: str = "train", transforms: Optional[Callable] = None) -> None:
         super().__init__(root=root, transforms=transforms)
 
         verify_str_arg(split, "split", valid_values=("train", "val"))
@@ -329,7 +328,7 @@ class FlyingThings3D(FlowDataset):
 
     def __init__(
         self,
-        root: str,
+        root: Union[str, Path],
         split: str = "train",
         pass_name: str = "clean",
         camera: str = "left",
@@ -419,7 +418,7 @@ class HD1K(FlowDataset):
 
     _has_builtin_flow_mask = True
 
-    def __init__(self, root: str, split: str = "train", transforms: Optional[Callable] = None) -> None:
+    def __init__(self, root: Union[str, Path], split: str = "train", transforms: Optional[Callable] = None) -> None:
         super().__init__(root=root, transforms=transforms)
 
         verify_str_arg(split, "split", valid_values=("train", "test"))

--- a/torchvision/datasets/_stereo_matching.py
+++ b/torchvision/datasets/_stereo_matching.py
@@ -27,7 +27,7 @@ class StereoMatchingDataset(ABC, VisionDataset):
 
     _has_built_in_disparity_mask = False
 
-    def __init__(self, root: str, transforms: Optional[Callable] = None) -> None:
+    def __init__(self, root: Union[str, Path], transforms: Optional[Callable] = None) -> None:
         """
         Args:
             root(str): Root directory of the dataset.
@@ -163,7 +163,7 @@ class CarlaStereo(StereoMatchingDataset):
         transforms (callable, optional): A function/transform that takes in a sample and returns a transformed version.
     """
 
-    def __init__(self, root: str, transforms: Optional[Callable] = None) -> None:
+    def __init__(self, root: Union[str, Path], transforms: Optional[Callable] = None) -> None:
         super().__init__(root, transforms)
 
         root = Path(root) / "carla-highres"
@@ -240,7 +240,7 @@ class Kitti2012Stereo(StereoMatchingDataset):
 
     _has_built_in_disparity_mask = True
 
-    def __init__(self, root: str, split: str = "train", transforms: Optional[Callable] = None) -> None:
+    def __init__(self, root: Union[str, Path], split: str = "train", transforms: Optional[Callable] = None) -> None:
         super().__init__(root, transforms)
 
         verify_str_arg(split, "split", valid_values=("train", "test"))
@@ -328,7 +328,7 @@ class Kitti2015Stereo(StereoMatchingDataset):
 
     _has_built_in_disparity_mask = True
 
-    def __init__(self, root: str, split: str = "train", transforms: Optional[Callable] = None) -> None:
+    def __init__(self, root: Union[str, Path], split: str = "train", transforms: Optional[Callable] = None) -> None:
         super().__init__(root, transforms)
 
         verify_str_arg(split, "split", valid_values=("train", "test"))
@@ -480,7 +480,7 @@ class Middlebury2014Stereo(StereoMatchingDataset):
 
     def __init__(
         self,
-        root: str,
+        root: Union[str, Path],
         split: str = "train",
         calibration: Optional[str] = "perfect",
         use_ambient_views: bool = False,
@@ -576,7 +576,7 @@ class Middlebury2014Stereo(StereoMatchingDataset):
         valid_mask = (disparity_map > 0).squeeze(0)  # mask out invalid disparities
         return disparity_map, valid_mask
 
-    def _download_dataset(self, root: str) -> None:
+    def _download_dataset(self, root: Union[str, Path]) -> None:
         base_url = "https://vision.middlebury.edu/stereo/data/scenes2014/zip"
         # train and additional splits have 2 different calibration settings
         root = Path(root) / "Middlebury2014"
@@ -675,7 +675,7 @@ class CREStereo(StereoMatchingDataset):
 
     def __init__(
         self,
-        root: str,
+        root: Union[str, Path],
         transforms: Optional[Callable] = None,
     ) -> None:
         super().__init__(root, transforms)
@@ -762,7 +762,7 @@ class FallingThingsStereo(StereoMatchingDataset):
         transforms (callable, optional): A function/transform that takes in a sample and returns a transformed version.
     """
 
-    def __init__(self, root: str, variant: str = "single", transforms: Optional[Callable] = None) -> None:
+    def __init__(self, root: Union[str, Path], variant: str = "single", transforms: Optional[Callable] = None) -> None:
         super().__init__(root, transforms)
 
         root = Path(root) / "FallingThings"
@@ -877,7 +877,7 @@ class SceneFlowStereo(StereoMatchingDataset):
 
     def __init__(
         self,
-        root: str,
+        root: Union[str, Path],
         variant: str = "FlyingThings3D",
         pass_name: str = "clean",
         transforms: Optional[Callable] = None,
@@ -980,7 +980,7 @@ class SintelStereo(StereoMatchingDataset):
 
     _has_built_in_disparity_mask = True
 
-    def __init__(self, root: str, pass_name: str = "final", transforms: Optional[Callable] = None) -> None:
+    def __init__(self, root: Union[str, Path], pass_name: str = "final", transforms: Optional[Callable] = None) -> None:
         super().__init__(root, transforms)
 
         verify_str_arg(pass_name, "pass_name", valid_values=("final", "clean", "both"))
@@ -1087,7 +1087,7 @@ class InStereo2k(StereoMatchingDataset):
         transforms (callable, optional): A function/transform that takes in a sample and returns a transformed version.
     """
 
-    def __init__(self, root: str, split: str = "train", transforms: Optional[Callable] = None) -> None:
+    def __init__(self, root: Union[str, Path], split: str = "train", transforms: Optional[Callable] = None) -> None:
         super().__init__(root, transforms)
 
         root = Path(root) / "InStereo2k" / split
@@ -1176,7 +1176,7 @@ class ETH3DStereo(StereoMatchingDataset):
 
     _has_built_in_disparity_mask = True
 
-    def __init__(self, root: str, split: str = "train", transforms: Optional[Callable] = None) -> None:
+    def __init__(self, root: Union[str, Path], split: str = "train", transforms: Optional[Callable] = None) -> None:
         super().__init__(root, transforms)
 
         verify_str_arg(split, "split", valid_values=("train", "test"))

--- a/torchvision/datasets/_stereo_matching.py
+++ b/torchvision/datasets/_stereo_matching.py
@@ -159,7 +159,7 @@ class CarlaStereo(StereoMatchingDataset):
                     ...
 
     Args:
-        root (string): Root directory where `carla-highres` is located.
+        root (str or ``pathlib.Path``): Root directory where `carla-highres` is located.
         transforms (callable, optional): A function/transform that takes in a sample and returns a transformed version.
     """
 
@@ -233,7 +233,7 @@ class Kitti2012Stereo(StereoMatchingDataset):
                     calib
 
     Args:
-        root (string): Root directory where `Kitti2012` is located.
+        root (str or ``pathlib.Path``): Root directory where `Kitti2012` is located.
         split (string, optional): The dataset split of scenes, either "train" (default) or "test".
         transforms (callable, optional): A function/transform that takes in a sample and returns a transformed version.
     """
@@ -321,7 +321,7 @@ class Kitti2015Stereo(StereoMatchingDataset):
                     calib
 
     Args:
-        root (string): Root directory where `Kitti2015` is located.
+        root (str or ``pathlib.Path``): Root directory where `Kitti2015` is located.
         split (string, optional): The dataset split of scenes, either "train" (default) or "test".
         transforms (callable, optional): A function/transform that takes in a sample and returns a transformed version.
     """
@@ -420,7 +420,7 @@ class Middlebury2014Stereo(StereoMatchingDataset):
                     ...
 
     Args:
-        root (string): Root directory of the Middleburry 2014 Dataset.
+        root (str or ``pathlib.Path``): Root directory of the Middleburry 2014 Dataset.
         split (string, optional): The dataset split of scenes, either "train" (default), "test", or "additional"
         use_ambient_views (boolean, optional): Whether to use different expose or lightning views when possible.
             The dataset samples with equal probability between ``[im1.png, im1E.png, im1L.png]``.
@@ -757,7 +757,7 @@ class FallingThingsStereo(StereoMatchingDataset):
                     ...
 
     Args:
-        root (string): Root directory where FallingThings is located.
+        root (str or ``pathlib.Path``): Root directory where FallingThings is located.
         variant (string): Which variant to use. Either "single", "mixed", or "both".
         transforms (callable, optional): A function/transform that takes in a sample and returns a transformed version.
     """
@@ -868,7 +868,7 @@ class SceneFlowStereo(StereoMatchingDataset):
                     ...
 
     Args:
-        root (string): Root directory where SceneFlow is located.
+        root (str or ``pathlib.Path``): Root directory where SceneFlow is located.
         variant (string): Which dataset variant to user, "FlyingThings3D" (default), "Monkaa" or "Driving".
         pass_name (string): Which pass to use, "clean" (default), "final" or "both".
         transforms (callable, optional): A function/transform that takes in a sample and returns a transformed version.
@@ -973,7 +973,7 @@ class SintelStereo(StereoMatchingDataset):
                         ...
 
     Args:
-        root (string): Root directory where Sintel Stereo is located.
+        root (str or ``pathlib.Path``): Root directory where Sintel Stereo is located.
         pass_name (string): The name of the pass to use, either "final", "clean" or "both".
         transforms (callable, optional): A function/transform that takes in a sample and returns a transformed version.
     """
@@ -1082,7 +1082,7 @@ class InStereo2k(StereoMatchingDataset):
                     ...
 
     Args:
-        root (string): Root directory where InStereo2k is located.
+        root (str or ``pathlib.Path``): Root directory where InStereo2k is located.
         split (string): Either "train" or "test".
         transforms (callable, optional): A function/transform that takes in a sample and returns a transformed version.
     """
@@ -1169,7 +1169,7 @@ class ETH3DStereo(StereoMatchingDataset):
                     ...
 
     Args:
-        root (string): Root directory of the ETH3D Dataset.
+        root (str or ``pathlib.Path``): Root directory of the ETH3D Dataset.
         split (string, optional): The dataset split of scenes, either "train" (default) or "test".
         transforms (callable, optional): A function/transform that takes in a sample and returns a transformed version.
     """

--- a/torchvision/datasets/caltech.py
+++ b/torchvision/datasets/caltech.py
@@ -1,5 +1,6 @@
 import os
 import os.path
+from pathlib import Path
 from typing import Any, Callable, List, Optional, Tuple, Union
 
 from PIL import Image
@@ -38,7 +39,7 @@ class Caltech101(VisionDataset):
 
     def __init__(
         self,
-        root: str,
+        root: Union[str, Path],
         target_type: Union[List[str], str] = "category",
         transform: Optional[Callable] = None,
         target_transform: Optional[Callable] = None,

--- a/torchvision/datasets/caltech.py
+++ b/torchvision/datasets/caltech.py
@@ -16,7 +16,7 @@ class Caltech101(VisionDataset):
         This class needs `scipy <https://docs.scipy.org/doc/>`_ to load target files from `.mat` format.
 
     Args:
-        root (string): Root directory of dataset where directory
+        root (str or ``pathlib.Path``): Root directory of dataset where directory
             ``caltech101`` exists or will be saved to if download is set to True.
         target_type (string or list, optional): Type of target to use, ``category`` or
             ``annotation``. Can also be a list to output a tuple with all specified
@@ -153,7 +153,7 @@ class Caltech256(VisionDataset):
     """`Caltech 256 <https://data.caltech.edu/records/20087>`_ Dataset.
 
     Args:
-        root (string): Root directory of dataset where directory
+        root (str or ``pathlib.Path``): Root directory of dataset where directory
             ``caltech256`` exists or will be saved to if download is set to True.
         transform (callable, optional): A function/transform that takes in a PIL image
             and returns a transformed version. E.g, ``transforms.RandomCrop``

--- a/torchvision/datasets/celeba.py
+++ b/torchvision/datasets/celeba.py
@@ -1,6 +1,7 @@
 import csv
 import os
 from collections import namedtuple
+from pathlib import Path
 from typing import Any, Callable, List, Optional, Tuple, Union
 
 import PIL
@@ -63,7 +64,7 @@ class CelebA(VisionDataset):
 
     def __init__(
         self,
-        root: str,
+        root: Union[str, Path],
         split: str = "train",
         target_type: Union[List[str], str] = "attr",
         transform: Optional[Callable] = None,

--- a/torchvision/datasets/celeba.py
+++ b/torchvision/datasets/celeba.py
@@ -16,7 +16,7 @@ class CelebA(VisionDataset):
     """`Large-scale CelebFaces Attributes (CelebA) Dataset <http://mmlab.ie.cuhk.edu.hk/projects/CelebA.html>`_ Dataset.
 
     Args:
-        root (string): Root directory where images are downloaded to.
+        root (str or ``pathlib.Path``): Root directory where images are downloaded to.
         split (string): One of {'train', 'valid', 'test', 'all'}.
             Accordingly dataset is selected.
         target_type (string or list, optional): Type of target to use, ``attr``, ``identity``, ``bbox``,

--- a/torchvision/datasets/cifar.py
+++ b/torchvision/datasets/cifar.py
@@ -13,7 +13,7 @@ class CIFAR10(VisionDataset):
     """`CIFAR10 <https://www.cs.toronto.edu/~kriz/cifar.html>`_ Dataset.
 
     Args:
-        root (string): Root directory of dataset where directory
+        root (str or ``pathlib.Path``): Root directory of dataset where directory
             ``cifar-10-batches-py`` exists or will be saved to if download is set to True.
         train (bool, optional): If True, creates dataset from training set, otherwise
             creates from test set.

--- a/torchvision/datasets/cifar.py
+++ b/torchvision/datasets/cifar.py
@@ -1,6 +1,7 @@
 import os.path
 import pickle
-from typing import Any, Callable, Optional, Tuple
+from pathlib import Path
+from typing import Any, Callable, Optional, Tuple, Union
 
 import numpy as np
 from PIL import Image
@@ -50,7 +51,7 @@ class CIFAR10(VisionDataset):
 
     def __init__(
         self,
-        root: str,
+        root: Union[str, Path],
         train: bool = True,
         transform: Optional[Callable] = None,
         target_transform: Optional[Callable] = None,

--- a/torchvision/datasets/cityscapes.py
+++ b/torchvision/datasets/cityscapes.py
@@ -1,6 +1,7 @@
 import json
 import os
 from collections import namedtuple
+from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 from PIL import Image
@@ -103,7 +104,7 @@ class Cityscapes(VisionDataset):
 
     def __init__(
         self,
-        root: str,
+        root: Union[str, Path],
         split: str = "train",
         mode: str = "fine",
         target_type: Union[List[str], str] = "instance",

--- a/torchvision/datasets/cityscapes.py
+++ b/torchvision/datasets/cityscapes.py
@@ -13,7 +13,7 @@ class Cityscapes(VisionDataset):
     """`Cityscapes <http://www.cityscapes-dataset.com/>`_ Dataset.
 
     Args:
-        root (string): Root directory of dataset where directory ``leftImg8bit``
+        root (str or ``pathlib.Path``): Root directory of dataset where directory ``leftImg8bit``
             and ``gtFine`` or ``gtCoarse`` are located.
         split (string, optional): The image split to use, ``train``, ``test`` or ``val`` if mode="fine"
             otherwise ``train``, ``train_extra`` or ``val``

--- a/torchvision/datasets/clevr.py
+++ b/torchvision/datasets/clevr.py
@@ -1,6 +1,6 @@
 import json
 import pathlib
-from typing import Any, Callable, List, Optional, Tuple
+from typing import Any, Callable, List, Optional, Tuple, Union
 from urllib.parse import urlparse
 
 from PIL import Image
@@ -30,7 +30,7 @@ class CLEVRClassification(VisionDataset):
 
     def __init__(
         self,
-        root: str,
+        root: Union[str, pathlib.Path],
         split: str = "train",
         transform: Optional[Callable] = None,
         target_transform: Optional[Callable] = None,

--- a/torchvision/datasets/clevr.py
+++ b/torchvision/datasets/clevr.py
@@ -15,7 +15,7 @@ class CLEVRClassification(VisionDataset):
     The number of objects in a scene are used as label.
 
     Args:
-        root (string): Root directory of dataset where directory ``root/clevr`` exists or will be saved to if download is
+        root (str or ``pathlib.Path``): Root directory of dataset where directory ``root/clevr`` exists or will be saved to if download is
             set to True.
         split (string, optional): The dataset split, supports ``"train"`` (default), ``"val"``, or ``"test"``.
         transform (callable, optional): A function/transform that takes in a PIL image and returns a transformed

--- a/torchvision/datasets/coco.py
+++ b/torchvision/datasets/coco.py
@@ -12,7 +12,7 @@ class CocoDetection(VisionDataset):
     It requires the `COCO API to be installed <https://github.com/pdollar/coco/tree/master/PythonAPI>`_.
 
     Args:
-        root (string): Root directory where images are downloaded to.
+        root (str or ``pathlib.Path``): Root directory where images are downloaded to.
         annFile (string): Path to json annotation file.
         transform (callable, optional): A function/transform that takes in a PIL image
             and returns a transformed version. E.g, ``transforms.PILToTensor``
@@ -67,7 +67,7 @@ class CocoCaptions(CocoDetection):
     It requires the `COCO API to be installed <https://github.com/pdollar/coco/tree/master/PythonAPI>`_.
 
     Args:
-        root (string): Root directory where images are downloaded to.
+        root (str or ``pathlib.Path``): Root directory where images are downloaded to.
         annFile (string): Path to json annotation file.
         transform (callable, optional): A function/transform that  takes in a PIL image
             and returns a transformed version. E.g, ``transforms.PILToTensor``

--- a/torchvision/datasets/coco.py
+++ b/torchvision/datasets/coco.py
@@ -1,5 +1,6 @@
 import os.path
-from typing import Any, Callable, List, Optional, Tuple
+from pathlib import Path
+from typing import Any, Callable, List, Optional, Tuple, Union
 
 from PIL import Image
 
@@ -24,7 +25,7 @@ class CocoDetection(VisionDataset):
 
     def __init__(
         self,
-        root: str,
+        root: Union[str, Path],
         annFile: str,
         transform: Optional[Callable] = None,
         target_transform: Optional[Callable] = None,

--- a/torchvision/datasets/country211.py
+++ b/torchvision/datasets/country211.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Callable, Optional
+from typing import Callable, Optional, Union
 
 from .folder import ImageFolder
 from .utils import download_and_extract_archive, verify_str_arg
@@ -28,7 +28,7 @@ class Country211(ImageFolder):
 
     def __init__(
         self,
-        root: str,
+        root: Union[str, Path],
         split: str = "train",
         transform: Optional[Callable] = None,
         target_transform: Optional[Callable] = None,

--- a/torchvision/datasets/country211.py
+++ b/torchvision/datasets/country211.py
@@ -14,7 +14,7 @@ class Country211(ImageFolder):
     100 test images for each country.
 
     Args:
-        root (string): Root directory of the dataset.
+        root (str or ``pathlib.Path``): Root directory of the dataset.
         split (string, optional): The dataset split, supports ``"train"`` (default), ``"valid"`` and ``"test"``.
         transform (callable, optional): A function/transform that takes in a PIL image and returns a transformed
             version. E.g, ``transforms.RandomCrop``.

--- a/torchvision/datasets/dtd.py
+++ b/torchvision/datasets/dtd.py
@@ -1,6 +1,6 @@
 import os
 import pathlib
-from typing import Any, Callable, Optional, Tuple
+from typing import Any, Callable, Optional, Tuple, Union
 
 import PIL.Image
 
@@ -34,7 +34,7 @@ class DTD(VisionDataset):
 
     def __init__(
         self,
-        root: str,
+        root: Union[str, pathlib.Path],
         split: str = "train",
         partition: int = 1,
         transform: Optional[Callable] = None,

--- a/torchvision/datasets/dtd.py
+++ b/torchvision/datasets/dtd.py
@@ -12,7 +12,7 @@ class DTD(VisionDataset):
     """`Describable Textures Dataset (DTD) <https://www.robots.ox.ac.uk/~vgg/data/dtd/>`_.
 
     Args:
-        root (string): Root directory of the dataset.
+        root (str or ``pathlib.Path``): Root directory of the dataset.
         split (string, optional): The dataset split, supports ``"train"`` (default), ``"val"``, or ``"test"``.
         partition (int, optional): The dataset partition. Should be ``1 <= partition <= 10``. Defaults to ``1``.
 

--- a/torchvision/datasets/eurosat.py
+++ b/torchvision/datasets/eurosat.py
@@ -9,7 +9,7 @@ class EuroSAT(ImageFolder):
     """RGB version of the `EuroSAT <https://github.com/phelber/eurosat>`_ Dataset.
 
     Args:
-        root (string): Root directory of dataset where ``root/eurosat`` exists.
+        root (str or ``pathlib.Path``): Root directory of dataset where ``root/eurosat`` exists.
         transform (callable, optional): A function/transform that takes in a PIL image
             and returns a transformed version. E.g, ``transforms.RandomCrop``
         target_transform (callable, optional): A function/transform that takes in the

--- a/torchvision/datasets/eurosat.py
+++ b/torchvision/datasets/eurosat.py
@@ -1,5 +1,6 @@
 import os
-from typing import Callable, Optional
+from pathlib import Path
+from typing import Callable, Optional, Union
 
 from .folder import ImageFolder
 from .utils import download_and_extract_archive
@@ -21,7 +22,7 @@ class EuroSAT(ImageFolder):
 
     def __init__(
         self,
-        root: str,
+        root: Union[str, Path],
         transform: Optional[Callable] = None,
         target_transform: Optional[Callable] = None,
         download: bool = False,

--- a/torchvision/datasets/fer2013.py
+++ b/torchvision/datasets/fer2013.py
@@ -14,7 +14,7 @@ class FER2013(VisionDataset):
     <https://www.kaggle.com/c/challenges-in-representation-learning-facial-expression-recognition-challenge>`_ Dataset.
 
     Args:
-        root (string): Root directory of dataset where directory
+        root (str or ``pathlib.Path``): Root directory of dataset where directory
             ``root/fer2013`` exists.
         split (string, optional): The dataset split, supports ``"train"`` (default), or ``"test"``.
         transform (callable, optional): A function/transform that takes in a PIL image and returns a transformed

--- a/torchvision/datasets/fer2013.py
+++ b/torchvision/datasets/fer2013.py
@@ -1,6 +1,6 @@
 import csv
 import pathlib
-from typing import Any, Callable, Optional, Tuple
+from typing import Any, Callable, Optional, Tuple, Union
 
 import torch
 from PIL import Image
@@ -29,7 +29,7 @@ class FER2013(VisionDataset):
 
     def __init__(
         self,
-        root: str,
+        root: Union[str, pathlib.Path],
         split: str = "train",
         transform: Optional[Callable] = None,
         target_transform: Optional[Callable] = None,

--- a/torchvision/datasets/fgvc_aircraft.py
+++ b/torchvision/datasets/fgvc_aircraft.py
@@ -23,7 +23,7 @@ class FGVCAircraft(VisionDataset):
     - ``manufacturer``, e.g. Boeing. The dataset comprises 30 different manufacturers.
 
     Args:
-        root (string): Root directory of the FGVC Aircraft dataset.
+        root (str or ``pathlib.Path``): Root directory of the FGVC Aircraft dataset.
         split (string, optional): The dataset split, supports ``train``, ``val``,
             ``trainval`` and ``test``.
         annotation_level (str, optional): The annotation level, supports ``variant``,

--- a/torchvision/datasets/fgvc_aircraft.py
+++ b/torchvision/datasets/fgvc_aircraft.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import os
-from typing import Any, Callable, Optional, Tuple
+from pathlib import Path
+from typing import Any, Callable, Optional, Tuple, Union
 
 import PIL.Image
 
@@ -41,7 +42,7 @@ class FGVCAircraft(VisionDataset):
 
     def __init__(
         self,
-        root: str,
+        root: Union[str, Path],
         split: str = "trainval",
         annotation_level: str = "variant",
         transform: Optional[Callable] = None,

--- a/torchvision/datasets/flickr.py
+++ b/torchvision/datasets/flickr.py
@@ -2,7 +2,9 @@ import glob
 import os
 from collections import defaultdict
 from html.parser import HTMLParser
-from typing import Any, Callable, Dict, List, Optional, Tuple
+
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 from PIL import Image
 
@@ -12,7 +14,7 @@ from .vision import VisionDataset
 class Flickr8kParser(HTMLParser):
     """Parser for extracting captions from the Flickr8k dataset web page."""
 
-    def __init__(self, root: str) -> None:
+    def __init__(self, root: Union[str, Path]) -> None:
         super().__init__()
 
         self.root = root

--- a/torchvision/datasets/flickr.py
+++ b/torchvision/datasets/flickr.py
@@ -56,7 +56,7 @@ class Flickr8k(VisionDataset):
     """`Flickr8k Entities <http://hockenmaier.cs.illinois.edu/8k-pictures.html>`_ Dataset.
 
     Args:
-        root (string): Root directory where images are downloaded to.
+        root (str or ``pathlib.Path``): Root directory where images are downloaded to.
         ann_file (string): Path to annotation file.
         transform (callable, optional): A function/transform that takes in a PIL image
             and returns a transformed version. E.g, ``transforms.PILToTensor``
@@ -112,7 +112,7 @@ class Flickr30k(VisionDataset):
     """`Flickr30k Entities <https://bryanplummer.com/Flickr30kEntities/>`_ Dataset.
 
     Args:
-        root (string): Root directory where images are downloaded to.
+        root (str or ``pathlib.Path``): Root directory where images are downloaded to.
         ann_file (string): Path to annotation file.
         transform (callable, optional): A function/transform that takes in a PIL image
             and returns a transformed version. E.g, ``transforms.PILToTensor``

--- a/torchvision/datasets/flickr.py
+++ b/torchvision/datasets/flickr.py
@@ -2,7 +2,6 @@ import glob
 import os
 from collections import defaultdict
 from html.parser import HTMLParser
-
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
@@ -68,7 +67,7 @@ class Flickr8k(VisionDataset):
 
     def __init__(
         self,
-        root: str,
+        root: Union[str, Path],
         ann_file: str,
         transform: Optional[Callable] = None,
         target_transform: Optional[Callable] = None,

--- a/torchvision/datasets/flowers102.py
+++ b/torchvision/datasets/flowers102.py
@@ -22,7 +22,7 @@ class Flowers102(VisionDataset):
     have large variations within the category, and several very similar categories.
 
     Args:
-        root (string): Root directory of the dataset.
+        root (str or ``pathlib.Path``): Root directory of the dataset.
         split (string, optional): The dataset split, supports ``"train"`` (default), ``"val"``, or ``"test"``.
         transform (callable, optional): A function/transform that takes in a PIL image and returns a
             transformed version. E.g, ``transforms.RandomCrop``.

--- a/torchvision/datasets/flowers102.py
+++ b/torchvision/datasets/flowers102.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any, Callable, Optional, Tuple
+from typing import Any, Callable, Optional, Tuple, Union
 
 import PIL.Image
 
@@ -42,7 +42,7 @@ class Flowers102(VisionDataset):
 
     def __init__(
         self,
-        root: str,
+        root: Union[str, Path],
         split: str = "train",
         transform: Optional[Callable] = None,
         target_transform: Optional[Callable] = None,

--- a/torchvision/datasets/folder.py
+++ b/torchvision/datasets/folder.py
@@ -1,6 +1,5 @@
 import os
 import os.path
-
 from pathlib import Path
 from typing import Any, Callable, cast, Dict, List, Optional, Tuple, Union
 

--- a/torchvision/datasets/folder.py
+++ b/torchvision/datasets/folder.py
@@ -112,7 +112,7 @@ class DatasetFolder(VisionDataset):
     :meth:`find_classes` method.
 
     Args:
-        root (string): Root directory path.
+        root (str or ``pathlib.Path``): Root directory path.
         loader (callable): A function to load a sample given its path.
         extensions (tuple[string]): A list of allowed extensions.
             both extensions and is_valid_file should not be passed.
@@ -298,7 +298,7 @@ class ImageFolder(DatasetFolder):
     the same methods can be overridden to customize the dataset.
 
     Args:
-        root (string): Root directory path.
+        root (str or ``pathlib.Path``): Root directory path.
         transform (callable, optional): A function/transform that takes in a PIL image
             and returns a transformed version. E.g, ``transforms.RandomCrop``
         target_transform (callable, optional): A function/transform that takes in the

--- a/torchvision/datasets/folder.py
+++ b/torchvision/datasets/folder.py
@@ -1,5 +1,7 @@
 import os
 import os.path
+
+from pathlib import Path
 from typing import Any, Callable, cast, Dict, List, Optional, Tuple, Union
 
 from PIL import Image
@@ -32,7 +34,7 @@ def is_image_file(filename: str) -> bool:
     return has_file_allowed_extension(filename, IMG_EXTENSIONS)
 
 
-def find_classes(directory: str) -> Tuple[List[str], Dict[str, int]]:
+def find_classes(directory: Union[str, Path]) -> Tuple[List[str], Dict[str, int]]:
     """Finds the class folders in a dataset.
 
     See :class:`DatasetFolder` for details.
@@ -46,7 +48,7 @@ def find_classes(directory: str) -> Tuple[List[str], Dict[str, int]]:
 
 
 def make_dataset(
-    directory: str,
+    directory: Union[str, Path],
     class_to_idx: Optional[Dict[str, int]] = None,
     extensions: Optional[Union[str, Tuple[str, ...]]] = None,
     is_valid_file: Optional[Callable[[str], bool]] = None,
@@ -136,7 +138,7 @@ class DatasetFolder(VisionDataset):
 
     def __init__(
         self,
-        root: str,
+        root: Union[str, Path],
         loader: Callable[[str], Any],
         extensions: Optional[Tuple[str, ...]] = None,
         transform: Optional[Callable] = None,
@@ -164,7 +166,7 @@ class DatasetFolder(VisionDataset):
 
     @staticmethod
     def make_dataset(
-        directory: str,
+        directory: Union[str, Path],
         class_to_idx: Dict[str, int],
         extensions: Optional[Tuple[str, ...]] = None,
         is_valid_file: Optional[Callable[[str], bool]] = None,
@@ -203,7 +205,7 @@ class DatasetFolder(VisionDataset):
             directory, class_to_idx, extensions=extensions, is_valid_file=is_valid_file, allow_empty=allow_empty
         )
 
-    def find_classes(self, directory: str) -> Tuple[List[str], Dict[str, int]]:
+    def find_classes(self, directory: Union[str, Path]) -> Tuple[List[str], Dict[str, int]]:
         """Find the class folders in a dataset structured as follows::
 
             directory/

--- a/torchvision/datasets/food101.py
+++ b/torchvision/datasets/food101.py
@@ -19,7 +19,7 @@ class Food101(VisionDataset):
 
 
     Args:
-        root (string): Root directory of the dataset.
+        root (str or ``pathlib.Path``): Root directory of the dataset.
         split (string, optional): The dataset split, supports ``"train"`` (default) and ``"test"``.
         transform (callable, optional): A function/transform that takes in a PIL image and returns a transformed
             version. E.g, ``transforms.RandomCrop``.

--- a/torchvision/datasets/food101.py
+++ b/torchvision/datasets/food101.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from typing import Any, Callable, Optional, Tuple
+from typing import Any, Callable, Optional, Tuple, Union
 
 import PIL.Image
 
@@ -34,7 +34,7 @@ class Food101(VisionDataset):
 
     def __init__(
         self,
-        root: str,
+        root: Union[str, Path],
         split: str = "train",
         transform: Optional[Callable] = None,
         target_transform: Optional[Callable] = None,

--- a/torchvision/datasets/gtsrb.py
+++ b/torchvision/datasets/gtsrb.py
@@ -1,6 +1,6 @@
 import csv
 import pathlib
-from typing import Any, Callable, Optional, Tuple
+from typing import Any, Callable, Optional, Tuple, Union
 
 import PIL
 
@@ -25,7 +25,7 @@ class GTSRB(VisionDataset):
 
     def __init__(
         self,
-        root: str,
+        root: Union[str, pathlib.Path],
         split: str = "train",
         transform: Optional[Callable] = None,
         target_transform: Optional[Callable] = None,

--- a/torchvision/datasets/gtsrb.py
+++ b/torchvision/datasets/gtsrb.py
@@ -13,7 +13,7 @@ class GTSRB(VisionDataset):
     """`German Traffic Sign Recognition Benchmark (GTSRB) <https://benchmark.ini.rub.de/>`_ Dataset.
 
     Args:
-        root (string): Root directory of the dataset.
+        root (str or ``pathlib.Path``): Root directory of the dataset.
         split (string, optional): The dataset split, supports ``"train"`` (default), or ``"test"``.
         transform (callable, optional): A function/transform that takes in a PIL image and returns a transformed
             version. E.g, ``transforms.RandomCrop``.

--- a/torchvision/datasets/hmdb51.py
+++ b/torchvision/datasets/hmdb51.py
@@ -1,6 +1,7 @@
 import glob
 import os
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 from torch import Tensor
 
@@ -59,7 +60,7 @@ class HMDB51(VisionDataset):
 
     def __init__(
         self,
-        root: str,
+        root: Union[str, Path],
         annotation_path: str,
         frames_per_clip: int,
         step_between_clips: int = 1,

--- a/torchvision/datasets/hmdb51.py
+++ b/torchvision/datasets/hmdb51.py
@@ -28,7 +28,7 @@ class HMDB51(VisionDataset):
     Internally, it uses a VideoClips object to handle clip creation.
 
     Args:
-        root (string): Root directory of the HMDB51 Dataset.
+        root (str or ``pathlib.Path``): Root directory of the HMDB51 Dataset.
         annotation_path (str): Path to the folder containing the split files.
         frames_per_clip (int): Number of frames in a clip.
         step_between_clips (int): Number of frames between each clip.

--- a/torchvision/datasets/imagenet.py
+++ b/torchvision/datasets/imagenet.py
@@ -28,7 +28,7 @@ class ImageNet(ImageFolder):
         or ``ILSVRC2012_img_val.tar`` based on ``split`` in the root directory.
 
     Args:
-        root (string): Root directory of the ImageNet Dataset.
+        root (str or ``pathlib.Path``): Root directory of the ImageNet Dataset.
         split (string, optional): The dataset split, supports ``train``, or ``val``.
         transform (callable, optional): A function/transform that takes in a PIL image
             and returns a transformed version. E.g, ``transforms.RandomCrop``

--- a/torchvision/datasets/imagenet.py
+++ b/torchvision/datasets/imagenet.py
@@ -2,7 +2,9 @@ import os
 import shutil
 import tempfile
 from contextlib import contextmanager
-from typing import Any, Dict, Iterator, List, Optional, Tuple
+
+from pathlib import Path
+from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 
 import torch
 
@@ -78,7 +80,7 @@ class ImageNet(ImageFolder):
         return "Split: {split}".format(**self.__dict__)
 
 
-def load_meta_file(root: str, file: Optional[str] = None) -> Tuple[Dict[str, str], List[str]]:
+def load_meta_file(root: Union[str, Path], file: Optional[str] = None) -> Tuple[Dict[str, str], List[str]]:
     if file is None:
         file = META_FILE
     file = os.path.join(root, file)
@@ -93,7 +95,7 @@ def load_meta_file(root: str, file: Optional[str] = None) -> Tuple[Dict[str, str
         raise RuntimeError(msg.format(file, root))
 
 
-def _verify_archive(root: str, file: str, md5: str) -> None:
+def _verify_archive(root: Union[str, Path], file: str, md5: str) -> None:
     if not check_integrity(os.path.join(root, file), md5):
         msg = (
             "The archive {} is not present in the root directory or is corrupted. "
@@ -102,12 +104,12 @@ def _verify_archive(root: str, file: str, md5: str) -> None:
         raise RuntimeError(msg.format(file, root))
 
 
-def parse_devkit_archive(root: str, file: Optional[str] = None) -> None:
+def parse_devkit_archive(root: Union[str, Path], file: Optional[str] = None) -> None:
     """Parse the devkit archive of the ImageNet2012 classification dataset and save
     the meta information in a binary file.
 
     Args:
-        root (str): Root directory containing the devkit archive
+        root (str or ``pathlib.Path``): Root directory containing the devkit archive
         file (str, optional): Name of devkit archive. Defaults to
             'ILSVRC2012_devkit_t12.tar.gz'
     """
@@ -156,12 +158,12 @@ def parse_devkit_archive(root: str, file: Optional[str] = None) -> None:
         torch.save((wnid_to_classes, val_wnids), os.path.join(root, META_FILE))
 
 
-def parse_train_archive(root: str, file: Optional[str] = None, folder: str = "train") -> None:
+def parse_train_archive(root: Union[str, Path], file: Optional[str] = None, folder: str = "train") -> None:
     """Parse the train images archive of the ImageNet2012 classification dataset and
     prepare it for usage with the ImageNet dataset.
 
     Args:
-        root (str): Root directory containing the train images archive
+        root (str or ``pathlib.Path``): Root directory containing the train images archive
         file (str, optional): Name of train images archive. Defaults to
             'ILSVRC2012_img_train.tar'
         folder (str, optional): Optional name for train images folder. Defaults to
@@ -183,13 +185,13 @@ def parse_train_archive(root: str, file: Optional[str] = None, folder: str = "tr
 
 
 def parse_val_archive(
-    root: str, file: Optional[str] = None, wnids: Optional[List[str]] = None, folder: str = "val"
+    root: Union[str, Path], file: Optional[str] = None, wnids: Optional[List[str]] = None, folder: str = "val"
 ) -> None:
     """Parse the validation images archive of the ImageNet2012 classification dataset
     and prepare it for usage with the ImageNet dataset.
 
     Args:
-        root (str): Root directory containing the validation images archive
+        root (str or ``pathlib.Path``): Root directory containing the validation images archive
         file (str, optional): Name of validation images archive. Defaults to
             'ILSVRC2012_img_val.tar'
         wnids (list, optional): List of WordNet IDs of the validation images. If None

--- a/torchvision/datasets/imagenet.py
+++ b/torchvision/datasets/imagenet.py
@@ -2,7 +2,6 @@ import os
 import shutil
 import tempfile
 from contextlib import contextmanager
-
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 
@@ -47,7 +46,7 @@ class ImageNet(ImageFolder):
         targets (list): The class_index value for each image in the dataset
     """
 
-    def __init__(self, root: str, split: str = "train", **kwargs: Any) -> None:
+    def __init__(self, root: Union[str, Path], split: str = "train", **kwargs: Any) -> None:
         root = self.root = os.path.expanduser(root)
         self.split = verify_str_arg(split, "split", ("train", "val"))
 

--- a/torchvision/datasets/imagenette.py
+++ b/torchvision/datasets/imagenette.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any, Callable, Optional, Tuple
+from typing import Any, Callable, Optional, Tuple, Union
 
 from PIL import Image
 
@@ -48,7 +48,7 @@ class Imagenette(VisionDataset):
 
     def __init__(
         self,
-        root: str,
+        root: Union[str, Path],
         split: str = "train",
         size: str = "full",
         download=False,

--- a/torchvision/datasets/imagenette.py
+++ b/torchvision/datasets/imagenette.py
@@ -12,7 +12,7 @@ class Imagenette(VisionDataset):
     """`Imagenette <https://github.com/fastai/imagenette#imagenette-1>`_ image classification dataset.
 
     Args:
-        root (string): Root directory of the Imagenette dataset.
+        root (str or ``pathlib.Path``): Root directory of the Imagenette dataset.
         split (string, optional): The dataset split. Supports ``"train"`` (default), and ``"val"``.
         size (string, optional): The image size. Supports ``"full"`` (default), ``"320px"``, and ``"160px"``.
         download (bool, optional): If ``True``, downloads the dataset components and places them in ``root``. Already

--- a/torchvision/datasets/inaturalist.py
+++ b/torchvision/datasets/inaturalist.py
@@ -1,5 +1,6 @@
 import os
 import os.path
+from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 from PIL import Image
@@ -65,7 +66,7 @@ class INaturalist(VisionDataset):
 
     def __init__(
         self,
-        root: str,
+        root: Union[str, Path],
         version: str = "2021_train",
         target_type: Union[List[str], str] = "full",
         transform: Optional[Callable] = None,

--- a/torchvision/datasets/inaturalist.py
+++ b/torchvision/datasets/inaturalist.py
@@ -32,7 +32,7 @@ class INaturalist(VisionDataset):
     """`iNaturalist <https://github.com/visipedia/inat_comp>`_ Dataset.
 
     Args:
-        root (string): Root directory of dataset where the image files are stored.
+        root (str or ``pathlib.Path``): Root directory of dataset where the image files are stored.
             This class does not require/use annotation files.
         version (string, optional): Which version of the dataset to download/use. One of
             '2017', '2018', '2019', '2021_train', '2021_train_mini', '2021_valid'.

--- a/torchvision/datasets/kinetics.py
+++ b/torchvision/datasets/kinetics.py
@@ -5,7 +5,8 @@ import urllib
 from functools import partial
 from multiprocessing import Pool
 from os import path
-from typing import Any, Callable, Dict, Optional, Tuple
+from pathlib import Path
+from typing import Any, Callable, Dict, Optional, Tuple, Union
 
 from torch import Tensor
 
@@ -90,7 +91,7 @@ class Kinetics(VisionDataset):
 
     def __init__(
         self,
-        root: str,
+        root: Union[str, Path],
         frames_per_clip: int,
         num_classes: str = "400",
         split: str = "train",

--- a/torchvision/datasets/kinetics.py
+++ b/torchvision/datasets/kinetics.py
@@ -35,7 +35,7 @@ class Kinetics(VisionDataset):
     frames in a video might be present.
 
     Args:
-        root (string): Root directory of the Kinetics Dataset.
+        root (str or ``pathlib.Path``): Root directory of the Kinetics Dataset.
             Directory should be structured as follows:
             .. code::
 

--- a/torchvision/datasets/kitti.py
+++ b/torchvision/datasets/kitti.py
@@ -14,7 +14,7 @@ class Kitti(VisionDataset):
     It corresponds to the "left color images of object" dataset, for object detection.
 
     Args:
-        root (string): Root directory where images are downloaded to.
+        root (str or ``pathlib.Path``): Root directory where images are downloaded to.
             Expects the following folder structure if download=False:
 
             .. code::

--- a/torchvision/datasets/kitti.py
+++ b/torchvision/datasets/kitti.py
@@ -1,6 +1,7 @@
 import csv
 import os
-from typing import Any, Callable, List, Optional, Tuple
+from pathlib import Path
+from typing import Any, Callable, List, Optional, Tuple, Union
 
 from PIL import Image
 
@@ -51,7 +52,7 @@ class Kitti(VisionDataset):
 
     def __init__(
         self,
-        root: str,
+        root: Union[str, Path],
         train: bool = True,
         transform: Optional[Callable] = None,
         target_transform: Optional[Callable] = None,

--- a/torchvision/datasets/lfw.py
+++ b/torchvision/datasets/lfw.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 from PIL import Image
@@ -31,7 +32,7 @@ class _LFW(VisionDataset):
 
     def __init__(
         self,
-        root: str,
+        root: Union[str, Path],
         split: str,
         image_set: str,
         view: str,

--- a/torchvision/datasets/lfw.py
+++ b/torchvision/datasets/lfw.py
@@ -95,7 +95,7 @@ class LFWPeople(_LFW):
     """`LFW <http://vis-www.cs.umass.edu/lfw/>`_ Dataset.
 
     Args:
-        root (string): Root directory of dataset where directory
+        root (str or ``pathlib.Path``): Root directory of dataset where directory
             ``lfw-py`` exists or will be saved to if download is set to True.
         split (string, optional): The image split to use. Can be one of ``train``, ``test``,
             ``10fold`` (default).
@@ -177,7 +177,7 @@ class LFWPairs(_LFW):
     """`LFW <http://vis-www.cs.umass.edu/lfw/>`_ Dataset.
 
     Args:
-        root (string): Root directory of dataset where directory
+        root (str or ``pathlib.Path``): Root directory of dataset where directory
             ``lfw-py`` exists or will be saved to if download is set to True.
         split (string, optional): The image split to use. Can be one of ``train``, ``test``,
             ``10fold``. Defaults to ``10fold``.

--- a/torchvision/datasets/lsun.py
+++ b/torchvision/datasets/lsun.py
@@ -60,7 +60,7 @@ class LSUN(VisionDataset):
     ``pip install lmdb``
 
     Args:
-        root (string): Root directory for the database files.
+        root (str or ``pathlib.Path``): Root directory for the database files.
         classes (string or list): One of {'train', 'val', 'test'} or a list of
             categories to load. e,g. ['bedroom_train', 'church_outdoor_train'].
         transform (callable, optional): A function/transform that takes in a PIL image

--- a/torchvision/datasets/lsun.py
+++ b/torchvision/datasets/lsun.py
@@ -3,6 +3,7 @@ import os.path
 import pickle
 import string
 from collections.abc import Iterable
+from pathlib import Path
 from typing import Any, Callable, cast, List, Optional, Tuple, Union
 
 from PIL import Image
@@ -71,7 +72,7 @@ class LSUN(VisionDataset):
 
     def __init__(
         self,
-        root: str,
+        root: Union[str, Path],
         classes: Union[str, List[str]] = "train",
         transform: Optional[Callable] = None,
         target_transform: Optional[Callable] = None,

--- a/torchvision/datasets/mnist.py
+++ b/torchvision/datasets/mnist.py
@@ -20,7 +20,7 @@ class MNIST(VisionDataset):
     """`MNIST <http://yann.lecun.com/exdb/mnist/>`_ Dataset.
 
     Args:
-        root (string): Root directory of dataset where ``MNIST/raw/train-images-idx3-ubyte``
+        root (str or ``pathlib.Path``): Root directory of dataset where ``MNIST/raw/train-images-idx3-ubyte``
             and  ``MNIST/raw/t10k-images-idx3-ubyte`` exist.
         train (bool, optional): If True, creates dataset from ``train-images-idx3-ubyte``,
             otherwise from ``t10k-images-idx3-ubyte``.
@@ -203,7 +203,7 @@ class FashionMNIST(MNIST):
     """`Fashion-MNIST <https://github.com/zalandoresearch/fashion-mnist>`_ Dataset.
 
     Args:
-        root (string): Root directory of dataset where ``FashionMNIST/raw/train-images-idx3-ubyte``
+        root (str or ``pathlib.Path``): Root directory of dataset where ``FashionMNIST/raw/train-images-idx3-ubyte``
             and  ``FashionMNIST/raw/t10k-images-idx3-ubyte`` exist.
         train (bool, optional): If True, creates dataset from ``train-images-idx3-ubyte``,
             otherwise from ``t10k-images-idx3-ubyte``.
@@ -231,7 +231,7 @@ class KMNIST(MNIST):
     """`Kuzushiji-MNIST <https://github.com/rois-codh/kmnist>`_ Dataset.
 
     Args:
-        root (string): Root directory of dataset where ``KMNIST/raw/train-images-idx3-ubyte``
+        root (str or ``pathlib.Path``): Root directory of dataset where ``KMNIST/raw/train-images-idx3-ubyte``
             and  ``KMNIST/raw/t10k-images-idx3-ubyte`` exist.
         train (bool, optional): If True, creates dataset from ``train-images-idx3-ubyte``,
             otherwise from ``t10k-images-idx3-ubyte``.
@@ -259,7 +259,7 @@ class EMNIST(MNIST):
     """`EMNIST <https://www.westernsydney.edu.au/bens/home/reproducible_research/emnist>`_ Dataset.
 
     Args:
-        root (string): Root directory of dataset where ``EMNIST/raw/train-images-idx3-ubyte``
+        root (str or ``pathlib.Path``): Root directory of dataset where ``EMNIST/raw/train-images-idx3-ubyte``
             and  ``EMNIST/raw/t10k-images-idx3-ubyte`` exist.
         split (string): The dataset has 6 different splits: ``byclass``, ``bymerge``,
             ``balanced``, ``letters``, ``digits`` and ``mnist``. This argument specifies
@@ -343,7 +343,7 @@ class QMNIST(MNIST):
     """`QMNIST <https://github.com/facebookresearch/qmnist>`_ Dataset.
 
     Args:
-        root (string): Root directory of dataset whose ``raw``
+        root (str or ``pathlib.Path``): Root directory of dataset whose ``raw``
             subdir contains binary files of the datasets.
         what (string,optional): Can be 'train', 'test', 'test10k',
             'test50k', or 'nist' for respectively the mnist compatible

--- a/torchvision/datasets/mnist.py
+++ b/torchvision/datasets/mnist.py
@@ -5,7 +5,8 @@ import shutil
 import string
 import sys
 import warnings
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 from urllib.error import URLError
 
 import numpy as np
@@ -82,7 +83,7 @@ class MNIST(VisionDataset):
 
     def __init__(
         self,
-        root: str,
+        root: Union[str, Path],
         train: bool = True,
         transform: Optional[Callable] = None,
         target_transform: Optional[Callable] = None,
@@ -290,7 +291,7 @@ class EMNIST(MNIST):
         "mnist": list(string.digits),
     }
 
-    def __init__(self, root: str, split: str, **kwargs: Any) -> None:
+    def __init__(self, root: Union[str, Path], split: str, **kwargs: Any) -> None:
         self.split = verify_str_arg(split, "split", self.splits)
         self.training_file = self._training_file(split)
         self.test_file = self._test_file(split)
@@ -416,7 +417,7 @@ class QMNIST(MNIST):
     ]
 
     def __init__(
-        self, root: str, what: Optional[str] = None, compat: bool = True, train: bool = True, **kwargs: Any
+        self, root: Union[str, Path], what: Optional[str] = None, compat: bool = True, train: bool = True, **kwargs: Any
     ) -> None:
         if what is None:
             what = "train" if train else "test"

--- a/torchvision/datasets/moving_mnist.py
+++ b/torchvision/datasets/moving_mnist.py
@@ -11,7 +11,7 @@ class MovingMNIST(VisionDataset):
     """`MovingMNIST <http://www.cs.toronto.edu/~nitish/unsupervised_video/>`_ Dataset.
 
     Args:
-        root (string): Root directory of dataset where ``MovingMNIST/mnist_test_seq.npy`` exists.
+        root (str or ``pathlib.Path``): Root directory of dataset where ``MovingMNIST/mnist_test_seq.npy`` exists.
         split (string, optional): The dataset split, supports ``None`` (default), ``"train"`` and ``"test"``.
             If ``split=None``, the full data is returned.
         split_ratio (int, optional): The split ratio of number of frames. If ``split="train"``, the first split

--- a/torchvision/datasets/moving_mnist.py
+++ b/torchvision/datasets/moving_mnist.py
@@ -1,5 +1,6 @@
 import os.path
-from typing import Callable, Optional
+from pathlib import Path
+from typing import Callable, Optional, Union
 
 import numpy as np
 import torch
@@ -28,7 +29,7 @@ class MovingMNIST(VisionDataset):
 
     def __init__(
         self,
-        root: str,
+        root: Union[str, Path],
         split: Optional[str] = None,
         split_ratio: int = 10,
         download: bool = False,

--- a/torchvision/datasets/omniglot.py
+++ b/torchvision/datasets/omniglot.py
@@ -1,5 +1,6 @@
 from os.path import join
-from typing import Any, Callable, List, Optional, Tuple
+from pathlib import Path
+from typing import Any, Callable, List, Optional, Tuple, Union
 
 from PIL import Image
 
@@ -33,7 +34,7 @@ class Omniglot(VisionDataset):
 
     def __init__(
         self,
-        root: str,
+        root: Union[str, Path],
         background: bool = True,
         transform: Optional[Callable] = None,
         target_transform: Optional[Callable] = None,

--- a/torchvision/datasets/omniglot.py
+++ b/torchvision/datasets/omniglot.py
@@ -11,7 +11,7 @@ class Omniglot(VisionDataset):
     """`Omniglot <https://github.com/brendenlake/omniglot>`_ Dataset.
 
     Args:
-        root (string): Root directory of dataset where directory
+        root (str or ``pathlib.Path``): Root directory of dataset where directory
             ``omniglot-py`` exists.
         background (bool, optional): If True, creates dataset from the "background" set, otherwise
             creates from the "evaluation" set. This terminology is defined by the authors.

--- a/torchvision/datasets/oxford_iiit_pet.py
+++ b/torchvision/datasets/oxford_iiit_pet.py
@@ -38,7 +38,7 @@ class OxfordIIITPet(VisionDataset):
 
     def __init__(
         self,
-        root: str,
+        root: Union[str, pathlib.Path],
         split: str = "trainval",
         target_types: Union[Sequence[str], str] = "category",
         transforms: Optional[Callable] = None,

--- a/torchvision/datasets/oxford_iiit_pet.py
+++ b/torchvision/datasets/oxford_iiit_pet.py
@@ -13,7 +13,7 @@ class OxfordIIITPet(VisionDataset):
     """`Oxford-IIIT Pet Dataset   <https://www.robots.ox.ac.uk/~vgg/data/pets/>`_.
 
     Args:
-        root (string): Root directory of the dataset.
+        root (str or ``pathlib.Path``): Root directory of the dataset.
         split (string, optional): The dataset split, supports ``"trainval"`` (default) or ``"test"``.
         target_types (string, sequence of strings, optional): Types of target to use. Can be ``category`` (default) or
             ``segmentation``. Can also be a list to output a tuple with all specified target types. The types represent:

--- a/torchvision/datasets/pcam.py
+++ b/torchvision/datasets/pcam.py
@@ -18,7 +18,7 @@ class PCAM(VisionDataset):
     This dataset requires the ``h5py`` package which you can install with ``pip install h5py``.
 
     Args:
-         root (string): Root directory of the dataset.
+         root (str or ``pathlib.Path``): Root directory of the dataset.
          split (string, optional): The dataset split, supports ``"train"`` (default), ``"test"`` or ``"val"``.
          transform (callable, optional): A function/transform that takes in a PIL image and returns a transformed
              version. E.g, ``transforms.RandomCrop``.

--- a/torchvision/datasets/pcam.py
+++ b/torchvision/datasets/pcam.py
@@ -1,5 +1,5 @@
 import pathlib
-from typing import Any, Callable, Optional, Tuple
+from typing import Any, Callable, Optional, Tuple, Union
 
 from PIL import Image
 
@@ -72,7 +72,7 @@ class PCAM(VisionDataset):
 
     def __init__(
         self,
-        root: str,
+        root: Union[str, pathlib.Path],
         split: str = "train",
         transform: Optional[Callable] = None,
         target_transform: Optional[Callable] = None,

--- a/torchvision/datasets/phototour.py
+++ b/torchvision/datasets/phototour.py
@@ -24,7 +24,7 @@ class PhotoTour(VisionDataset):
 
 
     Args:
-        root (string): Root directory where images are.
+        root (str or ``pathlib.Path``): Root directory where images are.
         name (string): Name of the dataset to load.
         transform (callable, optional): A function/transform that takes in a PIL image
             and returns a transformed version.

--- a/torchvision/datasets/phototour.py
+++ b/torchvision/datasets/phototour.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 from typing import Any, Callable, List, Optional, Tuple, Union
 
 import numpy as np
@@ -87,7 +88,12 @@ class PhotoTour(VisionDataset):
     matches_files = "m50_100000_100000_0.txt"
 
     def __init__(
-        self, root: str, name: str, train: bool = True, transform: Optional[Callable] = None, download: bool = False
+        self,
+        root: Union[str, Path],
+        name: str,
+        train: bool = True,
+        transform: Optional[Callable] = None,
+        download: bool = False,
     ) -> None:
         super().__init__(root, transform=transform)
         self.name = name

--- a/torchvision/datasets/places365.py
+++ b/torchvision/datasets/places365.py
@@ -1,6 +1,7 @@
 import os
 from os import path
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 from urllib.parse import urljoin
 
 from .folder import default_loader
@@ -62,7 +63,7 @@ class Places365(VisionDataset):
 
     def __init__(
         self,
-        root: str,
+        root: Union[str, Path],
         split: str = "train-standard",
         small: bool = False,
         download: bool = False,

--- a/torchvision/datasets/places365.py
+++ b/torchvision/datasets/places365.py
@@ -12,7 +12,7 @@ class Places365(VisionDataset):
     r"""`Places365 <http://places2.csail.mit.edu/index.html>`_ classification dataset.
 
     Args:
-        root (string): Root directory of the Places365 dataset.
+        root (str or ``pathlib.Path``): Root directory of the Places365 dataset.
         split (string, optional): The dataset split. Can be one of ``train-standard`` (default), ``train-challenge``,
             ``val``.
         small (bool, optional): If ``True``, uses the small images, i.e. resized to 256 x 256 pixels, instead of the

--- a/torchvision/datasets/rendered_sst2.py
+++ b/torchvision/datasets/rendered_sst2.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any, Callable, Optional, Tuple
+from typing import Any, Callable, Optional, Tuple, Union
 
 import PIL.Image
 
@@ -35,7 +35,7 @@ class RenderedSST2(VisionDataset):
 
     def __init__(
         self,
-        root: str,
+        root: Union[str, Path],
         split: str = "train",
         transform: Optional[Callable] = None,
         target_transform: Optional[Callable] = None,

--- a/torchvision/datasets/rendered_sst2.py
+++ b/torchvision/datasets/rendered_sst2.py
@@ -20,7 +20,7 @@ class RenderedSST2(VisionDataset):
     (444 positive and 428 negative), and a test split containing 1821 images (909 positive and 912 negative).
 
     Args:
-        root (string): Root directory of the dataset.
+        root (str or ``pathlib.Path``): Root directory of the dataset.
         split (string, optional): The dataset split, supports ``"train"`` (default), `"val"` and ``"test"``.
         transform (callable, optional): A function/transform that takes in a PIL image and returns a transformed
             version. E.g, ``transforms.RandomCrop``.

--- a/torchvision/datasets/sbd.py
+++ b/torchvision/datasets/sbd.py
@@ -27,7 +27,7 @@ class SBDataset(VisionDataset):
         This class needs `scipy <https://docs.scipy.org/doc/>`_ to load target files from `.mat` format.
 
     Args:
-        root (string): Root directory of the Semantic Boundaries Dataset
+        root (str or ``pathlib.Path``): Root directory of the Semantic Boundaries Dataset
         image_set (string, optional): Select the image_set to use, ``train``, ``val`` or ``train_noval``.
             Image set ``train_noval`` excludes VOC 2012 val images.
         mode (string, optional): Select target type. Possible values 'boundaries' or 'segmentation'.

--- a/torchvision/datasets/sbd.py
+++ b/torchvision/datasets/sbd.py
@@ -1,6 +1,7 @@
 import os
 import shutil
-from typing import Any, Callable, Optional, Tuple
+from pathlib import Path
+from typing import Any, Callable, Optional, Tuple, Union
 
 import numpy as np
 from PIL import Image
@@ -51,7 +52,7 @@ class SBDataset(VisionDataset):
 
     def __init__(
         self,
-        root: str,
+        root: Union[str, Path],
         image_set: str = "train",
         mode: str = "boundaries",
         download: bool = False,

--- a/torchvision/datasets/sbu.py
+++ b/torchvision/datasets/sbu.py
@@ -1,5 +1,6 @@
 import os
-from typing import Any, Callable, Optional, Tuple
+from pathlib import Path
+from typing import Any, Callable, Optional, Tuple, Union
 
 from PIL import Image
 
@@ -28,7 +29,7 @@ class SBU(VisionDataset):
 
     def __init__(
         self,
-        root: str,
+        root: Union[str, Path],
         transform: Optional[Callable] = None,
         target_transform: Optional[Callable] = None,
         download: bool = True,

--- a/torchvision/datasets/sbu.py
+++ b/torchvision/datasets/sbu.py
@@ -11,7 +11,7 @@ class SBU(VisionDataset):
     """`SBU Captioned Photo <http://www.cs.virginia.edu/~vicente/sbucaptions/>`_ Dataset.
 
     Args:
-        root (string): Root directory of dataset where tarball
+        root (str or ``pathlib.Path``): Root directory of dataset where tarball
             ``SBUCaptionedPhotoDataset.tar.gz`` exists.
         transform (callable, optional): A function/transform that takes in a PIL image
             and returns a transformed version. E.g, ``transforms.RandomCrop``

--- a/torchvision/datasets/semeion.py
+++ b/torchvision/datasets/semeion.py
@@ -12,7 +12,7 @@ class SEMEION(VisionDataset):
     r"""`SEMEION <http://archive.ics.uci.edu/ml/datasets/semeion+handwritten+digit>`_ Dataset.
 
     Args:
-        root (string): Root directory of dataset where directory
+        root (str or ``pathlib.Path``): Root directory of dataset where directory
             ``semeion.py`` exists.
         transform (callable, optional): A function/transform that takes in a PIL image
             and returns a transformed version. E.g, ``transforms.RandomCrop``

--- a/torchvision/datasets/semeion.py
+++ b/torchvision/datasets/semeion.py
@@ -1,5 +1,6 @@
 import os.path
-from typing import Any, Callable, Optional, Tuple
+from pathlib import Path
+from typing import Any, Callable, Optional, Tuple, Union
 
 import numpy as np
 from PIL import Image
@@ -29,7 +30,7 @@ class SEMEION(VisionDataset):
 
     def __init__(
         self,
-        root: str,
+        root: Union[str, Path],
         transform: Optional[Callable] = None,
         target_transform: Optional[Callable] = None,
         download: bool = True,

--- a/torchvision/datasets/stanford_cars.py
+++ b/torchvision/datasets/stanford_cars.py
@@ -21,7 +21,7 @@ class StanfordCars(VisionDataset):
         This class needs `scipy <https://docs.scipy.org/doc/>`_ to load target files from `.mat` format.
 
     Args:
-        root (string): Root directory of dataset
+        root (str or ``pathlib.Path``): Root directory of dataset
         split (string, optional): The dataset split, supports ``"train"`` (default) or ``"test"``.
         transform (callable, optional): A function/transform that takes in a PIL image
             and returns a transformed version. E.g, ``transforms.RandomCrop``

--- a/torchvision/datasets/stanford_cars.py
+++ b/torchvision/datasets/stanford_cars.py
@@ -1,5 +1,5 @@
 import pathlib
-from typing import Any, Callable, Optional, Tuple
+from typing import Any, Callable, Optional, Tuple, Union
 
 from PIL import Image
 
@@ -35,7 +35,7 @@ class StanfordCars(VisionDataset):
 
     def __init__(
         self,
-        root: str,
+        root: Union[str, pathlib.Path],
         split: str = "train",
         transform: Optional[Callable] = None,
         target_transform: Optional[Callable] = None,

--- a/torchvision/datasets/stl10.py
+++ b/torchvision/datasets/stl10.py
@@ -12,7 +12,7 @@ class STL10(VisionDataset):
     """`STL10 <https://cs.stanford.edu/~acoates/stl10/>`_ Dataset.
 
     Args:
-        root (string): Root directory of dataset where directory
+        root (str or ``pathlib.Path``): Root directory of dataset where directory
             ``stl10_binary`` exists.
         split (string): One of {'train', 'test', 'unlabeled', 'train+unlabeled'}.
             Accordingly, dataset is selected.

--- a/torchvision/datasets/stl10.py
+++ b/torchvision/datasets/stl10.py
@@ -1,5 +1,6 @@
 import os.path
-from typing import Any, Callable, cast, Optional, Tuple
+from pathlib import Path
+from typing import Any, Callable, cast, Optional, Tuple, Union
 
 import numpy as np
 from PIL import Image
@@ -45,7 +46,7 @@ class STL10(VisionDataset):
 
     def __init__(
         self,
-        root: str,
+        root: Union[str, Path],
         split: str = "train",
         folds: Optional[int] = None,
         transform: Optional[Callable] = None,

--- a/torchvision/datasets/sun397.py
+++ b/torchvision/datasets/sun397.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any, Callable, Optional, Tuple
+from typing import Any, Callable, Optional, Tuple, Union
 
 import PIL.Image
 
@@ -28,7 +28,7 @@ class SUN397(VisionDataset):
 
     def __init__(
         self,
-        root: str,
+        root: Union[str, Path],
         transform: Optional[Callable] = None,
         target_transform: Optional[Callable] = None,
         download: bool = False,

--- a/torchvision/datasets/sun397.py
+++ b/torchvision/datasets/sun397.py
@@ -14,7 +14,7 @@ class SUN397(VisionDataset):
     397 categories with 108'754 images.
 
     Args:
-        root (string): Root directory of the dataset.
+        root (str or ``pathlib.Path``): Root directory of the dataset.
         transform (callable, optional): A function/transform that takes in a PIL image and returns a transformed
             version. E.g, ``transforms.RandomCrop``.
         target_transform (callable, optional): A function/transform that takes in the target and transforms it.

--- a/torchvision/datasets/svhn.py
+++ b/torchvision/datasets/svhn.py
@@ -19,7 +19,7 @@ class SVHN(VisionDataset):
         This class needs `scipy <https://docs.scipy.org/doc/>`_ to load data from `.mat` format.
 
     Args:
-        root (string): Root directory of the dataset where the data is stored.
+        root (str or ``pathlib.Path``): Root directory of the dataset where the data is stored.
         split (string): One of {'train', 'test', 'extra'}.
             Accordingly dataset is selected. 'extra' is Extra training set.
         transform (callable, optional): A function/transform that takes in a PIL image

--- a/torchvision/datasets/svhn.py
+++ b/torchvision/datasets/svhn.py
@@ -1,5 +1,6 @@
 import os.path
-from typing import Any, Callable, Optional, Tuple
+from pathlib import Path
+from typing import Any, Callable, Optional, Tuple, Union
 
 import numpy as np
 from PIL import Image
@@ -52,7 +53,7 @@ class SVHN(VisionDataset):
 
     def __init__(
         self,
-        root: str,
+        root: Union[str, Path],
         split: str = "train",
         transform: Optional[Callable] = None,
         target_transform: Optional[Callable] = None,

--- a/torchvision/datasets/ucf101.py
+++ b/torchvision/datasets/ucf101.py
@@ -28,7 +28,7 @@ class UCF101(VisionDataset):
     Internally, it uses a VideoClips object to handle clip creation.
 
     Args:
-        root (string): Root directory of the UCF101 Dataset.
+        root (str or ``pathlib.Path``): Root directory of the UCF101 Dataset.
         annotation_path (str): path to the folder containing the split files;
             see docstring above for download instructions of these files
         frames_per_clip (int): number of frames in a clip.

--- a/torchvision/datasets/ucf101.py
+++ b/torchvision/datasets/ucf101.py
@@ -1,5 +1,6 @@
 import os
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 from torch import Tensor
 
@@ -52,7 +53,7 @@ class UCF101(VisionDataset):
 
     def __init__(
         self,
-        root: str,
+        root: Union[str, Path],
         annotation_path: str,
         frames_per_clip: int,
         step_between_clips: int = 1,

--- a/torchvision/datasets/usps.py
+++ b/torchvision/datasets/usps.py
@@ -15,7 +15,7 @@ class USPS(VisionDataset):
     and make pixel values in ``[0, 255]``.
 
     Args:
-        root (string): Root directory of dataset to store``USPS`` data files.
+        root (str or ``pathlib.Path``): Root directory of dataset to store``USPS`` data files.
         train (bool, optional): If True, creates dataset from ``usps.bz2``,
             otherwise from ``usps.t.bz2``.
         transform (callable, optional): A function/transform that takes in a PIL image

--- a/torchvision/datasets/usps.py
+++ b/torchvision/datasets/usps.py
@@ -1,5 +1,6 @@
 import os
-from typing import Any, Callable, Optional, Tuple
+from pathlib import Path
+from typing import Any, Callable, Optional, Tuple, Union
 
 import numpy as np
 from PIL import Image
@@ -43,7 +44,7 @@ class USPS(VisionDataset):
 
     def __init__(
         self,
-        root: str,
+        root: Union[str, Path],
         train: bool = True,
         transform: Optional[Callable] = None,
         target_transform: Optional[Callable] = None,

--- a/torchvision/datasets/vision.py
+++ b/torchvision/datasets/vision.py
@@ -1,5 +1,6 @@
 import os
-from typing import Any, Callable, List, Optional, Tuple
+from pathlib import Path
+from typing import Any, Callable, List, Optional, Tuple, Union
 
 import torch.utils.data as data
 
@@ -29,7 +30,7 @@ class VisionDataset(data.Dataset):
 
     def __init__(
         self,
-        root: str = None,  # type: ignore[assignment]
+        root: Union[str, Path] = None,  # type: ignore[assignment]
         transforms: Optional[Callable] = None,
         transform: Optional[Callable] = None,
         target_transform: Optional[Callable] = None,

--- a/torchvision/datasets/voc.py
+++ b/torchvision/datasets/voc.py
@@ -121,7 +121,7 @@ class VOCSegmentation(_VOCBase):
     """`Pascal VOC <http://host.robots.ox.ac.uk/pascal/VOC/>`_ Segmentation Dataset.
 
     Args:
-        root (string): Root directory of the VOC Dataset.
+        root (str or ``pathlib.Path``): Root directory of the VOC Dataset.
         year (string, optional): The dataset year, supports years ``"2007"`` to ``"2012"``.
         image_set (string, optional): Select the image_set to use, ``"train"``, ``"trainval"`` or ``"val"``. If
             ``year=="2007"``, can also be ``"test"``.
@@ -165,7 +165,7 @@ class VOCDetection(_VOCBase):
     """`Pascal VOC <http://host.robots.ox.ac.uk/pascal/VOC/>`_ Detection Dataset.
 
     Args:
-        root (string): Root directory of the VOC Dataset.
+        root (str or ``pathlib.Path``): Root directory of the VOC Dataset.
         year (string, optional): The dataset year, supports years ``"2007"`` to ``"2012"``.
         image_set (string, optional): Select the image_set to use, ``"train"``, ``"trainval"`` or ``"val"``. If
             ``year=="2007"``, can also be ``"test"``.

--- a/torchvision/datasets/voc.py
+++ b/torchvision/datasets/voc.py
@@ -1,18 +1,18 @@
 import collections
 import os
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 from xml.etree.ElementTree import Element as ET_Element
-
-from .vision import VisionDataset
 
 try:
     from defusedxml.ElementTree import parse as ET_parse
 except ImportError:
     from xml.etree.ElementTree import parse as ET_parse
-from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from PIL import Image
 
 from .utils import download_and_extract_archive, verify_str_arg
+from .vision import VisionDataset
 
 DATASET_YEAR_DICT = {
     "2012": {
@@ -67,7 +67,7 @@ class _VOCBase(VisionDataset):
 
     def __init__(
         self,
-        root: str,
+        root: Union[str, Path],
         year: str = "2012",
         image_set: str = "train",
         download: bool = False,

--- a/torchvision/datasets/widerface.py
+++ b/torchvision/datasets/widerface.py
@@ -1,5 +1,7 @@
 import os
 from os.path import abspath, expanduser
+from pathlib import Path
+
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import torch
@@ -55,7 +57,7 @@ class WIDERFace(VisionDataset):
 
     def __init__(
         self,
-        root: str,
+        root: Union[str, Path],
         split: str = "train",
         transform: Optional[Callable] = None,
         target_transform: Optional[Callable] = None,

--- a/torchvision/datasets/widerface.py
+++ b/torchvision/datasets/widerface.py
@@ -13,7 +13,7 @@ class WIDERFace(VisionDataset):
     """`WIDERFace <http://shuoyang1213.me/WIDERFACE/>`_ Dataset.
 
     Args:
-        root (string): Root directory where images and annotations are downloaded to.
+        root (str or ``pathlib.Path``): Root directory where images and annotations are downloaded to.
             Expects the following folder structure if download=False:
 
             .. code::


### PR DESCRIPTION
All datasets' `root` param already supports `pathlib.Path` because they just call `os.expanduser()` under the hood, which will nicely handle `Path`. So this PR just adds that to the docstrings.

This isn't explicitly tested, but https://github.com/pytorch/vision/pull/8320 should prove that `Path` works fine (@pmeier if there's a better way to test that consistently, LMK).


I'm not updating the type annotations because in all honestly I really, REALLY don't want to spend my time doing that. I gave it a go adding the annotations mentioned in https://github.com/pytorch/vision/issues/8120#issue-2000458034 to just the imagenet file, and after running for 3+ minutes mypy started to give me hell. So I'm just not doing it. If someone wants to spend the time and add the annotations, I'll be happy to stamp the PR.


With that and https://github.com/pytorch/vision/pull/8314, https://github.com/pytorch/vision/issues/8120 could be closed.