### PR TITLE
Enforce PIL < 11.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -111,7 +111,8 @@ def get_requirements():
     ]
 
     # Excluding 8.3.* because of https://github.com/pytorch/vision/issues/4934
-    pillow_ver = " >= 5.3.0, !=8.3.*"
+    # TODO remove <11.3 bound and address corresponding deprecation warnings
+    pillow_ver = " >= 5.3.0, !=8.3.*, <11.3"
     pillow_req = "pillow-simd" if get_dist("pillow-simd") is not None else "pillow"
     requirements.append(pillow_req + pillow_ver)
 


### PR DESCRIPTION
Seeing some failures on https://github.com/pytorch/vision/pull/9133 related to PIL `mode` param:

```
2025-07-01T09:56:56.6381364Z FAILED test/test_transforms_v2.py::TestJPEG::test_transform_image_correctness[1-RGB-quality1] - DeprecationWarning: 'mode' parameter is deprecated and will be removed in Pillow 13 (2026-10-15)
```

This is probably related to the new [PIL 11.3](https://github.com/python-pillow/Pillow/releases/tag/11.3.0) which was released 30 minutes ago. Enforcing `<11.3` for now to keep the CI green, we should address this soon though.