### PR TITLE
split NVCC_FLAGS but not quoted string

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ import shutil
 import subprocess
 import sys
 import warnings
+import shlex
 from pathlib import Path
 
 import torch
@@ -123,7 +124,7 @@ def get_macros_and_flags():
             if NVCC_FLAGS is None:
                 nvcc_flags = []
             else:
-                nvcc_flags = NVCC_FLAGS.split(" ")
+                nvcc_flags = shlex.split(NVCC_FLAGS)
         extra_compile_args["nvcc"] = nvcc_flags
 
     if sys.platform == "win32":


### PR DESCRIPTION
In case NVCC_FLAGS contains something like --compiler-options \"-march=native -O2 -pipe\" the quoted parts needs to stay entirely (not splitted)

<!-- Before submitting a PR, please make sure to check our contributing guidelines regarding code formatting, tests, and documentation: https://github.com/pytorch/vision/blob/main/CONTRIBUTING.md -->
