### PR TITLE
Added detection target types to Oxford III Pet dataset

### DIFF
--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -2553,7 +2553,7 @@ class OxfordIIITPetTestCase(datasets_utils.ImageDatasetTestCase):
 
     ADDITIONAL_CONFIGS = combinations_grid(
         split=("trainval", "test"),
-        target_types=("category", "binary-category", "segmentation", ["category", "segmentation"], []),
+        target_types=("category", "binary-category", "detection", "binary-detection", "segmentation", ["category", "segmentation"], []),
     )
 
     def inject_fake_data(self, tmpdir, config):

--- a/torchvision/datasets/oxford_iiit_pet.py
+++ b/torchvision/datasets/oxford_iiit_pet.py
@@ -102,7 +102,7 @@ class OxfordIIITPet(VisionDataset):
         if "detection" in target_types or "binary-detection" in target_types:
             # Notify users this is not a complete dataset
             print('Dataset does not contain detection annotations for every sample. Filtering to include' \
-                  'only those that do.') # TODO: Is a simple print the right call here?
+                  ' only those that do.') # TODO: Is a simple print the right call here?
             # Set up filtered arrays
             self._labels = [lbl for lbl,xml_file in zip(self._labels,self._xmls) if os.path.isfile(xml_file)]
             self._bin_labels = [lbl for lbl,xml_file in zip(self._bin_labels,self._xmls) if os.path.isfile(xml_file)]


### PR DESCRIPTION
Added the detection and binary-detection target types to the Oxford III pet data set loader as discussed in #8364 

The dataset loader will load bounding box annotations in the format expected by torchvision's faster RCNN network. It will also filter out images that exist in the dataset that do not include bounding box annotations when one of the detection types is selected. A message is printed to the console indicating that some images are filtered in this case.

Demonstration of the functionality of the detection target types can be found [here](https://github.com/matlabninja/contribution_staging/blob/main/notebooks/resnet_detect.ipynb) and [here](https://github.com/matlabninja/contribution_staging/blob/main/notebooks/resnet_detect_bin.ipynb).

Looking for feedback on 2 things:
1. Given that some images have to be filtered out for this to work, is a simple print statement the best way to notify users?
2. Given that the _to_rcnn function should work with any dataset using VOC-style detection labels, should we move it to the VOC loader and import it instead of defining it here?