### PR TITLE
Fix typo at `permutate_channels`

### DIFF
--- a/torchvision/transforms/v2/functional/_color.py
+++ b/torchvision/transforms/v2/functional/_color.py
@@ -687,7 +687,7 @@ def permute_channels(inpt: torch.Tensor, permutation: List[int]) -> torch.Tensor
 
     Example:
         >>> rgb_image = torch.rand(3, 256, 256)
-        >>> bgr_image = F.permutate_channels(rgb_image, permutation=[2, 1, 0])
+        >>> bgr_image = F.permute_channels(rgb_image, permutation=[2, 1, 0])
 
     Args:
         permutation (List[int]): Valid permutation of the input channel indices. The index of the element determines the


### PR DESCRIPTION
There was a typo in the docstring for [permute_channels](https://pytorch.org/vision/stable/generated/torchvision.transforms.v2.functional.permute_channels.html?highlight=permute_channels#torchvision.transforms.v2.functional.permute_channels). This PR fixes that

Resolves https://github.com/pytorch/vision/issues/8428

