### PR TITLE
torchvision.datasets.voc: update dataset and project site URLs

### DIFF
--- a/torchvision/datasets/voc.py
+++ b/torchvision/datasets/voc.py
@@ -16,43 +16,43 @@ from .vision import VisionDataset
 
 DATASET_YEAR_DICT = {
     "2012": {
-        "url": "http://host.robots.ox.ac.uk/pascal/VOC/voc2012/VOCtrainval_11-May-2012.tar",
+        "url": "https://thor.robots.ox.ac.uk/pascal/VOC/voc2012/VOCtrainval_11-May-2012.tar",
         "filename": "VOCtrainval_11-May-2012.tar",
         "md5": "6cd6e144f989b92b3379bac3b3de84fd",
         "base_dir": os.path.join("VOCdevkit", "VOC2012"),
     },
     "2011": {
-        "url": "http://host.robots.ox.ac.uk/pascal/VOC/voc2011/VOCtrainval_25-May-2011.tar",
+        "url": "https://thor.robots.ox.ac.uk/pascal/VOC/voc2011/VOCtrainval_25-May-2011.tar",
         "filename": "VOCtrainval_25-May-2011.tar",
         "md5": "6c3384ef61512963050cb5d687e5bf1e",
         "base_dir": os.path.join("TrainVal", "VOCdevkit", "VOC2011"),
     },
     "2010": {
-        "url": "http://host.robots.ox.ac.uk/pascal/VOC/voc2010/VOCtrainval_03-May-2010.tar",
+        "url": "https://thor.robots.ox.ac.uk/pascal/VOC/voc2010/VOCtrainval_03-May-2010.tar",
         "filename": "VOCtrainval_03-May-2010.tar",
         "md5": "da459979d0c395079b5c75ee67908abb",
         "base_dir": os.path.join("VOCdevkit", "VOC2010"),
     },
     "2009": {
-        "url": "http://host.robots.ox.ac.uk/pascal/VOC/voc2009/VOCtrainval_11-May-2009.tar",
+        "url": "https://thor.robots.ox.ac.uk/pascal/VOC/voc2009/VOCtrainval_11-May-2009.tar",
         "filename": "VOCtrainval_11-May-2009.tar",
         "md5": "a3e00b113cfcfebf17e343f59da3caa1",
         "base_dir": os.path.join("VOCdevkit", "VOC2009"),
     },
     "2008": {
-        "url": "http://host.robots.ox.ac.uk/pascal/VOC/voc2008/VOCtrainval_14-Jul-2008.tar",
+        "url": "https://thor.robots.ox.ac.uk/pascal/VOC/voc2008/VOCtrainval_14-Jul-2008.tar",
         "filename": "VOCtrainval_11-May-2012.tar",
         "md5": "2629fa636546599198acfcfbfcf1904a",
         "base_dir": os.path.join("VOCdevkit", "VOC2008"),
     },
     "2007": {
-        "url": "http://host.robots.ox.ac.uk/pascal/VOC/voc2007/VOCtrainval_06-Nov-2007.tar",
+        "url": "https://thor.robots.ox.ac.uk/pascal/VOC/voc2007/VOCtrainval_06-Nov-2007.tar",
         "filename": "VOCtrainval_06-Nov-2007.tar",
         "md5": "c52e279531787c972589f7e41ab4ae64",
         "base_dir": os.path.join("VOCdevkit", "VOC2007"),
     },
     "2007-test": {
-        "url": "http://host.robots.ox.ac.uk/pascal/VOC/voc2007/VOCtest_06-Nov-2007.tar",
+        "url": "https://thor.robots.ox.ac.uk/pascal/VOC/voc2007/VOCtest_06-Nov-2007.tar",
         "filename": "VOCtest_06-Nov-2007.tar",
         "md5": "b6e924de25625d8de591ea690078ad9f",
         "base_dir": os.path.join("VOCdevkit", "VOC2007"),
@@ -118,7 +118,7 @@ class _VOCBase(VisionDataset):
 
 
 class VOCSegmentation(_VOCBase):
-    """`Pascal VOC <http://host.robots.ox.ac.uk/pascal/VOC/>`_ Segmentation Dataset.
+    """`Pascal VOC <https://www.robots.ox.ac.uk/~vgg/projects/pascal/VOC/>`_ Segmentation Dataset.
 
     Args:
         root (str or ``pathlib.Path``): Root directory of the VOC Dataset.
@@ -162,7 +162,7 @@ class VOCSegmentation(_VOCBase):
 
 
 class VOCDetection(_VOCBase):
-    """`Pascal VOC <http://host.robots.ox.ac.uk/pascal/VOC/>`_ Detection Dataset.
+    """`Pascal VOC <https://www.robots.ox.ac.uk/~vgg/projects/pascal/VOC/>`_ Detection Dataset.
 
     Args:
         root (str or ``pathlib.Path``): Root directory of the VOC Dataset.

--- a/torchvision/prototype/datasets/_builtin/voc.py
+++ b/torchvision/prototype/datasets/_builtin/voc.py
@@ -32,7 +32,7 @@ def _info() -> dict[str, Any]:
 @register_dataset(NAME)
 class VOC(Dataset):
     """
-    - **homepage**: http://host.robots.ox.ac.uk/pascal/VOC/
+    - **homepage**: https://www.robots.ox.ac.uk/~vgg/projects/pascal/VOC/
     """
 
     def __init__(
@@ -72,7 +72,7 @@ class VOC(Dataset):
 
     def _resources(self) -> list[OnlineResource]:
         file_name, sha256 = (self._TEST_ARCHIVES if self._split == "test" else self._TRAIN_VAL_ARCHIVES)[self._year]
-        archive = HttpResource(f"http://host.robots.ox.ac.uk/pascal/VOC/voc{self._year}/{file_name}", sha256=sha256)
+        archive = HttpResource(f"https://thor.robots.ox.ac.uk/pascal/VOC/voc{self._year}/{file_name}", sha256=sha256)
         return [archive]
 
     def _is_in_folder(self, data: tuple[str, Any], *, name: str, depth: int = 1) -> bool:


### PR DESCRIPTION
The location for the PASCAL VOC datasets 2005-2012 has changed as well as the location of the project website. This PR updates the URLs for the new locations. The previous system `host.robots.ox.ac.uk` is no longer online.