### PR TITLE
Remove use of deprecated pkg_resources

### DIFF
--- a/.github/scripts/setup-env.sh
+++ b/.github/scripts/setup-env.sh
@@ -44,7 +44,7 @@ conda create \
   'ffmpeg<4.3'
 conda activate ci
 conda install --quiet --yes libjpeg-turbo -c pytorch
-pip install --progress-bar=off --upgrade setuptools
+pip install --progress-bar=off --upgrade setuptools packaging
 
 # See https://github.com/pytorch/vision/issues/6790
 if [[ "${PYTHON_VERSION}" != "3.11" ]]; then

--- a/.github/workflows/build-conda-linux.yml
+++ b/.github/workflows/build-conda-linux.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         include:
           - repository: pytorch/vision
-            pre-script: ""
+            pre-script: packaging/pre_build_script.sh
             post-script: ""
             conda-package-directory: packaging/torchvision
             smoke-test-script: test/smoke_test.py

--- a/.github/workflows/build-conda-m1.yml
+++ b/.github/workflows/build-conda-m1.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         include:
           - repository: pytorch/vision
-            pre-script: ""
+            pre-script: packaging/pre_build_script.sh
             post-script: ""
             conda-package-directory: packaging/torchvision
             smoke-test-script: test/smoke_test.py

--- a/packaging/pre_build_script.sh
+++ b/packaging/pre_build_script.sh
@@ -47,4 +47,4 @@ else
 fi
 
 pip install numpy pyyaml future ninja
-pip install --upgrade setuptools
+pip install --upgrade setuptools packaging

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,8 @@ import subprocess
 import sys
 
 import torch
-from pkg_resources import DistributionNotFound, get_distribution, parse_version
+from packaging.version import parse
+import importlib.util
 from setuptools import find_packages, setup
 from torch.utils.cpp_extension import BuildExtension, CppExtension, CUDA_HOME, CUDAExtension
 
@@ -15,13 +16,6 @@ from torch.utils.cpp_extension import BuildExtension, CppExtension, CUDA_HOME, C
 def read(*names, **kwargs):
     with open(os.path.join(os.path.dirname(__file__), *names), encoding=kwargs.get("encoding", "utf8")) as fp:
         return fp.read()
-
-
-def get_dist(pkgname):
-    try:
-        return get_distribution(pkgname)
-    except DistributionNotFound:
-        return None
 
 
 cwd = os.path.dirname(os.path.abspath(__file__))
@@ -64,7 +58,7 @@ requirements = [
 
 # Excluding 8.3.* because of https://github.com/pytorch/vision/issues/4934
 pillow_ver = " >= 5.3.0, !=8.3.*"
-pillow_req = "pillow-simd" if get_dist("pillow-simd") is not None else "pillow"
+pillow_req = "pillow-simd" if importlib.util.find_spec("pillow-simd") is not None else "pillow"
 requirements.append(pillow_req + pillow_ver)
 
 
@@ -266,8 +260,8 @@ def get_extensions():
             min_version = "1.6.0"
             png_version = subprocess.run([libpng, "--version"], stdout=subprocess.PIPE)
             png_version = png_version.stdout.strip().decode("utf-8")
-            png_version = parse_version(png_version)
-            if png_version >= parse_version(min_version):
+            png_version = parse(png_version)
+            if png_version >= parse(min_version):
                 print("Building torchvision with PNG image support")
                 png_lib = subprocess.run([libpng, "--libdir"], stdout=subprocess.PIPE)
                 png_lib = png_lib.stdout.strip().decode("utf-8")

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 import distutils.command.clean
 import distutils.spawn
 import glob
+import importlib.util
 import os
 import shutil
 import subprocess
@@ -8,7 +9,6 @@ import sys
 
 import torch
 from packaging.version import parse
-import importlib.util
 from setuptools import find_packages, setup
 from torch.utils.cpp_extension import BuildExtension, CppExtension, CUDA_HOME, CUDAExtension
 


### PR DESCRIPTION
These are [deprecated](https://setuptools.pypa.io/en/latest/pkg_resources.html) and ~all MacOS jobs are currently [red  ](https://github.com/pytorch/vision/actions/runs/9267707197/job/25494742087?pr=7990) with~

```
Install third party dependencies prior to TorchVision install
  + python setup.py egg_info
  /usr/local/miniconda/envs/ci/lib/python3.8/site-packages/torch/nn/modules/transformer.py:20: UserWarning: Failed to initialize NumPy: No module named 'numpy' (Triggered internally at /Users/runner/work/pytorch/pytorch/pytorch/torch/csrc/utils/tensor_numpy.cpp:84.)
    device: torch.device = torch.device(torch._C._get_default_device()),  # torch.device('cpu'),
  setup.py:10: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
    from pkg_resources import DistributionNotFound, get_distribution, parse_version
  Traceback (most recent call last):
    File "setup.py", line 12, in <module>
      from torch.utils.cpp_extension import BuildExtension, CppExtension, CUDA_HOME, CUDAExtension
    File "/usr/local/miniconda/envs/ci/lib/python3.8/site-packages/torch/utils/cpp_extension.py", line 28, in <module>
      from pkg_resources import packaging  # type: ignore[attr-defined]
  ImportError: cannot import name 'packaging' from 'pkg_resources' (/usr/local/miniconda/envs/ci/lib/python3.8/site-packages/pkg_resources/__init__.py)
```


EDIT: actually the error above is due to the fact that the CI currently installs torch nightly from October 2023 (tracked in https://github.com/pytorch/vision/issues/8445), but this PR is still relevant to merge. We need to fix https://github.com/pytorch/vision/issues/8445 first.