### PR TITLE
Remove unnecessary list() calls before/after sorted()

### DIFF
--- a/gallery/others/plot_repurposing_annotations.py
+++ b/gallery/others/plot_repurposing_annotations.py
@@ -173,8 +173,8 @@ class SegmentationToDetectionDataset(torch.utils.data.Dataset):
         self.transforms = transforms
         # load all image files, sorting them to
         # ensure that they are aligned
-        self.imgs = list(sorted(os.listdir(os.path.join(root, "PNGImages"))))
-        self.masks = list(sorted(os.listdir(os.path.join(root, "PedMasks"))))
+        self.imgs = sorted(os.listdir(os.path.join(root, "PNGImages")))
+        self.masks = sorted(os.listdir(os.path.join(root, "PedMasks")))
 
     def __getitem__(self, idx):
         # load images and masks

--- a/torchvision/datasets/_stereo_matching.py
+++ b/torchvision/datasets/_stereo_matching.py
@@ -67,13 +67,13 @@ class StereoMatchingDataset(ABC, VisionDataset):
         paths_right_pattern: Optional[str] = None,
     ) -> list[tuple[str, Optional[str]]]:
 
-        left_paths = list(sorted(glob(paths_left_pattern)))
+        left_paths = sorted(glob(paths_left_pattern))
 
         right_paths: list[Union[None, str]]
         if paths_right_pattern:
-            right_paths = list(sorted(glob(paths_right_pattern)))
+            right_paths = sorted(glob(paths_right_pattern))
         else:
-            right_paths = list(None for _ in left_paths)
+            right_paths = [None for _ in left_paths]
 
         if not left_paths:
             raise FileNotFoundError(f"Could not find any files matching the patterns: {paths_left_pattern}")

--- a/torchvision/datasets/coco.py
+++ b/torchvision/datasets/coco.py
@@ -36,7 +36,7 @@ class CocoDetection(VisionDataset):
         from pycocotools.coco import COCO
 
         self.coco = COCO(annFile)
-        self.ids = list(sorted(self.coco.imgs.keys()))
+        self.ids = sorted(self.coco.imgs.keys())
 
     def _load_image(self, id: int) -> Image.Image:
         path = self.coco.loadImgs(id)[0]["file_name"]

--- a/torchvision/datasets/flickr.py
+++ b/torchvision/datasets/flickr.py
@@ -84,7 +84,7 @@ class Flickr8k(VisionDataset):
             parser.feed(fh.read())
         self.annotations = parser.annotations
 
-        self.ids = list(sorted(self.annotations.keys()))
+        self.ids = sorted(self.annotations.keys())
         self.loader = loader
 
     def __getitem__(self, index: int) -> tuple[Any, Any]:

--- a/torchvision/datasets/mnist.py
+++ b/torchvision/datasets/mnist.py
@@ -284,9 +284,9 @@ class EMNIST(MNIST):
     _merged_classes = {"c", "i", "j", "k", "l", "m", "o", "p", "s", "u", "v", "w", "x", "y", "z"}
     _all_classes = set(string.digits + string.ascii_letters)
     classes_split_dict = {
-        "byclass": sorted(list(_all_classes)),
-        "bymerge": sorted(list(_all_classes - _merged_classes)),
-        "balanced": sorted(list(_all_classes - _merged_classes)),
+        "byclass": sorted(_all_classes),
+        "bymerge": sorted(_all_classes - _merged_classes),
+        "balanced": sorted(_all_classes - _merged_classes),
         "letters": ["N/A"] + list(string.ascii_lowercase),
         "digits": list(string.digits),
         "mnist": list(string.digits),


### PR DESCRIPTION
Python's built-in [`sorted()`](https://docs.python.org/3/library/functions.html#sorted) function always returns a list. Therefore, there is no need to call `list(sorted(...))` or `sorted(list(...))`. Simply calling `sorted(...)` is sufficient.