### PR TITLE
Allow native uint8 resize on avx512

### DIFF
--- a/torchvision/transforms/v2/functional/_geometry.py
+++ b/torchvision/transforms/v2/functional/_geometry.py
@@ -261,7 +261,7 @@ def _do_native_uint8_resize_on_cpu(interpolation: InterpolationMode) -> bool:
         if torch.compiler.is_compiling():
             return True
         else:
-            return "AVX2" in torch.backends.cpu.get_cpu_capability()
+            return torch.backends.cpu.get_cpu_capability() in ("AVX2", "AVX512")
 
     return interpolation == InterpolationMode.BICUBIC
 


### PR DESCRIPTION
This should drastically speed-up the v2 `resize` transform on machines with AVX512 support.

From my understanding if a machine reports `AVX512` support then it necessarily mean that it also supports `AVX2`, so this should be safe.