### PR TITLE
Make v2 transforms authoring public

### DIFF
--- a/references/segmentation/v2_extras.py
+++ b/references/segmentation/v2_extras.py
@@ -10,7 +10,7 @@ class PadIfSmaller(v2.Transform):
         self.size = size
         self.fill = v2._utils._setup_fill_arg(fill)
 
-    def _get_params(self, sample):
+    def make_params(self, sample):
         _, height, width = v2._utils.query_chw(sample)
         padding = [0, 0, max(self.size - width, 0), max(self.size - height, 0)]
         needs_padding = any(padding)

--- a/references/segmentation/v2_extras.py
+++ b/references/segmentation/v2_extras.py
@@ -16,7 +16,7 @@ class PadIfSmaller(v2.Transform):
         needs_padding = any(padding)
         return dict(padding=padding, needs_padding=needs_padding)
 
-    def _transform(self, inpt, params):
+    def transform(self, inpt, params):
         if not params["needs_padding"]:
             return inpt
 

--- a/test/test_prototype_transforms.py
+++ b/test/test_prototype_transforms.py
@@ -159,7 +159,7 @@ class TestSimpleCopyPaste:
 
 
 class TestFixedSizeCrop:
-    def test__get_params(self, mocker):
+    def test_make_params(self, mocker):
         crop_size = (7, 7)
         batch_shape = (10,)
         canvas_size = (11, 5)
@@ -170,7 +170,7 @@ class TestFixedSizeCrop:
             make_image(size=canvas_size, color_space="RGB"),
             make_bounding_boxes(format=BoundingBoxFormat.XYXY, canvas_size=canvas_size, num_boxes=batch_shape[0]),
         ]
-        params = transform._get_params(flat_inputs)
+        params = transform.make_params(flat_inputs)
 
         assert params["needs_crop"]
         assert params["height"] <= crop_size[0]
@@ -191,7 +191,7 @@ class TestFixedSizeCrop:
 
         is_valid = torch.randint(0, 2, (batch_size,), dtype=torch.bool)
         mocker.patch(
-            "torchvision.prototype.transforms._geometry.FixedSizeCrop._get_params",
+            "torchvision.prototype.transforms._geometry.FixedSizeCrop.make_params",
             return_value=dict(
                 needs_crop=True,
                 top=0,
@@ -229,7 +229,7 @@ class TestFixedSizeCrop:
         canvas_size = (10, 10)
 
         mocker.patch(
-            "torchvision.prototype.transforms._geometry.FixedSizeCrop._get_params",
+            "torchvision.prototype.transforms._geometry.FixedSizeCrop.make_params",
             return_value=dict(
                 needs_crop=True,
                 top=0,

--- a/test/test_transforms_v2.py
+++ b/test/test_transforms_v2.py
@@ -1355,7 +1355,7 @@ class TestAffine:
         transform = transforms.RandomAffine(**self._CORRECTNESS_TRANSFORM_AFFINE_RANGES, center=center)
 
         torch.manual_seed(seed)
-        params = transform._get_params([bounding_boxes])
+        params = transform.make_params([bounding_boxes])
 
         torch.manual_seed(seed)
         actual = transform(bounding_boxes)
@@ -1369,14 +1369,14 @@ class TestAffine:
     @pytest.mark.parametrize("scale", _EXHAUSTIVE_TYPE_TRANSFORM_AFFINE_RANGES["scale"])
     @pytest.mark.parametrize("shear", _EXHAUSTIVE_TYPE_TRANSFORM_AFFINE_RANGES["shear"])
     @pytest.mark.parametrize("seed", list(range(10)))
-    def test_transform_get_params_bounds(self, degrees, translate, scale, shear, seed):
+    def test_transformmake_params_bounds(self, degrees, translate, scale, shear, seed):
         image = make_image()
         height, width = F.get_size(image)
 
         transform = transforms.RandomAffine(degrees=degrees, translate=translate, scale=scale, shear=shear)
 
         torch.manual_seed(seed)
-        params = transform._get_params([image])
+        params = transform.make_params([image])
 
         if isinstance(degrees, (int, float)):
             assert -degrees <= params["angle"] <= degrees
@@ -1783,7 +1783,7 @@ class TestRotate:
         transform = transforms.RandomRotation(**self._CORRECTNESS_TRANSFORM_AFFINE_RANGES, expand=expand, center=center)
 
         torch.manual_seed(seed)
-        params = transform._get_params([bounding_boxes])
+        params = transform.make_params([bounding_boxes])
 
         torch.manual_seed(seed)
         actual = transform(bounding_boxes)
@@ -1795,11 +1795,11 @@ class TestRotate:
 
     @pytest.mark.parametrize("degrees", _EXHAUSTIVE_TYPE_TRANSFORM_AFFINE_RANGES["degrees"])
     @pytest.mark.parametrize("seed", list(range(10)))
-    def test_transform_get_params_bounds(self, degrees, seed):
+    def test_transformmake_params_bounds(self, degrees, seed):
         transform = transforms.RandomRotation(degrees=degrees)
 
         torch.manual_seed(seed)
-        params = transform._get_params([])
+        params = transform.make_params([])
 
         if isinstance(degrees, (int, float)):
             assert -degrees <= params["angle"] <= degrees
@@ -2996,7 +2996,7 @@ class TestCrop:
 
         with freeze_rng_state():
             torch.manual_seed(seed)
-            params = transform._get_params([bounding_boxes])
+            params = transform.make_params([bounding_boxes])
             assert not params.pop("needs_pad")
             del params["padding"]
             assert params.pop("needs_crop")
@@ -3129,9 +3129,9 @@ class TestErase:
 
         with freeze_rng_state():
             torch.manual_seed(seed)
-            # This emulates the random apply check that happens before _get_params is called
+            # This emulates the random apply check that happens before make_params is called
             torch.rand(1)
-            params = transform._get_params([image])
+            params = transform.make_params([image])
 
             torch.manual_seed(seed)
             actual = transform(image)
@@ -3159,7 +3159,7 @@ class TestErase:
         transform = transforms.RandomErasing(value=[1, 2, 3, 4])
 
         with pytest.raises(ValueError, match="If value is a sequence, it should have either a single value"):
-            transform._get_params([make_image()])
+            transform.make_params([make_image()])
 
 
 class TestGaussianBlur:
@@ -3244,9 +3244,9 @@ class TestGaussianBlur:
             transforms.GaussianBlur(3, sigma={})
 
     @pytest.mark.parametrize("sigma", [10.0, [10.0, 12.0], (10, 12.0), [10]])
-    def test__get_params(self, sigma):
+    def test_make_params(self, sigma):
         transform = transforms.GaussianBlur(3, sigma=sigma)
-        params = transform._get_params([])
+        params = transform.make_params([])
 
         if isinstance(sigma, float):
             assert params["sigma"][0] == params["sigma"][1] == sigma
@@ -5251,7 +5251,7 @@ class TestRandomZoomOut:
         input = make_input()
         height, width = F.get_size(input)
 
-        params = transform._get_params([input])
+        params = transform.make_params([input])
         assert "padding" in params
 
         padding = params["padding"]
@@ -5305,13 +5305,13 @@ class TestScaleJitter:
 
         check_transform(transforms.ScaleJitter(self.TARGET_SIZE), make_input(self.INPUT_SIZE, device=device))
 
-    def test__get_params(self):
+    def test_make_params(self):
         input_size = self.INPUT_SIZE
         target_size = self.TARGET_SIZE
         scale_range = (0.5, 1.5)
 
         transform = transforms.ScaleJitter(target_size=target_size, scale_range=scale_range)
-        params = transform._get_params([make_image(input_size)])
+        params = transform.make_params([make_image(input_size)])
 
         assert "size" in params
         size = params["size"]
@@ -5580,7 +5580,7 @@ def test_pure_tensor_heuristic(make_inputs):
 class TestRandomIoUCrop:
     @pytest.mark.parametrize("device", cpu_and_cuda())
     @pytest.mark.parametrize("options", [[0.5, 0.9], [2.0]])
-    def test__get_params(self, device, options):
+    def test_make_params(self, device, options):
         orig_h, orig_w = size = (24, 32)
         image = make_image(size)
         bboxes = tv_tensors.BoundingBoxes(
@@ -5596,7 +5596,7 @@ class TestRandomIoUCrop:
         n_samples = 5
         for _ in range(n_samples):
 
-            params = transform._get_params(sample)
+            params = transform.make_params(sample)
 
             if options == [2.0]:
                 assert len(params) == 0
@@ -5622,8 +5622,8 @@ class TestRandomIoUCrop:
         bboxes = tv_tensors.BoundingBoxes(torch.tensor([[1, 1, 2, 2]]), format="XYXY", canvas_size=(4, 4))
         label = torch.tensor([1])
         sample = [image, bboxes, label]
-        # Let's mock transform._get_params to control the output:
-        transform._get_params = mocker.MagicMock(return_value={})
+        # Let's mock transform.make_params to control the output:
+        transform.make_params = mocker.MagicMock(return_value={})
         output = transform(sample)
         torch.testing.assert_close(output, sample)
 
@@ -5648,7 +5648,7 @@ class TestRandomIoUCrop:
         is_within_crop_area = torch.tensor([0, 1, 0, 1, 0, 1], dtype=torch.bool)
 
         params = dict(top=1, left=2, height=12, width=12, is_within_crop_area=is_within_crop_area)
-        transform._get_params = mocker.MagicMock(return_value=params)
+        transform.make_params = mocker.MagicMock(return_value=params)
         output = transform(sample)
 
         # check number of bboxes vs number of labels:
@@ -5662,13 +5662,13 @@ class TestRandomIoUCrop:
 
 class TestRandomShortestSize:
     @pytest.mark.parametrize("min_size,max_size", [([5, 9], 20), ([5, 9], None)])
-    def test__get_params(self, min_size, max_size):
+    def test_make_params(self, min_size, max_size):
         canvas_size = (3, 10)
 
         transform = transforms.RandomShortestSize(min_size=min_size, max_size=max_size, antialias=True)
 
         sample = make_image(canvas_size)
-        params = transform._get_params([sample])
+        params = transform.make_params([sample])
 
         assert "size" in params
         size = params["size"]
@@ -5685,14 +5685,14 @@ class TestRandomShortestSize:
 
 
 class TestRandomResize:
-    def test__get_params(self):
+    def test_make_params(self):
         min_size = 3
         max_size = 6
 
         transform = transforms.RandomResize(min_size=min_size, max_size=max_size, antialias=True)
 
         for _ in range(10):
-            params = transform._get_params([])
+            params = transform.make_params([])
 
             assert isinstance(params["size"], list) and len(params["size"]) == 1
             size = params["size"][0]
@@ -6148,12 +6148,12 @@ class TestJPEG:
 
     @pytest.mark.parametrize("quality", [5, (10, 20)])
     @pytest.mark.parametrize("seed", list(range(10)))
-    def test_transform_get_params_bounds(self, quality, seed):
+    def test_transformmake_params_bounds(self, quality, seed):
         transform = transforms.JPEG(quality=quality)
 
         with freeze_rng_state():
             torch.manual_seed(seed)
-            params = transform._get_params([])
+            params = transform.make_params([])
 
         if isinstance(quality, int):
             assert params["quality"] == quality

--- a/test/test_transforms_v2.py
+++ b/test/test_transforms_v2.py
@@ -1843,7 +1843,7 @@ class TestRotate:
 
 class TestContainerTransforms:
     class BuiltinTransform(transforms.Transform):
-        def _transform(self, inpt, params):
+        def transform(self, inpt, params):
             return inpt
 
     class PackedInputTransform(nn.Module):
@@ -5544,7 +5544,7 @@ def test_pure_tensor_heuristic(make_inputs):
         return pure_tensors[0] if pure_tensors else None, pure_tensors[1:], others
 
     class CopyCloneTransform(transforms.Transform):
-        def _transform(self, inpt, params):
+        def transform(self, inpt, params):
             return inpt.clone() if isinstance(inpt, torch.Tensor) else inpt.copy()
 
         @staticmethod

--- a/torchvision/prototype/transforms/_geometry.py
+++ b/torchvision/prototype/transforms/_geometry.py
@@ -53,7 +53,7 @@ class FixedSizeCrop(Transform):
                 f"{type(self).__name__}() also requires it to contain a Label or OneHotLabel."
             )
 
-    def _get_params(self, flat_inputs: List[Any]) -> Dict[str, Any]:
+    def make_params(self, flat_inputs: List[Any]) -> Dict[str, Any]:
         height, width = query_size(flat_inputs)
         new_height = min(height, self.crop_height)
         new_width = min(width, self.crop_width)

--- a/torchvision/prototype/transforms/_geometry.py
+++ b/torchvision/prototype/transforms/_geometry.py
@@ -35,7 +35,7 @@ class FixedSizeCrop(Transform):
 
         self.padding_mode = padding_mode
 
-    def _check_inputs(self, flat_inputs: List[Any]) -> None:
+    def check_inputs(self, flat_inputs: List[Any]) -> None:
         if not has_any(
             flat_inputs,
             PIL.Image.Image,

--- a/torchvision/prototype/transforms/_geometry.py
+++ b/torchvision/prototype/transforms/_geometry.py
@@ -107,7 +107,7 @@ class FixedSizeCrop(Transform):
             needs_pad=needs_pad,
         )
 
-    def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
+    def transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
         if params["needs_crop"]:
             inpt = self._call_kernel(
                 F.crop,

--- a/torchvision/prototype/transforms/_misc.py
+++ b/torchvision/prototype/transforms/_misc.py
@@ -39,7 +39,7 @@ class PermuteDimensions(Transform):
             )
         self.dims = dims
 
-    def _transform(self, inpt: Any, params: Dict[str, Any]) -> torch.Tensor:
+    def transform(self, inpt: Any, params: Dict[str, Any]) -> torch.Tensor:
         dims = self.dims[type(inpt)]
         if dims is None:
             return inpt.as_subclass(torch.Tensor)
@@ -61,7 +61,7 @@ class TransposeDimensions(Transform):
             )
         self.dims = dims
 
-    def _transform(self, inpt: Any, params: Dict[str, Any]) -> torch.Tensor:
+    def transform(self, inpt: Any, params: Dict[str, Any]) -> torch.Tensor:
         dims = self.dims[type(inpt)]
         if dims is None:
             return inpt.as_subclass(torch.Tensor)

--- a/torchvision/prototype/transforms/_type_conversion.py
+++ b/torchvision/prototype/transforms/_type_conversion.py
@@ -15,7 +15,7 @@ class LabelToOneHot(Transform):
         super().__init__()
         self.num_categories = num_categories
 
-    def _transform(self, inpt: proto_tv_tensors.Label, params: Dict[str, Any]) -> proto_tv_tensors.OneHotLabel:
+    def transform(self, inpt: proto_tv_tensors.Label, params: Dict[str, Any]) -> proto_tv_tensors.OneHotLabel:
         num_categories = self.num_categories
         if num_categories == -1 and inpt.categories is not None:
             num_categories = len(inpt.categories)

--- a/torchvision/transforms/v2/_augment.py
+++ b/torchvision/transforms/v2/_augment.py
@@ -96,7 +96,7 @@ class RandomErasing(_RandomApplyTransform):
             )
         return super()._call_kernel(functional, inpt, *args, **kwargs)
 
-    def _get_params(self, flat_inputs: List[Any]) -> Dict[str, Any]:
+    def make_params(self, flat_inputs: List[Any]) -> Dict[str, Any]:
         img_c, img_h, img_w = query_chw(flat_inputs)
 
         if self.value is not None and not (len(self.value) in (1, img_c)):
@@ -181,7 +181,7 @@ class _BaseMixUpCutMix(Transform):
         params = {
             "labels": labels,
             "batch_size": labels.shape[0],
-            **self._get_params(
+            **self.make_params(
                 [inpt for (inpt, needs_transform) in zip(flat_inputs, needs_transform_list) if needs_transform]
             ),
         }
@@ -243,7 +243,7 @@ class MixUp(_BaseMixUpCutMix):
             It can also be a callable that takes the same input as the transform, and returns the labels.
     """
 
-    def _get_params(self, flat_inputs: List[Any]) -> Dict[str, Any]:
+    def make_params(self, flat_inputs: List[Any]) -> Dict[str, Any]:
         return dict(lam=float(self._dist.sample(())))  # type: ignore[arg-type]
 
     def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
@@ -292,7 +292,7 @@ class CutMix(_BaseMixUpCutMix):
             It can also be a callable that takes the same input as the transform, and returns the labels.
     """
 
-    def _get_params(self, flat_inputs: List[Any]) -> Dict[str, Any]:
+    def make_params(self, flat_inputs: List[Any]) -> Dict[str, Any]:
         lam = float(self._dist.sample(()))  # type: ignore[arg-type]
 
         H, W = query_size(flat_inputs)
@@ -361,7 +361,7 @@ class JPEG(Transform):
 
         self.quality = quality
 
-    def _get_params(self, flat_inputs: List[Any]) -> Dict[str, Any]:
+    def make_params(self, flat_inputs: List[Any]) -> Dict[str, Any]:
         quality = torch.randint(self.quality[0], self.quality[1] + 1, ()).item()
         return dict(quality=quality)
 

--- a/torchvision/transforms/v2/_augment.py
+++ b/torchvision/transforms/v2/_augment.py
@@ -134,7 +134,7 @@ class RandomErasing(_RandomApplyTransform):
 
         return dict(i=i, j=j, h=h, w=w, v=v)
 
-    def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
+    def transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
         if params["v"] is not None:
             inpt = self._call_kernel(F.erase, inpt, **params, inplace=self.inplace)
 
@@ -190,7 +190,7 @@ class _BaseMixUpCutMix(Transform):
         # after an image or video. However, we need to handle them in _transform, so we make sure to set them to True
         needs_transform_list[next(idx for idx, inpt in enumerate(flat_inputs) if inpt is labels)] = True
         flat_outputs = [
-            self._transform(inpt, params) if needs_transform else inpt
+            self.transform(inpt, params) if needs_transform else inpt
             for (inpt, needs_transform) in zip(flat_inputs, needs_transform_list)
         ]
 
@@ -246,7 +246,7 @@ class MixUp(_BaseMixUpCutMix):
     def make_params(self, flat_inputs: List[Any]) -> Dict[str, Any]:
         return dict(lam=float(self._dist.sample(())))  # type: ignore[arg-type]
 
-    def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
+    def transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
         lam = params["lam"]
 
         if inpt is params["labels"]:
@@ -314,7 +314,7 @@ class CutMix(_BaseMixUpCutMix):
 
         return dict(box=box, lam_adjusted=lam_adjusted)
 
-    def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
+    def transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
         if inpt is params["labels"]:
             return self._mixup_label(inpt, lam=params["lam_adjusted"])
         elif isinstance(inpt, (tv_tensors.Image, tv_tensors.Video)) or is_pure_tensor(inpt):
@@ -365,5 +365,5 @@ class JPEG(Transform):
         quality = torch.randint(self.quality[0], self.quality[1] + 1, ()).item()
         return dict(quality=quality)
 
-    def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
+    def transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
         return self._call_kernel(F.jpeg, inpt, quality=params["quality"])

--- a/torchvision/transforms/v2/_color.py
+++ b/torchvision/transforms/v2/_color.py
@@ -46,7 +46,7 @@ class RandomGrayscale(_RandomApplyTransform):
     def __init__(self, p: float = 0.1) -> None:
         super().__init__(p=p)
 
-    def _get_params(self, flat_inputs: List[Any]) -> Dict[str, Any]:
+    def make_params(self, flat_inputs: List[Any]) -> Dict[str, Any]:
         num_input_channels, *_ = query_chw(flat_inputs)
         return dict(num_input_channels=num_input_channels)
 
@@ -142,7 +142,7 @@ class ColorJitter(Transform):
     def _generate_value(left: float, right: float) -> float:
         return torch.empty(1).uniform_(left, right).item()
 
-    def _get_params(self, flat_inputs: List[Any]) -> Dict[str, Any]:
+    def make_params(self, flat_inputs: List[Any]) -> Dict[str, Any]:
         fn_idx = torch.randperm(4)
 
         b = None if self.brightness is None else self._generate_value(self.brightness[0], self.brightness[1])
@@ -173,7 +173,7 @@ class ColorJitter(Transform):
 class RandomChannelPermutation(Transform):
     """Randomly permute the channels of an image or video"""
 
-    def _get_params(self, flat_inputs: List[Any]) -> Dict[str, Any]:
+    def make_params(self, flat_inputs: List[Any]) -> Dict[str, Any]:
         num_channels, *_ = query_chw(flat_inputs)
         return dict(permutation=torch.randperm(num_channels))
 
@@ -220,7 +220,7 @@ class RandomPhotometricDistort(Transform):
         self.saturation = saturation
         self.p = p
 
-    def _get_params(self, flat_inputs: List[Any]) -> Dict[str, Any]:
+    def make_params(self, flat_inputs: List[Any]) -> Dict[str, Any]:
         num_channels, *_ = query_chw(flat_inputs)
         params: Dict[str, Any] = {
             key: ColorJitter._generate_value(range[0], range[1]) if torch.rand(1) < self.p else None

--- a/torchvision/transforms/v2/_color.py
+++ b/torchvision/transforms/v2/_color.py
@@ -25,7 +25,7 @@ class Grayscale(Transform):
         super().__init__()
         self.num_output_channels = num_output_channels
 
-    def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
+    def transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
         return self._call_kernel(F.rgb_to_grayscale, inpt, num_output_channels=self.num_output_channels)
 
 
@@ -50,7 +50,7 @@ class RandomGrayscale(_RandomApplyTransform):
         num_input_channels, *_ = query_chw(flat_inputs)
         return dict(num_input_channels=num_input_channels)
 
-    def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
+    def transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
         return self._call_kernel(F.rgb_to_grayscale, inpt, num_output_channels=params["num_input_channels"])
 
 
@@ -64,7 +64,7 @@ class RGB(Transform):
     def __init__(self):
         super().__init__()
 
-    def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
+    def transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
         return self._call_kernel(F.grayscale_to_rgb, inpt)
 
 
@@ -152,7 +152,7 @@ class ColorJitter(Transform):
 
         return dict(fn_idx=fn_idx, brightness_factor=b, contrast_factor=c, saturation_factor=s, hue_factor=h)
 
-    def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
+    def transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
         output = inpt
         brightness_factor = params["brightness_factor"]
         contrast_factor = params["contrast_factor"]
@@ -177,7 +177,7 @@ class RandomChannelPermutation(Transform):
         num_channels, *_ = query_chw(flat_inputs)
         return dict(permutation=torch.randperm(num_channels))
 
-    def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
+    def transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
         return self._call_kernel(F.permute_channels, inpt, params["permutation"])
 
 
@@ -235,7 +235,7 @@ class RandomPhotometricDistort(Transform):
         params["channel_permutation"] = torch.randperm(num_channels) if torch.rand(1) < self.p else None
         return params
 
-    def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
+    def transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
         if params["brightness_factor"] is not None:
             inpt = self._call_kernel(F.adjust_brightness, inpt, brightness_factor=params["brightness_factor"])
         if params["contrast_factor"] is not None and params["contrast_before"]:
@@ -264,7 +264,7 @@ class RandomEqualize(_RandomApplyTransform):
 
     _v1_transform_cls = _transforms.RandomEqualize
 
-    def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
+    def transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
         return self._call_kernel(F.equalize, inpt)
 
 
@@ -281,7 +281,7 @@ class RandomInvert(_RandomApplyTransform):
 
     _v1_transform_cls = _transforms.RandomInvert
 
-    def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
+    def transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
         return self._call_kernel(F.invert, inpt)
 
 
@@ -304,7 +304,7 @@ class RandomPosterize(_RandomApplyTransform):
         super().__init__(p=p)
         self.bits = bits
 
-    def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
+    def transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
         return self._call_kernel(F.posterize, inpt, bits=self.bits)
 
 
@@ -332,7 +332,7 @@ class RandomSolarize(_RandomApplyTransform):
         super().__init__(p=p)
         self.threshold = threshold
 
-    def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
+    def transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
         return self._call_kernel(F.solarize, inpt, threshold=self.threshold)
 
 
@@ -349,7 +349,7 @@ class RandomAutocontrast(_RandomApplyTransform):
 
     _v1_transform_cls = _transforms.RandomAutocontrast
 
-    def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
+    def transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
         return self._call_kernel(F.autocontrast, inpt)
 
 
@@ -372,5 +372,5 @@ class RandomAdjustSharpness(_RandomApplyTransform):
         super().__init__(p=p)
         self.sharpness_factor = sharpness_factor
 
-    def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
+    def transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
         return self._call_kernel(F.adjust_sharpness, inpt, sharpness_factor=self.sharpness_factor)

--- a/torchvision/transforms/v2/_deprecated.py
+++ b/torchvision/transforms/v2/_deprecated.py
@@ -46,5 +46,5 @@ class ToTensor(Transform):
         )
         super().__init__()
 
-    def _transform(self, inpt: Union[PIL.Image.Image, np.ndarray], params: Dict[str, Any]) -> torch.Tensor:
+    def transform(self, inpt: Union[PIL.Image.Image, np.ndarray], params: Dict[str, Any]) -> torch.Tensor:
         return _F.to_tensor(inpt)

--- a/torchvision/transforms/v2/_geometry.py
+++ b/torchvision/transforms/v2/_geometry.py
@@ -268,7 +268,7 @@ class RandomResizedCrop(Transform):
 
         self._log_ratio = torch.log(torch.tensor(self.ratio))
 
-    def _get_params(self, flat_inputs: List[Any]) -> Dict[str, Any]:
+    def make_params(self, flat_inputs: List[Any]) -> Dict[str, Any]:
         height, width = query_size(flat_inputs)
         area = height * width
 
@@ -535,7 +535,7 @@ class RandomZoomOut(_RandomApplyTransform):
         if side_range[0] < 1.0 or side_range[0] > side_range[1]:
             raise ValueError(f"Invalid side range provided {side_range}.")
 
-    def _get_params(self, flat_inputs: List[Any]) -> Dict[str, Any]:
+    def make_params(self, flat_inputs: List[Any]) -> Dict[str, Any]:
         orig_h, orig_w = query_size(flat_inputs)
 
         r = self.side_range[0] + torch.rand(1) * (self.side_range[1] - self.side_range[0])
@@ -618,7 +618,7 @@ class RandomRotation(Transform):
 
         self.center = center
 
-    def _get_params(self, flat_inputs: List[Any]) -> Dict[str, Any]:
+    def make_params(self, flat_inputs: List[Any]) -> Dict[str, Any]:
         angle = torch.empty(1).uniform_(self.degrees[0], self.degrees[1]).item()
         return dict(angle=angle)
 
@@ -716,7 +716,7 @@ class RandomAffine(Transform):
 
         self.center = center
 
-    def _get_params(self, flat_inputs: List[Any]) -> Dict[str, Any]:
+    def make_params(self, flat_inputs: List[Any]) -> Dict[str, Any]:
         height, width = query_size(flat_inputs)
 
         angle = torch.empty(1).uniform_(self.degrees[0], self.degrees[1]).item()
@@ -839,7 +839,7 @@ class RandomCrop(Transform):
         self._fill = _setup_fill_arg(fill)
         self.padding_mode = padding_mode
 
-    def _get_params(self, flat_inputs: List[Any]) -> Dict[str, Any]:
+    def make_params(self, flat_inputs: List[Any]) -> Dict[str, Any]:
         padded_height, padded_width = query_size(flat_inputs)
 
         if self.padding is not None:
@@ -952,7 +952,7 @@ class RandomPerspective(_RandomApplyTransform):
         self.fill = fill
         self._fill = _setup_fill_arg(fill)
 
-    def _get_params(self, flat_inputs: List[Any]) -> Dict[str, Any]:
+    def make_params(self, flat_inputs: List[Any]) -> Dict[str, Any]:
         height, width = query_size(flat_inputs)
 
         distortion_scale = self.distortion_scale
@@ -1051,7 +1051,7 @@ class ElasticTransform(Transform):
         self.fill = fill
         self._fill = _setup_fill_arg(fill)
 
-    def _get_params(self, flat_inputs: List[Any]) -> Dict[str, Any]:
+    def make_params(self, flat_inputs: List[Any]) -> Dict[str, Any]:
         size = list(query_size(flat_inputs))
 
         dx = torch.rand([1, 1] + size) * 2 - 1
@@ -1142,7 +1142,7 @@ class RandomIoUCrop(Transform):
                 "and bounding boxes. Sample can also contain masks."
             )
 
-    def _get_params(self, flat_inputs: List[Any]) -> Dict[str, Any]:
+    def make_params(self, flat_inputs: List[Any]) -> Dict[str, Any]:
         orig_h, orig_w = query_size(flat_inputs)
         bboxes = get_bounding_boxes(flat_inputs)
 
@@ -1262,7 +1262,7 @@ class ScaleJitter(Transform):
         self.interpolation = interpolation
         self.antialias = antialias
 
-    def _get_params(self, flat_inputs: List[Any]) -> Dict[str, Any]:
+    def make_params(self, flat_inputs: List[Any]) -> Dict[str, Any]:
         orig_height, orig_width = query_size(flat_inputs)
 
         scale = self.scale_range[0] + torch.rand(1) * (self.scale_range[1] - self.scale_range[0])
@@ -1327,7 +1327,7 @@ class RandomShortestSize(Transform):
         self.interpolation = interpolation
         self.antialias = antialias
 
-    def _get_params(self, flat_inputs: List[Any]) -> Dict[str, Any]:
+    def make_params(self, flat_inputs: List[Any]) -> Dict[str, Any]:
         orig_height, orig_width = query_size(flat_inputs)
 
         min_size = self.min_size[int(torch.randint(len(self.min_size), ()))]
@@ -1406,7 +1406,7 @@ class RandomResize(Transform):
         self.interpolation = interpolation
         self.antialias = antialias
 
-    def _get_params(self, flat_inputs: List[Any]) -> Dict[str, Any]:
+    def make_params(self, flat_inputs: List[Any]) -> Dict[str, Any]:
         size = int(torch.randint(self.min_size, self.max_size, ()))
         return dict(size=[size])
 

--- a/torchvision/transforms/v2/_geometry.py
+++ b/torchvision/transforms/v2/_geometry.py
@@ -44,7 +44,7 @@ class RandomHorizontalFlip(_RandomApplyTransform):
 
     _v1_transform_cls = _transforms.RandomHorizontalFlip
 
-    def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
+    def transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
         return self._call_kernel(F.horizontal_flip, inpt)
 
 
@@ -62,7 +62,7 @@ class RandomVerticalFlip(_RandomApplyTransform):
 
     _v1_transform_cls = _transforms.RandomVerticalFlip
 
-    def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
+    def transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
         return self._call_kernel(F.vertical_flip, inpt)
 
 
@@ -156,7 +156,7 @@ class Resize(Transform):
         self.max_size = max_size
         self.antialias = antialias
 
-    def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
+    def transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
         return self._call_kernel(
             F.resize,
             inpt,
@@ -189,7 +189,7 @@ class CenterCrop(Transform):
         super().__init__()
         self.size = _setup_size(size, error_msg="Please provide only two dimensions (h, w) for size.")
 
-    def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
+    def transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
         return self._call_kernel(F.center_crop, inpt, output_size=self.size)
 
 
@@ -306,7 +306,7 @@ class RandomResizedCrop(Transform):
 
         return dict(top=i, left=j, height=h, width=w)
 
-    def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
+    def transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
         return self._call_kernel(
             F.resized_crop, inpt, **params, size=self.size, interpolation=self.interpolation, antialias=self.antialias
         )
@@ -363,7 +363,7 @@ class FiveCrop(Transform):
             )
         return super()._call_kernel(functional, inpt, *args, **kwargs)
 
-    def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
+    def transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
         return self._call_kernel(F.five_crop, inpt, self.size)
 
     def check_inputs(self, flat_inputs: List[Any]) -> None:
@@ -412,7 +412,7 @@ class TenCrop(Transform):
         if has_any(flat_inputs, tv_tensors.BoundingBoxes, tv_tensors.Mask):
             raise TypeError(f"BoundingBoxes'es and Mask's are not supported by {type(self).__name__}()")
 
-    def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
+    def transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
         return self._call_kernel(F.ten_crop, inpt, self.size, vertical_flip=self.vertical_flip)
 
 
@@ -483,7 +483,7 @@ class Pad(Transform):
         self._fill = _setup_fill_arg(fill)
         self.padding_mode = padding_mode
 
-    def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
+    def transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
         fill = _get_fill(self._fill, type(inpt))
         return self._call_kernel(F.pad, inpt, padding=self.padding, fill=fill, padding_mode=self.padding_mode)  # type: ignore[arg-type]
 
@@ -551,7 +551,7 @@ class RandomZoomOut(_RandomApplyTransform):
 
         return dict(padding=padding)
 
-    def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
+    def transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
         fill = _get_fill(self._fill, type(inpt))
         return self._call_kernel(F.pad, inpt, **params, fill=fill)
 
@@ -622,7 +622,7 @@ class RandomRotation(Transform):
         angle = torch.empty(1).uniform_(self.degrees[0], self.degrees[1]).item()
         return dict(angle=angle)
 
-    def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
+    def transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
         fill = _get_fill(self._fill, type(inpt))
         return self._call_kernel(
             F.rotate,
@@ -743,7 +743,7 @@ class RandomAffine(Transform):
         shear = (shear_x, shear_y)
         return dict(angle=angle, translate=translate, scale=scale, shear=shear)
 
-    def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
+    def transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
         fill = _get_fill(self._fill, type(inpt))
         return self._call_kernel(
             F.affine,
@@ -897,7 +897,7 @@ class RandomCrop(Transform):
             padding=padding,
         )
 
-    def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
+    def transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
         if params["needs_pad"]:
             fill = _get_fill(self._fill, type(inpt))
             inpt = self._call_kernel(F.pad, inpt, padding=params["padding"], fill=fill, padding_mode=self.padding_mode)
@@ -982,7 +982,7 @@ class RandomPerspective(_RandomApplyTransform):
         perspective_coeffs = _get_perspective_coeffs(startpoints, endpoints)
         return dict(coefficients=perspective_coeffs)
 
-    def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
+    def transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
         fill = _get_fill(self._fill, type(inpt))
         return self._call_kernel(
             F.perspective,
@@ -1074,7 +1074,7 @@ class ElasticTransform(Transform):
         displacement = torch.concat([dx, dy], 1).permute([0, 2, 3, 1])  # 1 x H x W x 2
         return dict(displacement=displacement)
 
-    def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
+    def transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
         fill = _get_fill(self._fill, type(inpt))
         return self._call_kernel(
             F.elastic,
@@ -1194,7 +1194,7 @@ class RandomIoUCrop(Transform):
 
                 return dict(top=top, left=left, height=new_h, width=new_w, is_within_crop_area=is_within_crop_area)
 
-    def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
+    def transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
 
         if len(params) < 1:
             return inpt
@@ -1272,7 +1272,7 @@ class ScaleJitter(Transform):
 
         return dict(size=(new_height, new_width))
 
-    def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
+    def transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
         return self._call_kernel(
             F.resize, inpt, size=params["size"], interpolation=self.interpolation, antialias=self.antialias
         )
@@ -1340,7 +1340,7 @@ class RandomShortestSize(Transform):
 
         return dict(size=(new_height, new_width))
 
-    def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
+    def transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
         return self._call_kernel(
             F.resize, inpt, size=params["size"], interpolation=self.interpolation, antialias=self.antialias
         )
@@ -1410,7 +1410,7 @@ class RandomResize(Transform):
         size = int(torch.randint(self.min_size, self.max_size, ()))
         return dict(size=[size])
 
-    def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
+    def transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
         return self._call_kernel(
             F.resize, inpt, params["size"], interpolation=self.interpolation, antialias=self.antialias
         )

--- a/torchvision/transforms/v2/_geometry.py
+++ b/torchvision/transforms/v2/_geometry.py
@@ -366,7 +366,7 @@ class FiveCrop(Transform):
     def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
         return self._call_kernel(F.five_crop, inpt, self.size)
 
-    def _check_inputs(self, flat_inputs: List[Any]) -> None:
+    def check_inputs(self, flat_inputs: List[Any]) -> None:
         if has_any(flat_inputs, tv_tensors.BoundingBoxes, tv_tensors.Mask):
             raise TypeError(f"BoundingBoxes'es and Mask's are not supported by {type(self).__name__}()")
 
@@ -408,7 +408,7 @@ class TenCrop(Transform):
             )
         return super()._call_kernel(functional, inpt, *args, **kwargs)
 
-    def _check_inputs(self, flat_inputs: List[Any]) -> None:
+    def check_inputs(self, flat_inputs: List[Any]) -> None:
         if has_any(flat_inputs, tv_tensors.BoundingBoxes, tv_tensors.Mask):
             raise TypeError(f"BoundingBoxes'es and Mask's are not supported by {type(self).__name__}()")
 
@@ -1132,7 +1132,7 @@ class RandomIoUCrop(Transform):
         self.options = sampler_options
         self.trials = trials
 
-    def _check_inputs(self, flat_inputs: List[Any]) -> None:
+    def check_inputs(self, flat_inputs: List[Any]) -> None:
         if not (
             has_all(flat_inputs, tv_tensors.BoundingBoxes)
             and has_any(flat_inputs, PIL.Image.Image, tv_tensors.Image, is_pure_tensor)

--- a/torchvision/transforms/v2/_meta.py
+++ b/torchvision/transforms/v2/_meta.py
@@ -19,7 +19,7 @@ class ConvertBoundingBoxFormat(Transform):
         super().__init__()
         self.format = format
 
-    def _transform(self, inpt: tv_tensors.BoundingBoxes, params: Dict[str, Any]) -> tv_tensors.BoundingBoxes:
+    def transform(self, inpt: tv_tensors.BoundingBoxes, params: Dict[str, Any]) -> tv_tensors.BoundingBoxes:
         return F.convert_bounding_box_format(inpt, new_format=self.format)  # type: ignore[return-value, arg-type]
 
 
@@ -32,5 +32,5 @@ class ClampBoundingBoxes(Transform):
 
     _transformed_types = (tv_tensors.BoundingBoxes,)
 
-    def _transform(self, inpt: tv_tensors.BoundingBoxes, params: Dict[str, Any]) -> tv_tensors.BoundingBoxes:
+    def transform(self, inpt: tv_tensors.BoundingBoxes, params: Dict[str, Any]) -> tv_tensors.BoundingBoxes:
         return F.clamp_bounding_boxes(inpt)  # type: ignore[return-value]

--- a/torchvision/transforms/v2/_misc.py
+++ b/torchvision/transforms/v2/_misc.py
@@ -197,7 +197,7 @@ class GaussianBlur(Transform):
         if not 0.0 < self.sigma[0] <= self.sigma[1]:
             raise ValueError(f"sigma values should be positive and of the form (min, max). Got {self.sigma}")
 
-    def _get_params(self, flat_inputs: List[Any]) -> Dict[str, Any]:
+    def make_params(self, flat_inputs: List[Any]) -> Dict[str, Any]:
         sigma = torch.empty(1).uniform_(self.sigma[0], self.sigma[1]).item()
         return dict(sigma=[sigma, sigma])
 

--- a/torchvision/transforms/v2/_misc.py
+++ b/torchvision/transforms/v2/_misc.py
@@ -99,7 +99,7 @@ class LinearTransformation(Transform):
         self.transformation_matrix = transformation_matrix
         self.mean_vector = mean_vector
 
-    def _check_inputs(self, sample: Any) -> Any:
+    def check_inputs(self, sample: Any) -> Any:
         if has_any(sample, PIL.Image.Image):
             raise TypeError(f"{type(self).__name__}() does not support PIL images.")
 
@@ -157,7 +157,7 @@ class Normalize(Transform):
         self.std = list(std)
         self.inplace = inplace
 
-    def _check_inputs(self, sample: Any) -> Any:
+    def check_inputs(self, sample: Any) -> Any:
         if has_any(sample, PIL.Image.Image):
             raise TypeError(f"{type(self).__name__}() does not support PIL images.")
 

--- a/torchvision/transforms/v2/_temporal.py
+++ b/torchvision/transforms/v2/_temporal.py
@@ -22,5 +22,5 @@ class UniformTemporalSubsample(Transform):
         super().__init__()
         self.num_samples = num_samples
 
-    def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
+    def transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
         return self._call_kernel(F.uniform_temporal_subsample, inpt, self.num_samples)

--- a/torchvision/transforms/v2/_transform.py
+++ b/torchvision/transforms/v2/_transform.py
@@ -40,7 +40,7 @@ class Transform(nn.Module):
         kernel = _get_kernel(functional, type(inpt), allow_passthrough=True)
         return kernel(inpt, *args, **kwargs)
 
-    def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
+    def transform(self, inpt: Any, params: Dict[str, Any]) -> Any:
         raise NotImplementedError
 
     def forward(self, *inputs: Any) -> Any:
@@ -54,7 +54,7 @@ class Transform(nn.Module):
         )
 
         flat_outputs = [
-            self._transform(inpt, params) if needs_transform else inpt
+            self.transform(inpt, params) if needs_transform else inpt
             for (inpt, needs_transform) in zip(flat_inputs, needs_transform_list)
         ]
 
@@ -175,7 +175,7 @@ class _RandomApplyTransform(Transform):
         )
 
         flat_outputs = [
-            self._transform(inpt, params) if needs_transform else inpt
+            self.transform(inpt, params) if needs_transform else inpt
             for (inpt, needs_transform) in zip(flat_inputs, needs_transform_list)
         ]
 

--- a/torchvision/transforms/v2/_transform.py
+++ b/torchvision/transforms/v2/_transform.py
@@ -27,7 +27,15 @@ class Transform(nn.Module):
     def _check_inputs(self, flat_inputs: List[Any]) -> None:
         pass
 
+    # This exists for BC. When v2 was introduced, this method was private. Now
+    # it's publicly exposed as `make_params()`. It cannot be exposed as
+    # `get_params()` because there is already a `get_params()` methods for v2
+    # transforms: it's the v1's `get_params()` that we have  to keep in order to
+    # guarantee 100% BC with v1. (It's defined in __init_subclass__ below).
     def _get_params(self, flat_inputs: List[Any]) -> Dict[str, Any]:
+        return self.make_params(flat_inputs)
+
+    def make_params(self, flat_inputs: List[Any]) -> Dict[str, Any]:
         return dict()
 
     def _call_kernel(self, functional: Callable, inpt: Any, *args: Any, **kwargs: Any) -> Any:
@@ -43,7 +51,7 @@ class Transform(nn.Module):
         self._check_inputs(flat_inputs)
 
         needs_transform_list = self._needs_transform_list(flat_inputs)
-        params = self._get_params(
+        params = self.make_params(
             [inpt for (inpt, needs_transform) in zip(flat_inputs, needs_transform_list) if needs_transform]
         )
 
@@ -164,7 +172,7 @@ class _RandomApplyTransform(Transform):
             return inputs
 
         needs_transform_list = self._needs_transform_list(flat_inputs)
-        params = self._get_params(
+        params = self.make_params(
             [inpt for (inpt, needs_transform) in zip(flat_inputs, needs_transform_list) if needs_transform]
         )
 

--- a/torchvision/transforms/v2/_type_conversion.py
+++ b/torchvision/transforms/v2/_type_conversion.py
@@ -20,7 +20,7 @@ class PILToTensor(Transform):
 
     _transformed_types = (PIL.Image.Image,)
 
-    def _transform(self, inpt: PIL.Image.Image, params: Dict[str, Any]) -> torch.Tensor:
+    def transform(self, inpt: PIL.Image.Image, params: Dict[str, Any]) -> torch.Tensor:
         return F.pil_to_tensor(inpt)
 
 
@@ -33,7 +33,7 @@ class ToImage(Transform):
 
     _transformed_types = (is_pure_tensor, PIL.Image.Image, np.ndarray)
 
-    def _transform(
+    def transform(
         self, inpt: Union[torch.Tensor, PIL.Image.Image, np.ndarray], params: Dict[str, Any]
     ) -> tv_tensors.Image:
         return F.to_image(inpt)
@@ -66,7 +66,7 @@ class ToPILImage(Transform):
         super().__init__()
         self.mode = mode
 
-    def _transform(
+    def transform(
         self, inpt: Union[torch.Tensor, PIL.Image.Image, np.ndarray], params: Dict[str, Any]
     ) -> PIL.Image.Image:
         return F.to_pil_image(inpt, mode=self.mode)
@@ -80,5 +80,5 @@ class ToPureTensor(Transform):
 
     _transformed_types = (tv_tensors.TVTensor,)
 
-    def _transform(self, inpt: Any, params: Dict[str, Any]) -> torch.Tensor:
+    def transform(self, inpt: Any, params: Dict[str, Any]) -> torch.Tensor:
         return inpt.as_subclass(torch.Tensor)


### PR DESCRIPTION
Closes https://github.com/pytorch/vision/issues/8721

This PR enables users to implement their own v2 transforms without using private methods. It was so far possible to implement v2 transforms, but private methods were necessary in order to fully support arbitrary inputs.

Concretely, we're now publicly exposing `_transform()`, `_get_params()` (as `make_params())`, and `_check_inputs()`.


Note that existing users transforms that use these existing (private!) methods may break.