### PR TITLE
Rotated bboxes transforms

### DIFF
--- a/test/test_transforms_v2.py
+++ b/test/test_transforms_v2.py
@@ -3006,11 +3006,21 @@ class TestElastic:
             check_cuda_vs_cpu=dtype is not torch.float16,
         )
 
-    @pytest.mark.parametrize("format", SUPPORTED_BOX_FORMATS)
+    @pytest.mark.parametrize("format", list(tv_tensors.BoundingBoxFormat))
     @pytest.mark.parametrize("dtype", [torch.float32, torch.int64])
     @pytest.mark.parametrize("device", cpu_and_cuda())
     def test_kernel_bounding_boxes(self, format, dtype, device):
         bounding_boxes = make_bounding_boxes(format=format, dtype=dtype, device=device)
+        if tv_tensors.is_rotated_bounding_format(format):
+            # generated test rotated boxes can be out of the canvas size
+            # but elastic transformation expect the boxes to be clamped
+            # Also by convention the integer boxes should be allowed to
+            # reach width and height. But the grid for the elastic transform
+            # only covers up to width - 1 and height -1. So we are tricking the
+            # test by making sure we are clamping the boxes up to width - 1 and height -1.
+            bounding_boxes.canvas_size = (bounding_boxes.canvas_size[0] - 1, bounding_boxes.canvas_size[1] - 1)
+            bounding_boxes = F.clamp_bounding_boxes(bounding_boxes)
+            bounding_boxes.canvas_size = (bounding_boxes.canvas_size[0] + 1, bounding_boxes.canvas_size[1] + 1)
 
         check_kernel(
             F.elastic_bounding_boxes,

--- a/test/test_transforms_v2.py
+++ b/test/test_transforms_v2.py
@@ -3846,8 +3846,14 @@ class TestAutoAugmentTransforms:
 
 
 class TestConvertBoundingBoxFormat:
-    old_new_formats = list(itertools.permutations(SUPPORTED_BOX_FORMATS, 2))
-    old_new_formats += list(itertools.permutations(NEW_BOX_FORMATS, 2))
+    old_new_formats = list(
+        itertools.permutations(
+            [f for f in tv_tensors.BoundingBoxFormat if not tv_tensors.is_rotated_bounding_format(f)], 2
+        )
+    )
+    old_new_formats += list(
+        itertools.permutations([f for f in tv_tensors.BoundingBoxFormat if tv_tensors.is_rotated_bounding_format(f)], 2)
+    )
 
     @pytest.mark.parametrize(("old_format", "new_format"), old_new_formats)
     def test_kernel(self, old_format, new_format):
@@ -3858,7 +3864,7 @@ class TestConvertBoundingBoxFormat:
             old_format=old_format,
         )
 
-    @pytest.mark.parametrize("format", SUPPORTED_BOX_FORMATS)
+    @pytest.mark.parametrize("format", list(tv_tensors.BoundingBoxFormat))
     @pytest.mark.parametrize("inplace", [False, True])
     def test_kernel_noop(self, format, inplace):
         input = make_bounding_boxes(format=format).as_subclass(torch.Tensor)

--- a/test/test_transforms_v2.py
+++ b/test/test_transforms_v2.py
@@ -4770,7 +4770,7 @@ class TestNormalize:
 
 
 class TestClampBoundingBoxes:
-    @pytest.mark.parametrize("format", SUPPORTED_BOX_FORMATS)
+    @pytest.mark.parametrize("format", list(tv_tensors.BoundingBoxFormat))
     @pytest.mark.parametrize("dtype", [torch.int64, torch.float32])
     @pytest.mark.parametrize("device", cpu_and_cuda())
     def test_kernel(self, format, dtype, device):
@@ -4782,7 +4782,7 @@ class TestClampBoundingBoxes:
             canvas_size=bounding_boxes.canvas_size,
         )
 
-    @pytest.mark.parametrize("format", SUPPORTED_BOX_FORMATS)
+    @pytest.mark.parametrize("format", list(tv_tensors.BoundingBoxFormat))
     def test_functional(self, format):
         check_functional(F.clamp_bounding_boxes, make_bounding_boxes(format=format))
 

--- a/test/test_transforms_v2.py
+++ b/test/test_transforms_v2.py
@@ -53,15 +53,6 @@ from torchvision.transforms.v2.functional._geometry import _get_perspective_coef
 from torchvision.transforms.v2.functional._utils import _get_kernel, _register_kernel_internal
 
 
-# While we are working on adjusting transform functions
-# for rotated and oriented bounding boxes formats,
-# we limit the perimeter of tests to formats
-#  for which transform functions are already implemented.
-# In the future, this global variable will be replaced with `list(tv_tensors.BoundingBoxFormat)`
-# to support all available formats.
-SUPPORTED_BOX_FORMATS = [tv_tensors.BoundingBoxFormat[x] for x in ["XYXY", "XYWH", "CXCYWH"]]
-NEW_BOX_FORMATS = [tv_tensors.BoundingBoxFormat[x] for x in ["XYWHR", "CXCYWHR", "XYXYXYXY"]]
-
 # turns all warnings into errors for this module
 pytestmark = [pytest.mark.filterwarnings("error")]
 

--- a/test/test_transforms_v2.py
+++ b/test/test_transforms_v2.py
@@ -1641,7 +1641,7 @@ class TestAffine:
 
         torch.testing.assert_close(actual, expected)
 
-    @pytest.mark.parametrize("format", SUPPORTED_BOX_FORMATS)
+    @pytest.mark.parametrize("format", list(tv_tensors.BoundingBoxFormat))
     @pytest.mark.parametrize("center", _CORRECTNESS_AFFINE_KWARGS["center"])
     @pytest.mark.parametrize("seed", list(range(5)))
     def test_transform_bounding_boxes_correctness(self, format, center, seed):

--- a/torchvision/transforms/v2/functional/_geometry.py
+++ b/torchvision/transforms/v2/functional/_geometry.py
@@ -983,7 +983,7 @@ def _affine_bounding_boxes_with_expand(
         new_points = torch.matmul(points, transposed_affine_matrix)
         tr = torch.amin(new_points, dim=0, keepdim=True)
         # Translate bounding boxes
-        out_bboxes.sub_(tr.repeat((1, 2)))
+        out_bboxes.sub_(tr.repeat((1, 4 if is_rotated else 2)))
         # Estimate meta-data for image with inverted=True
         affine_vector = _get_inverse_affine_matrix(center, angle, translate, scale, shear)
         new_width, new_height = _compute_affine_output_size(affine_vector, width, height)

--- a/torchvision/transforms/v2/functional/_misc.py
+++ b/torchvision/transforms/v2/functional/_misc.py
@@ -405,16 +405,27 @@ def _get_sanitize_bounding_boxes_mask(
     min_area: float = 1.0,
 ) -> torch.Tensor:
 
-    bounding_boxes = _convert_bounding_box_format(
-        bounding_boxes, new_format=tv_tensors.BoundingBoxFormat.XYXY, old_format=format
-    )
+    is_rotated = tv_tensors.is_rotated_bounding_format(format)
+    intermediate_format = tv_tensors.BoundingBoxFormat.XYXYXYXY if is_rotated else tv_tensors.BoundingBoxFormat.XYXY
+    bounding_boxes = _convert_bounding_box_format(bounding_boxes, new_format=intermediate_format, old_format=format)
 
     image_h, image_w = canvas_size
-    ws, hs = bounding_boxes[:, 2] - bounding_boxes[:, 0], bounding_boxes[:, 3] - bounding_boxes[:, 1]
+    if is_rotated:
+        dx12 = bounding_boxes[..., 0] - bounding_boxes[..., 2]
+        dy12 = bounding_boxes[..., 1] - bounding_boxes[..., 3]
+        dx23 = bounding_boxes[..., 3] - bounding_boxes[..., 5]
+        dy23 = bounding_boxes[..., 4] - bounding_boxes[..., 6]
+        ws = torch.sqrt(dx12**2 + dy12**2)
+        hs = torch.sqrt(dx23**2 + dy23**2)
+    else:
+        ws, hs = bounding_boxes[:, 2] - bounding_boxes[:, 0], bounding_boxes[:, 3] - bounding_boxes[:, 1]
     valid = (ws >= min_size) & (hs >= min_size) & (bounding_boxes >= 0).all(dim=-1) & (ws * hs >= min_area)
     # TODO: Do we really need to check for out of bounds here? All
     # transforms should be clamping anyway, so this should never happen?
     image_h, image_w = canvas_size
     valid &= (bounding_boxes[:, 0] <= image_w) & (bounding_boxes[:, 2] <= image_w)
     valid &= (bounding_boxes[:, 1] <= image_h) & (bounding_boxes[:, 3] <= image_h)
+    if is_rotated:
+        valid &= (bounding_boxes[..., 4] <= image_w) & (bounding_boxes[..., 5] <= image_h)
+        valid &= (bounding_boxes[..., 6] <= image_w) & (bounding_boxes[..., 7] <= image_h)
     return valid


### PR DESCRIPTION
## Add Transforms support for Rotated Boxes

This PR implements the last transforms for rotated boxes and follows what has been implemented in #9095 and #9084. This PR implements in particular the following modifications :
* Add support for [perspective](https://github.com/pytorch/vision/blob/fcca6ff8bde4a2636102a11b2f7c12e84e005da6/torchvision/transforms/v2/functional/_geometry.py#L1742) for rotated boxes;
* Fix missing tests for [affine](https://github.com/pytorch/vision/blob/main/torchvision/transforms/v2/functional/_geometry.py#L809) transformation and rotated boxes;
* Fix the [`_affine_bounding_boxes_with_expand`](https://github.com/pytorch/vision/blob/fcca6ff8bde4a2636102a11b2f7c12e84e005da6/torchvision/transforms/v2/functional/_geometry.py#L904) function for rotated boxes when `expand=True`;
* Fix [`clamp_bounding_boxes`](https://github.com/pytorch/vision/blob/fcca6ff8bde4a2636102a11b2f7c12e84e005da6/torchvision/transforms/v2/functional/_meta.py#L337) function with behavior detailed below;
* Add support for [elastic](https://github.com/pytorch/vision/blob/fcca6ff8bde4a2636102a11b2f7c12e84e005da6/torchvision/transforms/v2/functional/_geometry.py) for rotated boxes;
* Add support for [crop](https://github.com/pytorch/vision/blob/main/torchvision/transforms/v2/functional/_geometry.py#L1455) for rotated boxes.
* Add missing tests for `TestConvertBoundingBoxFormat`;
* Remove the `SUPPORTED_BOX_FORMATS` and `NEW_BOX_FORMATS` variable in the tests as tests for transform now full cover rotated boxes
* Add support for [sanitize](https://github.com/pytorch/vision/blob/fcca6ff8bde4a2636102a11b2f7c12e84e005da6/torchvision/transforms/v2/functional/_misc.py#L330C5-L330C28) for rotated boxes

## Details on the clamping function

![image](https://github.com/user-attachments/assets/c3b4e1e7-84f9-429b-8afc-caa5bc505b62)
![image](https://github.com/user-attachments/assets/f198b07c-a0c0-4ce8-b0a6-1f2b78f63e78)
![image](https://github.com/user-attachments/assets/f48d9708-b135-46eb-af03-c011c3162143)
![image](https://github.com/user-attachments/assets/a7ac40f8-5909-4d90-a372-d1c2fe11cc81)
![image](https://github.com/user-attachments/assets/46bc29de-d678-462e-974d-8b20b98979be)

For the clamping, we re-order the point of the box such that the point with the lowest value on the x-axis is the point 1 (c.f. `_order_bounding_boxes_points`). Given the position of the 4 vertices with respect to the y-axis (c.f. cases above), we are going to adjust the points (x1, y1), (x2, y2), and (x4, y4) to make sure the point (x1, y1) is on the right side of the y-axis. We loop through the four vertices of the rotated box and apply the same operation. In the end we are guaranteed that the bounding box will be within the canvas size and will be completely included within the area of the original box.

We propose some illustration examples below.
![image](https://github.com/user-attachments/assets/90b7c896-64ff-4330-834b-c0a2a1ffc2ff)
![image](https://github.com/user-attachments/assets/f72d06d0-f5a2-4fe4-9507-2cad36d97ac6)

Please note that depending on the order in which we loop through the vertices, we are not guaranteed the output boxes is the box with the largest area that meet the condition above (we might be too aggressive with the clamping. This can occur if the box is largely out of bounds along multiple axis).

## Test plan

Please run the following tests:
```bash
pytest test/test_transforms_v2.py -vvv -k "TestPerspective and test_kernel_bounding_boxes"
pytest test/test_transforms_v2.py -vvv -k "TestPerspective and test_correctness_perspective_bounding_boxes"

pytest test/test_transforms_v2.py -vvv -k "TestAffine and test_transform_bounding_boxes_correctness"

pytest test/test_transforms_v2.py -vvv -k "TestRotate and test_kernel_bounding_boxes"
pytest test/test_transforms_v2.py -vvv -k "TestRotate and test_functional_bounding_boxes_correctness"
pytest test/test_transforms_v2.py -vvv -k "TestRotate and test_transform_bounding_boxes_correctness"

pytest test/test_transforms_v2.py -vvv -k "TestClampBoundingBoxes and test_kernel"
pytest test/test_transforms_v2.py -vvv -k "TestClampBoundingBoxes and test_functional"

pytest test/test_transforms_v2.py -vvv -k "TestElastic and test_kernel_bounding_boxes"

pytest test/test_transforms_v2.py -vvv -k "TestConvertBoundingBoxFormat and test_kernel"
pytest test/test_transforms_v2.py -vvv -k "TestConvertBoundingBoxFormat and test_kernel_noop"
```

## Questions

Please note that this PR introduces a change in the API signature of the [`resize_bounding_boxes`](https://github.com/pytorch/vision/blob/main/torchvision/transforms/v2/functional/_geometry.py#L384) function to add `format: tv_tensors.BoundingBoxFormat` and specialize the operation given whether the box is rotated or not. Contrary to other transforms, this function did typically not received the `format` parameter as input before. Is it possible to add it here? Should we maybe add a default value in this case to preserve the behavior for non-rotated box by default?

## Future work

This PR implements only 4 transforms for rotated boxes. We plan to release the remaining 3 transforms in a subsequent PR.