### PR TITLE
Remove include Python.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,6 @@ option(WITH_CUDA "Enable CUDA support" OFF)
 option(WITH_MPS "Enable MPS support" OFF)
 option(WITH_PNG "Enable features requiring LibPNG." ON)
 option(WITH_JPEG "Enable features requiring LibJPEG." ON)
-option(USE_PYTHON "Link to Python when building" OFF)
 
 if(WITH_CUDA)
   enable_language(CUDA)
@@ -31,11 +30,6 @@ endif()
 if (WITH_JPEG)
     add_definitions(-DJPEG_FOUND)
     find_package(JPEG REQUIRED)
-endif()
-
-if (USE_PYTHON)
-  add_definitions(-DUSE_PYTHON)
-  find_package(Python3 REQUIRED COMPONENTS Development)
 endif()
 
 function(CUDA_CONVERT_FLAGS EXISTING_TARGET)
@@ -108,10 +102,6 @@ endif()
 
 if (WITH_JPEG)
     target_link_libraries(${PROJECT_NAME} PRIVATE ${JPEG_LIBRARIES})
-endif()
-
-if (USE_PYTHON)
-  target_link_libraries(${PROJECT_NAME} PRIVATE Python3::Python)
 endif()
 
 set_target_properties(${PROJECT_NAME} PROPERTIES

--- a/cmake/TorchVisionConfig.cmake.in
+++ b/cmake/TorchVisionConfig.cmake.in
@@ -46,13 +46,5 @@ if(@WITH_JPEG@)
   target_compile_definitions(${PN}::${PN} INTERFACE JPEG_FOUND)
 endif()
 
-if (@USE_PYTHON@)
-  if(NOT TARGET Python3::Python)
-    find_package(Python3 COMPONENTS Development)
-  endif()
-  target_link_libraries(torch INTERFACE Python3::Python)
-  target_compile_definitions(${PN}::${PN} INTERFACE USE_PYTHON)
-endif()
-
 endif()
 endif()

--- a/examples/cpp/README.rst
+++ b/examples/cpp/README.rst
@@ -81,9 +81,6 @@ cmake --install .
 You may want to pass `-DCMAKE_INSTALL_PREFIX=/path/to/libtorchvision` for
 cmake to copy/install the files to a specific location (e.g. `$CONDA_PREFIX`).
 
-On Windows, you may also need to pass `-DUSE_PYTHON`. Refer to the corresponding
-`CMakeLists.txt` for additional options.
-
 **DISCLAIMER**: the `libtorchvision` library includes the torchvision
 custom ops as well as most of the C++ torchvision APIs. Those APIs do not come
 with any backward-compatibility guarantees and may change from one version to

--- a/setup.py
+++ b/setup.py
@@ -209,7 +209,6 @@ def get_extensions():
 
     if sys.platform == "win32":
         define_macros += [("torchvision_EXPORTS", None)]
-        define_macros += [("USE_PYTHON", None)]
         extra_compile_args["cxx"].append("/MP")
 
     if debug_mode:
@@ -253,9 +252,6 @@ def get_extensions():
     image_include = [extensions_dir]
     image_library = []
     image_link_flags = []
-
-    if sys.platform == "win32":
-        image_macros += [("USE_PYTHON", None)]
 
     # Locating libPNG
     libpng = shutil.which("libpng-config")

--- a/torchvision/csrc/io/image/image.cpp
+++ b/torchvision/csrc/io/image/image.cpp
@@ -1,20 +1,20 @@
 #include "image.h"
 
 #include <ATen/core/op_registration/op_registration.h>
-#ifdef USE_PYTHON
-#include <Python.h>
-#endif
+// #ifdef USE_PYTHON
+// #include <Python.h>
+// #endif
 
-// If we are in a Windows environment, we need to define
-// initialization functions for the _custom_ops extension
-#ifdef USE_PYTHON
-#ifdef _WIN32
-PyMODINIT_FUNC PyInit_image(void) {
-  // No need to do anything.
-  return nullptr;
-}
-#endif
-#endif // USE_PYTHON
+// // If we are in a Windows environment, we need to define
+// // initialization functions for the _custom_ops extension
+// #ifdef USE_PYTHON
+// #ifdef _WIN32
+// PyMODINIT_FUNC PyInit_image(void) {
+//   // No need to do anything.
+//   return nullptr;
+// }
+// #endif
+// #endif // USE_PYTHON
 
 namespace vision {
 namespace image {

--- a/torchvision/csrc/io/image/image.cpp
+++ b/torchvision/csrc/io/image/image.cpp
@@ -5,7 +5,7 @@
 // If we are in a Windows environment, we need to define
 // initialization functions for the _custom_ops extension
 #ifdef _WIN32
-void * PyInit_image(void) {
+void* PyInit_image(void) {
   return nullptr;
 }
 #endif

--- a/torchvision/csrc/io/image/image.cpp
+++ b/torchvision/csrc/io/image/image.cpp
@@ -8,12 +8,12 @@
 // // If we are in a Windows environment, we need to define
 // // initialization functions for the _custom_ops extension
 // #ifdef USE_PYTHON
-// #ifdef _WIN32
-// PyMODINIT_FUNC PyInit_image(void) {
-//   // No need to do anything.
-//   return nullptr;
-// }
-// #endif
+#ifdef _WIN32
+void * PyInit_image(void) {
+  // No need to do anything.
+  return nullptr;
+}
+#endif
 // #endif // USE_PYTHON
 
 namespace vision {

--- a/torchvision/csrc/io/image/image.cpp
+++ b/torchvision/csrc/io/image/image.cpp
@@ -1,20 +1,14 @@
 #include "image.h"
 
 #include <ATen/core/op_registration/op_registration.h>
-// #ifdef USE_PYTHON
-// #include <Python.h>
-// #endif
 
-// // If we are in a Windows environment, we need to define
-// // initialization functions for the _custom_ops extension
-// #ifdef USE_PYTHON
+// If we are in a Windows environment, we need to define
+// initialization functions for the _custom_ops extension
 #ifdef _WIN32
 void * PyInit_image(void) {
-  // No need to do anything.
   return nullptr;
 }
 #endif
-// #endif // USE_PYTHON
 
 namespace vision {
 namespace image {

--- a/torchvision/csrc/io/video_reader/video_reader.cpp
+++ b/torchvision/csrc/io/video_reader/video_reader.cpp
@@ -10,12 +10,12 @@
 // #ifdef USE_PYTHON
 // // If we are in a Windows environment, we need to define
 // // initialization functions for the _custom_ops extension
-// #ifdef _WIN32
-// PyMODINIT_FUNC PyInit_video_reader(void) {
-//   // No need to do anything.
-//   return nullptr;
-// }
-// #endif
+#ifdef _WIN32
+void * PyInit_video_reader(void) {
+  // No need to do anything.
+  return nullptr;
+}
+#endif
 // #endif // USE_PYTHONs
 
 using namespace ffmpeg;

--- a/torchvision/csrc/io/video_reader/video_reader.cpp
+++ b/torchvision/csrc/io/video_reader/video_reader.cpp
@@ -6,7 +6,7 @@
 // If we are in a Windows environment, we need to define
 // initialization functions for the _custom_ops extension
 #ifdef _WIN32
-void * PyInit_video_reader(void) {
+void* PyInit_video_reader(void) {
   return nullptr;
 }
 #endif

--- a/torchvision/csrc/io/video_reader/video_reader.cpp
+++ b/torchvision/csrc/io/video_reader/video_reader.cpp
@@ -1,22 +1,15 @@
 #include "video_reader.h"
 
-// #ifdef USE_PYTHON
-// #include <Python.h>
-// #endif
-
 #include "../decoder/memory_buffer.h"
 #include "../decoder/sync_decoder.h"
 
-// #ifdef USE_PYTHON
-// // If we are in a Windows environment, we need to define
-// // initialization functions for the _custom_ops extension
+// If we are in a Windows environment, we need to define
+// initialization functions for the _custom_ops extension
 #ifdef _WIN32
 void * PyInit_video_reader(void) {
-  // No need to do anything.
   return nullptr;
 }
 #endif
-// #endif // USE_PYTHONs
 
 using namespace ffmpeg;
 

--- a/torchvision/csrc/io/video_reader/video_reader.cpp
+++ b/torchvision/csrc/io/video_reader/video_reader.cpp
@@ -1,22 +1,22 @@
 #include "video_reader.h"
 
-#ifdef USE_PYTHON
-#include <Python.h>
-#endif
+// #ifdef USE_PYTHON
+// #include <Python.h>
+// #endif
 
 #include "../decoder/memory_buffer.h"
 #include "../decoder/sync_decoder.h"
 
-#ifdef USE_PYTHON
-// If we are in a Windows environment, we need to define
-// initialization functions for the _custom_ops extension
-#ifdef _WIN32
-PyMODINIT_FUNC PyInit_video_reader(void) {
-  // No need to do anything.
-  return nullptr;
-}
-#endif
-#endif // USE_PYTHONs
+// #ifdef USE_PYTHON
+// // If we are in a Windows environment, we need to define
+// // initialization functions for the _custom_ops extension
+// #ifdef _WIN32
+// PyMODINIT_FUNC PyInit_video_reader(void) {
+//   // No need to do anything.
+//   return nullptr;
+// }
+// #endif
+// #endif // USE_PYTHONs
 
 using namespace ffmpeg;
 

--- a/torchvision/csrc/vision.cpp
+++ b/torchvision/csrc/vision.cpp
@@ -1,10 +1,10 @@
 #include "vision.h"
 
-#ifndef MOBILE
-#ifdef USE_PYTHON
-#include <Python.h>
-#endif
-#endif
+// #ifndef MOBILE
+// #ifdef USE_PYTHON
+// #include <Python.h>
+// #endif
+// #endif
 #include <torch/library.h>
 
 #ifdef WITH_CUDA
@@ -15,16 +15,16 @@
 #endif
 
 // If we are in a Windows environment, we need to define
-// initialization functions for the _custom_ops extension.
-// For PyMODINIT_FUNC to work, we need to include Python.h
-#if !defined(MOBILE) && defined(_WIN32)
-#ifdef USE_PYTHON
-PyMODINIT_FUNC PyInit__C(void) {
-  // No need to do anything.
-  return nullptr;
-}
-#endif // USE_PYTHON
-#endif // !defined(MOBILE) && defined(_WIN32)
+// // initialization functions for the _custom_ops extension.
+// // For PyMODINIT_FUNC to work, we need to include Python.h
+// #if !defined(MOBILE) && defined(_WIN32)
+// #ifdef USE_PYTHON
+// PyMODINIT_FUNC PyInit__C(void) {
+//   // No need to do anything.
+//   return nullptr;
+// }
+// #endif // USE_PYTHON
+// #endif // !defined(MOBILE) && defined(_WIN32)
 
 namespace vision {
 int64_t cuda_version() {

--- a/torchvision/csrc/vision.cpp
+++ b/torchvision/csrc/vision.cpp
@@ -1,10 +1,5 @@
 #include "vision.h"
 
-// #ifndef MOBILE
-// #ifdef USE_PYTHON
-// #include <Python.h>
-// #endif
-// #endif
 #include <torch/library.h>
 
 #ifdef WITH_CUDA
@@ -16,14 +11,10 @@
 
 // If we are in a Windows environment, we need to define
 // initialization functions for the _custom_ops extension.
-// For PyMODINIT_FUNC to work, we need to include Python.h
 #if !defined(MOBILE) && defined(_WIN32)
-// #ifdef USE_PYTHON
-void * PyInit__C(void) {
-  // No need to do anything.
+void* PyInit__C(void) {
   return nullptr;
 }
-// #endif // USE_PYTHON
 #endif // !defined(MOBILE) && defined(_WIN32)
 
 namespace vision {

--- a/torchvision/csrc/vision.cpp
+++ b/torchvision/csrc/vision.cpp
@@ -15,16 +15,16 @@
 #endif
 
 // If we are in a Windows environment, we need to define
-// // initialization functions for the _custom_ops extension.
-// // For PyMODINIT_FUNC to work, we need to include Python.h
-// #if !defined(MOBILE) && defined(_WIN32)
+// initialization functions for the _custom_ops extension.
+// For PyMODINIT_FUNC to work, we need to include Python.h
+#if !defined(MOBILE) && defined(_WIN32)
 // #ifdef USE_PYTHON
-// PyMODINIT_FUNC PyInit__C(void) {
-//   // No need to do anything.
-//   return nullptr;
-// }
+void * PyInit__C(void) {
+  // No need to do anything.
+  return nullptr;
+}
 // #endif // USE_PYTHON
-// #endif // !defined(MOBILE) && defined(_WIN32)
+#endif // !defined(MOBILE) && defined(_WIN32)
 
 namespace vision {
 int64_t cuda_version() {


### PR DESCRIPTION
Closes https://github.com/pytorch/vision/issues/3965

For some reason, on Windows we need to define the `PyInit_video_reader` `PyInit_image` and `PyInit__C` symbols, otherwise the windows linker fails with something like

```
LINK : error LNK2001: unresolved external symbol PyInit__C
%SRC_DIR%\build\temp.win-amd64-cpython-38\Release\Jenkins\Miniconda3\conda-bld\torchvision_1715167042718\work\torchvision\csrc\ops\autocast\_C.lib : fatal error LNK1120: 1 unresolved externals
```


To avoid that we were defining the symbols as

```
PyMODINIT_FUNC PyInit__C(void) {
  // No need to do anything.
  return nullptr;
}
```

But that `PyMODINIT_FUNC` forced us to include `Python.h` and take a dependency on Libpython. (BTW, we probably never needed to *link* to libpython like we did in the CMakeFile.txt, we probably only needed the headers, but that's another story.)

This PR changes this `PyMODINIT_FUNC` into a `void*`, which seems to work. In reality, `PyMODINIT_FUNC` is `PyObject_t*`.