### PR TITLE
Remove pre_build_script from windows conda build

### DIFF
--- a/.github/workflows/build-conda-windows.yml
+++ b/.github/workflows/build-conda-windows.yml
@@ -15,12 +15,12 @@ on:
 
 jobs:
   generate-matrix:
-    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
+    uses: nicolashug/test-infra/.github/workflows/generate_binary_build_matrix.yml@lol
     with:
       package-type: conda
       os: windows
-      test-infra-repository: pytorch/test-infra
-      test-infra-ref: main
+      test-infra-repository: nicolashug/test-infra
+      test-infra-ref: lol
   build:
     needs: generate-matrix
     strategy:
@@ -28,7 +28,7 @@ jobs:
       matrix:
         include:
           - repository: pytorch/vision
-            pre-script: packaging/pre_build_script.sh
+            pre-script: ""
             env-script: packaging/windows/internal/vc_env_helper.bat
             post-script: ""
             smoke-test-script: test/smoke_test.py

--- a/.github/workflows/build-conda-windows.yml
+++ b/.github/workflows/build-conda-windows.yml
@@ -15,12 +15,12 @@ on:
 
 jobs:
   generate-matrix:
-    uses: nicolashug/test-infra/.github/workflows/generate_binary_build_matrix.yml@lol
+    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
     with:
       package-type: conda
       os: windows
-      test-infra-repository: nicolashug/test-infra
-      test-infra-ref: lol
+      test-infra-repository: pytorch/test-infra
+      test-infra-ref: main
   build:
     needs: generate-matrix
     strategy:

--- a/.github/workflows/build-conda-windows.yml
+++ b/.github/workflows/build-conda-windows.yml
@@ -29,8 +29,9 @@ jobs:
         include:
           - repository: pytorch/vision
             pre-script: ""
-            env-script: packaging/windows/internal/vc_env_helper.bat
             post-script: ""
+            env-script: packaging/windows/internal/vc_env_helper.bat
+            conda-package-directory: packaging/torchvision
             smoke-test-script: test/smoke_test.py
             package-name: torchvision
     name: ${{ matrix.repository }}


### PR DESCRIPTION
pre-build-script should be only be used for wheel builds