### PR TITLE
Add XPU, CPU Autocast for torchvision ops

### DIFF
--- a/torchvision/csrc/ops/autocast/ps_roi_align_kernel.cpp
+++ b/torchvision/csrc/ops/autocast/ps_roi_align_kernel.cpp
@@ -9,6 +9,7 @@ namespace ops {
 
 namespace {
 
+template <c10::DispatchKey autocast_key, c10::DeviceType device_type>
 std::tuple<at::Tensor, at::Tensor> ps_roi_align_autocast(
     const at::Tensor& input,
     const at::Tensor& rois,
@@ -16,10 +17,10 @@ std::tuple<at::Tensor, at::Tensor> ps_roi_align_autocast(
     int64_t pooled_height,
     int64_t pooled_width,
     int64_t sampling_ratio) {
-  c10::impl::ExcludeDispatchKeyGuard no_autocast(c10::DispatchKey::Autocast);
+  c10::impl::ExcludeDispatchKeyGuard no_autocast(autocast_key);
   auto result = ps_roi_align(
-      at::autocast::cached_cast(at::kFloat, input),
-      at::autocast::cached_cast(at::kFloat, rois),
+      at::autocast::cached_cast(at::kFloat, input, device_type),
+      at::autocast::cached_cast(at::kFloat, rois, device_type),
       spatial_scale,
       pooled_height,
       pooled_width,
@@ -35,7 +36,25 @@ std::tuple<at::Tensor, at::Tensor> ps_roi_align_autocast(
 TORCH_LIBRARY_IMPL(torchvision, Autocast, m) {
   m.impl(
       TORCH_SELECTIVE_NAME("torchvision::ps_roi_align"),
-      TORCH_FN(ps_roi_align_autocast));
+      TORCH_FN((ps_roi_align_autocast<
+               c10::DispatchKey::Autocast,
+               c10::DeviceType::CUDA>)));
+}
+
+TORCH_LIBRARY_IMPL(torchvision, AutocastCPU, m) {
+  m.impl(
+      TORCH_SELECTIVE_NAME("torchvision::ps_roi_align"),
+      TORCH_FN((ps_roi_align_autocast<
+               c10::DispatchKey::AutocastCPU,
+               c10::DeviceType::CPU>)));
+}
+
+TORCH_LIBRARY_IMPL(torchvision, AutocastXPU, m) {
+  m.impl(
+      TORCH_SELECTIVE_NAME("torchvision::ps_roi_align"),
+      TORCH_FN((ps_roi_align_autocast<
+               c10::DispatchKey::AutocastXPU,
+               c10::DeviceType::XPU>)));
 }
 
 } // namespace ops

--- a/torchvision/csrc/ops/autocast/ps_roi_pool_kernel.cpp
+++ b/torchvision/csrc/ops/autocast/ps_roi_pool_kernel.cpp
@@ -9,16 +9,17 @@ namespace ops {
 
 namespace {
 
+template <c10::DispatchKey autocast_key, c10::DeviceType device_type>
 std::tuple<at::Tensor, at::Tensor> ps_roi_pool_autocast(
     const at::Tensor& input,
     const at::Tensor& rois,
     double spatial_scale,
     int64_t pooled_height,
     int64_t pooled_width) {
-  c10::impl::ExcludeDispatchKeyGuard no_autocast(c10::DispatchKey::Autocast);
+  c10::impl::ExcludeDispatchKeyGuard no_autocast(autocast_key);
   auto result = ps_roi_pool(
-      at::autocast::cached_cast(at::kFloat, input),
-      at::autocast::cached_cast(at::kFloat, rois),
+      at::autocast::cached_cast(at::kFloat, input, device_type),
+      at::autocast::cached_cast(at::kFloat, rois, device_type),
       spatial_scale,
       pooled_height,
       pooled_width);
@@ -33,7 +34,25 @@ std::tuple<at::Tensor, at::Tensor> ps_roi_pool_autocast(
 TORCH_LIBRARY_IMPL(torchvision, Autocast, m) {
   m.impl(
       TORCH_SELECTIVE_NAME("torchvision::ps_roi_pool"),
-      TORCH_FN(ps_roi_pool_autocast));
+      TORCH_FN((ps_roi_pool_autocast<
+                c10::DispatchKey::Autocast,
+                c10::DeviceType::CUDA>)));
+}
+
+TORCH_LIBRARY_IMPL(torchvision, AutocastCPU, m) {
+  m.impl(
+      TORCH_SELECTIVE_NAME("torchvision::ps_roi_pool"),
+      TORCH_FN((ps_roi_pool_autocast<
+                c10::DispatchKey::AutocastCPU,
+                c10::DeviceType::CPU>)));
+}
+
+TORCH_LIBRARY_IMPL(torchvision, AutocastXPU, m) {
+  m.impl(
+      TORCH_SELECTIVE_NAME("torchvision::ps_roi_pool"),
+      TORCH_FN((ps_roi_pool_autocast<
+                c10::DispatchKey::AutocastXPU,
+                c10::DeviceType::XPU>)));
 }
 
 } // namespace ops

--- a/torchvision/csrc/ops/autocast/roi_pool_kernel.cpp
+++ b/torchvision/csrc/ops/autocast/roi_pool_kernel.cpp
@@ -9,16 +9,17 @@ namespace ops {
 
 namespace {
 
+template <c10::DispatchKey autocast_key, c10::DeviceType device_type>
 std::tuple<at::Tensor, at::Tensor> roi_pool_autocast(
     const at::Tensor& input,
     const at::Tensor& rois,
     double spatial_scale,
     int64_t pooled_height,
     int64_t pooled_width) {
-  c10::impl::ExcludeDispatchKeyGuard no_autocast(c10::DispatchKey::Autocast);
+  c10::impl::ExcludeDispatchKeyGuard no_autocast(autocast_key);
   auto result = roi_pool(
-      at::autocast::cached_cast(at::kFloat, input),
-      at::autocast::cached_cast(at::kFloat, rois),
+      at::autocast::cached_cast(at::kFloat, input, device_type),
+      at::autocast::cached_cast(at::kFloat, rois, device_type),
       spatial_scale,
       pooled_height,
       pooled_width);
@@ -33,7 +34,25 @@ std::tuple<at::Tensor, at::Tensor> roi_pool_autocast(
 TORCH_LIBRARY_IMPL(torchvision, Autocast, m) {
   m.impl(
       TORCH_SELECTIVE_NAME("torchvision::roi_pool"),
-      TORCH_FN(roi_pool_autocast));
+      TORCH_FN((roi_pool_autocast<
+                c10::DispatchKey::Autocast,
+                c10::DeviceType::CUDA>)));
+}
+
+TORCH_LIBRARY_IMPL(torchvision, AutocastCPU, m) {
+  m.impl(
+      TORCH_SELECTIVE_NAME("torchvision::roi_pool"),
+      TORCH_FN((roi_pool_autocast<
+                c10::DispatchKey::AutocastCPU,
+                c10::DeviceType::CPU>)));
+}
+
+TORCH_LIBRARY_IMPL(torchvision, AutocastXPU, m) {
+  m.impl(
+      TORCH_SELECTIVE_NAME("torchvision::roi_pool"),
+      TORCH_FN((roi_pool_autocast<
+                c10::DispatchKey::AutocastXPU,
+                c10::DeviceType::XPU>)));
 }
 
 } // namespace ops


### PR DESCRIPTION
This PR enables autocast for ops that do not yet have autocast support (`roi_pool`, `ps_roi_align`, `ps_roi_pool`, `deform_conv2d`)

Tests have been updated to check autocast on CPU. In regards to the flaky test in #8580 , additional testing on my end showed flakiness only with bfloat16, so that test is still skipped.

Regarding XPU tests, since torchvision doesn't currently have XPU CI/CD integration,  autocast tests will be submitted to [torch-xpu-ops](https://github.com/intel/torch-xpu-ops)