### PR TITLE
[FBcode->GH] [codemod] Remove "using namespace" dep

### DIFF
--- a/torchvision/csrc/io/video/video.cpp
+++ b/torchvision/csrc/io/video/video.cpp
@@ -2,6 +2,8 @@
 
 #include <regex>
 
+using namespace ffmpeg;
+
 namespace vision {
 namespace video {
 

--- a/torchvision/csrc/io/video/video.h
+++ b/torchvision/csrc/io/video/video.h
@@ -64,12 +64,12 @@ struct Video : torch::CustomClassHolder {
 
   std::map<std::string, std::vector<double>> streamTimeBase; // not used
 
-  DecoderInCallback callback = nullptr;
-  std::vector<DecoderMetadata> metadata;
+  ffmpeg::DecoderInCallback callback = nullptr;
+  std::vector<ffmpeg::DecoderMetadata> metadata;
 
  protected:
-  SyncDecoder decoder;
-  DecoderParameters params;
+  ffmpeg::SyncDecoder decoder;
+  ffmpeg::DecoderParameters params;
 
 }; // struct Video
 


### PR DESCRIPTION
Summary:
The files modified in this diff rely on `using namespace` in the global namespace. In this diff we break that reliance by adding appropriate namespace qualifiers.

Landing this diff helps us onboard our code to the `-Wheader-hygiene` warning flag.

D54681732 aggregates many of these files and D54681798 removes the associated headers; however, I have broken D54681732 up to make landing and rollbacks safer.

Reviewed By: palmje

Differential Revision: D54692584

fbshipit-source-id: 09e04b9c8f8d3d49664d33dbc2fe2f61aa8c0cfb

<!-- Before submitting a PR, please make sure to check our contributing guidelines regarding code formatting, tests, and documentation: https://github.com/pytorch/vision/blob/main/CONTRIBUTING.md -->
