### PR TITLE
make center_crop traceable with torch.jit.trace

### DIFF
--- a/torchvision/transforms/functional.py
+++ b/torchvision/transforms/functional.py
@@ -589,8 +589,8 @@ def center_crop(img: Tensor, output_size: List[int]) -> Tensor:
         if crop_width == image_width and crop_height == image_height:
             return img
 
-    crop_top = int(round((image_height - crop_height) / 2.0))
-    crop_left = int(round((image_width - crop_width) / 2.0))
+    crop_top = (image_height - crop_height) // 2 + (image_height - crop_height) % 2
+    crop_left = (image_width - crop_width) // 2 + (image_width - crop_width) % 2
     return crop(img, crop_top, crop_left, crop_height, crop_width)
 
 


### PR DESCRIPTION
I ran all the tests and the formatting commands from `CONTRIBUTING.md`
This links to an issue I opened #7705

CenterCrop is not traceable

```python
from torchvision.transforms import CenterCrop

c = CenterCrop(size=(112, 112))
torch.jit.trace(c, example_inputs=torch.ones((200, 200)))
```
```bash
TypeError: type Tensor doesn't define __round__ method
```

The reason being these 2 lines in `torchvision.transforms.functional.py` (line 590)
```
crop_top = int(round((image_height - crop_height) / 2.0))
crop_left = int(round((image_width - crop_width) / 2.0))
```

rewriting this with the `val // 2 + val % 2` operator instead of `int(round(val / 2.0))` will have exactly the same output and be traceable.

```python
crop_top = (image_height - crop_height) // 2 + (image_height - crop_height) % 2
crop_left = (image_width - crop_width) // 2 + (image_width - crop_width) % 2
```
