### PR TITLE
Update CONTRIBUTING.md to reflect libjpeg dependency

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,13 +38,19 @@ instructions](https://pytorch.org/get-started/locally/). Note that the official
 instructions may ask you to install torchvision itself. If you are doing development
 on torchvision, you should not install prebuilt torchvision packages.
 
-**Optionally**, install `libpng` and `libjpeg-turbo` if you want to enable
+**Optionally**, install `libpng` if you want to enable
 support for
-native encoding / decoding of PNG and JPEG formats in
+native encoding / decoding of PNG formats in
 [torchvision.io](https://pytorch.org/vision/stable/io.html#image):
 
 ```bash
-conda install libpng libjpeg-turbo -c pytorch
+conda install libpng -c pytorch
+```
+
+`libjpeg-turbo` or `libjpeg` must be present on your system.
+
+```bash
+conda install libjpeg-turbo -c pytorch
 ```
 
 Note: you can use the `TORCHVISION_INCLUDE` and `TORCHVISION_LIBRARY`


### PR DESCRIPTION
Discovered via #8339 that libjpeg or libjpeg-turbo headers must be present for building from source.
Updating documentation in this PR. Thanks!


