### PR TITLE
Better progress bar for file downloading

### DIFF
--- a/torchvision/datasets/utils.py
+++ b/torchvision/datasets/utils.py
@@ -26,7 +26,7 @@ USER_AGENT = "pytorch/vision"
 
 def _urlretrieve(url: str, filename: Union[str, pathlib.Path], chunk_size: int = 1024 * 32) -> None:
     with urllib.request.urlopen(urllib.request.Request(url, headers={"User-Agent": USER_AGENT})) as response:
-        with open(filename, "wb") as fh, tqdm(total=response.length) as pbar:
+        with open(filename, "wb") as fh, tqdm(total=response.length, unit="B", unit_scale=True) as pbar:
             while chunk := response.read(chunk_size):
                 fh.write(chunk)
                 pbar.update(len(chunk))


### PR DESCRIPTION
Set the unit to "B" (byte) and enable unit_scale.

Without this change:
```
Downloading https://www.cs.toronto.edu/~kriz/cifar-100-python.tar.gz to /data/datasets/cifar100/cifar-100-python.tar.gz
  4%|███                                                                    | 6324224/169001437 [00:04<01:03, 2581642.25it/s]
```

With this change:
```
Downloading https://www.cs.toronto.edu/~kriz/cifar-100-python.tar.gz to /data/datasets/cifar100/cifar-100-python.tar.gz
  3%|███▏                                                                  | 5.54M/169M [00:03<00:47, 3.47MB/s]
```

cc @NicolasHug 