### PR TITLE
[Build] Add `homebrew` as library search location

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -276,8 +276,8 @@ def find_library(header):
         include_dir = HOMEBREW_PATH / "include"
         library_dir = HOMEBREW_PATH / "lib"
         if (include_dir / header).exists():
-                print(f"{searching_for}. Found in {include_dir}.")
-                return True, str(include_dir), str(library_dir)
+            print(f"{searching_for}. Found in {include_dir}.")
+            return True, str(include_dir), str(library_dir)
 
     return False, None, None
 

--- a/setup.py
+++ b/setup.py
@@ -271,6 +271,14 @@ def find_library(header):
                 return True, None, None
             print(f"{searching_for}. Didn't find in {prefix}")
 
+    if sys.platform == "darwin":
+        HOMEBREW_PATH = Path("/opt/homebrew")
+        include_dir = HOMEBREW_PATH / "include"
+        library_dir = HOMEBREW_PATH / "lib"
+        if (include_dir / header).exists():
+                print(f"{searching_for}. Found in {include_dir}.")
+                return True, str(include_dir), str(library_dir)
+
     return False, None, None
 
 


### PR DESCRIPTION
So that one can build TorchVision on MacOS by installing jpeg/webp dependencies as
`brew install jpeg-turbo webp`

<!-- Before submitting a PR, please make sure to check our contributing guidelines regarding code formatting, tests, and documentation: https://github.com/pytorch/vision/blob/main/CONTRIBUTING.md -->
