### PR TITLE
Resolve torchvision + opencv version issues

### DIFF
--- a/torchvision/csrc/io/decoder/audio_sampler.cpp
+++ b/torchvision/csrc/io/decoder/audio_sampler.cpp
@@ -54,7 +54,7 @@ bool AudioSampler::init(const SamplerParameters& params) {
   AVChannelLayout channel_in;
   av_channel_layout_default(&channel_out, params.out.audio.channels);
   av_channel_layout_default(&channel_in, params.in.audio.channels);
-  int ret = swr_alloc_set_opts2(
+  swr_alloc_set_opts2(
       &swrContext_,
       &channel_out,
       (AVSampleFormat)params.out.audio.format,


### PR DESCRIPTION
Summary: Silence a warning about an unused variable that comes up when certain ffmpeg versions are used

Differential Revision: D80843100


