### PR TITLE
Add extra to install gdown

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -554,7 +554,7 @@ if __name__ == "__main__":
         zip_safe=False,
         install_requires=requirements,
         extras_require={
-            "gdown": ["gdown"],
+            "gdown": ["gdown>=4.7.3"],
             "scipy": ["scipy"],
         },
         ext_modules=get_extensions(),

--- a/setup.py
+++ b/setup.py
@@ -554,6 +554,7 @@ if __name__ == "__main__":
         zip_safe=False,
         install_requires=requirements,
         extras_require={
+            "gdown": ["gdown"],
             "scipy": ["scipy"],
         },
         ext_modules=get_extensions(),


### PR DESCRIPTION
Torchvision has an optional dependency on gdown, but this is not currently documented in pyproject.toml or setup.py. This PR adds a new "gdown" extra so that users can install torchvision and its optional dependencies at the same time.

Alternatively, we could create a single unified extra for all optional dataset dependencies like we do in [TorchGeo](https://github.com/microsoft/torchgeo/blob/v0.5.2/pyproject.toml#L85).