### PR TITLE
[FBcode->GH] Support moving window sampling by leveraging the video duration obtai…

### DIFF
--- a/torchvision/csrc/io/decoder/decoder.cpp
+++ b/torchvision/csrc/io/decoder/decoder.cpp
@@ -381,7 +381,7 @@ bool Decoder::init(
 
     av_seek_frame(inputCtx_, -1, offset, AVSEEK_FLAG_BACKWARD);
   }
-
+  videoDurationMs_ = inputCtx_->duration / (double) AV_TIME_BASE * 1000;
   VLOG(1) << "Decoder initialized, log level: " << params_.logLevel;
   return true;
 }

--- a/torchvision/csrc/io/decoder/decoder.h
+++ b/torchvision/csrc/io/decoder/decoder.h
@@ -56,6 +56,7 @@ class Decoder : public MediaDecoder {
   int* getPrintPrefix() {
     return &printPrefix;
   }
+  double videoDurationMs_ = -1;
 
  private:
   // mark below function for a proper invocation
@@ -79,6 +80,7 @@ class Decoder : public MediaDecoder {
 
  protected:
   DecoderParameters params_;
+
 
  private:
   SeekableBuffer seekableBuffer_;


### PR DESCRIPTION
…ned prior the first frame


Cherry-pick of 1fd5055c0f

Summary: To reduce memory util

Reviewed By: jinhohwang-meta

Differential Revision: D56866455

fbshipit-source-id: 0a91a6f9078d0af1a080d34c94acd00c4b0d3884

<!-- Before submitting a PR, please make sure to check our contributing guidelines regarding code formatting, tests, and documentation: https://github.com/pytorch/vision/blob/main/CONTRIBUTING.md -->
