### PR TITLE
sava image_path in target of coco annotation data

### DIFF
--- a/torchvision/datasets/coco.py
+++ b/torchvision/datasets/coco.py
@@ -43,7 +43,10 @@ class CocoDetection(VisionDataset):
         return Image.open(os.path.join(self.root, path)).convert("RGB")
 
     def _load_target(self, id: int) -> List[Any]:
-        return self.coco.loadAnns(self.coco.getAnnIds(id))
+        target = self.coco.loadAnns(self.coco.getAnnIds(id))
+        path = self.coco.loadImgs(id)[0]["file_name"]
+        target[0]["image_path"] = os.path.join(self.root, path)
+        return target
 
     def __getitem__(self, index: int) -> Tuple[Any, Any]:
 


### PR DESCRIPTION
<!-- Before submitting a PR, please make sure to check our contributing guidelines regarding code formatting, tests, and documentation: https://github.com/pytorch/vision/blob/main/CONTRIBUTING.md -->

The current version only saves the image_id into the target, making it difficult to identify the image intuitively. To address this, I've added image_path to the target, which provides intuitive information and makes debugging easier for users during development.