### PR TITLE
SBDataset: Only download noval file when image_set='train_noval'

### DIFF
--- a/torchvision/datasets/sbd.py
+++ b/torchvision/datasets/sbd.py
@@ -81,7 +81,9 @@ class SBDataset(VisionDataset):
             for f in ["cls", "img", "inst", "train.txt", "val.txt"]:
                 old_path = os.path.join(extracted_ds_root, f)
                 shutil.move(old_path, sbd_root)
-            download_url(self.voc_train_url, sbd_root, self.voc_split_filename, self.voc_split_md5)
+            if self.image_set == "train_noval":
+                # Note: this is failing as of June 2024 https://github.com/pytorch/vision/issues/8471
+                download_url(self.voc_train_url, sbd_root, self.voc_split_filename, self.voc_split_md5)
 
         if not os.path.isdir(sbd_root):
             raise RuntimeError("Dataset not found or corrupted. You can use download=True to download it")


### PR DESCRIPTION
This file's URL currently gives a `403` and I can't find an alternative URL. This should avoid erros in cases this file is not needed i.e. when `image_set!="train_noval"`.

Partial workaround for https://github.com/pytorch/vision/issues/8471