### PR TITLE
Warn when webp is asked to decode into grayscale

### DIFF
--- a/test/test_image.py
+++ b/test/test_image.py
@@ -934,6 +934,20 @@ def test_decode_webp(decode_fun, scripted):
     img += 123  # make sure image buffer wasn't freed by underlying decoding lib
 
 
+@pytest.mark.parametrize("decode_fun", (decode_webp, decode_image))
+def test_decode_webp_grayscale(decode_fun):
+    encoded_bytes = read_file(next(get_images(FAKEDATA_DIR, ".webp")))
+
+    # Note that we warn at the C++ layer because dispatching for decode_image
+    # doesn't happen until we hit C++. The C++ layer does not propagate
+    # warnings up to Python, so we can't test for them.
+    img = decode_fun(encoded_bytes, mode=ImageReadMode.GRAY)
+
+    # Note that because we do not support grayscale conversions, we expect
+    # that the number of color channels is still 3.
+    assert img.shape == (3, 100, 100)
+
+
 # This test is skipped by default because it requires webp images that we're not
 # including within the repo. The test images were downloaded manually from the
 # different pages of https://developers.google.com/speed/webp/gallery

--- a/test/test_image.py
+++ b/test/test_image.py
@@ -1,4 +1,5 @@
 import concurrent.futures
+import contextlib
 import glob
 import io
 import os
@@ -935,17 +936,29 @@ def test_decode_webp(decode_fun, scripted):
 
 
 @pytest.mark.parametrize("decode_fun", (decode_webp, decode_image))
-def test_decode_webp_grayscale(decode_fun):
+def test_decode_webp_grayscale(decode_fun, capfd):
     encoded_bytes = read_file(next(get_images(FAKEDATA_DIR, ".webp")))
 
-    # Note that we warn at the C++ layer because dispatching for decode_image
-    # doesn't happen until we hit C++. The C++ layer does not propagate
-    # warnings up to Python, so we can't test for them.
-    img = decode_fun(encoded_bytes, mode=ImageReadMode.GRAY)
+    # We warn at the C++ layer because for decode_image(), we don't do the image
+    # type dispatch until we get to the C++ version of decode_image(). We could
+    # warn at the Python layer in decode_webp(), but then users would get a
+    # double wanring: one from the Python layer and one from the C++ layer.
+    #
+    # Because we use the TORCH_WARN_ONCE macro, we need to do this dance to
+    # temporarily always warn so we can test.
+    @contextlib.contextmanager
+    def set_always_warn():
+        torch._C._set_warnAlways(True)
+        yield
+        torch._C._set_warnAlways(False)
 
-    # Note that because we do not support grayscale conversions, we expect
-    # that the number of color channels is still 3.
-    assert img.shape == (3, 100, 100)
+    with set_always_warn():
+        img = decode_fun(encoded_bytes, mode=ImageReadMode.GRAY)
+        assert "Webp does not support grayscale conversions" in capfd.readouterr().err
+
+        # Note that because we do not support grayscale conversions, we expect
+        # that the number of color channels is still 3.
+        assert img.shape == (3, 100, 100)
 
 
 # This test is skipped by default because it requires webp images that we're not

--- a/torchvision/csrc/io/image/cpu/decode_webp.cpp
+++ b/torchvision/csrc/io/image/cpu/decode_webp.cpp
@@ -32,6 +32,11 @@ torch::Tensor decode_webp(
       res == VP8_STATUS_OK, "WebPGetFeatures failed with error code ", res);
   TORCH_CHECK(
       !features.has_animation, "Animated webp files are not supported.");
+  TORCH_WARN_ONCE(
+      mode == IMAGE_READ_MODE_GRAY ||
+      mode == IMAGE_READ_MODE_GRAY_ALPHA,
+      "Webp does not support grayscale conversions. "
+      "The returned tensor will be in the colorspace of the original image.");
 
   auto return_rgb =
       should_this_return_rgb_or_rgba_let_me_know_in_the_comments_down_below_guys_see_you_in_the_next_video(

--- a/torchvision/csrc/io/image/cpu/decode_webp.cpp
+++ b/torchvision/csrc/io/image/cpu/decode_webp.cpp
@@ -32,11 +32,13 @@ torch::Tensor decode_webp(
       res == VP8_STATUS_OK, "WebPGetFeatures failed with error code ", res);
   TORCH_CHECK(
       !features.has_animation, "Animated webp files are not supported.");
-  TORCH_WARN_ONCE(
-      mode == IMAGE_READ_MODE_GRAY ||
-      mode == IMAGE_READ_MODE_GRAY_ALPHA,
-      "Webp does not support grayscale conversions. "
-      "The returned tensor will be in the colorspace of the original image.");
+
+  if (mode == IMAGE_READ_MODE_GRAY ||
+      mode == IMAGE_READ_MODE_GRAY_ALPHA) {
+    TORCH_WARN_ONCE(
+        "Webp does not support grayscale conversions. "
+        "The returned tensor will be in the colorspace of the original image.");
+  }
 
   auto return_rgb =
       should_this_return_rgb_or_rgba_let_me_know_in_the_comments_down_below_guys_see_you_in_the_next_video(


### PR DESCRIPTION
Addresses #8753 by adding a warning when users request to decode a webp image into a grayscale format.

Note that we only warn at the C++ layer, and not the Python layer. My reasoning is that for `decode_image()`, we only can warn at the C++ layer because we don't know the image format until we get to the C++ layer. We could warn at the Python level in the Python function `decode_webp()`, but then users would get a double warning: one at the Python level and one at the C++ level. I figure it's cleaner to only do the warning in one place.