### PR TITLE
Check average_rate availability in video reader

### DIFF
--- a/torchvision/io/video_reader.py
+++ b/torchvision/io/video_reader.py
@@ -251,12 +251,7 @@ class VideoReader:
                         rate_n = "framerate"
                     metadata[stream.type] = {rate_n: [], "duration": []}
 
-                    rate = (
-                        stream.average_rate
-                        if hasattr(stream, "average_rate")
-                        and stream.average_rate is not None
-                        else stream.sample_rate
-                    )
+                    rate = getattr(stream, "average_rate", None) or stream.sample_rate
 
                 metadata[stream.type]["duration"].append(float(stream.duration * stream.time_base))
                 metadata[stream.type][rate_n].append(float(rate))

--- a/torchvision/io/video_reader.py
+++ b/torchvision/io/video_reader.py
@@ -251,7 +251,7 @@ class VideoReader:
                         rate_n = "framerate"
                     metadata[stream.type] = {rate_n: [], "duration": []}
 
-                    rate = getattr(stream, "average_rate", None) or stream.sample_rate
+                rate = getattr(stream, "average_rate", None) or stream.sample_rate
 
                 metadata[stream.type]["duration"].append(float(stream.duration * stream.time_base))
                 metadata[stream.type][rate_n].append(float(rate))

--- a/torchvision/io/video_reader.py
+++ b/torchvision/io/video_reader.py
@@ -251,7 +251,12 @@ class VideoReader:
                         rate_n = "framerate"
                     metadata[stream.type] = {rate_n: [], "duration": []}
 
-                rate = stream.average_rate if stream.average_rate is not None else stream.sample_rate
+                    rate = (
+                        stream.average_rate
+                        if hasattr(stream, "average_rate")
+                        and stream.average_rate is not None
+                        else stream.sample_rate
+                    )
 
                 metadata[stream.type]["duration"].append(float(stream.duration * stream.time_base))
                 metadata[stream.type][rate_n].append(float(rate))


### PR DESCRIPTION
<!-- Before submitting a PR, please make sure to check our contributing guidelines regarding code formatting, tests, and documentation: https://github.com/pytorch/vision/blob/main/CONTRIBUTING.md -->
This PR addresses #8420 by adding a simple check of whether the `average_rate` attribute exists on the stream in question before trying to access it. The general behavior is not changed by this PR, as the original fallback to using `stream.sample_rate` instead is retained.