### PR TITLE
[codemod] facebook-unused-include-check in fbcode/pytorch

### DIFF
--- a/torchvision/csrc/io/decoder/stream.cpp
+++ b/torchvision/csrc/io/decoder/stream.cpp
@@ -1,6 +1,5 @@
 #include "stream.h"
 #include <c10/util/Logging.h>
-#include <stdio.h>
 #include <string.h>
 #include "util.h"
 

--- a/torchvision/csrc/io/decoder/subtitle_stream.cpp
+++ b/torchvision/csrc/io/decoder/subtitle_stream.cpp
@@ -1,6 +1,5 @@
 #include "subtitle_stream.h"
 #include <c10/util/Logging.h>
-#include <limits>
 #include "util.h"
 
 namespace ffmpeg {

--- a/torchvision/csrc/io/decoder/util_test.cpp
+++ b/torchvision/csrc/io/decoder/util_test.cpp
@@ -1,5 +1,4 @@
 #include <c10/util/Logging.h>
-#include <dirent.h>
 #include <gtest/gtest.h>
 #include "util.h"
 

--- a/torchvision/csrc/io/image/common.cpp
+++ b/torchvision/csrc/io/image/common.cpp
@@ -1,6 +1,5 @@
 
 #include "common.h"
-#include <torch/torch.h>
 
 namespace vision {
 namespace image {


### PR DESCRIPTION
Summary:
Remove headers flagged by facebook-unused-include-check over fbcode.pytorch.

+ format and autodeps

This is a codemod. It was automatically generated and will be landed once it is approved and tests are passing in sandcastle.
You have been added as a reviewer by Sentinel or Butterfly.

Autodiff project: uip
Autodiff partition: fbcode.pytorch
Autodiff bookmark: ad.uip.fbcode.pytorch

Reviewed By: dtolnay

Differential Revision: D69621180


