### PR TITLE
Fix warning raised by torch.meshgrid on missing indexing

### DIFF
--- a/references/depth/stereo/utils/losses.py
+++ b/references/depth/stereo/utils/losses.py
@@ -13,7 +13,7 @@ def make_gaussian_kernel(kernel_size: int, sigma: float) -> torch.Tensor:
     y = torch.arange(kernel_size, dtype=torch.float32)
     x = x - (kernel_size - 1) / 2
     y = y - (kernel_size - 1) / 2
-    x, y = torch.meshgrid(x, y)
+    x, y = torch.meshgrid(x, y, indexing="ij")
     grid = (x**2 + y**2) / (2 * sigma**2)
     kernel = torch.exp(-grid)
     kernel = kernel / kernel.sum()

--- a/torchvision/models/maxvit.py
+++ b/torchvision/models/maxvit.py
@@ -40,7 +40,7 @@ def _make_block_input_shapes(input_size: Tuple[int, int], n_blocks: int) -> List
 
 
 def _get_relative_position_index(height: int, width: int) -> torch.Tensor:
-    coords = torch.stack(torch.meshgrid([torch.arange(height), torch.arange(width)]))
+    coords = torch.stack(torch.meshgrid([torch.arange(height), torch.arange(width)], indexing="ij"))
     coords_flat = torch.flatten(coords, 1)
     relative_coords = coords_flat[:, :, None] - coords_flat[:, None, :]
     relative_coords = relative_coords.permute(1, 2, 0).contiguous()


### PR DESCRIPTION
Description:

Calling `torch.meshgrid(x, y)` without `indexing` argument raises this warning:

```
[/opt/conda/lib/python3.11/site-packages/torch/functional.py:513](http://localhost:2211/lab/tree/jax-ai-stack/docs/opt/conda/lib/python3.11/site-packages/torch/functional.py#line=512): UserWarning: torch.meshgrid: in an upcoming release, it will be required to pass the indexing argument. (Triggered internally at /opt/conda/conda-bld/pytorch_1720538435607/work/aten/src/ATen/native/TensorShape.cpp:3609.)
  return _VF.meshgrid(tensors, **kwargs)  # type: ignore[attr-defined]
```

This PR added indexing with its default value in the places where it is missing.