### PR TITLE
[Torchvision] Fix FFmpeg 7.1+ support

### DIFF
--- a/torchvision/csrc/io/decoder/decoder.cpp
+++ b/torchvision/csrc/io/decoder/decoder.cpp
@@ -154,7 +154,8 @@ int Decoder::readFunction(void* opaque, uint8_t* buf, int size) {
   if (decoder == nullptr) {
     return 0;
   }
-  return decoder->readCallback(buf, size);
+  int bytesRead = decoder->readCallback(buf, size);
+  return bytesRead == 0 ? AVERROR_EOF : bytesRead;
 }
 
 /* static */


### PR DESCRIPTION
Summary:
* Fix `SwrContext` variable shadowing leading to null pointer dereference
* Fix EOF signaling for AVIO read callbacks

Differential Revision: D82494990


