### PR TITLE
Fix post-build-script

### DIFF
--- a/packaging/post_build_script.sh
+++ b/packaging/post_build_script.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -euxo pipefail
+
 LD_LIBRARY_PATH="/usr/local/lib:$CUDA_HOME/lib64:$LD_LIBRARY_PATH" python packaging/wheel/relocate.py
 
 if [[ "$(uname)" == "Linux" && "$(uname -m)" != "aarch64" ]]; then

--- a/packaging/post_build_script.sh
+++ b/packaging/post_build_script.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 set -euxo pipefail
 
-LD_LIBRARY_PATH="/usr/local/lib:$CUDA_HOME/lib64:$LD_LIBRARY_PATH" python packaging/wheel/relocate.py
+if [ -n "${CUDA_HOME:-}" ]; then
+    LD_LIBRARY_PATH="/usr/local/lib:${CUDA_HOME}/lib64:${LD_LIBRARY_PATH}"
+fi
+
+python packaging/wheel/relocate.py
 
 if [[ "$(uname)" == "Linux" && "$(uname -m)" != "aarch64" ]]; then
     extra_decoders_channel="--pre --index-url https://download.pytorch.org/whl/nightly/cpu"

--- a/packaging/pre_build_script.sh
+++ b/packaging/pre_build_script.sh
@@ -36,7 +36,7 @@ else
   conda install libwebp -y
   conda install libjpeg-turbo -c pytorch
   yum install -y freetype gnutls
-  pip install auditwheel
+  pip install "auditwheel<6.3.0"
 fi
 
 pip install numpy pyyaml future ninja

--- a/packaging/wheel/relocate.py
+++ b/packaging/wheel/relocate.py
@@ -15,7 +15,10 @@ from base64 import urlsafe_b64encode
 
 # Third party imports
 if sys.platform == "linux":
-    from auditwheel.lddtree import lddtree
+    try:
+        from auditwheel.lddtree import lddtree
+    except ImportError:
+        from auditwheel import lddtree
 
 
 ALLOWLIST = {


### PR DESCRIPTION
Job has been failing with various issues

The CUDA_HOME variable wasn't set on some job which led to a failure.

Also, `lddtree` must be imported differently from auditwheel 6.3 as mentioned in https://github.com/pytorch/vision/issues/8981:

```
ImportError: cannot import name 'lddtree' from 'auditwheel.lddtree' (/__w/_temp/conda_environment_13920830566/lib/python3.9/site-packages/auditwheel/lddtree.py)
```

And we didn't know this job was failing because we didn't raise on failure. So wheel relocation has been silently failing, which was probably causing all wheel jobs to fail: https://github.com/pytorch/vision/issues/8980


So, hopefully, this PR fixes all this mess. UGH.

Fixes https://github.com/pytorch/vision/issues/8981
Fixes https://github.com/pytorch/vision/issues/8980
