### PR TITLE
Skip libavif/libheic tests

### DIFF
--- a/test/test_image.py
+++ b/test/test_image.py
@@ -897,12 +897,16 @@ def test_decode_gif(tmpdir, name, scripted):
         (decode_gif, re.escape("DGifOpenFileName() failed - 103")),
         (decode_webp, "WebPGetFeatures failed."),
         pytest.param(
-            decode_avif, "BMFF parsing failed", marks=pytest.mark.skipif(not IS_LINUX, reason=HEIC_AVIF_MESSAGE)
+            decode_avif,
+            "BMFF parsing failed",
+            # marks=pytest.mark.skipif(not IS_LINUX, reason=HEIC_AVIF_MESSAGE)
+            marks=pytest.mark.skipif(True, reason="Skipping avif/heic tests for now."),
         ),
         pytest.param(
             decode_heic,
             "Invalid input: No 'ftyp' box",
-            marks=pytest.mark.skipif(not IS_LINUX, reason=HEIC_AVIF_MESSAGE),
+            # marks=pytest.mark.skipif(not IS_LINUX, reason=HEIC_AVIF_MESSAGE),
+            marks=pytest.mark.skipif(True, reason="Skipping avif/heic tests for now."),
         ),
     ],
 )
@@ -961,7 +965,8 @@ def test_decode_webp_against_pil(decode_fun, scripted, mode, pil_mode, filename)
     img += 123  # make sure image buffer wasn't freed by underlying decoding lib
 
 
-@pytest.mark.skipif(not IS_LINUX, reason=HEIC_AVIF_MESSAGE)
+# @pytest.mark.skipif(not IS_LINUX, reason=HEIC_AVIF_MESSAGE)
+@pytest.mark.skipif(True, reason="Skipping avif/heic tests for now.")
 @pytest.mark.parametrize("decode_fun", (decode_avif,))
 def test_decode_avif(decode_fun):
     encoded_bytes = read_file(next(get_images(FAKEDATA_DIR, ".avif")))
@@ -973,7 +978,8 @@ def test_decode_avif(decode_fun):
 
 # Note: decode_image fails because some of these files have a (valid) signature
 # we don't recognize. We should probably use libmagic....
-@pytest.mark.skipif(not IS_LINUX, reason=HEIC_AVIF_MESSAGE)
+# @pytest.mark.skipif(not IS_LINUX, reason=HEIC_AVIF_MESSAGE)
+@pytest.mark.skipif(True, reason="Skipping avif/heic tests for now.")
 @pytest.mark.parametrize("decode_fun", (decode_avif, decode_heic))
 @pytest.mark.parametrize(
     "mode, pil_mode",
@@ -1050,7 +1056,8 @@ def test_decode_avif_heic_against_pil(decode_fun, mode, pil_mode, filename):
     torch.testing.assert_close(img, from_pil, rtol=0, atol=3)
 
 
-@pytest.mark.skipif(not IS_LINUX, reason=HEIC_AVIF_MESSAGE)
+# @pytest.mark.skipif(not IS_LINUX, reason=HEIC_AVIF_MESSAGE)
+@pytest.mark.skipif(True, reason="Skipping avif/heic tests for now.")
 @pytest.mark.parametrize("decode_fun", (decode_heic,))
 def test_decode_heic(decode_fun):
     encoded_bytes = read_file(next(get_images(FAKEDATA_DIR, ".heic")))


### PR DESCRIPTION
They're failing with 

```
2025-03-17T12:56:28.1186348Z �[31mFAILED�[0m test/test_image.py::�[1mtest_decode_avif[decode_avif]�[0m - OSError: /opt/conda/envs/ci/bin/../lib/libstdc++.so.6: version `GLIBCXX_3.4.31' not found (required by /opt/conda/envs/ci/lib/python3.10/site-packages/torchvision_extra_decoders/../torchvision_extra_decoders.libs/libheif-2b91cd5e.so.1)

```

As mentioned in https://github.com/pytorch/vision/pull/8963:

> As a first step I'll deactivate the tests but I'll also try to look into building torchvision-extra-decoder` with older dependencies (libheif, libavif) which hopefully won't require recent version symbols.