### PR TITLE
Disable Windows CMake build jobs

### DIFF
--- a/.github/workflows/build-cmake.yml
+++ b/.github/workflows/build-cmake.yml
@@ -58,30 +58,30 @@ jobs:
 
         ${CONDA_RUN} ./.github/scripts/cmake.sh
 
-  windows:
-    strategy:
-      matrix:
-        include:
-          - runner: windows.4xlarge
-            gpu-arch-type: cpu
-          - runner: windows.g5.4xlarge.nvidia.gpu
-            gpu-arch-type: cuda
-            gpu-arch-version: "12.6"
-      fail-fast: false
-    uses: pytorch/test-infra/.github/workflows/windows_job.yml@main
-    with:
-      repository: pytorch/vision
-      runner: ${{ matrix.runner }}
-      gpu-arch-type: ${{ matrix.gpu-arch-type }}
-      gpu-arch-version: ${{ matrix.gpu-arch-version }}
-      test-infra-ref: main
-      script: |
-        set -euo pipefail
+  # windows:
+  #   strategy:
+  #     matrix:
+  #       include:
+  #         - runner: windows.4xlarge
+  #           gpu-arch-type: cpu
+  #         - runner: windows.g5.4xlarge.nvidia.gpu
+  #           gpu-arch-type: cuda
+  #           gpu-arch-version: "12.6"
+  #     fail-fast: false
+  #   uses: pytorch/test-infra/.github/workflows/windows_job.yml@main
+  #   with:
+  #     repository: pytorch/vision
+  #     runner: ${{ matrix.runner }}
+  #     gpu-arch-type: ${{ matrix.gpu-arch-type }}
+  #     gpu-arch-version: ${{ matrix.gpu-arch-version }}
+  #     test-infra-ref: main
+  #     script: |
+  #       set -euo pipefail
 
-        export PYTHON_VERSION=3.9
-        export VC_YEAR=2022
-        export VSDEVCMD_ARGS=""
-        export GPU_ARCH_TYPE=${{ matrix.gpu-arch-type }}
-        export GPU_ARCH_VERSION=${{ matrix.gpu-arch-version }}
+  #       export PYTHON_VERSION=3.9
+  #       export VC_YEAR=2022
+  #       export VSDEVCMD_ARGS=""
+  #       export GPU_ARCH_TYPE=${{ matrix.gpu-arch-type }}
+  #       export GPU_ARCH_VERSION=${{ matrix.gpu-arch-version }}
 
-        ./.github/scripts/cmake.sh
+  #       ./.github/scripts/cmake.sh


### PR DESCRIPTION
This PR is disabling windows CMake build jobs for Maxwell architecture running against CUDA 13.0 as this version is not supported on this platform and thus are causing [errors](https://github.com/pytorch/vision/actions/runs/17975405815/job/51127610134).