### PR TITLE
Use pre_build_script.sh for conda build on linux and macos

### DIFF
--- a/.github/workflows/build-conda-linux.yml
+++ b/.github/workflows/build-conda-linux.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         include:
           - repository: pytorch/vision
-            pre-script: ""
+            pre-script: packaging/pre_build_script.sh
             post-script: ""
             conda-package-directory: packaging/torchvision
             smoke-test-script: test/smoke_test.py

--- a/.github/workflows/build-conda-m1.yml
+++ b/.github/workflows/build-conda-m1.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         include:
           - repository: pytorch/vision
-            pre-script: ""
+            pre-script: packaging/pre_build_script.sh
             post-script: ""
             conda-package-directory: packaging/torchvision
             smoke-test-script: test/smoke_test.py


### PR DESCRIPTION
`pre_build_script.sh` is currently being used for all of the wheel build jobs, but only for the windows conda build job. This adds it to the conda build jobs for linux and macOS as well.

(related to https://github.com/pytorch/vision/pull/8444 where this change is needed as well for the `packaging` dependency to be properly installed on those CI instances).