### PR TITLE
Remove broken MPS build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ import os
 import shutil
 import subprocess
 import sys
+import warnings
 
 import torch
 from pkg_resources import DistributionNotFound, get_distribution, parse_version
@@ -204,8 +205,14 @@ def get_extensions():
             define_macros += [("WITH_HIP", None)]
             nvcc_flags = []
         extra_compile_args["nvcc"] = nvcc_flags
-    elif torch.backends.mps.is_available() or force_mps:
-        sources += source_mps
+
+    # FIXME: MPS build breaks custom ops registration, so it was disabled.
+    # See https://github.com/pytorch/vision/issues/8456.
+    # TODO: Fix MPS build, remove warning below, and put back commented-out elif block.V
+    if force_mps:
+        warnings.warn("MPS build is temporarily disabled!!!!")
+    # elif torch.backends.mps.is_available() or force_mps:
+    #     sources += source_mps
 
     if sys.platform == "win32":
         define_macros += [("torchvision_EXPORTS", None)]


### PR DESCRIPTION
All M1 CI jobs have been broken for more than a week with the errors mentioned in https://github.com/pytorch/vision/issues/8456. It seems that MPS build is the issue. We're temporarily deactivating MPS builds for the CI to be back.