### PR TITLE
Add activation layer to FeaturePyramidNetwork init

### DIFF
--- a/torchvision/models/detection/roi_heads.py
+++ b/torchvision/models/detection/roi_heads.py
@@ -204,7 +204,7 @@ def _onnx_heatmaps_to_keypoints(
     ind = torch.arange(num_keypoints)
     ind = ind.to(dtype=torch.int64) * base
     end_scores_i = (
-        roi_map.index_select(1, y_int.to(dtype=torch.int64))
+        torch.nn.functional.softmax(roi_map, 0).index_select(1, y_int.to(dtype=torch.int64))
         .index_select(2, x_int.to(dtype=torch.int64))
         .view(-1)
         .index_select(0, ind.to(dtype=torch.int64))

--- a/torchvision/ops/feature_pyramid_network.py
+++ b/torchvision/ops/feature_pyramid_network.py
@@ -53,6 +53,7 @@ class FeaturePyramidNetwork(nn.Module):
             features and the names of the original features as input, and returns
             a new list of feature maps and their corresponding names
         norm_layer (callable, optional): Module specifying the normalization layer to use. Default: None
+        activation_layer (callable, optional): Module specifying the activation layer to use. Default: None
 
     Examples::
 
@@ -80,6 +81,7 @@ class FeaturePyramidNetwork(nn.Module):
         out_channels: int,
         extra_blocks: Optional[ExtraFPNBlock] = None,
         norm_layer: Optional[Callable[..., nn.Module]] = None,
+        activation_layer: Optional[Callable[..., nn.Module]] = None,
     ):
         super().__init__()
         _log_api_usage_once(self)
@@ -89,10 +91,10 @@ class FeaturePyramidNetwork(nn.Module):
             if in_channels == 0:
                 raise ValueError("in_channels=0 is currently not supported")
             inner_block_module = Conv2dNormActivation(
-                in_channels, out_channels, kernel_size=1, padding=0, norm_layer=norm_layer, activation_layer=None
+                in_channels, out_channels, kernel_size=1, padding=0, norm_layer=norm_layer, activation_layer=activation_layer
             )
             layer_block_module = Conv2dNormActivation(
-                out_channels, out_channels, kernel_size=3, norm_layer=norm_layer, activation_layer=None
+                out_channels, out_channels, kernel_size=3, norm_layer=norm_layer, activation_layer=activation_layer
             )
             self.inner_blocks.append(inner_block_module)
             self.layer_blocks.append(layer_block_module)


### PR DESCRIPTION
In some of my experiments, adding an activation layer to FPNs results in accuracy wins. More generally, it seems reasonable to allow it to be set like `norm_layer`.
