### PR TITLE
Ignore mypy for `prototype.transforms.*`

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -23,17 +23,7 @@ allow_redefinition = True
 
 [mypy-torchvision.prototype.transforms.*]
 
-; untyped definitions and calls
-disallow_untyped_defs = True
-
-; None and Optional handling
-no_implicit_optional = True
-
-; warnings
-warn_unused_ignores = True
-
-; miscellaneous strictness flags
-allow_redefinition = True
+ignore_errors = True
 
 [mypy-torchvision.prototype.datasets.*]
 


### PR DESCRIPTION
Towards https://github.com/pytorch/vision/issues/8377

This removes the following mypy errors:

```
  torchvision/prototype/transforms/_presets.py:47: error: Incompatible types in
  assignment (expression has type "Tensor", variable has type "Image") 
  [assignment]
                      img = F.pil_to_tensor(img)
                            ^~~~~~~~~~~~~~~~~~~~
  torchvision/prototype/transforms/_presets.py:53: error: Incompatible types in
  assignment (expression has type "Tensor", variable has type "Image") 
  [assignment]
                      img = F.resize(img, self.resize_size, interpolation=se...
                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~...
  torchvision/prototype/transforms/_presets.py:53: error: Argument 1 to "resize"
  has incompatible type "Image"; expected "Tensor"  [arg-type]
                      img = F.resize(img, self.resize_size, interpolation=se...
                                     ^~~
  torchvision/prototype/transforms/_presets.py:55: error: Incompatible types in
  assignment (expression has type "Tensor", variable has type "Image") 
  [assignment]
                      img = F.rgb_to_grayscale(img)
                            ^~~~~~~~~~~~~~~~~~~~~~~
  torchvision/prototype/transforms/_presets.py:55: error: Argument 1 to
  "rgb_to_grayscale" has incompatible type "Image"; expected "Tensor"  [arg-type]
                      img = F.rgb_to_grayscale(img)
                                               ^~~
  torchvision/prototype/transforms/_presets.py:56: error: Argument 1 to
  "convert_image_dtype" has incompatible type "Image"; expected "Tensor" 
  [arg-type]
                  img = F.convert_image_dtype(img, torch.float)
                                              ^~~
  torchvision/prototype/transforms/_presets.py:61: error: Argument 1 to
  "_process_image" has incompatible type "Tensor"; expected "Image"  [arg-type]
              left_image = _process_image(left_image)
                                          ^~~~~~~~~~
  torchvision/prototype/transforms/_presets.py:62: error: Argument 1 to
  "_process_image" has incompatible type "Tensor"; expected "Image"  [arg-type]
              right_image = _process_image(right_image)
```


Those are (I assume) partly due to incorrect annotation, partly due to incompatibilities between torchscript and mypy. In any case, this is the prototype module and that file only contains the stereo presets which is an area that hasn't been developed/maintained in a while.

cc @bjuncek