### PR TITLE
Fix torch.compile smoke test include it for py 3.12, 3.13

### DIFF
--- a/test/smoke_test.py
+++ b/test/smoke_test.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+import sysconfig
 from pathlib import Path
 
 import torch
@@ -134,8 +135,8 @@ def main() -> None:
         smoke_test_torchvision_decode_jpeg("cuda")
         smoke_test_torchvision_resnet50_classify("cuda")
 
-        # TODO: remove once pytorch/pytorch#110436 is resolved
-        if sys.version_info < (3, 12, 0):
+        #  torch.compile is not supported on Python 3.14+ and Python built with GIL disabled
+        if sys.version_info < (3, 14, 0) and sysconfig.get_config_var("Py_GIL_DISABLED") == 0:
             smoke_test_compile()
 
     if torch.backends.mps.is_available():

--- a/test/smoke_test.py
+++ b/test/smoke_test.py
@@ -136,7 +136,7 @@ def main() -> None:
         smoke_test_torchvision_resnet50_classify("cuda")
 
         #  torch.compile is not supported on Python 3.14+ and Python built with GIL disabled
-        if sys.version_info < (3, 14, 0) and sysconfig.get_config_var("Py_GIL_DISABLED") == 0:
+        if sys.version_info < (3, 14, 0) and not sysconfig.get_config_var("Py_GIL_DISABLED"):
             smoke_test_compile()
 
     if torch.backends.mps.is_available():


### PR DESCRIPTION
Run toch compile test on py 3.12 and 3.13 however exclude 3.13t

Test:
```
>>> is_gil = not sysconfig.get_config_var("Py_GIL_DISABLED")
>>> print(f"{is_gil}")
True
>>> print(sysconfig.get_config_var("Py_GIL_DISABLED"))
None
>>> 
```