### PR TITLE
Don't error when dataset is already downloaded

### DIFF
--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -1869,11 +1869,6 @@ class Places365TestCase(datasets_utils.ImageDatasetTestCase):
         with self.create_dataset() as (dataset, _):
             assert dataset.class_to_idx == class_to_idx
 
-    def test_images_download_preexisting(self):
-        with pytest.raises(RuntimeError):
-            with self.create_dataset({"download": True}):
-                pass
-
 
 class INaturalistTestCase(datasets_utils.ImageDatasetTestCase):
     DATASET_CLASS = datasets.INaturalist

--- a/torchvision/datasets/inaturalist.py
+++ b/torchvision/datasets/inaturalist.py
@@ -81,7 +81,7 @@ class INaturalist(VisionDataset):
         if download:
             self.download()
 
-        if not self._check_integrity():
+        if not self._check_exists():
             raise RuntimeError("Dataset not found or corrupted. You can use download=True to download it")
 
         self.all_categories: List[str] = []
@@ -219,15 +219,12 @@ class INaturalist(VisionDataset):
                         return name
                 raise ValueError(f"Invalid category id {category_id} for {category_type}")
 
-    def _check_integrity(self) -> bool:
+    def _check_exists(self) -> bool:
         return os.path.exists(self.root) and len(os.listdir(self.root)) > 0
 
     def download(self) -> None:
-        if self._check_integrity():
-            raise RuntimeError(
-                f"The directory {self.root} already exists. "
-                f"If you want to re-download or re-extract the images, delete the directory."
-            )
+        if self._check_exists():
+            return
 
         base_root = os.path.dirname(self.root)
 

--- a/torchvision/datasets/kinetics.py
+++ b/torchvision/datasets/kinetics.py
@@ -166,10 +166,7 @@ class Kinetics(VisionDataset):
             RuntimeError: if download folder exists, break to prevent downloading entire dataset again.
         """
         if path.exists(self.split_folder):
-            raise RuntimeError(
-                f"The directory {self.split_folder} already exists. "
-                f"If you want to re-download or re-extract the images, delete the directory."
-            )
+            return
         tar_path = path.join(self.root, "tars")
         file_list_path = path.join(self.root, "files")
 

--- a/torchvision/datasets/places365.py
+++ b/torchvision/datasets/places365.py
@@ -145,10 +145,7 @@ class Places365(VisionDataset):
 
     def download_images(self) -> None:
         if path.exists(self.images_dir):
-            raise RuntimeError(
-                f"The directory {self.images_dir} already exists. If you want to re-download or re-extract the images, "
-                f"delete the directory."
-            )
+            return
 
         file, md5 = self._IMAGES_META[(self.split, self.small)]
         download_and_extract_archive(urljoin(self._BASE_URL, file), self.root, md5=md5)


### PR DESCRIPTION
Towards https://github.com/pytorch/vision/issues/8668, similar to what was done for ImageNette in https://github.com/pytorch/vision/pull/8681. I had missed those remaining datasets, thanks you @pmeier  for the heads up!