### PR TITLE
decode_gif: add transparency support and image offsets

### DIFF
--- a/test/test_image.py
+++ b/test/test_image.py
@@ -551,7 +551,7 @@ def test_pathlib_support(tmpdir):
     write_png(img, write_path)
 
 
-@pytest.mark.parametrize("name", ("gifgrid", "fire", "porsche", "treescap", "treescap-interlaced", "solid2", "x-trans"))
+@pytest.mark.parametrize("name", ("gifgrid", "fire", "porsche", "treescap", "treescap-interlaced", "solid2", "x-trans", "earth"))
 @pytest.mark.parametrize("scripted", (True, False))
 def test_decode_gif(tmpdir, name, scripted):
     # Using test images from GIFLIB
@@ -560,9 +560,16 @@ def test_decode_gif(tmpdir, name, scripted):
     # We're not testing against "welcome2" because PIL and GIFLIB disagee on what
     # the background color should be (likely a difference in the way they handle
     # transparency?)
+    # 'earth' image is from wikipedia, licensed under CC BY-SA 3.0
+    # https://creativecommons.org/licenses/by-sa/3.0/
+    # it allows to properly test for transparency, TOP-LEFT offsets, and
+    # disposal modes.
 
     path = tmpdir / f"{name}.gif"
-    url = f"https://sourceforge.net/p/giflib/code/ci/master/tree/pic/{name}.gif?format=raw"
+    if name == "earth":
+        url = "https://upload.wikimedia.org/wikipedia/commons/2/2c/Rotating_earth_%28large%29.gif"
+    else:
+        url = f"https://sourceforge.net/p/giflib/code/ci/master/tree/pic/{name}.gif?format=raw"
     with open(path, "wb") as f:
         f.write(requests.get(url).content)
 

--- a/test/test_image.py
+++ b/test/test_image.py
@@ -551,7 +551,9 @@ def test_pathlib_support(tmpdir):
     write_png(img, write_path)
 
 
-@pytest.mark.parametrize("name", ("gifgrid", "fire", "porsche", "treescap", "treescap-interlaced", "solid2", "x-trans", "earth"))
+@pytest.mark.parametrize(
+    "name", ("gifgrid", "fire", "porsche", "treescap", "treescap-interlaced", "solid2", "x-trans", "earth")
+)
 @pytest.mark.parametrize("scripted", (True, False))
 def test_decode_gif(tmpdir, name, scripted):
     # Using test images from GIFLIB

--- a/torchvision/csrc/io/image/cpu/decode_gif.cpp
+++ b/torchvision/csrc/io/image/cpu/decode_gif.cpp
@@ -135,13 +135,7 @@ torch::Tensor decode_gif(const torch::Tensor& encoded_data) {
     // which according to GIFLIB is not widely supported.
     // (https://giflib.sourceforge.net/whatsinagif/animation_and_transparency.html).
     if (i > 0 && gcb.DisposalMode == DISPOSE_DO_NOT) {
-      for (int h = 0; h < gifFile->SHeight; h++) {
-        for (int w = 0; w < gifFile->SWidth; w++) {
-          out_a[i][0][h][w] = out_a[i - 1][0][h][w];
-          out_a[i][1][h][w] = out_a[i - 1][1][h][w];
-          out_a[i][2][h][w] = out_a[i - 1][2][h][w];
-        }
-      }
+      out[i] = out[i - 1];
     } else {
       // Background. If bg wasn't defined, it will be (0, 0, 0)
       for (int h = 0; h < gifFile->SHeight; h++) {


### PR DESCRIPTION
This PR now properly handles transparency within the GIF, and also allows each individual image to start at its own Top and Left offset. For docs on how transparency is encoded in GIFs, see https://giflib.sourceforge.net/whatsinagif/animation_and_transparency.html

Turns out the decoder was unable to properly decode https://en.wikipedia.org/wiki/GIF#/media/File:Rotating_earth_(large).gif, but now it's fine.


Benchmark. Slighly slower than before but the relative speed compared with PIL is similar to before.

<details>

```
fire.gif                   size=[33, 3, 60, 30]
tv : med = 0.87ms +- 0.07
pil: med = 1.30ms +- 0.15
tv is 1.50x faster

gifgrid.gif                size=[3, 100, 100]
tv : med = 0.10ms +- 0.02
pil: med = 0.10ms +- 0.02
tv is 0.94x faster

porsche.gif                size=[3, 200, 320]
tv : med = 0.68ms +- 0.08
pil: med = 0.29ms +- 0.03
tv is 0.43x faster

solid2.gif                 size=[3, 400, 640]
tv : med = 2.46ms +- 0.15
pil: med = 0.90ms +- 0.12
tv is 0.37x faster

treescap-interlaced.gif    size=[3, 40, 40]
tv : med = 0.03ms +- 0.01
pil: med = 0.07ms +- 0.01
tv is 1.95x faster

treescap.gif               size=[3, 40, 40]
tv : med = 0.03ms +- 0.00
pil: med = 0.07ms +- 0.01
tv is 2.19x faster

welcome2.gif               size=[6, 3, 48, 290]
tv : med = 0.90ms +- 0.06
pil: med = 1.06ms +- 0.09
tv is 1.19x faster

x-trans.gif                size=[3, 100, 100]
tv : med = 0.09ms +- 0.01
pil: med = 0.11ms +- 0.02
tv is 1.23x faster

grace.gif                  size=[3, 606, 517]
tv : med = 4.31ms +- 0.23
pil: med = 2.70ms +- 0.12
tv is 0.63x faster

```

```py
import torch
from time import perf_counter_ns


def bench(f, *args, num_exp=100, warmup=0, **kwargs):

    for _ in range(warmup):
        f(*args, **kwargs)

    times = []
    for _ in range(num_exp):
        start = perf_counter_ns()
        f(*args, **kwargs)
        end = perf_counter_ns()
        times.append(end - start)
    return torch.tensor(times).float()

def report_stats(times, unit="ms"):
    mul = {
        "ns": 1,
        "µs": 1e-3,
        "ms": 1e-6,
        "s": 1e-9,
    }[unit]
    times = times * mul
    std = times.std().item()
    med = times.median().item()
    print(f"{med = :.2f}{unit} +- {std:.2f}")
    return med


from PIL import Image, ImageSequence
from torchvision import io
from pathlib import Path

# files from https://sourceforge.net/p/giflib/code/ci/master/tree/pic/
paths = list(Path("/home/nicolashug/dev/giflib-code/pic/").glob("*.gif"))
paths += [Path("/home/nicolashug/grace.gif")]  # grace_hopper from torchvision/test/assets

def read_image_pil(path):
    for img in ImageSequence.Iterator(Image.open(path)):
        img.convert("RGB")

for path in paths:
    print()
    print(f"{path.name:<26} size={list(io.read_image(path).shape)}")
    print("tv : ", end="")
    times = bench(io.read_image, path, warmup=10)
    tv_med = report_stats(times)
    print("pil: ", end="")
    times = bench(read_image_pil, path, warmup=10)
    pil_med = report_stats(times)
    print(f"tv is {pil_med / tv_med:.2f}x faster")

```

</details>
