### PR TITLE
Support specifying a torch range

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -99,6 +99,10 @@ def get_requirements():
     if version_pin := os.getenv("PYTORCH_VERSION"):
         pytorch_dep += "==" + version_pin
     elif (version_pin_ge := os.getenv("PYTORCH_VERSION_GE")) and (version_pin_lt := os.getenv("PYTORCH_VERSION_LT")):
+        # This branch and the associated env vars exist to help third-party
+        # builds like in https://github.com/pytorch/vision/pull/8936. This is
+        # supported on a best-effort basis, we don't guarantee that this won't
+        # eventually break (and we don't test it.)
         pytorch_dep += f">={version_pin_ge},<{version_pin_lt}"
 
     requirements = [

--- a/setup.py
+++ b/setup.py
@@ -96,8 +96,10 @@ def get_requirements():
             return None
 
     pytorch_dep = os.getenv("TORCH_PACKAGE_NAME", "torch")
-    if os.getenv("PYTORCH_VERSION"):
-        pytorch_dep += "==" + os.getenv("PYTORCH_VERSION")
+    if version_pin := os.getenv("PYTORCH_VERSION"):
+        pytorch_dep += "==" + version_pin
+    elif (version_pin_ge := os.getenv("PYTORCH_VERSION_GE")) and (version_pin_lt := os.getenv("PYTORCH_VERSION_LT")):
+        pytorch_dep += f">={version_pin_ge},<{version_pin_lt}"
 
     requirements = [
         "numpy",


### PR DESCRIPTION
Motivation: we're using a custom pytorch build and have patch release more recently than upstream. While those updates do not change any abi, we want to allow torchvision/torchaudio (https://github.com/pytorch/audio/pull/3886) to tolerance the changed pytorch version when we update pytorch, otherwise pip will raise a warning.

In this PR, we add two new envionment variable to generate a version range for pytorch.
