### PR TITLE
Add default info dictionary to dataset

### DIFF
--- a/references/detection/coco_utils.py
+++ b/references/detection/coco_utils.py
@@ -123,7 +123,7 @@ def convert_to_coco_api(ds):
     coco_ds = COCO()
     # annotation IDs need to start at 1, not 0, see torchvision issue #1530
     ann_id = 1
-    dataset = {"images": [], "categories": [], "annotations": []}
+    dataset = {"images": [], "categories": [], "annotations": [], "info": {}}
     categories = set()
     for img_idx in range(len(ds)):
         # find better way to get target


### PR DESCRIPTION
Add default info dictionary to dataset so that when pycocotools copies the dataset to results it will not break
This fixes #9092 

<!-- Before submitting a PR, please make sure to check our contributing guidelines regarding code formatting, tests, and documentation: https://github.com/pytorch/vision/blob/main/CONTRIBUTING.md -->
