### PR TITLE
Raise error when download=True for LFW dataset #8888

### DIFF
--- a/torchvision/datasets/lfw.py
+++ b/torchvision/datasets/lfw.py
@@ -51,7 +51,12 @@ class _LFW(VisionDataset):
         self.data: list[Any] = []
 
         if download:
+            raise RuntimeError(
+                "LFW dataset is no longer available for download."
+                "Please download the dataset manually and place it in the specified directory"
+            )
             self.download()
+
 
         if not self._check_integrity():
             raise RuntimeError("Dataset not found or corrupted. You can use download=True to download it")


### PR DESCRIPTION
<!-- Before submitting a PR, please make sure to check our contributing guidelines regarding code formatting, tests, and documentation: https://github.com/pytorch/vision/blob/main/CONTRIBUTING.md -->


LFW dataset is no longer available for download, this PR raises a RuntimeError when download=True in the _LFW class