### PR TITLE
Remove numpy<2.0 windows pin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -91,8 +91,7 @@ def get_requirements():
         pytorch_dep += "==" + os.getenv("PYTORCH_VERSION")
 
     requirements = [
-        # TODO: Remove <2 constraint! https://github.com/pytorch/vision/issues/8531
-        "numpy<2" if sys.platform == "win32" else "numpy",
+        "numpy",
         pytorch_dep,
     ]
 


### PR DESCRIPTION
Issue with torch core should be fixed by: https://github.com/pytorch/builder/pull/1945
