### PR TITLE
Make `_get_perspective_coeffs` device agnostic

### DIFF
--- a/torchvision/transforms/functional.py
+++ b/torchvision/transforms/functional.py
@@ -671,32 +671,39 @@ def hflip(img: Tensor) -> Tensor:
     return F_t.hflip(img)
 
 
-def _get_perspective_coeffs(startpoints: List[List[int]], endpoints: List[List[int]]) -> List[float]:
+def _get_perspective_coeffs(startpoints: List[List[int]] | Tensor, endpoints: List[List[int]] | Tensor) -> List[float]:
     """Helper function to get the coefficients (a, b, c, d, e, f, g, h) for the perspective transforms.
 
     In Perspective Transform each pixel (x, y) in the original image gets transformed as,
      (x, y) -> ( (ax + by + c) / (gx + hy + 1), (dx + ey + f) / (gx + hy + 1) )
 
     Args:
-        startpoints (list of list of ints): List containing four lists of two integers corresponding to four corners
+        startpoints (list of list of ints or Tensor): List or Tensor containing four lists of two integers corresponding to four corners
             ``[top-left, top-right, bottom-right, bottom-left]`` of the original image.
-        endpoints (list of list of ints): List containing four lists of two integers corresponding to four corners
+        endpoints (list of list of ints or Tensor): List or Tensor containing four lists of two integers corresponding to four corners
             ``[top-left, top-right, bottom-right, bottom-left]`` of the transformed image.
 
     Returns:
         octuple (a, b, c, d, e, f, g, h) for transforming each pixel.
     """
+
+    startpoints = startpoints if isinstance(startpoints, Tensor) else torch.tensor(startpoints, dtype=torch.float64)
+    endpoints = endpoints if isinstance(endpoints, Tensor) else torch.tensor(endpoints, dtype=torch.float64)
+
     if len(startpoints) != 4 or len(endpoints) != 4:
         raise ValueError(
             f"Please provide exactly four corners, got {len(startpoints)} startpoints and {len(endpoints)} endpoints."
         )
-    a_matrix = torch.zeros(2 * len(startpoints), 8, dtype=torch.float64)
 
-    for i, (p1, p2) in enumerate(zip(endpoints, startpoints)):
-        a_matrix[2 * i, :] = torch.tensor([p1[0], p1[1], 1, 0, 0, 0, -p2[0] * p1[0], -p2[0] * p1[1]])
-        a_matrix[2 * i + 1, :] = torch.tensor([0, 0, 0, p1[0], p1[1], 1, -p2[1] * p1[0], -p2[1] * p1[1]])
+    a_matrix = torch.zeros(2 * len(startpoints), 8, dtype=torch.float64, device=startpoints.device)
+    a_matrix[::2, :2] = endpoints
+    a_matrix[1::2, 3:5] = endpoints
+    a_matrix[::2, 2] = 1
+    a_matrix[1::2, 5] = 1
+    a_matrix[::2, 6:] = -startpoints[:, 0:1] * endpoints
+    a_matrix[1::2, 6:] = -startpoints[:, 1:2] * endpoints
 
-    b_matrix = torch.tensor(startpoints, dtype=torch.float64).view(8)
+    b_matrix = startpoints.to(dtype=torch.float64).view(8)
     # do least squares in double precision to prevent numerical issues
     res = torch.linalg.lstsq(a_matrix, b_matrix, driver="gels").solution.to(torch.float32)
 
@@ -706,8 +713,8 @@ def _get_perspective_coeffs(startpoints: List[List[int]], endpoints: List[List[i
 
 def perspective(
     img: Tensor,
-    startpoints: List[List[int]],
-    endpoints: List[List[int]],
+    startpoints: List[List[int]] | Tensor,
+    endpoints: List[List[int]] | Tensor,
     interpolation: InterpolationMode = InterpolationMode.BILINEAR,
     fill: Optional[List[float]] = None,
 ) -> Tensor:
@@ -717,9 +724,9 @@ def perspective(
 
     Args:
         img (PIL Image or Tensor): Image to be transformed.
-        startpoints (list of list of ints): List containing four lists of two integers corresponding to four corners
+        startpoints (list of list of ints or Tensor): List or Tensor containing four lists of two integers corresponding to four corners
             ``[top-left, top-right, bottom-right, bottom-left]`` of the original image.
-        endpoints (list of list of ints): List containing four lists of two integers corresponding to four corners
+        endpoints (list of list of ints or Tensor): List or Tensor containing four lists of two integers corresponding to four corners
             ``[top-left, top-right, bottom-right, bottom-left]`` of the transformed image.
         interpolation (InterpolationMode): Desired interpolation enum defined by
             :class:`torchvision.transforms.InterpolationMode`. Default is ``InterpolationMode.BILINEAR``.


### PR DESCRIPTION
## Context

This PR is an attempt to solve the issue mentioned in #9076 and explicitly accept tensor on any device as input for the function [`_get_perspective_coeffs`](https://github.com/pytorch/vision/blob/d02b1845a2fabea1eb8f9d09310369a5cbb5514f/torchvision/transforms/functional.py#L674-L704).

## proposed solution

This PR proposes to cast `startpoints` and `endpoints` as `Tensor` if a `List[List[int]]` is passed as input. We then modify how the `a_matrix` is build to avoid the for loop and make sure the construction of the matrix is compatible with torchscript. The `b_matrix` is then directly constructed from `startpoints` (reshaping and modifying the precision).

## Testing

We add one test (`test_perspective_tensor_input`) to make sure the function is compatible with tensor inputs.

```bash
pytest test/test_functional_tensor.py -vvv -k test_perspective
...
337 passed, 336 skipped, 21843 deselected in 5.75s (on CPU machine)
```