### PR TITLE
Fix compilation error when there is no libjpeg

### DIFF
--- a/torchvision/csrc/io/image/cpu/exif.h
+++ b/torchvision/csrc/io/image/cpu/exif.h
@@ -196,10 +196,6 @@ inline int fetch_jpeg_exif_orientation(j_decompress_ptr cinfo) {
 
   return fetch_exif_orientation(exif_data_ptr, size);
 }
-#else // #if JPEG_FOUND
-inline int fetch_jpeg_exif_orientation(j_decompress_ptr cinfo) {
-  return -1;
-}
 #endif // #if JPEG_FOUND
 
 #if PNG_FOUND && defined(PNG_eXIf_SUPPORTED)
@@ -215,10 +211,6 @@ inline int fetch_png_exif_orientation(png_structp png_ptr, png_infop info_ptr) {
   if (exif && num_exif > 0) {
     return fetch_exif_orientation(exif, num_exif);
   }
-}
-#else // #if PNG_FOUND && defined(PNG_eXIf_SUPPORTED)
-inline int fetch_png_exif_orientation(png_structp png_ptr, png_infop info_ptr) {
-  return -1;
 }
 #endif // #if PNG_FOUND && defined(PNG_eXIf_SUPPORTED)
 


### PR DESCRIPTION
Fix https://github.com/pytorch/vision/issues/8339. The `png_structp` and `j_decompress_ptr` are defined in png.h and jpeglib.h and there seems no need to define `fetch_jpeg_exif_orientation` when libraries are not found?