### PR TITLE
Update docstrings of MaskRCNN

### DIFF
--- a/torchvision/models/detection/mask_rcnn.py
+++ b/torchvision/models/detection/mask_rcnn.py
@@ -50,7 +50,7 @@ class MaskRCNN(FasterRCNN):
           ``0 <= x1 < x2 <= W`` and ``0 <= y1 < y2 <= H``.
         - labels (Int64Tensor[N]): the predicted labels for each image
         - scores (Tensor[N]): the scores or each prediction
-        - masks (UInt8Tensor[N, 1, H, W]): the predicted masks for each instance, in 0-1 range. In order to
+        - masks (FloatTensor[N, 1, H, W]): the predicted masks for each instance, in 0-1 range. In order to
           obtain the final segmentation masks, the soft masks can be thresholded, generally
           with a value of 0.5 (mask >= 0.5)
 


### PR DESCRIPTION
<!-- Before submitting a PR, please make sure to check our contributing guidelines regarding code formatting, tests, and documentation: https://github.com/pytorch/vision/blob/main/CONTRIBUTING.md -->
The original docstring of MaskRCNN class says the returned mask is a `UInt8Tensor` in inference mode, which is not true. This can be verified by the following code:

```python
import torch
from torchvision.models.detection import maskrcnn_resnet50_fpn_v2

model = maskrcnn_resnet50_fpn_v2()
model.eval()

with torch.no_grad():
    output = model([torch.randn(3, 100, 100)])

print(output[0]["masks"].dtype) # torch.float32
```
