### PR TITLE
Put back StanfordCars.download (the function, NOT the feature)

### DIFF
--- a/torchvision/datasets/stanford_cars.py
+++ b/torchvision/datasets/stanford_cars.py
@@ -61,12 +61,7 @@ class StanfordCars(VisionDataset):
             self._images_base_path = self._base_folder / "cars_test"
 
         if download:
-            raise ValueError(
-                "The original URL is broken so the StanfordCars dataset is not available for automatic "
-                "download anymore. You can try to download it manually following "
-                "https://github.com/pytorch/vision/issues/7545#issuecomment-1631441616, "
-                "and set download=False to avoid this error."
-            )
+            self.download()
 
         if not self._check_exists():
             raise RuntimeError(
@@ -104,3 +99,11 @@ class StanfordCars(VisionDataset):
             return False
 
         return self._annotations_mat_path.exists() and self._images_base_path.is_dir()
+
+    def download(self):
+        raise ValueError(
+            "The original URL is broken so the StanfordCars dataset is not available for automatic "
+            "download anymore. You can try to download it manually following "
+            "https://github.com/pytorch/vision/issues/7545#issuecomment-1631441616, "
+            "and set download=False to avoid this error."
+        )


### PR DESCRIPTION
The `download()` method was removed in https://github.com/pytorch/vision/pull/8309 but since it's public it's best to keep it and raise the error there. Addresses https://github.com/pytorch/vision/pull/8309#discussion_r1522697168 which I missed - sorry


test:


```py
[ins] In [1]: from torchvision.datasets import StanfordCars
[ins] In [2]: StanfordCars(root="/tmp", download=True)
         ...: 
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-2-a557e888a29e> in <module>
----> 1 StanfordCars(root="/tmp", download=True)

~/dev/vision/torchvision/datasets/stanford_cars.py in __init__(self, root, split, transform, target_transform, download)
     62 
     63         if download:
---> 64             self.download()
     65 
     66         if not self._check_exists():

~/dev/vision/torchvision/datasets/stanford_cars.py in download(self)
    102 
    103     def download(self):
--> 104         raise ValueError(
    105             "The original URL is broken so the StanfordCars dataset is not available for automatic "
    106             "download anymore. You can try to download it manually following "

ValueError: The original URL is broken so the StanfordCars dataset is not available for automatic download anymore. You can try to download it manually following https://github.com/pytorch/vision/issues/7545#issuecomment-1631441616, and set download=False to avoid this error.
````