### PR TITLE
Remove `#pragma comment(linker, "/include:_register_ops")`

### DIFF
--- a/torchvision/csrc/macros.h
+++ b/torchvision/csrc/macros.h
@@ -15,7 +15,6 @@
 #else
 #ifdef _MSC_VER
 #define VISION_INLINE_VARIABLE __declspec(selectany)
-#define HINT_MSVC_LINKER_INCLUDE_SYMBOL
 #else
 #define VISION_INLINE_VARIABLE __attribute__((weak))
 #endif

--- a/torchvision/csrc/vision.h
+++ b/torchvision/csrc/vision.h
@@ -8,9 +8,9 @@ VISION_API int64_t cuda_version();
 
 namespace detail {
 extern "C" VISION_INLINE_VARIABLE auto _register_ops = &cuda_version;
-#ifdef HINT_MSVC_LINKER_INCLUDE_SYMBOL
-#pragma comment(linker, "/include:_register_ops")
-#endif
+// #ifdef HINT_MSVC_LINKER_INCLUDE_SYMBOL
+// #pragma comment(linker, "/include:_register_ops")
+// #endif
 
 } // namespace detail
 } // namespace vision

--- a/torchvision/csrc/vision.h
+++ b/torchvision/csrc/vision.h
@@ -8,9 +8,5 @@ VISION_API int64_t cuda_version();
 
 namespace detail {
 extern "C" VISION_INLINE_VARIABLE auto _register_ops = &cuda_version;
-// #ifdef HINT_MSVC_LINKER_INCLUDE_SYMBOL
-// #pragma comment(linker, "/include:_register_ops")
-// #endif
-
 } // namespace detail
 } // namespace vision


### PR DESCRIPTION
Probably an artefact from years ago. CI is geen, so this is probably not needed anymore.