### PR TITLE
Add setup-miniconda to M1 workflows

### DIFF
--- a/.github/workflows/build-wheels-m1.yml
+++ b/.github/workflows/build-wheels-m1.yml
@@ -43,6 +43,7 @@ jobs:
       ref: ""
       test-infra-repository: pytorch/test-infra
       test-infra-ref: main
+      setup-miniconda: true
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
       pre-script: ${{ matrix.pre-script }}
       post-script: ${{ matrix.post-script }}


### PR DESCRIPTION
Fix missing miniconda : https://github.com/pytorch/vision/actions/runs/15907734617/job/44866992300#step:6:200
