### PR TITLE
Deterministic order of classes and images for the Omniglot dataset

### DIFF
--- a/torchvision/datasets/utils.py
+++ b/torchvision/datasets/utils.py
@@ -155,6 +155,8 @@ def list_dir(root: Union[str, pathlib.Path], prefix: bool = False) -> List[str]:
     directories = [p for p in os.listdir(root) if os.path.isdir(os.path.join(root, p))]
     if prefix is True:
         directories = [os.path.join(root, d) for d in directories]
+    # sort directories to get deterministic order across OSes
+    directories.sort()
     return directories
 
 
@@ -172,6 +174,8 @@ def list_files(root: Union[str, pathlib.Path], suffix: str, prefix: bool = False
     files = [p for p in os.listdir(root) if os.path.isfile(os.path.join(root, p)) and p.endswith(suffix)]
     if prefix is True:
         files = [os.path.join(root, d) for d in files]
+    # sort filenames to get deterministic order across OSes
+    files.sort()
     return files
 
 


### PR DESCRIPTION
PR for #8677 

By sorting the output of the `list_files()` and `list_dir()` helper functions, the order of samples in the Omniglot dataset can be made deterministic across OSes which helps reproducibility across machines for few-shot learning tasks where the accuracy can change significantly when different classes are used at a certain instant.


