### PR TITLE
Disable M1 3.11 unittests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,7 +52,8 @@ jobs:
         python-version:
           - "3.9"
           - "3.10"
-          - "3.11"
+          # TODO put back 3.11 (See blame)
+          # - "3.11"
           - "3.12"
         runner: ["macos-m1-stable"]
       fail-fast: false


### PR DESCRIPTION
They've been failing for a while with

```
c:\actions-runner\_work\vision\vision\pytorch\vision\torchvision\io\image.py:14: UserWarning: Failed to load image Python extension: 'Could not find module 'C:\actions-runner\_work\vision\vision\pytorch\vision\torchvision\image.pyd' (or one of its dependencies). Try using the full path with constructor syntax.'If you don't plan on using image functionality from `torchvision.io`, you can ignore this warning. Otherwise, there might be something wrong with your environment. Did you have `libjpeg` or `libpng` installed before building `torchvision` from source?
  warn(
Traceback (most recent call last):
  File "C:\actions-runner\_work\vision\vision\pytorch\vision\test\smoke_test.py", line 147, in <module>
torchvision: 0.22.0a0+48722e8
    main()
torch.cuda.is_available: True
  File "C:\actions-runner\_work\vision\vision\pytorch\vision\test\smoke_test.py", line 119, in main
    print(f"{torch.ops.image._jpeg_version() = }")
  File "C:\Jenkins\Miniconda3\envs\ci\lib\site-packages\torch\_ops.py", line 1267, in __getattr__
    raise AttributeError(
AttributeError: '_OpNamespace' 'image' object has no attribute '_jpeg_version'
```


All other M1 jobs run fine (3.9, 3.10, 3.12, etc.). I'm unable to dedicate time to this, so I'm disabling the job.