### PR TITLE
[EZ] Replace `pytorch-labs` with `meta-pytorch`

### DIFF
--- a/torchvision/io/image.py
+++ b/torchvision/io/image.py
@@ -448,7 +448,7 @@ def decode_avif(input: torch.Tensor, mode: ImageReadMode = ImageReadMode.UNCHANG
         us know of any issue:
         https://github.com/pytorch/vision/issues/new/choose. Note that
         `torchvision-extra-decoders
-        <https://github.com/pytorch-labs/torchvision-extra-decoders/>`_ is
+        <https://github.com/meta-pytorch/torchvision-extra-decoders/>`_ is
         released under the LGPL license.
 
     The values of the output tensor are in uint8 in [0, 255] for most images. If
@@ -485,7 +485,7 @@ def decode_heic(input: torch.Tensor, mode: ImageReadMode = ImageReadMode.UNCHANG
         us know of any issue:
         https://github.com/pytorch/vision/issues/new/choose. Note that
         `torchvision-extra-decoders
-        <https://github.com/pytorch-labs/torchvision-extra-decoders/>`_ is
+        <https://github.com/meta-pytorch/torchvision-extra-decoders/>`_ is
         released under the LGPL license.
 
     The values of the output tensor are in uint8 in [0, 255] for most images. If


### PR DESCRIPTION
This PR replaces all instances of `pytorch-labs` with `meta-pytorch` in this repository now that the `pytorch-labs` org has been renamed to `meta-pytorch`

## Changes Made
- Replaced all occurrences of `pytorch-labs` with `meta-pytorch`
- Only modified files with extensions: .py, .md, .sh, .rst, .cpp, .h, .txt, .yml
- Skipped binary files and files larger than 1MB due to GitHub api payload limits in the script to cover all repos in this org. Will do a more manual second pass later to cover any larger files

## Files Modified
This PR updates files that contained the target text.

Generated by automated script on 2025-08-12T20:46:51.482111+00:00Z