### PR TITLE
[BE] Allow running test_ops with optional arguments

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -2035,4 +2035,5 @@ class TestDropBlock:
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    import sys
+    pytest.main([__file__] + sys.argv)


### PR DESCRIPTION
This allows one to pass `-v` or `-k` flag when running tests locally
