### PR TITLE
Deactivate mypy for `_functional_pil.py` and `video_reader.py`

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -47,6 +47,10 @@ ignore_errors = True
 
 ignore_errors = True
 
+[mypy-torchvision.io.video_reader]
+
+ignore_errors = True
+
 [mypy-torchvision.models.densenet.*]
 
 ignore_errors=True

--- a/mypy.ini
+++ b/mypy.ini
@@ -95,6 +95,10 @@ ignore_errors = True
 
 ignore_errors = True
 
+[mypy-torchvision.transforms._functional_pil]
+
+ignore_errors = True
+
 [mypy-torchvision.transforms.functional.*]
 
 ignore_errors = True


### PR DESCRIPTION
Towards https://github.com/pytorch/vision/issues/8377

This PR deactivates mypy for `_functional_pil.py`  because it started failing with PIL 10.3 with absurd errors like:


```
  torchvision/transforms/_functional_pil.py:242: error: Module has no attribute
  "BILINEAR"  [attr-defined]
          interpolation: int = Image.BILINEAR,
                               ^~~~~~~~~~~~~~
  torchvision/transforms/_functional_pil.py:288: error: Module has no attribute
  "NEAREST"  [attr-defined]
          interpolation: int = Image.NEAREST,
                               ^~~~~~~~~~~~~
  torchvision/transforms/_functional_pil.py:297: error: Module has no attribute
  "AFFINE"  [attr-defined]
          return img.transform(output_size, Image.AFFINE, matrix, interpolat...
                                            ^~~~~~~~~~~~
  torchvision/transforms/_functional_pil.py:304: error: Module has no attribute
  "NEAREST"  [attr-defined]
          interpolation: int = Image.NEAREST,
                               ^~~~~~~~~~~~~
  torchvision/transforms/_functional_pil.py:321: error: Module has no attribute
  "BICUBIC"  [attr-defined]
          interpolation: int = Image.BICUBIC,
                               ^~~~~~~~~~~~~
  torchvision/transforms/_functional_pil.py:330: error: Module has no attribute
  "PERSPECTIVE"  [attr-defined]
          return img.transform(img.size, Image.PERSPECTIVE, perspective_coef...
```


which is not true, PIL.Image does have those attributes, they're just set dynamically at import time (thanks @pmeier for pointing that out!) https://github.com/python-pillow/Pillow/blob/58a47978af9f34851ce926303d05fa677010ce2a/src/PIL/Image.py#L203-L206



This also deactivates mypy for `video_reader` which is failing with

```
  torchvision/io/video_reader.py:28: error: Incompatible types in assignment
  (expression has type "ImportError", variable has type Module)  [assignment]
              av = ImportError(
                   ^
  torchvision/io/video_reader.py:38: error: Incompatible types in assignment
  (expression has type "ImportError", variable has type Module)  [assignment]
          av = ImportError(
               ^
  torchvision/io/video_reader.py:200: error: Module has no attribute "EOFError" 
  [attr-defined]
                  except av.error.EOFError:
                         ^~~~~~~~~~~~~~~~~
  torchvision/io/video_reader.py:231: error: Unsupported operand types for /
  ("float" and "None")  [operator]
                  offset = int(round(time_s / temp_str.time_base))
                                     ^
  torchvision/io/video_reader.py:231: note: Right operand is of type "Optional[Fraction]"
  torchvision/io/video_reader.py:254: error: "Stream" has no attribute
  "sample_rate"  [attr-defined]
      ...verage_rate if stream.average_rate is not None else stream.sample_rate
                                                             ^~~~~~~~~~~~~~~~~~
  torchvision/io/video_reader.py:256: error: Unsupported operand types for *
  ("int" and "None")  [operator]
      ...  metadata[stream.type]["duration"].append(float(stream.duration * str...
                                                          ^
  torchvision/io/video_reader.py:256: error: No overload variant of "__rmul__" of
  "Fraction" matches argument type "None"  [operator]
      ...  metadata[stream.type]["duration"].append(float(stream.duration * str...
                                                          ^~~~~~~~~~~~~~~~~~~~~...
  torchvision/io/video_reader.py:256: note: Possible overload variants:
  torchvision/io/video_reader.py:256: note:     def __rmul__(b, Union[int, Fraction], /) -> Fraction
  torchvision/io/video_reader.py:256: note:     def __rmul__(b, float, /) -> float
  torchvision/io/video_reader.py:256: note:     def __rmul__(b, complex, /) -> complex
  torchvision/io/video_reader.py:256: error: Unsupported left operand type for *
  ("None")  [operator]
      ...  metadata[stream.type]["duration"].append(float(stream.duration * str...
                                                          ^~~~~~~~~~~~~~~~~~~~~...
  torchvision/io/video_reader.py:256: note: Both left and right operands are unions
```


That module will be deprecated soon, so there's no point spending time on it.