### PR TITLE
Add rotated bounding box formats

### DIFF
--- a/torchvision/ops/boxes.py
+++ b/torchvision/ops/boxes.py
@@ -6,7 +6,22 @@ from torch import Tensor
 from torchvision.extension import _assert_has_ops
 
 from ..utils import _log_api_usage_once
-from ._box_convert import _box_cxcywh_to_xyxy, _box_xywh_to_xyxy, _box_xyxy_to_cxcywh, _box_xyxy_to_xywh
+from ._box_convert import (
+    _box_cxcywh_to_xyxy,
+    _box_cxcywhr_to_xywhr,
+    _box_cxcywhr_to_xyxy,
+    _box_cxcywhr_to_xyxyr,
+    _box_cxcywhr_to_xyxyxyxy,
+    _box_xywh_to_xyxy,
+    _box_xywhr_to_cxcywhr,
+    _box_xywhr_to_xyxyr,
+    _box_xyxy_to_cxcywh,
+    _box_xyxy_to_cxcywhr,
+    _box_xyxy_to_xywh,
+    _box_xyxyr_to_cxcywhr,
+    _box_xyxyr_to_xywhr,
+    _box_xyxyxyxy_to_xyxyr,
+)
 from ._utils import _upcast
 
 
@@ -194,41 +209,97 @@ def box_convert(boxes: Tensor, in_fmt: str, out_fmt: str) -> Tensor:
     ``'cxcywh'``: boxes are represented via centre, width and height, cx, cy being center of box, w, h
     being width and height.
 
+    ``'xyxyr'``: boxes are represented via corners, x1, y1 being top left and x2, y2 being bottom right.
+    r is rotation angle w.r.t to the box center by :math:`|r|` degrees counter clock wise in the image plan
+
+    ``'xywhr'``: boxes are represented via corner, width and height, x1, y2 being top left, w, h being width and height.
+    r is rotation angle w.r.t to the box center by :math:`|r|` degrees counter clock wise in the image plan
+
+    ``'cxcywhr'``: boxes are represented via centre, width and height, cx, cy being center of box, w, h
+    being width and height.
+    r is rotation angle w.r.t to the box center by :math:`|r|` degrees counter clock wise in the image plan
+
+    ``'xyxyxyxy'``: boxes are represented via corners, x1, y1 being top left, x2, y2 bottom right, 
+    x3, y3 bottom left, and x4, y4 top right.
+
     Args:
-        boxes (Tensor[N, 4]): boxes which will be converted.
-        in_fmt (str): Input format of given boxes. Supported formats are ['xyxy', 'xywh', 'cxcywh'].
-        out_fmt (str): Output format of given boxes. Supported formats are ['xyxy', 'xywh', 'cxcywh']
+        boxes (Tensor[N, K]): boxes which will be converted. K is the number of coordinates (4 for unrotated bounding boxes or 5 for rotated bounding boxes)
+        in_fmt (str): Input format of given boxes. Supported formats are ['xyxy', 'xywh', 'cxcywh', 'xyxyr', 'xywhr', 'cxcywhr', 'xyxyxyxy'].
+        out_fmt (str): Output format of given boxes. Supported formats are ['xyxy', 'xywh', 'cxcywh', 'xyxyr', 'xywhr', 'cxcywhr', 'xyxyxyxy']
 
     Returns:
-        Tensor[N, 4]: Boxes into converted format.
+        Tensor[N, K]: Boxes into converted format.
     """
     if not torch.jit.is_scripting() and not torch.jit.is_tracing():
         _log_api_usage_once(box_convert)
-    allowed_fmts = ("xyxy", "xywh", "cxcywh")
+    allowed_fmts = (
+        "xyxy",
+        "xywh",
+        "cxcywh",
+        "xyxyr",
+        "xywhr",
+        "cxcywhr",
+        "xyxyxyxy",
+    )
     if in_fmt not in allowed_fmts or out_fmt not in allowed_fmts:
-        raise ValueError("Unsupported Bounding Box Conversions for given in_fmt and out_fmt")
+        raise ValueError(
+            f"Unsupported Bounding Box Conversions for given in_fmt {in_fmt} and out_fmt {out_fmt}"
+        )
 
     if in_fmt == out_fmt:
         return boxes.clone()
+    e = (in_fmt, out_fmt)
+    if e ==  ("xywh", "xyxy"):
+        boxes = _box_xywh_to_xyxy(boxes)
+    elif e ==  ("cxcywh", "xyxy"):
+        boxes = _box_cxcywh_to_xyxy(boxes)
+    elif e ==  ("xyxy", "xywh"):
+        boxes = _box_xyxy_to_xywh(boxes)
+    elif e ==  ("xyxy", "cxcywh"):
+        boxes = _box_xyxy_to_cxcywh(boxes)
+    elif e ==  ("xywh", "cxcywh"):
+        boxes = _box_xywh_to_xyxy(boxes)
+        boxes = _box_xyxy_to_cxcywh(boxes)
+    elif e ==  ("cxcywh", "xywh"):
+        boxes = _box_cxcywh_to_xyxy(boxes)
+        boxes = _box_xyxy_to_xywh(boxes)
+    elif e == ("xyxy", "cxcywhr"):
+        boxes = _box_xyxy_to_cxcywhr(boxes)
+    elif e == ("cxcywhr", "xyxyr"):
+        boxes = _box_cxcywhr_to_xyxyr(boxes)
+    elif e == ("xywhr", "xyxyr"):
+        boxes = _box_xywhr_to_xyxyr(boxes)
+    elif e == ("xyxyr", "cxcywhr"):
+        boxes = _box_xyxyr_to_cxcywhr(boxes)
+    elif e == ("xyxyr", "xywhr"):
+        boxes = _box_xyxyr_to_xywhr(boxes)
+    elif e == ("cxcywhr", "xyxy"):
+        boxes = _box_cxcywhr_to_xyxy(boxes)
+    elif e == ("cxcywhr", "xywhr"):
+        boxes = _box_cxcywhr_to_xywhr(boxes)
+    elif e == ("xywhr", "cxcywhr"):
+        boxes = _box_xywhr_to_cxcywhr(boxes)
+    elif e == ("cxcywhr", "xyxyxyxy"):
+        boxes = _box_cxcywhr_to_xyxyxyxy(boxes)
+    elif e == ("xyxyxyxy", "xyxyr"):
+        boxes = _box_xyxyxyxy_to_xyxyr(boxes)
+    elif e == ("xywhr", "xyxyxyxy"):
+        boxes = _box_xywhr_to_cxcywhr(boxes)
+        boxes = _box_cxcywhr_to_xyxyxyxy(boxes)
+    elif e == ("xyxyr", "xyxyxyxy"):
+        boxes = _box_xyxyr_to_cxcywhr(boxes)
+        boxes = _box_cxcywhr_to_xyxyxyxy(boxes)
+    elif e == ("xyxyxyxy", "cxcywhr"):
+        boxes = _box_xyxyxyxy_to_xyxyr(boxes)
+        boxes = _box_xyxyr_to_cxcywhr(boxes)
+    elif e == ("xyxyxyxy", "xywhr"):
+        boxes = _box_xyxyxyxy_to_xyxyr(boxes)
+        boxes = _box_xyxyr_to_xywhr(boxes)
+    else:
+        raise NotImplementedError(
+            f"Unsupported Bounding Box Conversions for given in_fmt {e[0]} and out_fmt {e[1]}"
+        )
 
-    if in_fmt != "xyxy" and out_fmt != "xyxy":
-        # convert to xyxy and change in_fmt xyxy
-        if in_fmt == "xywh":
-            boxes = _box_xywh_to_xyxy(boxes)
-        elif in_fmt == "cxcywh":
-            boxes = _box_cxcywh_to_xyxy(boxes)
-        in_fmt = "xyxy"
-
-    if in_fmt == "xyxy":
-        if out_fmt == "xywh":
-            boxes = _box_xyxy_to_xywh(boxes)
-        elif out_fmt == "cxcywh":
-            boxes = _box_xyxy_to_cxcywh(boxes)
-    elif out_fmt == "xyxy":
-        if in_fmt == "xywh":
-            boxes = _box_xywh_to_xyxy(boxes)
-        elif in_fmt == "cxcywh":
-            boxes = _box_cxcywh_to_xyxy(boxes)
     return boxes
 
 

--- a/torchvision/tv_tensors/_bounding_boxes.py
+++ b/torchvision/tv_tensors/_bounding_boxes.py
@@ -17,15 +17,25 @@ class BoundingBoxFormat(Enum):
     * ``XYXY``
     * ``XYWH``
     * ``CXCYWH``
+    * ``XYXYR``: rotated boxes represented via corners, x1, y1 being top left and x2, y2 being bottom right. r is rotation angle in degrees.
+    * ``XYWHR``: rotated boxes represented via corner, width and height, x1, y1 being top left, w, h being width and height. r is rotation angle in degrees.
+    * ``CXCYWHR``rotated boxes represented via centre, width and height, cx, cy being center of box, w, h being width and height. r is rotation angle in degrees.
+    * ``XYXYXYXY``rotated boxes represented via corners, x1, y1 being top left, , x2, y2 being bottom right, x3, y3 being bottom left, x4, y4 being top right.
     """
 
     XYXY = "XYXY"
     XYWH = "XYWH"
     CXCYWH = "CXCYWH"
+    XYXYR = "XYXYR"
+    XYWHR = "XYWHR"
+    CXCYWHR = "CXCYWHR"
+    XYXYXYXY = "XYXYXYXY"
 
 
 class BoundingBoxes(TVTensor):
-    """:class:`torch.Tensor` subclass for bounding boxes with shape ``[N, 4]``.
+    """:class:`torch.Tensor` subclass for bounding boxes with shape ``[N, K]``. 
+    Where ``N`` is the number of bounding boxes 
+    and ``K`` is either 4 for unrotated boxes or 5 for rotated boxes.
 
     .. note::
         There should be only one :class:`~torchvision.tv_tensors.BoundingBoxes`


### PR DESCRIPTION
This PR is part of a series of contributions aiming to add rotated boxes to torchvision. This first contribution aims at modifying the definition of bounding boxes in torchvision. We operate the two following modifications:

## Extend `BoundingBoxFormat` for rotated boxes

We add four multiple allowed formats in [`BoundingBoxFormat`](https://github.com/pytorch/vision/blob/main/torchvision/tv_tensors/_bounding_boxes.py#L12). The formats "xyxyr", "xywhr", "cxcywhr" simply extend the non-rotated counterparts by adding a 5th coordinate to the bounding box, `r`, the rotation angle with respect to the box center by `|r|` degrees counter clock wise in the image plan. The last format "xyxyxyxy" represents a box with 4 corners. 

Potential limitations: 
* We are proposing to extend [`BoundingBoxes`](https://github.com/pytorch/vision/blob/main/torchvision/tv_tensors/_bounding_boxes.py#L27) instead of creating a new `RoratedBoundingBoxes` class. The reason is to simplify the possible input types for transforms and avoid having two different paths for transformations. For instance keeping a single [`horizontal_flip_bounding_boxes`](https://github.com/pytorch/vision/blob/main/torchvision/transforms/v2/functional/_geometry.py#L68) and [`_horizontal_flip_bounding_boxes_dispatch`](https://github.com/pytorch/vision/blob/main/torchvision/transforms/v2/functional/_geometry.py#L86) instead of creating a new function `horizontal_flip_rotated_bounding_boxes`;
* This choice can have some disadvantages as some utility functions expect a 4-dimensional tensor and will be by design incompatible with rotated boxes. One example among other will be the [`generalized_box_iou_loss`](https://github.com/pytorch/vision/blob/main/torchvision/ops/giou_loss.py#L7). However, please note these functions do not expect a `BoundingBox` as input, but a `torch.Tensor[N, 4]` or `torch.Tensor[4]`. So there is no direct incompatibility.
 
## Add conversion functions for rotated boxes

We add 10 pairwise conversion functions in "[_box_convert.py](https://github.com/pytorch/vision/blob/main/torchvision/ops/_box_convert.py)" to allow converting rotated bounding boxes between all four new formats. We also modified the logic in [`box_convert`](https://github.com/pytorch/vision/blob/main/torchvision/ops/boxes.py#L177) to support all possible conversion directions.

Potential limitations:
* We chose to keep the convention previously used in torchvision for which (x1, y1) refer to top left of the bounding box and (x2, y2) refer to the bottom right of the bounding box. However, with the "xyxyxyxy" format it means that when going through the corner of the box in the counter clock-wise direction, we have the following sequence 1, 3, 2, 4. It would maybe make more sense to rename the bottom right of the bounding box as (x3, y3).

## Testing

Please run unit tests for the modifications with: `pytest test/test_ops.py -vvv -k TestBoxConvert`

## Next steps

Next modifications will aim at updating transforms functions (e.g. [`horizontal_flip_bounding_boxes`](https://github.com/pytorch/vision/blob/main/torchvision/transforms/v2/functional/_geometry.py#L68)), and adding utility functions specific to rotated boxes (e.g. `rotated_box_area`, `_rotated_box_inter_union`, `rotated_box_iou`).