### PR TITLE
Be consistent with grayscale images in draw_bounding_boxes

### DIFF
--- a/torchvision/utils.py
+++ b/torchvision/utils.py
@@ -210,11 +210,16 @@ def draw_bounding_boxes(
             "Boxes need to be in (xmin, ymin, xmax, ymax) format. Use torchvision.ops.box_convert to convert them"
         )
 
+    def to_rgb(image):
+        if image.size(0) == 1:
+            image = torch.tile(image, (3, 1, 1))
+        return image
+
     num_boxes = boxes.shape[0]
 
     if num_boxes == 0:
-        warnings.warn("boxes doesn't contain any box. No box was drawn")
-        return image
+        # Consistent handling of grayscale images
+        return to_rgb(image)
 
     if labels is None:
         labels: Union[list[str], list[None]] = [None] * num_boxes  # type: ignore[no-redef]
@@ -237,8 +242,7 @@ def draw_bounding_boxes(
         txt_font = ImageFont.truetype(font=font, size=font_size or 10)
 
     # Handle Grayscale images
-    if image.size(0) == 1:
-        image = torch.tile(image, (3, 1, 1))
+    image = to_rbg(image)
 
     original_dtype = image.dtype
     if original_dtype.is_floating_point:


### PR DESCRIPTION
Currently `draw_bounding_boxes` behaves differently when dealing with grayscale images in the case where no bounding boxes are given to the function. Reasonably, the output of the function should be the same in both cases: an rgb image with all (possibly none) bounding boxes drawn over it. Moreover, I removed the warning in the case an empty list of bounding boxes are passed to the function, as I consider it a common use-case for this util: I often use it to draw the predicted boxes on a long sequence of images, and some of them are expected to not have anything predicted in them, but currently I get an annoying warning in the logs for what I consider no good reason at all.