### PR TITLE
Use compiler.is_compiling() instead of deprecated _dynamo.is_compiling()

### DIFF
--- a/torchvision/transforms/v2/functional/_geometry.py
+++ b/torchvision/transforms/v2/functional/_geometry.py
@@ -194,7 +194,7 @@ def resize(
 # according to our benchmarks on eager, non-AVX CPUs should still prefer u8->f32->interpolate->u8 path for bilinear
 def _do_native_uint8_resize_on_cpu(interpolation: InterpolationMode) -> bool:
     if interpolation == InterpolationMode.BILINEAR:
-        if torch._dynamo.is_compiling():
+        if torch.compiler.is_compiling():
             return True
         else:
             return "AVX2" in torch.backends.cpu.get_cpu_capability()
@@ -525,7 +525,7 @@ def _get_inverse_affine_matrix(
 
 
 def _compute_affine_output_size(matrix: List[float], w: int, h: int) -> Tuple[int, int]:
-    if torch._dynamo.is_compiling() and not torch.jit.is_scripting():
+    if torch.compiler.is_compiling() and not torch.jit.is_scripting():
         return _compute_affine_output_size_python(matrix, w, h)
     else:
         return _compute_affine_output_size_tensor(matrix, w, h)


### PR DESCRIPTION
v2 transforms tests are failing because of the deprecation warning (treated as error)



```
2024-05-30T09:08:14.0827202Z FAILED test/test_transforms_v2.py::TestScaleJitter::test_transform[cpu-make_video] - FutureWarning: `is_compiling` is deprecated. Use `torch.compiler.is_compiling()` instead.
```

https://github.com/pytorch/vision/actions/runs/9299571569/job/25593772937?pr=7990

cc @vfdev-5