### PR TITLE
[ROCm][Windows] Fix compile torchvision image for ROCm

### DIFF
--- a/torchvision/csrc/io/image/common.cpp
+++ b/torchvision/csrc/io/image/common.cpp
@@ -2,6 +2,15 @@
 #include "common.h"
 #include <torch/torch.h>
 
+// If we are in a Windows environment, we need to define
+// initialization functions for the _custom_ops extension
+#ifdef _WIN32
+void* PyInit_image(void) {
+  return nullptr;
+}
+#endif
+
+
 namespace vision {
 namespace image {
 

--- a/torchvision/csrc/io/image/image.cpp
+++ b/torchvision/csrc/io/image/image.cpp
@@ -2,14 +2,6 @@
 
 #include <ATen/core/op_registration/op_registration.h>
 
-// If we are in a Windows environment, we need to define
-// initialization functions for the _custom_ops extension
-#ifdef _WIN32
-void* PyInit_image(void) {
-  return nullptr;
-}
-#endif
-
 namespace vision {
 namespace image {
 


### PR DESCRIPTION
moved PyInit_image definition to common.cpp since image.cpp is not used


cc @jeffdaily @jithunnair-amd