### PR TITLE
Ignore pickle warning for some v2 tests

### DIFF
--- a/test/test_transforms_v2.py
+++ b/test/test_transforms_v2.py
@@ -394,7 +394,8 @@ def _check_transform_sample_input_smoke(transform, input, *, adapter):
 
 
 def check_transform(transform, input, check_v1_compatibility=True, check_sample_input=True):
-    # TODO: remove this cm once https://github.com/pytorch/vision/issues/8517 and associated torch core issue is resolved
+    # TODO: remove this cm once https://github.com/pytorch/vision/issues/8517
+    # and https://github.com/pytorch/pytorch/issues/130242 are resolved.
     if isinstance(transform, (transforms.RandomResizedCrop, transforms.LinearTransformation)):
         cm = pytest.warns(FutureWarning, match="You are using `torch.load`")
     else:

--- a/test/test_transforms_v2.py
+++ b/test/test_transforms_v2.py
@@ -394,7 +394,14 @@ def _check_transform_sample_input_smoke(transform, input, *, adapter):
 
 
 def check_transform(transform, input, check_v1_compatibility=True, check_sample_input=True):
-    pickle.loads(pickle.dumps(transform))
+    # TODO: remove this cm once https://github.com/pytorch/vision/issues/8517 and associated torch core issue is resolved
+    if isinstance(transform, (transforms.RandomResizedCrop, transforms.LinearTransformation)):
+        cm = pytest.warns(FutureWarning, match="You are using `torch.load`")
+    else:
+        cm = contextlib.nullcontext()
+
+    with cm:
+        pickle.loads(pickle.dumps(transform))
 
     output = transform(input)
     assert isinstance(output, type(input))


### PR DESCRIPTION
Temporarily expect warnings due to https://github.com/pytorch/vision/issues/8517 and https://github.com/pytorch/pytorch/issues/130242