### PR TITLE
Change normalize to make it export friendly

### DIFF
--- a/torchvision/transforms/v2/functional/_misc.py
+++ b/torchvision/transforms/v2/functional/_misc.py
@@ -23,7 +23,7 @@ def normalize(
     inplace: bool = False,
 ) -> torch.Tensor:
     """See :class:`~torchvision.transforms.v2.Normalize` for details."""
-    if torch.jit.is_scripting():
+    if torch.jit.is_scripting() or torch._dynamo.is_compiling():
         return normalize_image(inpt, mean=mean, std=std, inplace=inplace)
 
     _log_api_usage_once(normalize)


### PR DESCRIPTION
As titled. torch.export doesn't work with `_get_kernel` since it looks into attributes of a class. Here we are assigning a kernel manually for torch.export.

<!-- Before submitting a PR, please make sure to check our contributing guidelines regarding code formatting, tests, and documentation: https://github.com/pytorch/vision/blob/main/CONTRIBUTING.md -->
