### PR TITLE
Fixed Caltech-101 and Caltech-256 broken links with the official ones

### DIFF
--- a/torchvision/datasets/caltech.py
+++ b/torchvision/datasets/caltech.py
@@ -1,11 +1,12 @@
 import os
 import os.path
+import shutil
 from pathlib import Path
 from typing import Any, Callable, Optional, Union
-import shutil
+
 from PIL import Image
 
-from .utils import download_and_extract_archive, verify_str_arg,extract_archive
+from .utils import download_and_extract_archive, extract_archive, verify_str_arg
 from .vision import VisionDataset
 
 
@@ -144,8 +145,6 @@ class Caltech101(VisionDataset):
                 extract_archive(os.path.join(gzip_folder, gzip_file), self.root)
         shutil.rmtree(gzip_folder)
         os.remove(os.path.join(self.root, "caltech-101.zip"))
-       
-
 
     def extra_repr(self) -> str:
         return "Target type: {target_type}".format(**self.__dict__)


### PR DESCRIPTION
## Context 
With reference to PR #9192 

## Issue
The google drive links are broken and does not download

## How to use?
```python
import torchvision
import torchvision.transforms as transforms

transform = transforms.Compose([
    transforms.Resize((224, 224)), # Resize to a common size for pre-trained models
    transforms.ToTensor(),         # Convert image to a tensor
    transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]) # Normalize
])


caltech101_dataset = torchvision.datasets.Caltech101(
    root='./data',        # Directory to store the dataset
    download=True,      # Set to True to download if not already present
    transform=transform # Apply the defined transformations
)

caltech256_dataset = torchvision.datasets.Caltech256(
    root='./data',        # Directory to store the dataset
    download=True,      # Set to True to download if not already present
    transform=transform # Apply the defined transformations
)
```

## Fix
Replaced the deadlinks with the official CalTech Repository site downloads and made sure that the data downloading is fixed accordingly 
