### PR TITLE
Remove stanford cars download instructions

### DIFF
--- a/torchvision/datasets/stanford_cars.py
+++ b/torchvision/datasets/stanford_cars.py
@@ -14,8 +14,8 @@ class StanfordCars(VisionDataset):
     split into 8,144 training images and 8,041 testing images, where each class
     has been split roughly in a 50-50 split
 
-    The original URL is https://ai.stanford.edu/~jkrause/cars/car_dataset.html, but it is broken.
-    Follow the instructions in ``download`` argument to obtain and use the dataset offline.
+    The original URL is https://ai.stanford.edu/~jkrause/cars/car_dataset.html,
+    the dataset isn't available online anymore.
 
     .. note::
 
@@ -29,13 +29,7 @@ class StanfordCars(VisionDataset):
         target_transform (callable, optional): A function/transform that takes in the
             target and transforms it.
         download (bool, optional): This parameter exists for backward compatibility but it does not
-            download the dataset, since the original URL is not available anymore. The dataset
-            seems to be available on Kaggle so you can try to manually download and configure it using
-            `these instructions <https://github.com/pytorch/vision/issues/7545#issuecomment-1631441616>`_,
-            or use an integrated
-            `dataset on Kaggle <https://github.com/pytorch/vision/issues/7545#issuecomment-2282674373>`_.
-            In both cases, first download and configure the dataset locally, and use the dataset with
-            ``"download=False"``.
+            download the dataset, since the original URL is not available anymore.
         loader (callable, optional): A function to load an image given its path.
             By default, it uses PIL as its image loader, but users could also pass in
             ``torchvision.io.decode_image`` for decoding image data into tensors directly.
@@ -73,10 +67,7 @@ class StanfordCars(VisionDataset):
             self.download()
 
         if not self._check_exists():
-            raise RuntimeError(
-                "Dataset not found. Try to manually download following the instructions in "
-                "https://github.com/pytorch/vision/issues/7545#issuecomment-1631441616."
-            )
+            raise RuntimeError("Dataset not found.")
 
         self._samples = [
             (
@@ -111,9 +102,4 @@ class StanfordCars(VisionDataset):
         return self._annotations_mat_path.exists() and self._images_base_path.is_dir()
 
     def download(self):
-        raise ValueError(
-            "The original URL is broken so the StanfordCars dataset is not available for automatic "
-            "download anymore. You can try to download it manually following "
-            "https://github.com/pytorch/vision/issues/7545#issuecomment-1631441616, "
-            "and set download=False to avoid this error."
-        )
+        raise ValueError("The original URL is broken so the StanfordCars dataset cannot be downloaded anymore.")


### PR DESCRIPTION
This PR removes download instructions of the Stanford Cars datasets from alternative sources.