### PR TITLE
Update mnist.py - change the order of mirror links

### DIFF
--- a/torchvision/datasets/mnist.py
+++ b/torchvision/datasets/mnist.py
@@ -35,8 +35,8 @@ class MNIST(VisionDataset):
     """
 
     mirrors = [
-        "http://yann.lecun.com/exdb/mnist/",
         "https://ossci-datasets.s3.amazonaws.com/mnist/",
+        "http://yann.lecun.com/exdb/mnist/",
     ]
 
     resources = [


### PR DESCRIPTION
**Problem** - MNIST download links for https://yann.lecun.com/exdb/mnist are not working for sometime now and the system tends to download it from https://ossci-datasets.s3.amazonaws.com/mnist eventually.
This is unnecessarily adding to the execution time. 

**Solution** - I have simply reversed the order of mirror links, so that it tries the working one first resulting in minimal execution time. Also, once the yann.lecun.com starts working, it will anyways be part of the list.
