### PR TITLE
Disable prototype tests

### DIFF
--- a/.github/workflows/prototype-tests-linux-gpu.yml
+++ b/.github/workflows/prototype-tests-linux-gpu.yml
@@ -1,5 +1,8 @@
 name: Prototype tests on Linux
 
+# IMPORTANT: This workflow has been manually disabled from the GitHub interface
+# in June 2024. The file is kept for reference in case we ever put this back.
+
 on:
   pull_request:
 


### PR DESCRIPTION
The prototype area hasn't been touched for a while (at least 1+ year) and we're not actively developing it.
Prototype datasets are dead, prototype models aren't developed, and prototype transforms aren't being worked-on either. We might consider migrating them to stable one day, but we don't need that CI job for that.

I deactivated that CI workflow from the GitHub web interface, this PR just adds a note to the workflow file.

cc @bjuncek