### PR TITLE
Download the dataset if it is missing

### DIFF
--- a/references/video_classification/train.py
+++ b/references/video_classification/train.py
@@ -182,6 +182,7 @@ def main(args):
                 "mp4",
             ),
             output_format="TCHW",
+            download=True,
         )
         if args.cache_dataset:
             print(f"Saving dataset_train to {cache_path}")


### PR DESCRIPTION
Without this change, if you run the example without data, it fails with this message:

```
python train.py --data-path=/data/users/ahmads/kinectics400 --kinetics-version="400" --batch-size=8 --cache-dataset
Not using distributed mode
Namespace(data_path='/data/users/ahmads/kinectics400', kinetics_version='400', model='r2plus1d_18', device='cuda', clip_len=16, frame_rate=15, clips_per_video=5, batch_size=8, epochs=45, workers=10, lr=0.64, momentum=0.9, weight_decay=0.0001, lr_milestones=[20, 30, 40], lr_gamma=0.1, lr_warmup_epochs=10, lr_warmup_method='linear', lr_warmup_decay=0.001, print_freq=10, output_dir='.', resume='', start_epoch=0, cache_dataset=True, sync_bn=False, test_only=False, use_deterministic_algorithms=False, world_size=1, dist_url='env://', val_resize_size=(128, 171), val_crop_size=(112, 112), train_resize_size=(128, 171), train_crop_size=(112, 112), weights=None, amp=False, distributed=False)
Loading data
Loading training data
Traceback (most recent call last):
  File "/data/users/ahmads/condahome/datasets/vision/references/video_classification/train.py", line 446, in <module>
    main(args)
  File "/data/users/ahmads/condahome/datasets/vision/references/video_classification/train.py", line 172, in main
    dataset = datasets.KineticsWithVideoId(
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ahmads/.conda/envs/datasets/lib/python3.12/site-packages/torchvision-0.19.0a0+2c4665f-py3.12-linux-x86_64.egg/torchvision/datasets/kinetics.py", line 139, in __init__
    self.classes, class_to_idx = find_classes(self.split_folder)
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ahmads/.conda/envs/datasets/lib/python3.12/site-packages/torchvision-0.19.0a0+2c4665f-py3.12-linux-x86_64.egg/torchvision/datasets/folder.py", line 41, in find_classes
    classes = sorted(entry.name for entry in os.scandir(directory) if entry.is_dir())
                                             ^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/data/users/ahmads/kinectics400/train'
```

With this change, it starts to download the data if it is missing.