### PR TITLE
Disable integer dtype for rotated bounding boxes

### DIFF
--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -424,13 +424,6 @@ def make_bounding_boxes(
         format = tv_tensors.BoundingBoxFormat[format]
 
     dtype = dtype or torch.float32
-    int_dtype = dtype in (
-        torch.uint8,
-        torch.int8,
-        torch.int16,
-        torch.int32,
-        torch.int64,
-    )
 
     h, w = (torch.randint(1, s, (num_boxes,)) for s in canvas_size)
     y = sample_position(h, canvas_size[0])
@@ -457,14 +450,14 @@ def make_bounding_boxes(
     elif format is tv_tensors.BoundingBoxFormat.XYXYXYXY:
         r_rad = r * torch.pi / 180.0
         cos, sin = torch.cos(r_rad), torch.sin(r_rad)
-        x1 = torch.round(x) if int_dtype else x
-        y1 = torch.round(y) if int_dtype else y
-        x2 = torch.round(x1 + w * cos) if int_dtype else x1 + w * cos
-        y2 = torch.round(y1 - w * sin) if int_dtype else y1 - w * sin
-        x3 = torch.round(x2 + h * sin) if int_dtype else x2 + h * sin
-        y3 = torch.round(y2 + h * cos) if int_dtype else y2 + h * cos
-        x4 = torch.round(x1 + h * sin) if int_dtype else x1 + h * sin
-        y4 = torch.round(y1 + h * cos) if int_dtype else y1 + h * cos
+        x1 = x
+        y1 = y
+        x2 = x1 + w * cos
+        y2 = y1 - w * sin
+        x3 = x2 + h * sin
+        y3 = y2 + h * cos
+        x4 = x1 + h * sin
+        y4 = y1 + h * cos
         parts = (x1, y1, x2, y2, x3, y3, x4, y4)
     else:
         raise ValueError(f"Format {format} is not supported")

--- a/test/test_transforms_v2.py
+++ b/test/test_transforms_v2.py
@@ -564,13 +564,6 @@ def reference_affine_rotated_bounding_boxes_helper(
 
     def affine_rotated_bounding_boxes(bounding_boxes):
         dtype = bounding_boxes.dtype
-        int_dtype = dtype in (
-            torch.uint8,
-            torch.int8,
-            torch.int16,
-            torch.int32,
-            torch.int64,
-        )
         device = bounding_boxes.device
 
         # Go to float before converting to prevent precision loss in case of CXCYWHR -> XYXYXYXY and W or H is 1
@@ -605,16 +598,11 @@ def reference_affine_rotated_bounding_boxes_helper(
         )
 
         output = output[[2, 3, 0, 1, 6, 7, 4, 5]] if flip else output
-        if not int_dtype:
-            output = _parallelogram_to_bounding_boxes(output)
+        output = _parallelogram_to_bounding_boxes(output)
 
         output = F.convert_bounding_box_format(
             output, old_format=tv_tensors.BoundingBoxFormat.XYXYXYXY, new_format=format
         )
-
-        if torch.is_floating_point(output) and int_dtype:
-            # It is important to round before cast.
-            output = torch.round(output)
 
         # For rotated boxes, it is important to cast before clamping.
         return (
@@ -760,6 +748,8 @@ class TestResize:
     def test_kernel_bounding_boxes(self, format, size, use_max_size, dtype, device):
         if not (max_size_kwarg := self._make_max_size_kwarg(use_max_size=use_max_size, size=size)):
             return
+        if not dtype.is_floating_point and tv_tensors.is_rotated_bounding_format(format):
+            pytest.xfail("Rotated bounding boxes should be floating point tensors")
 
         bounding_boxes = make_bounding_boxes(
             format=format,
@@ -1212,6 +1202,8 @@ class TestHorizontalFlip:
     @pytest.mark.parametrize("dtype", [torch.float32, torch.int64])
     @pytest.mark.parametrize("device", cpu_and_cuda())
     def test_kernel_bounding_boxes(self, format, dtype, device):
+        if not dtype.is_floating_point and tv_tensors.is_rotated_bounding_format(format):
+            pytest.xfail("Rotated bounding boxes should be floating point tensors")
         bounding_boxes = make_bounding_boxes(format=format, dtype=dtype, device=device)
         check_kernel(
             F.horizontal_flip_bounding_boxes,
@@ -1441,6 +1433,8 @@ class TestAffine:
     @pytest.mark.parametrize("dtype", [torch.float32, torch.int64])
     @pytest.mark.parametrize("device", cpu_and_cuda())
     def test_kernel_bounding_boxes(self, param, value, format, dtype, device):
+        if not dtype.is_floating_point and tv_tensors.is_rotated_bounding_format(format):
+            pytest.xfail("Rotated bounding boxes should be floating point tensors")
         bounding_boxes = make_bounding_boxes(format=format, dtype=dtype, device=device)
         self._check_kernel(
             F.affine_bounding_boxes,
@@ -1823,6 +1817,8 @@ class TestVerticalFlip:
     @pytest.mark.parametrize("dtype", [torch.float32, torch.int64])
     @pytest.mark.parametrize("device", cpu_and_cuda())
     def test_kernel_bounding_boxes(self, format, dtype, device):
+        if not dtype.is_floating_point and tv_tensors.is_rotated_bounding_format(format):
+            pytest.xfail("Rotated bounding boxes should be floating point tensors")
         bounding_boxes = make_bounding_boxes(format=format, dtype=dtype, device=device)
         check_kernel(
             F.vertical_flip_bounding_boxes,
@@ -2021,6 +2017,8 @@ class TestRotate:
         kwargs = {param: value}
         if param != "angle":
             kwargs["angle"] = self._MINIMAL_AFFINE_KWARGS["angle"]
+        if not dtype.is_floating_point and tv_tensors.is_rotated_bounding_format(format):
+            pytest.xfail("Rotated bounding boxes should be floating point tensors")
 
         bounding_boxes = make_bounding_boxes(format=format, dtype=dtype, device=device)
 
@@ -3236,6 +3234,8 @@ class TestElastic:
     @pytest.mark.parametrize("dtype", [torch.float32, torch.int64])
     @pytest.mark.parametrize("device", cpu_and_cuda())
     def test_kernel_bounding_boxes(self, format, dtype, device):
+        if not dtype.is_floating_point and tv_tensors.is_rotated_bounding_format(format):
+            pytest.xfail("Rotated bounding boxes should be floating point tensors")
         bounding_boxes = make_bounding_boxes(format=format, dtype=dtype, device=device)
 
         check_kernel(
@@ -3399,6 +3399,8 @@ class TestCrop:
     @pytest.mark.parametrize("dtype", [torch.float32, torch.int64])
     @pytest.mark.parametrize("device", cpu_and_cuda())
     def test_kernel_bounding_boxes(self, kwargs, format, dtype, device):
+        if not dtype.is_floating_point and tv_tensors.is_rotated_bounding_format(format):
+            pytest.xfail("Rotated bounding boxes should be floating point tensors")
         bounding_boxes = make_bounding_boxes(self.INPUT_SIZE, format=format, dtype=dtype, device=device)
         check_kernel(F.crop_bounding_boxes, bounding_boxes, format=format, **kwargs)
 
@@ -3576,6 +3578,8 @@ class TestCrop:
     @pytest.mark.parametrize("dtype", [torch.float32, torch.int64])
     @pytest.mark.parametrize("device", cpu_and_cuda())
     def test_functional_bounding_box_correctness(self, kwargs, format, dtype, device):
+        if not dtype.is_floating_point and tv_tensors.is_rotated_bounding_format(format):
+            pytest.xfail("Rotated bounding boxes should be floating point tensors")
         bounding_boxes = make_bounding_boxes(self.INPUT_SIZE, format=format, dtype=dtype, device=device)
 
         actual = F.crop(bounding_boxes, **kwargs)
@@ -3590,6 +3594,8 @@ class TestCrop:
     @pytest.mark.parametrize("device", cpu_and_cuda())
     @pytest.mark.parametrize("seed", list(range(5)))
     def test_transform_bounding_boxes_correctness(self, output_size, format, dtype, device, seed):
+        if not dtype.is_floating_point and tv_tensors.is_rotated_bounding_format(format):
+            pytest.xfail("Rotated bounding boxes should be floating point tensors")
         input_size = [s * 2 for s in output_size]
         bounding_boxes = make_bounding_boxes(input_size, format=format, dtype=dtype, device=device)
 
@@ -4267,6 +4273,10 @@ class TestConvertBoundingBoxFormat:
     @pytest.mark.parametrize("device", cpu_and_cuda())
     @pytest.mark.parametrize("fn_type", ["functional", "transform"])
     def test_correctness(self, old_format, new_format, dtype, device, fn_type):
+        if not dtype.is_floating_point and (
+            tv_tensors.is_rotated_bounding_format(old_format) or tv_tensors.is_rotated_bounding_format(new_format)
+        ):
+            pytest.xfail("Rotated bounding boxes should be floating point tensors")
         bounding_boxes = make_bounding_boxes(format=old_format, dtype=dtype, device=device)
 
         if fn_type == "functional":
@@ -4706,6 +4716,8 @@ class TestPad:
     @pytest.mark.parametrize("device", cpu_and_cuda())
     @pytest.mark.parametrize("fn", [F.pad, transform_cls_to_functional(transforms.Pad)])
     def test_bounding_boxes_correctness(self, padding, format, dtype, device, fn):
+        if not dtype.is_floating_point and tv_tensors.is_rotated_bounding_format(format):
+            pytest.xfail("Rotated bounding boxes should be floating point tensors")
         bounding_boxes = make_bounding_boxes(format=format, dtype=dtype, device=device)
 
         actual = fn(bounding_boxes, padding=padding)
@@ -4876,6 +4888,8 @@ class TestCenterCrop:
     @pytest.mark.parametrize("device", cpu_and_cuda())
     @pytest.mark.parametrize("fn", [F.center_crop, transform_cls_to_functional(transforms.CenterCrop)])
     def test_bounding_boxes_correctness(self, output_size, format, dtype, device, fn):
+        if not dtype.is_floating_point and tv_tensors.is_rotated_bounding_format(format):
+            pytest.xfail("Rotated bounding boxes should be floating point tensors")
         bounding_boxes = make_bounding_boxes(self.INPUT_SIZE, format=format, dtype=dtype, device=device)
 
         actual = fn(bounding_boxes, output_size)
@@ -5242,6 +5256,8 @@ class TestPerspective:
     @pytest.mark.parametrize("dtype", [torch.int64, torch.float32])
     @pytest.mark.parametrize("device", cpu_and_cuda())
     def test_correctness_perspective_bounding_boxes(self, startpoints, endpoints, format, dtype, device):
+        if not dtype.is_floating_point and tv_tensors.is_rotated_bounding_format(format):
+            pytest.xfail("Rotated bounding boxes should be floating point tensors")
         bounding_boxes = make_bounding_boxes(format=format, dtype=dtype, device=device)
 
         actual = F.perspective(bounding_boxes, startpoints=startpoints, endpoints=endpoints)
@@ -5511,6 +5527,8 @@ class TestClampBoundingBoxes:
     @pytest.mark.parametrize("dtype", [torch.int64, torch.float32])
     @pytest.mark.parametrize("device", cpu_and_cuda())
     def test_kernel(self, format, clamping_mode, dtype, device):
+        if not dtype.is_floating_point and tv_tensors.is_rotated_bounding_format(format):
+            pytest.xfail("Rotated bounding boxes should be floating point tensors")
         bounding_boxes = make_bounding_boxes(format=format, clamping_mode=clamping_mode, dtype=dtype, device=device)
         check_kernel(
             F.clamp_bounding_boxes,
@@ -6938,14 +6956,11 @@ def test_classification_preset(image_type, label_type, dataset_return_type, to_t
 
 
 @pytest.mark.parametrize("input_size", [(17, 11), (11, 17), (11, 11)])
-@pytest.mark.parametrize("dtype", [torch.float32, torch.int64])
 @pytest.mark.parametrize("device", cpu_and_cuda())
-def test_parallelogram_to_bounding_boxes(input_size, dtype, device):
+def test_parallelogram_to_bounding_boxes(input_size, device):
     # Assert that applying `_parallelogram_to_bounding_boxes` to rotated boxes
     # does not modify the input.
-    bounding_boxes = make_bounding_boxes(
-        input_size, format=tv_tensors.BoundingBoxFormat.XYXYXYXY, dtype=dtype, device=device
-    )
+    bounding_boxes = make_bounding_boxes(input_size, format=tv_tensors.BoundingBoxFormat.XYXYXYXY, device=device)
     actual = _parallelogram_to_bounding_boxes(bounding_boxes)
     torch.testing.assert_close(actual, bounding_boxes, rtol=0, atol=1)
 

--- a/test/test_transforms_v2.py
+++ b/test/test_transforms_v2.py
@@ -5593,7 +5593,7 @@ class TestClampBoundingBoxes:
 
         if rotated:
             boxes = tv_tensors.BoundingBoxes(
-                [0, 0, 100, 100, 0], format="XYWHR", canvas_size=(10, 10), clamping_mode=constructor_clamping_mode
+                [0., 0., 100., 100., 0.], format="XYWHR", canvas_size=(10, 10), clamping_mode=constructor_clamping_mode
             )
             expected_clamped_output = torch.tensor([[0.0, 0.0, 10.0, 10.0, 0.0]])
         else:

--- a/test/test_transforms_v2.py
+++ b/test/test_transforms_v2.py
@@ -1648,7 +1648,7 @@ class TestAffine:
             center=center,
         )
 
-        torch.testing.assert_close(actual, expected, atol=1e-5, rtol=1e-5)
+        torch.testing.assert_close(actual, expected, atol=1e-4, rtol=1e-4)
 
     @pytest.mark.parametrize("format", list(tv_tensors.BoundingBoxFormat))
     @pytest.mark.parametrize("center", _CORRECTNESS_AFFINE_KWARGS["center"])

--- a/test/test_transforms_v2.py
+++ b/test/test_transforms_v2.py
@@ -5593,7 +5593,10 @@ class TestClampBoundingBoxes:
 
         if rotated:
             boxes = tv_tensors.BoundingBoxes(
-                [0., 0., 100., 100., 0.], format="XYWHR", canvas_size=(10, 10), clamping_mode=constructor_clamping_mode
+                [0.0, 0.0, 100.0, 100.0, 0.0],
+                format="XYWHR",
+                canvas_size=(10, 10),
+                clamping_mode=constructor_clamping_mode,
             )
             expected_clamped_output = torch.tensor([[0.0, 0.0, 10.0, 10.0, 0.0]])
         else:

--- a/test/test_tv_tensors.py
+++ b/test/test_tv_tensors.py
@@ -69,9 +69,6 @@ def test_bbox_instance(data, format):
 )
 @pytest.mark.parametrize("scripted", (False, True))
 def test_bbox_format(format, is_rotated_expected, scripted):
-    if isinstance(format, str):
-        format = tv_tensors.BoundingBoxFormat[(format.upper())]
-
     fn = tv_tensors.is_rotated_bounding_format
     if scripted:
         fn = torch.jit.script(fn)
@@ -97,13 +94,12 @@ def test_bbox_format(format, is_rotated_expected, scripted):
 )
 @pytest.mark.parametrize("input_dtype", [torch.float32, torch.float64, torch.uint8])
 def test_bbox_format_dtype(format, support_integer_dtype, input_dtype):
-    print(format, support_integer_dtype, input_dtype)
+    tensor = torch.randint(0, 32, size=(5, 2), dtype=input_dtype)
     if not input_dtype.is_floating_point and not support_integer_dtype:
-        pytest.xfail("Rotated bounding boxes should be floating point tensors")
-        bboxes = tv_tensors.BoundingBoxes(torch.randint(0, 32, size=(5, 2)), format=format, canvas_size=(32, 32))
+        with pytest.raises(ValueError, match="Rotated bounding boxes should be floating point tensors"):
+            tv_tensors.BoundingBoxes(tensor, format=format, canvas_size=(32, 32))
     else:
-        bboxes = tv_tensors.BoundingBoxes(torch.rand(size=(5, 2)), format=format, canvas_size=(32, 32))
-        assert isinstance(bboxes, torch.Tensor)
+        tv_tensors.BoundingBoxes(tensor, format=format, canvas_size=(32, 32))
 
 
 def test_bbox_dim_error():
@@ -437,5 +433,5 @@ def test_return_type_input():
 
 
 def test_box_clamping_mode_default():
-    assert tv_tensors.BoundingBoxes([0, 0, 10, 10], format="XYXY", canvas_size=(100, 100)).clamping_mode == "soft"
-    assert tv_tensors.BoundingBoxes([0, 0, 10, 10, 0], format="XYWHR", canvas_size=(100, 100)).clamping_mode == "soft"
+    assert tv_tensors.BoundingBoxes([0., 0., 10., 10.], format="XYXY", canvas_size=(100, 100)).clamping_mode == "soft"
+    assert tv_tensors.BoundingBoxes([0., 0., 10., 10., 0.], format="XYWHR", canvas_size=(100, 100)).clamping_mode == "soft"

--- a/test/test_tv_tensors.py
+++ b/test/test_tv_tensors.py
@@ -433,5 +433,10 @@ def test_return_type_input():
 
 
 def test_box_clamping_mode_default():
-    assert tv_tensors.BoundingBoxes([0., 0., 10., 10.], format="XYXY", canvas_size=(100, 100)).clamping_mode == "soft"
-    assert tv_tensors.BoundingBoxes([0., 0., 10., 10., 0.], format="XYWHR", canvas_size=(100, 100)).clamping_mode == "soft"
+    assert (
+        tv_tensors.BoundingBoxes([0.0, 0.0, 10.0, 10.0], format="XYXY", canvas_size=(100, 100)).clamping_mode == "soft"
+    )
+    assert (
+        tv_tensors.BoundingBoxes([0.0, 0.0, 10.0, 10.0, 0.0], format="XYWHR", canvas_size=(100, 100)).clamping_mode
+        == "soft"
+    )

--- a/test/test_tv_tensors.py
+++ b/test/test_tv_tensors.py
@@ -77,6 +77,33 @@ def test_bbox_format(format, is_rotated_expected, scripted):
         fn = torch.jit.script(fn)
     assert fn(format) == is_rotated_expected
 
+@pytest.mark.parametrize(
+    "format, support_integer_dtype",
+    [
+        ("XYXY", True),
+        ("XYWH", True),
+        ("CXCYWH", True),
+        ("XYXYXYXY", False),
+        ("XYWHR", False),
+        ("CXCYWHR", False),
+        (tv_tensors.BoundingBoxFormat.XYXY, True),
+        (tv_tensors.BoundingBoxFormat.XYWH, True),
+        (tv_tensors.BoundingBoxFormat.CXCYWH, True),
+        (tv_tensors.BoundingBoxFormat.XYXYXYXY, False),
+        (tv_tensors.BoundingBoxFormat.XYWHR, False),
+        (tv_tensors.BoundingBoxFormat.CXCYWHR, False),
+    ],
+)
+@pytest.mark.parametrize("input_dtype", [torch.float32, torch.float64, torch.uint8])
+def test_bbox_format_dtype(format, support_integer_dtype, input_dtype):
+    print(format, support_integer_dtype, input_dtype)
+    if not input_dtype.is_floating_point and not support_integer_dtype:
+        pytest.xfail("Rotated bounding boxes should be floating point tensors")
+        bboxes = tv_tensors.BoundingBoxes(torch.randint(0, 32, size=(5, 2)), format=format, canvas_size=(32, 32))
+    else:
+        bboxes = tv_tensors.BoundingBoxes(torch.rand(size=(5, 2)), format=format, canvas_size=(32, 32))
+        assert isinstance(bboxes, torch.Tensor)
+
 
 def test_bbox_dim_error():
     data_3d = [[[1, 2, 3, 4]]]

--- a/test/test_tv_tensors.py
+++ b/test/test_tv_tensors.py
@@ -77,6 +77,7 @@ def test_bbox_format(format, is_rotated_expected, scripted):
         fn = torch.jit.script(fn)
     assert fn(format) == is_rotated_expected
 
+
 @pytest.mark.parametrize(
     "format, support_integer_dtype",
     [

--- a/torchvision/transforms/v2/functional/_meta.py
+++ b/torchvision/transforms/v2/functional/_meta.py
@@ -578,8 +578,6 @@ def _clamp_along_y_axis(
         bounding_boxes[..., 0].clamp_(0)  # Clamp x1 to 0
 
     if need_cast:
-        if dtype in (torch.uint8, torch.int8, torch.int16, torch.int32, torch.int64):
-            bounding_boxes.round_()
         bounding_boxes = bounding_boxes.to(dtype)
     return bounding_boxes.reshape(original_shape)
 
@@ -646,9 +644,6 @@ def _clamp_rotated_bounding_boxes(
     ).reshape(original_shape)
 
     if need_cast:
-        if dtype in (torch.uint8, torch.int8, torch.int16, torch.int32, torch.int64):
-            # Adding epsilon to ensure consistency between CPU and GPU rounding.
-            out_boxes.add_(1e-7).round_()
         out_boxes = out_boxes.to(dtype)
     return out_boxes
 

--- a/torchvision/tv_tensors/_bounding_boxes.py
+++ b/torchvision/tv_tensors/_bounding_boxes.py
@@ -40,7 +40,7 @@ class BoundingBoxFormat(Enum):
 
 # TODO: Once torchscript supports Enums with staticmethod
 # this can be put into BoundingBoxFormat as staticmethod
-def is_rotated_bounding_format(format: Union[BoundingBoxFormat, str]) -> bool:
+def is_rotated_bounding_format(format: BoundingBoxFormat | str) -> bool:
     if isinstance(format, BoundingBoxFormat):
         return (
             format == BoundingBoxFormat.XYWHR

--- a/torchvision/tv_tensors/_bounding_boxes.py
+++ b/torchvision/tv_tensors/_bounding_boxes.py
@@ -99,11 +99,6 @@ class BoundingBoxes(TVTensor):
         bounding_boxes.clamping_mode = clamping_mode
         return bounding_boxes
 
-    @staticmethod
-    def _check_format(tensor: torch.Tensor, format: BoundingBoxFormat) -> None:
-        if not torch.is_floating_point(tensor) and is_rotated_bounding_format(format):
-            raise ValueError("Rotated bounding boxes should be floating point tensors")
-
     def __new__(
         cls,
         data: Any,
@@ -116,7 +111,8 @@ class BoundingBoxes(TVTensor):
         requires_grad: bool | None = None,
     ) -> BoundingBoxes:
         tensor = cls._to_tensor(data, dtype=dtype, device=device, requires_grad=requires_grad)
-        cls._check_format(tensor, format=format)
+        if not torch.is_floating_point(tensor) and is_rotated_bounding_format(format):
+            raise ValueError("Rotated bounding boxes should be floating point tensors")
         return cls._wrap(tensor, format=format, canvas_size=canvas_size, clamping_mode=clamping_mode)
 
     @classmethod

--- a/torchvision/tv_tensors/_bounding_boxes.py
+++ b/torchvision/tv_tensors/_bounding_boxes.py
@@ -40,10 +40,13 @@ class BoundingBoxFormat(Enum):
 
 # TODO: Once torchscript supports Enums with staticmethod
 # this can be put into BoundingBoxFormat as staticmethod
-def is_rotated_bounding_format(format: BoundingBoxFormat) -> bool:
-    return (
-        format == BoundingBoxFormat.XYWHR or format == BoundingBoxFormat.CXCYWHR or format == BoundingBoxFormat.XYXYXYXY
-    )
+def is_rotated_bounding_format(format: Union[BoundingBoxFormat, str]) -> bool:
+    if isinstance(format, BoundingBoxFormat):
+        return (format == BoundingBoxFormat.XYWHR or format == BoundingBoxFormat.CXCYWHR or format == BoundingBoxFormat.XYXYXYXY)
+    elif isinstance(format, str):
+        return format in ("XYWHR", "CXCYWHR", "XYXYXYXY")
+    else:
+        raise ValueError(f"format should be str or BoundingBoxFormat, got {type(format)}")
 
 
 # TODOBB consider making this a Literal instead. Tried briefly and got
@@ -111,7 +114,7 @@ class BoundingBoxes(TVTensor):
     ) -> BoundingBoxes:
         tensor = cls._to_tensor(data, dtype=dtype, device=device, requires_grad=requires_grad)
         if not torch.is_floating_point(tensor) and is_rotated_bounding_format(format):
-            raise ValueError("Rotated bounding boxes should be floating point tensors")
+            raise ValueError(f"Rotated bounding boxes should be floating point tensors, got {tensor.dtype}.")
         return cls._wrap(tensor, format=format, canvas_size=canvas_size, clamping_mode=clamping_mode)
 
     @classmethod

--- a/torchvision/tv_tensors/_bounding_boxes.py
+++ b/torchvision/tv_tensors/_bounding_boxes.py
@@ -99,6 +99,11 @@ class BoundingBoxes(TVTensor):
         bounding_boxes.clamping_mode = clamping_mode
         return bounding_boxes
 
+    @staticmethod
+    def _check_format(tensor: torch.Tensor, format: BoundingBoxFormat) -> None:
+        if not torch.is_floating_point(tensor) and is_rotated_bounding_format(format):
+            raise ValueError("Rotated bounding boxes should be floating point tensors")
+
     def __new__(
         cls,
         data: Any,
@@ -111,6 +116,7 @@ class BoundingBoxes(TVTensor):
         requires_grad: bool | None = None,
     ) -> BoundingBoxes:
         tensor = cls._to_tensor(data, dtype=dtype, device=device, requires_grad=requires_grad)
+        cls._check_format(tensor, format=format)
         return cls._wrap(tensor, format=format, canvas_size=canvas_size, clamping_mode=clamping_mode)
 
     @classmethod

--- a/torchvision/tv_tensors/_bounding_boxes.py
+++ b/torchvision/tv_tensors/_bounding_boxes.py
@@ -42,7 +42,11 @@ class BoundingBoxFormat(Enum):
 # this can be put into BoundingBoxFormat as staticmethod
 def is_rotated_bounding_format(format: Union[BoundingBoxFormat, str]) -> bool:
     if isinstance(format, BoundingBoxFormat):
-        return (format == BoundingBoxFormat.XYWHR or format == BoundingBoxFormat.CXCYWHR or format == BoundingBoxFormat.XYXYXYXY)
+        return (
+            format == BoundingBoxFormat.XYWHR
+            or format == BoundingBoxFormat.CXCYWHR
+            or format == BoundingBoxFormat.XYXYXYXY
+        )
     elif isinstance(format, str):
         return format in ("XYWHR", "CXCYWHR", "XYXYXYXY")
     else:


### PR DESCRIPTION
## Context

This PR disables integer `dtype` for rotated bounding boxes. Indeed rotated bounding boxes typically have floating coordinates for vertices. Functions to generate boxes or to transform boxes will typically involves trigonometric sinus and cosinus functions, which does not guarantees the coordinates will be integer. Rounding to the nearest integer can lead to degenerated boxes. Chaining transformation can further exacerbate the degeneration as rounding error will compound. For these reason, we choose to raise an error in the `BoundingBoxes` constructor if a integer `dtype` tensor is passed together with a rotated bounding box format. This check is done in the `_check_format` static function.

## Testing
We adapt the tests with the following condition to verify that tests combining integer dtype and rotated bounding box formats are indeed failing.
```python
if not dtype.is_floating_point and (
            tv_tensors.is_rotated_bounding_format(old_format) or tv_tensors.is_rotated_bounding_format(new_format)
        ):
            pytest.xfail("Rotated bounding boxes should be floating point tensors")
```

We finally remove artifacts in the testing and transforms added to make sure the transforms were compatible with integer `dtype` for rotated boxes. This includes all the rounding operations as well as epsilon offsets in the testing.

Please run tests with:
```bash
pytest test/test_transforms_v2.py -k box -v
...
3230 passed, 5686 deselected, 678 xfailed in 129.91s (0:02:09)
```