### PR TITLE
[FBcode -> GH] Fix fetch_png_exif_orientation

### DIFF
--- a/torchvision/csrc/io/image/cpu/exif.h
+++ b/torchvision/csrc/io/image/cpu/exif.h
@@ -215,6 +215,7 @@ inline int fetch_png_exif_orientation(png_structp png_ptr, png_infop info_ptr) {
   if (exif && num_exif > 0) {
     return fetch_exif_orientation(exif, num_exif);
   }
+  return -1;
 }
 #else // #if PNG_FOUND && defined(PNG_eXIf_SUPPORTED)
 inline int fetch_png_exif_orientation(png_structp png_ptr, png_infop info_ptr) {


### PR DESCRIPTION
This function is failing the internal CI because it's not always retuning an int.

```
sion/torchvision/csrc/io/image/cpu/exif.h:218:1: error: non-void function does not return a value in all control paths [-Werror,-Wreturn-type]
```


Note for self: I fixed the issue in the original diff D55062769, so I'm just adding `[FBCode -> GH]` in this PR so that it doesn't get synced back to fbcode.