### PR TITLE
 Fix Missing Labels in FER2013 Dataset #8118

### DIFF
--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -2443,22 +2443,26 @@ class FER2013TestCase(datasets_utils.ImageDatasetTestCase):
         os.makedirs(base_folder)
 
         num_samples = 5
-        with open(os.path.join(base_folder, f"{config['split']}.csv"), "w", newline="") as file:
+        with open(os.path.join(base_folder, "icml_face_data.csv"), "w", newline="") as file:
             writer = csv.DictWriter(
                 file,
-                fieldnames=("emotion", "pixels") if config["split"] == "train" else ("pixels",),
+                fieldnames=("emotion", "pixels","Usage"),
                 quoting=csv.QUOTE_NONNUMERIC,
                 quotechar='"',
             )
             writer.writeheader()
-            for _ in range(num_samples):
+            for i in range(num_samples):
                 row = dict(
                     pixels=" ".join(
                         str(pixel) for pixel in datasets_utils.create_image_or_video_tensor((48, 48)).view(-1).tolist()
                     )
                 )
-                if config["split"] == "train":
-                    row["emotion"] = str(int(torch.randint(0, 7, ())))
+                row["emotion"] = str(int(torch.randint(0, 7, ())))
+
+                if config["split"] == "test":
+                    row["Usage"] = "PublicTest" if i % 2 == 0 else "PrivateTest"
+                else:
+                    row["Usage"] = "Training"
 
                 writer.writerow(row)
 

--- a/torchvision/datasets/fer2013.py
+++ b/torchvision/datasets/fer2013.py
@@ -51,8 +51,8 @@ class FER2013(VisionDataset):
             reader = csv.DictReader(file)
             self._samples = []
             for row in reader:
-                cleaned_row = {name.strip(): value for name, value in row.items()}
-                if self._split in cleaned_row["Usage"].lower():
+                cleaned_row = {name.strip().lower(): value for name, value in row.items()}
+                if self._split in cleaned_row["usage"].lower():
                     self._samples.append(
                         (
                             torch.tensor(

--- a/torchvision/datasets/fer2013.py
+++ b/torchvision/datasets/fer2013.py
@@ -23,8 +23,8 @@ class FER2013(VisionDataset):
     """
 
     _RESOURCES = {
-        "train": ("train.csv", "3f0dfb3d3fd99c811a1299cb947e3131"),
-        "test": ("test.csv", "b02c2298636a634e8c2faabbf3ea9a23"),
+        "train": ("icml_face_data.csv", "b114b9e04e6949e5fe8b6a98b3892b1d"),
+        "test": ("icml_face_data.csv", "b114b9e04e6949e5fe8b6a98b3892b1d"),
     }
 
     def __init__(
@@ -48,13 +48,19 @@ class FER2013(VisionDataset):
             )
 
         with open(data_file, "r", newline="") as file:
-            self._samples = [
-                (
-                    torch.tensor([int(idx) for idx in row["pixels"].split()], dtype=torch.uint8).reshape(48, 48),
-                    int(row["emotion"]) if "emotion" in row else None,
-                )
-                for row in csv.DictReader(file)
-            ]
+            reader = csv.DictReader(file)
+            self._samples = []
+            for row in reader:
+                cleaned_row = {name.strip(): value for name, value in row.items()}
+                if self._split in cleaned_row["Usage"].lower():
+                    self._samples.append(
+                        (
+                            torch.tensor(
+                                [int(idx) for idx in cleaned_row["pixels"].split()], dtype=torch.uint8
+                            ).reshape(48, 48),
+                            int(cleaned_row["emotion"]) if "emotion" in cleaned_row else None,
+                        )
+                    )
 
     def __len__(self) -> int:
         return len(self._samples)


### PR DESCRIPTION
In the current implementation,  labels are not provided for test split. 

The [FER2013 ](https://www.kaggle.com/c/challenges-in-representation-learning-facial-expression-recognition-challenge)dataset provides labels for both training and testing in the icml_face_data.csv file. 

This pull request reads the data from the icml_face_data.csv instead, providing labels for both the train and test splits. 





