### PR TITLE
EuroSAT: fix SSL certificate issues

### DIFF
--- a/torchvision/datasets/eurosat.py
+++ b/torchvision/datasets/eurosat.py
@@ -9,6 +9,9 @@ from .utils import download_and_extract_archive
 class EuroSAT(ImageFolder):
     """RGB version of the `EuroSAT <https://github.com/phelber/eurosat>`_ Dataset.
 
+    For the MS version of the dataset, see
+    `TorchGeo <https://torchgeo.readthedocs.io/en/stable/api/datasets.html#eurosat>`__.
+
     Args:
         root (str or ``pathlib.Path``): Root directory of dataset where ``root/eurosat`` exists.
         transform (callable, optional): A function/transform that takes in a PIL image
@@ -53,7 +56,7 @@ class EuroSAT(ImageFolder):
 
         os.makedirs(self._base_folder, exist_ok=True)
         download_and_extract_archive(
-            "https://madm.dfki.de/files/sentinel/EuroSAT.zip",
+            "https://huggingface.co/datasets/torchgeo/eurosat/resolve/c877bcd43f099cd0196738f714544e355477f3fd/EuroSAT.zip",
             download_root=self._base_folder,
             md5="c8fa014336c82ac7804f0398fcb19387",
         )

--- a/torchvision/prototype/datasets/_builtin/eurosat.py
+++ b/torchvision/prototype/datasets/_builtin/eurosat.py
@@ -31,11 +31,8 @@ def _info() -> Dict[str, Any]:
 
 @register_dataset(NAME)
 class EuroSAT(Dataset):
-    """RGB version of the EuroSAT Dataset.
+    """EuroSAT Dataset.
     homepage="https://github.com/phelber/eurosat",
-
-    For the MS version of the dataset, see
-    `TorchGeo <https://torchgeo.readthedocs.io/en/stable/api/datasets.html#eurosat>`__.
     """
 
     def __init__(self, root: Union[str, pathlib.Path], *, skip_integrity_check: bool = False) -> None:
@@ -45,7 +42,7 @@ class EuroSAT(Dataset):
     def _resources(self) -> List[OnlineResource]:
         return [
             HttpResource(
-                "https://huggingface.co/datasets/torchgeo/eurosat/resolve/c877bcd43f099cd0196738f714544e355477f3fd/EuroSAT.zip",
+                "https://madm.dfki.de/files/sentinel/EuroSAT.zip",
                 sha256="8ebea626349354c5328b142b96d0430e647051f26efc2dc974c843f25ecf70bd",
             )
         ]

--- a/torchvision/prototype/datasets/_builtin/eurosat.py
+++ b/torchvision/prototype/datasets/_builtin/eurosat.py
@@ -31,8 +31,11 @@ def _info() -> Dict[str, Any]:
 
 @register_dataset(NAME)
 class EuroSAT(Dataset):
-    """EuroSAT Dataset.
+    """RGB version of the EuroSAT Dataset.
     homepage="https://github.com/phelber/eurosat",
+
+    For the MS version of the dataset, see
+    `TorchGeo <https://torchgeo.readthedocs.io/en/stable/api/datasets.html#eurosat>`__.
     """
 
     def __init__(self, root: Union[str, pathlib.Path], *, skip_integrity_check: bool = False) -> None:
@@ -42,7 +45,7 @@ class EuroSAT(Dataset):
     def _resources(self) -> List[OnlineResource]:
         return [
             HttpResource(
-                "https://madm.dfki.de/files/sentinel/EuroSAT.zip",
+                "https://huggingface.co/datasets/torchgeo/eurosat/resolve/c877bcd43f099cd0196738f714544e355477f3fd/EuroSAT.zip",
                 sha256="8ebea626349354c5328b142b96d0430e647051f26efc2dc974c843f25ecf70bd",
             )
         ]


### PR DESCRIPTION
When downloading the EuroSAT dataset, users encounter the following error message:
```pycon
> python3
>>> from torchvision.datasets import EuroSAT
>>> EuroSAT('data', download=True)
...
urllib.error.URLError: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1006)>
```
This leads a lot of users to dangerous [StackOverflow suggestions](https://stackoverflow.com/q/71263622/5828163) to disable SSL verification entirely.

This PR switches the download URL to a stable mirror of the download on Hugging Face. This dataset was rehosted with permission from the original author of EuroSAT: https://github.com/phelber/EuroSAT/issues/10. The zip file is unmodified and has the same MD5 and SHA256 checksums.

Also added a link to a data loader for the multispectral (MS) version of the dataset for any other remote sensing researchers who need it.