### PR TITLE
Add circular padding

### DIFF
--- a/test/test_transforms_tensor.py
+++ b/test/test_transforms_tensor.py
@@ -206,7 +206,7 @@ class TestColorJitter:
 
 
 @pytest.mark.parametrize("device", cpu_and_cuda())
-@pytest.mark.parametrize("m", ["constant", "edge", "reflect", "symmetric"])
+@pytest.mark.parametrize("m", ["constant", "edge", "reflect", "symmetric", "circular"])
 @pytest.mark.parametrize("mul", [1, -1])
 def test_pad(m, mul, device):
     fill = 127 if m == "constant" else 0
@@ -264,6 +264,7 @@ def test_crop(device):
         {"padding_mode": "constant", "fill": 10},
         {"padding_mode": "edge"},
         {"padding_mode": "reflect"},
+        {"padding_mode": "circular"},
     ],
 )
 @pytest.mark.parametrize("pad_if_needed", [True, False])

--- a/torchvision/transforms/_functional_pil.py
+++ b/torchvision/transforms/_functional_pil.py
@@ -145,7 +145,7 @@ def pad(
     img: Image.Image,
     padding: Union[int, List[int], Tuple[int, ...]],
     fill: Optional[Union[float, List[float], Tuple[float, ...]]] = 0,
-    padding_mode: Literal["constant", "edge", "reflect", "symmetric"] = "constant",
+    padding_mode: Literal["constant", "edge", "reflect", "symmetric", "circular"] = "constant",
 ) -> Image.Image:
 
     if not _is_pil_image(img):
@@ -168,8 +168,8 @@ def pad(
         # Compatibility with `functional_tensor.pad`
         padding = padding[0]
 
-    if padding_mode not in ["constant", "edge", "reflect", "symmetric"]:
-        raise ValueError("Padding mode should be either constant, edge, reflect or symmetric")
+    if padding_mode not in ["constant", "edge", "reflect", "symmetric", "circular"]:
+        raise ValueError("Padding mode should be either constant, edge, reflect, symmetric, or circular")
 
     if padding_mode == "constant":
         opts = _parse_fill(fill, img, name="fill")
@@ -200,6 +200,9 @@ def pad(
             img = img.crop((crop_left, crop_top, img.width - crop_right, img.height - crop_bottom))
 
         pad_left, pad_top, pad_right, pad_bottom = np.maximum(p, 0)
+
+        if padding_mode == 'circular':
+            padding_mode = 'wrap' # For compatibility with np.pad terminology
 
         if img.mode == "P":
             palette = img.getpalette()

--- a/torchvision/transforms/_functional_tensor.py
+++ b/torchvision/transforms/_functional_tensor.py
@@ -398,8 +398,8 @@ def pad(
                 f"Padding must be an int or a 1, 2, or 4 element tuple, not a {len(padding)} element tuple"
             )
 
-    if padding_mode not in ["constant", "edge", "reflect", "symmetric"]:
-        raise ValueError("Padding mode should be either constant, edge, reflect or symmetric")
+    if padding_mode not in ["constant", "edge", "reflect", "symmetric", "circular"]:
+        raise ValueError("Padding mode should be either constant, edge, reflect, symmetric, or circular")
 
     p = _parse_pad_padding(padding)
 
@@ -424,7 +424,7 @@ def pad(
         need_cast = True
         img = img.to(torch.float32)
 
-    if padding_mode in ("reflect", "replicate"):
+    if padding_mode in ("reflect", "replicate", "circular"):
         img = torch_pad(img, p, mode=padding_mode)
     else:
         img = torch_pad(img, p, mode=padding_mode, value=float(fill))

--- a/torchvision/transforms/functional.py
+++ b/torchvision/transforms/functional.py
@@ -482,7 +482,7 @@ def resize(
 def pad(img: Tensor, padding: List[int], fill: Union[int, float] = 0, padding_mode: str = "constant") -> Tensor:
     r"""Pad the given image on all sides with the given "pad" value.
     If the image is torch Tensor, it is expected
-    to have [..., H, W] shape, where ... means at most 2 leading dimensions for mode reflect and symmetric,
+    to have [..., H, W] shape, where ... means at most 2 leading dimensions for modes reflect, symmetric, and circular,
     at most 3 leading dimensions for mode edge,
     and an arbitrary number of leading dimensions for mode constant
 
@@ -501,7 +501,7 @@ def pad(img: Tensor, padding: List[int], fill: Union[int, float] = 0, padding_mo
             This value is only used when the padding_mode is constant.
             Only number is supported for torch Tensor.
             Only int or tuple value is supported for PIL Image.
-        padding_mode (str): Type of padding. Should be: constant, edge, reflect or symmetric.
+        padding_mode (str): Type of padding. Should be: constant, edge, reflect, symmetric, or circular.
             Default is constant.
 
             - constant: pads with a constant value, this value is specified with fill
@@ -516,6 +516,10 @@ def pad(img: Tensor, padding: List[int], fill: Union[int, float] = 0, padding_mo
             - symmetric: pads with reflection of image repeating the last value on the edge.
               For example, padding [1, 2, 3, 4] with 2 elements on both sides in symmetric mode
               will result in [2, 1, 1, 2, 3, 4, 4, 3]
+
+            - circular: pads by repeating the values from the opposite side of the image in order.
+              For example, padding [1, 2, 3, 4] with 2 elements on both sides in circular mode
+              will result in [3, 4, 1, 2, 3, 4, 1, 2]
 
     Returns:
         PIL Image or Tensor: Padded image.


### PR DESCRIPTION
Not sure why this wasn't here already, it was already implemented in both pytorch and numpy, just under different names for the padding modes ("circular" and "wrap" respectively). I'm choosing "circular" here since this is for pytorch. Tested and it works fine.
