### PR TITLE
Add error message when setting 1D tensor `ToImage()`

### DIFF
--- a/torchvision/tv_tensors/_image.py
+++ b/torchvision/tv_tensors/_image.py
@@ -43,7 +43,7 @@ class Image(TVTensor):
 
         tensor = cls._to_tensor(data, dtype=dtype, device=device, requires_grad=requires_grad)
         if tensor.ndim < 2:
-            raise ValueError
+            raise ValueError(f"Tensor must be 2D or higher, got {tensor.ndim}D tensor.")
         elif tensor.ndim == 2:
             tensor = tensor.unsqueeze(0)
 


### PR DESCRIPTION
<!-- Before submitting a PR, please make sure to check our contributing guidelines regarding code formatting, tests, and documentation: https://github.com/pytorch/vision/blob/main/CONTRIBUTING.md -->

As per https://github.com/pytorch/vision/issues/9025, I added a descriptive error message to the `torchvision.transforms.v2.ToImage()` method when a 1D tensor is passed in.
