### PR TITLE
[docs] correct docs of `decode_heic`

### DIFF
--- a/torchvision/io/image.py
+++ b/torchvision/io/image.py
@@ -478,7 +478,7 @@ def decode_heic(input: torch.Tensor, mode: ImageReadMode = ImageReadMode.UNCHANG
     """Decode an HEIC image into a 3 dimensional RGB[A] Tensor.
 
     .. warning::
-        In order to enable the AVIF decoding capabilities of torchvision, you
+        In order to enable the HEIC decoding capabilities of torchvision, you
         first need to run ``pip install torchvision-extra-decoders``. Just
         install the package, you don't need to update your code. This is only
         supported on Linux, and this feature is still in BETA stage. Please let


### PR DESCRIPTION
this was prob a miss from copy/paste, that it still refers to AVIF in the HEIC method