### PR TITLE
Adding a FakeImageFolder

### DIFF
--- a/torchvision/datasets/fakedata.py
+++ b/torchvision/datasets/fakedata.py
@@ -65,3 +65,61 @@ class FakeData(VisionDataset):
 
     def __len__(self) -> int:
         return self.size
+
+
+class FakeImageFolder(FakeData):
+    """
+    A subclass of `FakeData` that simulates a dataset of randomly generated images, intended
+    to mimic the structure and functionality of a real image folder dataset. This class is 
+    useful for testing or benchmarking where access to actual image data is not necessary or 
+    desirable. Images are generated on-the-fly and can be returned as PIL images. 
+
+    Args:
+        root (str): Root directory of the dataset. This parameter is kept for interface
+            compatibility with other datasets but is not used since the data is fake.
+        transform (callable, optional): A function/transform that takes in a PIL image
+            and returns a transformed version. E.g., `transforms.RandomCrop`. This
+            is useful for applying data augmentation. (default: None)
+        target_transform (callable, optional): A function/transform that takes in the
+            target and transforms it. This can be used for transforming the numerical
+            labels. (default: None)
+        loader (callable, optional): A function to load an image given its path. This
+            parameter is kept for interface compatibility with other datasets but is
+            not used since the data is fake. (default: None)
+        is_valid_file (callable, optional): A function that takes path of an Image file
+            and checks if the file is a valid file (used to check corrupt files).
+            This parameter is kept for interface compatibility with other datasets but is
+            not used since the data is fake. (default: None)
+        size (int, optional): The size of the dataset, i.e., how many fake images to
+            generate. (default: 1000)
+        image_size (Tuple[int, int, int], optional): The dimensions of the generated images
+            as (channels, height, width). (default: (3, 224, 224))
+        num_classes (int, optional): The number of classes in the dataset. This determines
+            the range of labels for the generated targets. (default: 10)
+
+    Examples:
+        >>> dataset = FakeImageFolder(root='path/to/imaginary/dataset', transform=transforms.ToTensor())
+        >>> img, label = dataset[0]
+        >>> img.size()
+        torch.Size([3, 224, 224])
+        >>> label
+        5  # Randomly generated label
+    """
+    def __init__(
+        self,
+        root: str,
+        transform=None,
+        target_transform=None,
+        loader=None,
+        is_valid_file=None,
+        size: int = 1000,
+        image_size: Tuple[int, int, int] = (3, 224, 224),
+        num_classes: int = 10,
+    ):
+        super().__init__(
+            size=size,
+            image_size=image_size,
+            num_classes=num_classes,
+            transform=transform,
+            target_transform=target_transform,
+        )


### PR DESCRIPTION
Hi all,

I've added a convenience module for creating a fake image folder in torch vision. I recently needed to create a mock folder and this can be a little painful without a FakeImage folder like this

Thanks

Craig
