### PR TITLE
make_public_query_size

### DIFF
--- a/torchvision/transforms/v2/functional/__init__.py
+++ b/torchvision/transforms/v2/functional/__init__.py
@@ -151,3 +151,5 @@ from ._temporal import uniform_temporal_subsample, uniform_temporal_subsample_vi
 from ._type_conversion import pil_to_tensor, to_image, to_pil_image
 
 from ._deprecated import get_image_size, to_tensor  # usort: skip
+
+from ._utils import query_size


### PR DESCRIPTION
<!-- Before submitting a PR, please make sure to check our contributing guidelines regarding code formatting, tests, and documentation: https://github.com/pytorch/vision/blob/main/CONTRIBUTING.md -->

https://github.com/pytorch/vision/issues/7785#issuecomment-2382741248


```
pytest test/test_transforms_v2.py -vvv -k test_functional

test/test_transforms_v2.py::TestQuerySize::test_functional[pure_tensor] PASSED                                         [ 99%]
test/test_transforms_v2.py::TestQuerySize::test_functional[tv_tensor_image] PASSED                                     [ 99%]
test/test_transforms_v2.py::TestQuerySize::test_functional[pil_image] PASSED                                           [ 99%]
test/test_transforms_v2.py::TestQuerySize::test_functional[tv_tensor_video] PASSED                                     [ 99%]
test/test_transforms_v2.py::TestQuerySize::test_functional[tv_tensor_mask] PASSED                                      [ 99%]
test/test_transforms_v2.py::TestQuerySize::test_functional_mixed_types[pure_tensor] PASSED                             [ 99%]
test/test_transforms_v2.py::TestQuerySize::test_functional_mixed_types[tv_tensor_image] PASSED                         [ 99%]
test/test_transforms_v2.py::TestQuerySize::test_functional_mixed_types[pil_image] PASSED                               [ 99%]
test/test_transforms_v2.py::TestQuerySize::test_functional_mixed_types[tv_tensor_video] PASSED                         [ 99%]
test/test_transforms_v2.py::TestQuerySize::test_functional_mixed_types[tv_tensor_mask] PASSED                          [100%]


```