### PR TITLE
Fix compile with nvjpeg on Windows CUDA 12

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -376,7 +376,7 @@ def make_image_extension():
             Extension = CUDAExtension
         else:
             warnings.warn("Building torchvision without NVJPEG support")
-    else if USE_NVJPEG:
+    elif USE_NVJPEG:
         warnings.warn("Building torchvision without NVJPEG support")
 
     return Extension(

--- a/setup.py
+++ b/setup.py
@@ -366,7 +366,7 @@ def make_image_extension():
         else:
             warnings.warn("Building torchvision without AVIF support")
 
-    if USE_NVJPEG and ( torch.cuda.is_available() or FORCE_CUDA ):
+    if USE_NVJPEG and (torch.cuda.is_available() or FORCE_CUDA):
         nvjpeg_found = CUDA_HOME is not None and (Path(CUDA_HOME) / "include/nvjpeg.h").exists()
 
         if nvjpeg_found:

--- a/setup.py
+++ b/setup.py
@@ -366,7 +366,7 @@ def make_image_extension():
         else:
             warnings.warn("Building torchvision without AVIF support")
 
-    if USE_NVJPEG and torch.cuda.is_available():
+    if USE_NVJPEG and ( torch.cuda.is_available() or FORCE_CUDA ):
         nvjpeg_found = CUDA_HOME is not None and (Path(CUDA_HOME) / "include/nvjpeg.h").exists()
 
         if nvjpeg_found:
@@ -376,6 +376,8 @@ def make_image_extension():
             Extension = CUDAExtension
         else:
             warnings.warn("Building torchvision without NVJPEG support")
+    else if USE_NVJPEG:
+        warnings.warn("Building torchvision without NVJPEG support")
 
     return Extension(
         name="torchvision.image",


### PR DESCRIPTION
Root cause of the issue

```
C:\actions-runner\_work\_temp\conda_environment_10772459803\lib\site-packages\torch\cuda\__init__.py:129: UserWarning: CUDA initialization: The NVIDIA driver on your system is too old (found version 11040). Please update your GPU driver by downloading and installing a new version from the URL: http://www.nvidia.com/Download/index.aspx Alternatively, go to: https://pytorch.org/ to install a PyTorch version that has been compiled with your version of the CUDA driver. (Triggered internally at C:\actions-runner\_work\pytorch\pytorch\builder\windows\pytorch\c10\cuda\CUDAFunctions.cpp:108.)
```

Hence we are seeing for cuda 12+ jobs:
```
torch.cuda.is_available: False
```


As a result its failing builder checks here:
https://github.com/pytorch/builder/actions/runs/10776424717/job/29883192429

```
torchvision: 0.20.0.dev20240908+cu121
torch.cuda.is_available: True
torch.ops.image._jpeg_version() = 80
Is torchvision usable? True
German shepherd (cpu): 37.6%
Traceback (most recent call last):
  File "C:\actions-runner\_work\builder\builder\pytorch\builder\vision\test\smoke_test.py", line 113, in <module>
    main()
  File "C:\actions-runner\_work\builder\builder\pytorch\builder\vision\test\smoke_test.py", line 101, in main
    smoke_test_torchvision_decode_jpeg("cuda")
  File "C:\actions-runner\_work\builder\builder\pytorch\builder\vision\test\smoke_test.py", line 37, in smoke_test_torchvision_decode_jpeg
    img_jpg = decode_jpeg(img_jpg_data, device=device)
  File "C:\Jenkins\Miniconda3\envs\conda-env-10776424717\lib\site-packages\torchvision\io\image.py", line 223, in decode_jpeg
    return torch.ops.image.decode_jpegs_cuda([input], mode.value, device)[0]
  File "C:\Jenkins\Miniconda3\envs\conda-env-10776424717\lib\site-packages\torch\_ops.py", line 1116, in __call__
    return self._op(*args, **(kwargs or {}))
RuntimeError: decode_jpegs_cuda: torchvision not compiled with nvJPEG support
```


Driver Update issue should not prevent us to compile torchvision with full CUDA support. We can do it even with CPU instance. Hence when FORCE_CUDA flag is set, we should try to include nvjpeg module.


As a followup we should address Driver issue
