### PR TITLE
Pin setuptools to 72.1.0

### DIFF
--- a/.github/scripts/setup-env.sh
+++ b/.github/scripts/setup-env.sh
@@ -33,7 +33,7 @@ conda create \
   'ffmpeg<4.3'
 conda activate ci
 conda install --quiet --yes libjpeg-turbo -c pytorch
-pip install --progress-bar=off --upgrade setuptools
+pip install --progress-bar=off --upgrade setuptools==72.1.0
 
 # See https://github.com/pytorch/vision/issues/6790
 if [[ "${PYTHON_VERSION}" != "3.11" ]]; then

--- a/packaging/pre_build_script.sh
+++ b/packaging/pre_build_script.sh
@@ -34,4 +34,4 @@ else
 fi
 
 pip install numpy pyyaml future ninja
-pip install --upgrade setuptools
+pip install --upgrade setuptools==72.1.0


### PR DESCRIPTION
Fixes: https://github.com/pytorch/vision/issues/8591

This issue is related to 
https://pypi.org/project/setuptools/#files - Released: Aug 13, 2024
setuptools 72.2.0

I do see something like this in the log:
```
2024-08-14T17:47:49.2817611Z Collecting setuptools
2024-08-14T17:47:49.2818481Z   Downloading setuptools-72.2.0-py3-none-any.whl.metadata (6.6 kB)
2024-08-14T17:47:49.2819699Z Downloading setuptools-72.2.0-py3-none-any.whl (2.3 MB)
2024-08-14T17:47:49.2820771Z    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 2.3/2.3 MB 97.6 MB/s eta 0:00:00
2024-08-14T17:47:49.2821626Z Installing collected packages: setuptools
2024-08-14T17:47:49.2822330Z   Attempting uninstall: setuptools
2024-08-14T17:47:49.2823044Z     Found existing installation: setuptools 72.1.0
2024-08-14T17:47:49.2823855Z     Uninstalling setuptools-72.1.0:
2024-08-14T17:47:49.2824629Z       Successfully uninstalled setuptools-72.1.0
2024-08-14T17:47:49.2825454Z Successfully installed setuptools-72.2.0
2024-08-14T17:47:49.2825935Z 
```