### PR TITLE
Don't build video decoder homemade backend by default 

### DIFF
--- a/.github/scripts/setup-env.sh
+++ b/.github/scripts/setup-env.sh
@@ -29,7 +29,7 @@ conda create \
   python="${PYTHON_VERSION}" pip \
   ninja cmake \
   libpng \
-  libwebp \
+  libwebp
 conda activate ci
 conda install --quiet --yes libjpeg-turbo -c pytorch
 pip install --progress-bar=off --upgrade setuptools==72.1.0

--- a/.github/scripts/setup-env.sh
+++ b/.github/scripts/setup-env.sh
@@ -23,7 +23,6 @@ case $(uname) in
 esac
 
 echo '::group::Create build environment'
-# See https://github.com/pytorch/vision/issues/7296 for ffmpeg
 conda create \
   --name ci \
   --quiet --yes \
@@ -31,7 +30,6 @@ conda create \
   ninja cmake \
   libpng \
   libwebp \
-  'ffmpeg<4.3'
 conda activate ci
 conda install --quiet --yes libjpeg-turbo -c pytorch
 pip install --progress-bar=off --upgrade setuptools==72.1.0

--- a/packaging/pre_build_script.sh
+++ b/packaging/pre_build_script.sh
@@ -17,7 +17,6 @@ if [[ "$(uname)" == Darwin || "$OSTYPE" == "msys" ]]; then
   # Installing webp also installs a non-turbo jpeg, so we uninstall jpeg stuff
   # before re-installing them
   conda uninstall libjpeg-turbo libjpeg -y
-  conda install -y ffmpeg=4.2 -c pytorch
   conda install -y libjpeg-turbo -c pytorch
 
   # Copy binaries to be included in the wheel distribution
@@ -30,7 +29,7 @@ else
 
   if [[ "$ARCH" == "aarch64" ]]; then
     conda install libpng -y
-    conda install -y ffmpeg=4.2 libjpeg-turbo -c pytorch-nightly
+    conda install -y libjpeg-turbo -c pytorch-nightly
   fi
 
   conda install libwebp -y

--- a/setup.py
+++ b/setup.py
@@ -28,9 +28,9 @@ NVCC_FLAGS = os.getenv("NVCC_FLAGS", None)
 # video decoding backends in torchvision. I'm renaming this to "gpu video
 # decoder" where possible, keeping user facing names (like the env var below) to
 # the old scheme for BC.
-USE_GPU_VIDEO_DECODER = os.getenv("TORCHVISION_USE_VIDEO_CODEC", "1") == "1"
+USE_GPU_VIDEO_DECODER = os.getenv("TORCHVISION_USE_VIDEO_CODEC", "0") == "1"
 # Same here: "use ffmpeg" was used to denote "use cpu video decoder".
-USE_CPU_VIDEO_DECODER = os.getenv("TORCHVISION_USE_FFMPEG", "1") == "1"
+USE_CPU_VIDEO_DECODER = os.getenv("TORCHVISION_USE_FFMPEG", "0") == "1"
 
 TORCHVISION_INCLUDE = os.environ.get("TORCHVISION_INCLUDE", "")
 TORCHVISION_LIBRARY = os.environ.get("TORCHVISION_LIBRARY", "")


### PR DESCRIPTION
This PR avoids building the C++ video decoder by default and remove the installation of `ffmpeg` when we build a wheel.
As a result, the "homemade C++" backend of torchvision is removed from official releases. Some of the video decoding interface is still available, but only through an optional dependency on `pyav`. Eventually we'll want to remove everything, but this PR is an intermediate step that:

- removes the FFmpeg dependency, which was a major pain point
- doesn't touch anything on fbcode (which is important, because changes to fbcode are tricky to address).