### PR TITLE
Allow all deps of lib to be omitted

### DIFF
--- a/packaging/wheel/relocate.py
+++ b/packaging/wheel/relocate.py
@@ -213,7 +213,7 @@ def relocate_elf_library(patchelf, output_dir, output_library, binary):
             subprocess.check_output([patchelf, "--print-rpath", new_library_name], cwd=new_libraries_path)
 
     print("Update library dependencies")
-    library_dependencies = binary_dependencies[binary]
+    library_dependencies = binary_dependencies.get(binary, [])
     for dep in library_dependencies:
         new_dep = osp.basename(new_names[dep])
         print(f"{binary}: {dep} -> {new_dep}")


### PR DESCRIPTION
fix error when all deps of a library are omitted, where we occured on rocm and grace:

```
(venv) [root@33bf6c1a3e41 vision]# python packaging/wheel/relocate.py
Finding wheels...
Unzipping wheel...
torchvision-0.21.0-cp312-cp312-linux_x86_64.whl
Finding ELF dependencies...
Relocating image.so
libc10.so
Omitting libc10.so
libtorch.so
Omitting libtorch.so
libtorch_cpu.so
Omitting libtorch_cpu.so
libtorch_python.so
Omitting libtorch_python.so
libstdc++.so.6
Omitting libstdc++.so.6
libm.so.6
Omitting libm.so.6
libgcc_s.so.1
Omitting libgcc_s.so.1
libpthread.so.0
Omitting libpthread.so.0
libc.so.6
Omitting libc.so.6
Copying dependencies to wheel directory
Updating dependency names by new files
Update library dependencies
Traceback (most recent call last):
  File "/vision/packaging/wheel/relocate.py", line 378, in <module>
    patch_linux()
  File "/vision/packaging/wheel/relocate.py", line 335, in patch_linux
    relocate_elf_library(patchelf, output_dir, output_library, binary)
  File "/vision/packaging/wheel/relocate.py", line 216, in relocate_elf_library
    library_dependencies = binary_dependencies[binary]
                           ~~~~~~~~~~~~~~~~~~~^^^^^^^^
KeyError: 'image.so'
```