### PR TITLE
Fix incorrect boxes slicing in postprocess_detections

### DIFF
--- a/torchvision/models/detection/roi_heads.py
+++ b/torchvision/models/detection/roi_heads.py
@@ -698,7 +698,8 @@ class RoIHeads(nn.Module):
             labels = labels.view(1, -1).expand_as(scores)
 
             # remove predictions with the background label
-            boxes = boxes[:, 1:]
+            boxes = boxes.reshape(-1, num_classes, 4)
+            boxes = boxes[..., 1:, :]
             scores = scores[:, 1:]
             labels = labels[:, 1:]
 


### PR DESCRIPTION
<!-- Before submitting a PR, please make sure to check our contributing guidelines regarding code formatting, tests, and documentation: https://github.com/pytorch/vision/blob/main/CONTRIBUTING.md -->

Fix incorrect boxes slicing in postprocess_detections
This fixes https://github.com/pytorch/vision/issues/9110