### PR TITLE
Pin numpy dep to `numpy<2` for windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ if os.getenv("PYTORCH_VERSION"):
     pytorch_dep += "==" + os.getenv("PYTORCH_VERSION")
 
 requirements = [
+    # TODO: Remove <2 constraint! https://github.com/pytorch/vision/issues/8531
     "numpy<2" if sys.platform == "win32" else "numpy",
     pytorch_dep,
 ]

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ if os.getenv("PYTORCH_VERSION"):
     pytorch_dep += "==" + os.getenv("PYTORCH_VERSION")
 
 requirements = [
-    "numpy<2",
+    "numpy<2" if sys.platform == "win32" else "numpy",
     pytorch_dep,
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ if os.getenv("PYTORCH_VERSION"):
     pytorch_dep += "==" + os.getenv("PYTORCH_VERSION")
 
 requirements = [
-    "numpy",
+    "numpy<2",
     pytorch_dep,
 ]
 


### PR DESCRIPTION
Temporary measure to keep the CI green. Related to https://github.com/pytorch/vision/issues/8531