### PR TITLE
Add missing space in _depcrecated.py

### DIFF
--- a/torchvision/transforms/v2/_deprecated.py
+++ b/torchvision/transforms/v2/_deprecated.py
@@ -41,7 +41,7 @@ class ToTensor(Transform):
     def __init__(self) -> None:
         warnings.warn(
             "The transform `ToTensor()` is deprecated and will be removed in a future release. "
-            "Instead, please use `v2.Compose([v2.ToImage(), v2.ToDtype(torch.float32, scale=True)])`."
+            "Instead, please use `v2.Compose([v2.ToImage(), v2.ToDtype(torch.float32, scale=True)])`. "
             "Output is equivalent up to float precision."
         )
         super().__init__()


### PR DESCRIPTION
When using torchvision in an older notebook, I stumbled across the deprecated message and noticed this missing space.
