### PR TITLE
Ignore onnx tests

### DIFF
--- a/.github/scripts/unittest.sh
+++ b/.github/scripts/unittest.sh
@@ -15,4 +15,4 @@ echo '::endgroup::'
 python test/smoke_test.py
 
 # We explicitly ignore the video tests until we resolve https://github.com/pytorch/vision/issues/8162
-pytest --ignore-glob="*test_video*" --junit-xml="${RUNNER_TEST_RESULTS_DIR}/test-results.xml" -v --durations=25 -k "not TestFxFeatureExtraction"
+pytest --ignore-glob="*test_video*" --ignore-glob="test_onnx" --junit-xml="${RUNNER_TEST_RESULTS_DIR}/test-results.xml" -v --durations=25 -k "not TestFxFeatureExtraction"


### PR DESCRIPTION
They started recently segfaulting. I don't know why and I have no bandwidth to debug. This isn't a regression that originated in torchvision.