### PR TITLE
[SmokeTest] Test antialias on MPS device

### DIFF
--- a/test/smoke_test.py
+++ b/test/smoke_test.py
@@ -96,7 +96,7 @@ def smoke_test_torchvision_resnet50_classify(device: str = "cpu") -> None:
     model.eval()
 
     # Step 2: Initialize the inference transforms
-    preprocess = weights.transforms(antialias=(device != "mps"))  # antialias not supported on MPS
+    preprocess = weights.transforms(antialias=True)
 
     # Step 3: Apply inference preprocessing transforms
     batch = preprocess(img).unsqueeze(0)


### PR DESCRIPTION
It should be supported starting from 2.7, same way as on any other backend
And with that, both CPU and MPS backends report the same confidence value:
```
German shepherd (cpu): 37.6%
German shepherd (mps): 37.6%
```