### PR TITLE
Create kernel on-device for `transforms.functional.gaussian_blur`

### DIFF
--- a/torchvision/transforms/_functional_tensor.py
+++ b/torchvision/transforms/_functional_tensor.py
@@ -722,9 +722,7 @@ def perspective(
     return _apply_grid_transform(img, grid, interpolation, fill=fill)
 
 
-def _get_gaussian_kernel1d(
-    kernel_size: int, sigma: float, dtype: torch.dtype, device: torch.device
-) -> Tensor:
+def _get_gaussian_kernel1d(kernel_size: int, sigma: float, dtype: torch.dtype, device: torch.device) -> Tensor:
     ksize_half = (kernel_size - 1) * 0.5
 
     x = torch.linspace(-ksize_half, ksize_half, steps=kernel_size, dtype=dtype, device=device)

--- a/torchvision/transforms/_functional_tensor.py
+++ b/torchvision/transforms/_functional_tensor.py
@@ -722,10 +722,12 @@ def perspective(
     return _apply_grid_transform(img, grid, interpolation, fill=fill)
 
 
-def _get_gaussian_kernel1d(kernel_size: int, sigma: float) -> Tensor:
+def _get_gaussian_kernel1d(
+    kernel_size: int, sigma: float, dtype: torch.dtype, device: torch.device
+) -> Tensor:
     ksize_half = (kernel_size - 1) * 0.5
 
-    x = torch.linspace(-ksize_half, ksize_half, steps=kernel_size)
+    x = torch.linspace(-ksize_half, ksize_half, steps=kernel_size, dtype=dtype, device=device)
     pdf = torch.exp(-0.5 * (x / sigma).pow(2))
     kernel1d = pdf / pdf.sum()
 
@@ -735,8 +737,8 @@ def _get_gaussian_kernel1d(kernel_size: int, sigma: float) -> Tensor:
 def _get_gaussian_kernel2d(
     kernel_size: List[int], sigma: List[float], dtype: torch.dtype, device: torch.device
 ) -> Tensor:
-    kernel1d_x = _get_gaussian_kernel1d(kernel_size[0], sigma[0]).to(device, dtype=dtype)
-    kernel1d_y = _get_gaussian_kernel1d(kernel_size[1], sigma[1]).to(device, dtype=dtype)
+    kernel1d_x = _get_gaussian_kernel1d(kernel_size[0], sigma[0], dtype, device)
+    kernel1d_y = _get_gaussian_kernel1d(kernel_size[1], sigma[1], dtype, device)
     kernel2d = torch.mm(kernel1d_y[:, None], kernel1d_x[None, :])
     return kernel2d
 


### PR DESCRIPTION
<!-- Before submitting a PR, please make sure to check our contributing guidelines regarding code formatting, tests, and documentation: https://github.com/pytorch/vision/blob/main/CONTRIBUTING.md -->

The current implementation of gaussian blur creates the kernels on CPU and then moves them to the device and dtype of the image.  This goes against best practices for pytorch optimization, since it induces a forced device sync.

To fix it, I have passed the device and dtype parameters over to the linspace operation that creates the initial tensor.  This should remove the forced device sync.  It is worth noting that this may result in it being calculated in a lower precision than normal.  This would of course involve an extra call for the cast to get it to the correct precision.

There's probably room for more optimization in this, especially when GaussianBlur is used as a module -- really, I think it would be more appropriate to create the kernels one time and reuse them instead of constructing new ones.  This PR solves the more critical issue as is, though.

Closes https://github.com/pytorch/vision/issues/8401

cc @vfdev-5