### PR TITLE
Pass allow-unsupported compiler flag for nvcc during compilation

### DIFF
--- a/.github/workflows/build-cmake.yml
+++ b/.github/workflows/build-cmake.yml
@@ -79,6 +79,7 @@ jobs:
         export PYTHON_VERSION=3.8
         export VC_YEAR=2022
         export VSDEVCMD_ARGS=""
+        export NVCC_FLAGS="--allow-unsupported-compiler"
         export GPU_ARCH_TYPE=${{ matrix.gpu-arch-type }}
         export GPU_ARCH_VERSION=${{ matrix.gpu-arch-version }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -101,6 +101,7 @@ jobs:
         export PYTHON_VERSION=${{ matrix.python-version }}
         export VC_YEAR=2019
         export VSDEVCMD_ARGS=""
+        export NVCC_FLAGS="--allow-unsupported-compiler"
         export GPU_ARCH_TYPE=${{ matrix.gpu-arch-type }}
         export GPU_ARCH_VERSION=${{ matrix.gpu-arch-version }}
 

--- a/packaging/windows/internal/vc_env_helper.bat
+++ b/packaging/windows/internal/vc_env_helper.bat
@@ -1,5 +1,6 @@
 @echo on
 
+set NVCC_FLAGS="--allow-unsupported-compiler"
 set VC_VERSION_LOWER=17
 set VC_VERSION_UPPER=18
 if "%VC_YEAR%" == "2019" (


### PR DESCRIPTION
After updating to cudnn 9.1:
https://github.com/pytorch/test-infra/pull/5295


Getting fatal error from NVCC:
```
C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.1\include\crt/host_config.h(153): fatal error C1189: #error:  -- unsupported Microsoft Visual Studio version! Only the versions between 2017 and 2022 (inclusive) are supported! The nvcc flag '-allow-unsupported-compiler' can be used to override this version check; however, using an unsupported host compiler may cause compilation failure or incorrect run time execution. Use at your own risk.
nms_kernel.cu
```

For cuda 12.1 and 11.8

Failure:
https://github.com/pytorch/vision/actions/runs/9502323845/job/26204631855


Primary Suspect small VC update:
Old:
```
** Visual Studio 2022 Developer Command Prompt v17.9.6
```

New :
```
** Visual Studio 2022 Developer Command Prompt v17.10.1
```