### PR TITLE
remove invalid mnist download links

### DIFF
--- a/torchvision/datasets/mnist.py
+++ b/torchvision/datasets/mnist.py
@@ -35,7 +35,6 @@ class MNIST(VisionDataset):
     """
 
     mirrors = [
-        "http://yann.lecun.com/exdb/mnist/",
         "https://ossci-datasets.s3.amazonaws.com/mnist/",
     ]
 


### PR DESCRIPTION
The following links are no longer working.

- https://yann.lecun.com/exdb/mnist/train-images-idx3-ubyte.gz
- https://yann.lecun.com/exdb/mnist/train-labels-idx1-ubyte.gz
- https://yann.lecun.com/exdb/mnist/t10k-images-idx3-ubyte.gz
- https://yann.lecun.com/exdb/mnist/t10k-labels-idx1-ubyte.gz

See also the screenshot below.

Removing the invalid link gives us a cleaner log.

![Screenshot 2024-08-09 at 12 24 12](https://github.com/user-attachments/assets/f29c8949-bcb8-41d9-887a-cd61c65bd5ed)
