### PR TITLE
Skip flaky earth gif test on OSS CI

### DIFF
--- a/test/test_image.py
+++ b/test/test_image.py
@@ -10,7 +10,7 @@ import pytest
 import requests
 import torch
 import torchvision.transforms.functional as F
-from common_utils import assert_equal, needs_cuda
+from common_utils import assert_equal, IN_OSS_CI, needs_cuda
 from PIL import __version__ as PILLOW_VERSION, Image, ImageOps, ImageSequence
 from torchvision.io.image import (
     _read_png_16,
@@ -569,6 +569,9 @@ def test_decode_gif(tmpdir, name, scripted):
 
     path = tmpdir / f"{name}.gif"
     if name == "earth":
+        if IN_OSS_CI:
+            # TODO: Fix this... one day.
+            pytest.skip("Skipping 'earth' test as it's flaky on OSS CI")
         url = "https://upload.wikimedia.org/wikipedia/commons/2/2c/Rotating_earth_%28large%29.gif"
     else:
         url = f"https://sourceforge.net/p/giflib/code/ci/master/tree/pic/{name}.gif?format=raw"


### PR DESCRIPTION
This test has been really flaky lately (see e.g. https://hud.pytorch.org/pr/pytorch/vision/8451) so we have to deactivate it on the CI. It's still running locally so any bug / regression should be caught fine when doing local development on the gif decoder.