### PR TITLE
Ignore some mypy errors

### DIFF
--- a/torchvision/datasets/cityscapes.py
+++ b/torchvision/datasets/cityscapes.py
@@ -188,7 +188,7 @@ class Cityscapes(VisionDataset):
             if t == "polygon":
                 target = self._load_json(self.targets[index][i])
             else:
-                target = Image.open(self.targets[index][i])
+                target = Image.open(self.targets[index][i])  # type: ignore[assignment]
 
             targets.append(target)
 

--- a/torchvision/prototype/utils/_internal.py
+++ b/torchvision/prototype/utils/_internal.py
@@ -99,7 +99,7 @@ def fromfile(
 
 class ReadOnlyTensorBuffer:
     def __init__(self, tensor: torch.Tensor) -> None:
-        self._memory = memoryview(tensor.numpy())
+        self._memory = memoryview(tensor.numpy())  # type: ignore[arg-type]
         self._cursor: int = 0
 
     def tell(self) -> int:


### PR DESCRIPTION
This silences these 2 mypy errors:


```
  torchvision/prototype/utils/_internal.py:102: error: Argument 1 to "memoryview"
  has incompatible type "ndarray[Any, Any]"; expected "Buffer"  [arg-type]
              self._memory = memoryview(tensor.numpy())
                                        ^~~~~~~~~~~~~~
  torchvision/datasets/cityscapes.py:191: error: Incompatible types in assignment
  (expression has type "Image", variable has type "Dict[str, Any]")  [assignment]
                      target = Image.open(self.targets[index][i])
                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```