### PR TITLE
Restrict ffmpeg to 4.2+.X versions to resolve linux conda build failures

### DIFF
--- a/.github/workflows/build-conda-linux.yml
+++ b/.github/workflows/build-conda-linux.yml
@@ -34,7 +34,7 @@ jobs:
             smoke-test-script: test/smoke_test.py
             package-name: torchvision
     name: ${{ matrix.repository }}
-    uses: pytorch/test-infra/.github/workflows/build_conda_linux.yml@atalman-conda-build
+    uses: pytorch/test-infra/.github/workflows/build_conda_linux.yml@main
     with:
       conda-package-directory: ${{ matrix.conda-package-directory }}
       repository: ${{ matrix.repository }}

--- a/.github/workflows/build-conda-linux.yml
+++ b/.github/workflows/build-conda-linux.yml
@@ -34,7 +34,7 @@ jobs:
             smoke-test-script: test/smoke_test.py
             package-name: torchvision
     name: ${{ matrix.repository }}
-    uses: pytorch/test-infra/.github/workflows/build_conda_linux.yml@main
+    uses: pytorch/test-infra/.github/workflows/build_conda_linux.yml@atalman-conda-build
     with:
       conda-package-directory: ${{ matrix.conda-package-directory }}
       repository: ${{ matrix.repository }}

--- a/packaging/torchvision/meta.yaml
+++ b/packaging/torchvision/meta.yaml
@@ -11,7 +11,7 @@ requirements:
     - {{ compiler('c') }} # [win]
     - libpng
     - libjpeg-turbo
-    - ffmpeg >=4.2  # [linux]
+    - ffmpeg ==4.2.2  # [linux]
 
   host:
     - python
@@ -26,7 +26,7 @@ requirements:
     - numpy >=1.23.5 # [py >= 311]
     - requests
     - libpng
-    - ffmpeg >=4.2  # [linux]
+    - ffmpeg ==4.2.2  # [linux]
     - libjpeg-turbo
     - pillow >=5.3.0, !=8.3.*
     - pytorch-mutex 1.0 {{ build_variant }}  # [not osx ]

--- a/packaging/torchvision/meta.yaml
+++ b/packaging/torchvision/meta.yaml
@@ -11,7 +11,7 @@ requirements:
     - {{ compiler('c') }} # [win]
     - libpng
     - libjpeg-turbo
-    - ffmpeg ==4.2.2  # [linux]
+    - ffmpeg >=4.2.2, <5.0.0  # [linux]
 
   host:
     - python
@@ -26,7 +26,7 @@ requirements:
     - numpy >=1.23.5 # [py >= 311]
     - requests
     - libpng
-    - ffmpeg ==4.2.2  # [linux]
+    - ffmpeg >=4.2.2, <5.0.0  # [linux]
     - libjpeg-turbo
     - pillow >=5.3.0, !=8.3.*
     - pytorch-mutex 1.0 {{ build_variant }}  # [not osx ]

--- a/packaging/torchvision/meta.yaml
+++ b/packaging/torchvision/meta.yaml
@@ -12,6 +12,7 @@ requirements:
     - libpng
     - libjpeg-turbo
     - ffmpeg >=4.2  # [linux]
+    {{ environ.get('CONDA_PYTORCH_BUILD_CONSTRAINT') }}
 
   host:
     - python

--- a/packaging/torchvision/meta.yaml
+++ b/packaging/torchvision/meta.yaml
@@ -12,13 +12,12 @@ requirements:
     - libpng
     - libjpeg-turbo
     - ffmpeg >=4.2  # [linux]
-    {{ environ.get('CONDA_PYTORCH_BUILD_CONSTRAINT') }}
 
   host:
     - python
     - setuptools
     - pytorch-mutex 1.0 {{ build_variant }}  # [not osx ]
-    {{ environ.get('CONDA_PYTORCH_BUILD_CONSTRAINT') }}
+    {{ environ.get('CONDA_PYTORCH_BUILD_CONSTRAINT', 'pytorch') }}
     {{ environ.get('CONDA_CUDATOOLKIT_CONSTRAINT', '') }}
 
   run:
@@ -31,7 +30,7 @@ requirements:
     - libjpeg-turbo
     - pillow >=5.3.0, !=8.3.*
     - pytorch-mutex 1.0 {{ build_variant }}  # [not osx ]
-    {{ environ.get('CONDA_PYTORCH_CONSTRAINT') }}
+    {{ environ.get('CONDA_PYTORCH_CONSTRAINT', 'pytorch') }}
     {{ environ.get('CONDA_CUDATOOLKIT_CONSTRAINT', '') }}
 
   {% if build_variant == 'cpu' %}


### PR DESCRIPTION
Looks like ffmpeg release 6.1.1 broke our linux conda builds: https://anaconda.org/anaconda/ffmpeg/files?version=6.1.1
Fixes: https://github.com/pytorch/vision/issues/8560
