### PR TITLE
Don't print when dataset is already downloaded

### DIFF
--- a/torchvision/datasets/caltech.py
+++ b/torchvision/datasets/caltech.py
@@ -130,7 +130,6 @@ class Caltech101(VisionDataset):
 
     def download(self) -> None:
         if self._check_integrity():
-            print("Files already downloaded and verified")
             return
 
         download_and_extract_archive(
@@ -231,7 +230,6 @@ class Caltech256(VisionDataset):
 
     def download(self) -> None:
         if self._check_integrity():
-            print("Files already downloaded and verified")
             return
 
         download_and_extract_archive(

--- a/torchvision/datasets/celeba.py
+++ b/torchvision/datasets/celeba.py
@@ -148,7 +148,6 @@ class CelebA(VisionDataset):
 
     def download(self) -> None:
         if self._check_integrity():
-            print("Files already downloaded and verified")
             return
 
         for (file_id, md5, filename) in self.file_list:

--- a/torchvision/datasets/cifar.py
+++ b/torchvision/datasets/cifar.py
@@ -135,7 +135,6 @@ class CIFAR10(VisionDataset):
 
     def download(self) -> None:
         if self._check_integrity():
-            print("Files already downloaded and verified")
             return
         download_and_extract_archive(self.url, self.root, filename=self.filename, md5=self.tgz_md5)
 

--- a/torchvision/datasets/imagenette.py
+++ b/torchvision/datasets/imagenette.py
@@ -81,10 +81,7 @@ class Imagenette(VisionDataset):
 
     def _download(self):
         if self._check_exists():
-            raise RuntimeError(
-                f"The directory {self._size_root} already exists. "
-                f"If you want to re-download or re-extract the images, delete the directory."
-            )
+            return
 
         download_and_extract_archive(self._url, self.root, md5=self._md5)
 

--- a/torchvision/datasets/lfw.py
+++ b/torchvision/datasets/lfw.py
@@ -74,7 +74,6 @@ class _LFW(VisionDataset):
 
     def download(self) -> None:
         if self._check_integrity():
-            print("Files already downloaded and verified")
             return
         url = f"{self.download_url_prefix}{self.filename}"
         download_and_extract_archive(url, self.root, filename=self.filename, md5=self.md5)

--- a/torchvision/datasets/omniglot.py
+++ b/torchvision/datasets/omniglot.py
@@ -91,7 +91,6 @@ class Omniglot(VisionDataset):
 
     def download(self) -> None:
         if self._check_integrity():
-            print("Files already downloaded and verified")
             return
 
         filename = self._get_target_folder()

--- a/torchvision/datasets/sbu.py
+++ b/torchvision/datasets/sbu.py
@@ -93,7 +93,6 @@ class SBU(VisionDataset):
         """Download and extract the tarball, and download each individual photo."""
 
         if self._check_integrity():
-            print("Files already downloaded and verified")
             return
 
         download_and_extract_archive(self.url, self.root, self.root, self.filename, self.md5_checksum)

--- a/torchvision/datasets/semeion.py
+++ b/torchvision/datasets/semeion.py
@@ -85,7 +85,6 @@ class SEMEION(VisionDataset):
 
     def download(self) -> None:
         if self._check_integrity():
-            print("Files already downloaded and verified")
             return
 
         root = self.root

--- a/torchvision/datasets/stl10.py
+++ b/torchvision/datasets/stl10.py
@@ -154,7 +154,6 @@ class STL10(VisionDataset):
 
     def download(self) -> None:
         if self._check_integrity():
-            print("Files already downloaded and verified")
             return
         download_and_extract_archive(self.url, self.root, filename=self.filename, md5=self.tgz_md5)
         self._check_integrity()

--- a/torchvision/datasets/widerface.py
+++ b/torchvision/datasets/widerface.py
@@ -182,7 +182,6 @@ class WIDERFace(VisionDataset):
 
     def download(self) -> None:
         if self._check_integrity():
-            print("Files already downloaded and verified")
             return
 
         # download and extract image data


### PR DESCRIPTION
Closes https://github.com/pytorch/vision/issues/8680

Also made a change to `ImageNette` so that `download=True` doesn't raise if the dataset is already there., as requested in https://github.com/pytorch/vision/pull/8638