### PR TITLE
Fix non-rotated format to rotated format conversion logic

### DIFF
--- a/torchvision/transforms/v2/functional/_meta.py
+++ b/torchvision/transforms/v2/functional/_meta.py
@@ -263,12 +263,23 @@ def _xyxyxyxy_to_xywhr(xyxyxyxy: torch.Tensor, inplace: bool) -> torch.Tensor:
     return xyxyxyxy[..., :5].to(dtype)
 
 
+def is_rotated_bounding_box_format(format_: BoundingBoxFormat) -> bool:
+    return format_.value in [
+        BoundingBoxFormat.XYWHR.value,
+        BoundingBoxFormat.CXCYWHR.value,
+        BoundingBoxFormat.XYXYXYXY.value,
+    ]
+
+
 def _convert_bounding_box_format(
     bounding_boxes: torch.Tensor, old_format: BoundingBoxFormat, new_format: BoundingBoxFormat, inplace: bool = False
 ) -> torch.Tensor:
 
     if new_format == old_format:
         return bounding_boxes
+
+    if is_rotated_bounding_box_format(old_format) ^ is_rotated_bounding_box_format(new_format):
+        raise ValueError("Cannot convert between rotated and unrotated bounding boxes.")
 
     # TODO: Add _xywh_to_cxcywh and _cxcywh_to_xywh to improve performance
     if old_format == BoundingBoxFormat.XYWH:

--- a/torchvision/transforms/v2/functional/_meta.py
+++ b/torchvision/transforms/v2/functional/_meta.py
@@ -263,8 +263,8 @@ def _xyxyxyxy_to_xywhr(xyxyxyxy: torch.Tensor, inplace: bool) -> torch.Tensor:
     return xyxyxyxy[..., :5].to(dtype)
 
 
-def is_rotated_bounding_box_format(format_: BoundingBoxFormat) -> bool:
-    return format_.value in [
+def is_rotated_bounding_box_format(format: BoundingBoxFormat) -> bool:
+    return format.value in [
         BoundingBoxFormat.XYWHR.value,
         BoundingBoxFormat.CXCYWHR.value,
         BoundingBoxFormat.XYXYXYXY.value,

--- a/torchvision/tv_tensors/_bounding_boxes.py
+++ b/torchvision/tv_tensors/_bounding_boxes.py
@@ -20,7 +20,7 @@ class BoundingBoxFormat(Enum):
     * ``XYWHR``: rotated boxes represented via corner, width and height, x1, y1
       being top left, w, h being width and height. r is rotation angle in
       degrees.
-    * ``CXCYWHR``: jrotated boxes represented via centre, width and height, cx,
+    * ``CXCYWHR``: rotated boxes represented via centre, width and height, cx,
       cy being center of box, w, h being width and height. r is rotation angle
       in degrees.
     * ``XYXYXYXY``: rotated boxes represented via corners, x1, y1 being top


### PR DESCRIPTION
## Context

This PR fixes the conversion logic to convert a non-rotated format to a rotated format. This was previously a no-op. We are now just raising an error when converting non-rorated formats to rotated formats (and the other way around too). For example:

```python
from torchvision.tv_tensors import BoundingBoxes
from torchvision.transforms.v2 import functional as F

bboxes = BoundingBoxes(
    [[0, 0, 10, 10]],
    format="XYXY",
    canvas_size=(50, 50)
)
out = F.convert_bounding_box_format(bboxes, new_format="XYWHR")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/antoinesimoulin/vision/torchvision/transforms/v2/functional/_meta.py", line 335, in convert_bounding_box_format
    output = _convert_bounding_box_format(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/antoinesimoulin/vision/torchvision/transforms/v2/functional/_meta.py", line 282, in _convert_bounding_box_format
    raise ValueError("Cannot convert between rotated and unrotated bounding boxes.")
ValueError: Cannot convert between rotated and unrotated bounding boxes.
```

## Testing

Please execute the following unit tests to verify the modifications:

```bash
pytest test/test_ops.py -vvv -k TestBoxConvert
pytest test/test_transforms_v2.py -vvv -k "TestConvertBoundingBoxFormat"
```