### PR TITLE
Add `SanitizeKeyPoints` transform to remove keypoints outside of the image area

### DIFF
--- a/docs/source/transforms.rst
+++ b/docs/source/transforms.rst
@@ -413,6 +413,7 @@ Miscellaneous
     v2.RandomErasing
     v2.Lambda
     v2.SanitizeBoundingBoxes
+    v2.SanitizeKeyPoints
     v2.ClampBoundingBoxes
     v2.ClampKeyPoints
     v2.UniformTemporalSubsample
@@ -427,6 +428,7 @@ Functionals
     v2.functional.normalize
     v2.functional.erase
     v2.functional.sanitize_bounding_boxes
+    v2.functional.sanitize_keypoints
     v2.functional.clamp_bounding_boxes
     v2.functional.clamp_keypoints
     v2.functional.uniform_temporal_subsample
@@ -530,6 +532,7 @@ Developer tools
     v2.query_size
     v2.query_chw
     v2.get_bounding_boxes
+    v2.get_keypoints
 
 
 V1 API Reference

--- a/test/test_transforms_v2.py
+++ b/test/test_transforms_v2.py
@@ -7740,22 +7740,21 @@ class TestSanitizeKeyPoints:
         # Test missing labels key
         with pytest.raises(ValueError, match="Could not infer where the labels are"):
             bad_sample = {"keypoints": good_keypoints, "BAD_KEY": torch.tensor([0])}
-            transforms.SanitizeKeyPoints()(bad_sample)
+            transforms.SanitizeKeyPoints(labels_getter="default")(bad_sample)
 
         # Test labels not a tensor
         with pytest.raises(ValueError, match="must be a tensor"):
             bad_sample = {"keypoints": good_keypoints, "labels": [0]}
-            transforms.SanitizeKeyPoints()(bad_sample)
+            transforms.SanitizeKeyPoints(labels_getter="default")(bad_sample)
 
         # Test mismatched sizes
         with pytest.raises(ValueError, match="Number of"):
             bad_sample = {"keypoints": good_keypoints, "labels": torch.tensor([0, 1, 2])}
-            transforms.SanitizeKeyPoints()(bad_sample)
+            transforms.SanitizeKeyPoints(labels_getter="default")(bad_sample)
 
         # Test min_invalid_points > 1 for 2D keypoints
         with pytest.raises(ValueError, match="so min_invalid_points must be 1"):
-            sample = {"keypoints": good_keypoints, "labels": torch.tensor([0])}
-            transforms.SanitizeKeyPoints(min_invalid_points=2)(sample)
+            transforms.SanitizeKeyPoints(min_invalid_points=2)(good_keypoints)
 
     def test_no_label(self):
         """Test transform without labels."""
@@ -7764,7 +7763,7 @@ class TestSanitizeKeyPoints:
 
         # Should raise error without labels_getter=None
         with pytest.raises(ValueError, match="or a two-tuple whose second item is a dict"):
-            transforms.SanitizeKeyPoints()(img, keypoints)
+            transforms.SanitizeKeyPoints(labels_getter="default")(img, keypoints)
 
         # Should work with labels_getter=None
         out_img, out_keypoints = transforms.SanitizeKeyPoints(labels_getter=None)(img, keypoints)

--- a/torchvision/transforms/v2/__init__.py
+++ b/torchvision/transforms/v2/__init__.py
@@ -51,10 +51,11 @@ from ._misc import (
     LinearTransformation,
     Normalize,
     SanitizeBoundingBoxes,
+    SanitizeKeyPoints,
     ToDtype,
 )
 from ._temporal import UniformTemporalSubsample
 from ._type_conversion import PILToTensor, ToImage, ToPILImage, ToPureTensor
-from ._utils import check_type, get_bounding_boxes, has_all, has_any, query_chw, query_size
+from ._utils import check_type, get_bounding_boxes, get_keypoints, has_all, has_any, query_chw, query_size
 
 from ._deprecated import ToTensor  # usort: skip

--- a/torchvision/transforms/v2/_misc.py
+++ b/torchvision/transforms/v2/_misc.py
@@ -496,7 +496,7 @@ class SanitizeKeyPoints(Transform):
         min_invalid_points (int or float, optional): Minimum number or fraction of invalid keypoints required
             for a group of keypoints to be removed. For example, setting this to 1 will remove a group of keypoints
             if any of its keypoints is invalid, while setting it to 2 will only remove groups with at least 2 invalid keypoints.
-            If a float in (0.0, 1.0) is passed, it represents a fraction of the total number of keypoints in
+            If a float in ``(0.0, 1.0]`` is passed, it represents a fraction of the total number of keypoints in
             the group. For example, setting this to 0.3 will remove groups of keypoints with at least 30% invalid keypoints.
             Note that a value of `1` (integer) is very different from `1.0` (float). The former will remove groups
             with any invalid keypoint, while the latter will only remove groups where all keypoints are invalid.

--- a/torchvision/transforms/v2/_misc.py
+++ b/torchvision/transforms/v2/_misc.py
@@ -503,7 +503,7 @@ class SanitizeKeyPoints(Transform):
             Default is 1.
         labels_getter (callable or str or None, optional): indicates how to identify the labels in the input
             (or anything else that needs to be sanitized along with the keypoints).
-            By default, this will try to find a "labels" key in the input (case-insensitive), if
+            If set to the string ``"default"``, this will try to find a "labels" key in the input (case-insensitive), if
             the input is a dict or it is a tuple whose second element is a dict.
 
             It can also be a callable that takes the same input as the transform, and returns either:
@@ -511,14 +511,14 @@ class SanitizeKeyPoints(Transform):
             - A single tensor (the labels)
             - A tuple/list of tensors, each of which will be subject to the same sanitization as the keypoints.
 
-            If ``labels_getter`` is None then only keypoints are sanitized.
+            If ``labels_getter`` is None (the default), then only keypoints are sanitized.
     """
 
     def __init__(
         self,
         min_valid_edge_distance: int = 0,
         min_invalid_points: int | float = 1,
-        labels_getter: Union[Callable[[Any], Any], str, None] = "default",
+        labels_getter: Union[Callable[[Any], Any], str, None] = None,
     ) -> None:
         super().__init__()
         self.min_valid_edge_distance = min_valid_edge_distance

--- a/torchvision/transforms/v2/_utils.py
+++ b/torchvision/transforms/v2/_utils.py
@@ -165,6 +165,18 @@ def get_bounding_boxes(flat_inputs: list[Any]) -> tv_tensors.BoundingBoxes:
         raise ValueError("No bounding boxes were found in the sample")
 
 
+def get_keypoints(flat_inputs: list[Any]) -> tv_tensors.KeyPoints:
+    """Return the keypoints in the input.
+
+    Assumes only one ``KeyPoints`` object is present.
+    """
+    # This assumes there is only one keypoint per sample as per the general convention
+    try:
+        return next(inpt for inpt in flat_inputs if isinstance(inpt, tv_tensors.KeyPoints))
+    except StopIteration:
+        raise ValueError("No keypoints were found in the sample")
+
+
 def query_chw(flat_inputs: list[Any]) -> tuple[int, int, int]:
     """Return Channel, Height, and Width."""
     chws = {

--- a/torchvision/transforms/v2/functional/__init__.py
+++ b/torchvision/transforms/v2/functional/__init__.py
@@ -156,6 +156,7 @@ from ._misc import (
     normalize_image,
     normalize_video,
     sanitize_bounding_boxes,
+    sanitize_keypoints,
     to_dtype,
     to_dtype_image,
     to_dtype_video,

--- a/torchvision/transforms/v2/functional/_misc.py
+++ b/torchvision/transforms/v2/functional/_misc.py
@@ -480,7 +480,7 @@ def sanitize_keypoints(
         min_invalid_points (int or float, optional): Minimum number or fraction of invalid keypoints required
             for a group of keypoints to be removed. For example, setting this to 1 will remove a group of keypoints
             if any of its keypoints is invalid, while setting it to 2 will only remove groups with at least 2 invalid keypoints.
-            If a float in (0.0, 1.0) is passed, it represents a fraction of the total number of keypoints in
+            If a float in ``(0.0, 1.0]`` is passed, it represents a fraction of the total number of keypoints in
             the group. For example, setting this to 0.3 will remove groups of keypoints with at least 30% invalid keypoints.
             Note that a value of `1` (integer) is very different from `1.0` (float). The former will remove groups
             with any invalid keypoint, while the latter will only remove groups where all keypoints are invalid.

--- a/torchvision/transforms/v2/functional/_misc.py
+++ b/torchvision/transforms/v2/functional/_misc.py
@@ -442,3 +442,128 @@ def _get_sanitize_bounding_boxes_mask(
         valid &= (bounding_boxes[..., 4] <= image_w) & (bounding_boxes[..., 5] <= image_h)
         valid &= (bounding_boxes[..., 6] <= image_w) & (bounding_boxes[..., 7] <= image_h)
     return valid
+
+
+def sanitize_keypoints(
+    key_points: torch.Tensor,
+    canvas_size: Optional[tuple[int, int]] = None,
+    min_valid_edge_distance: int = 0,
+    min_invalid_points: int | float = 1,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Remove keypoints outside of the image area and their corresponding labels (if any).
+
+    This transform removes keypoints or groups of keypoints and their associated labels that
+    have coordinates outside of their corresponding image or within ``min_valid_edge_distance`` pixels
+    from the image edges.
+    If you would instead like to clamp such keypoints to the image edges, use
+    :class:`~torchvision.transforms.v2.ClampKeyPoints`.
+
+    It is recommended to call it at the end of a pipeline, before passing the
+    input to the models.
+
+    Keypoints can be passed as a set of individual keypoints of shape ``[N_points, 2]`` or as a
+    set of objects (e.g., polygons or polygonal chains) consisting of a fixed number of keypoints
+    of shape ``[N_objects, ..., 2]``.
+    When groups of keypoints are passed (i.e., an at least 3-dimensional tensor), this transform
+    will only remove entire groups, not individual keypoints within a group.
+
+    Args:
+        key_points (Tensor or :class:`~torchvision.tv_tensors.KeyPoints`): The keypoints to be sanitized.
+        canvas_size (tuple of int, optional): The canvas_size of the keypoints
+            (size of the corresponding image/video).
+            Must be left to none if ``key_points`` is a :class:`~torchvision.tv_tensors.KeyPoints` object.
+        min_valid_edge_distance (int, optional): The minimum distance that keypoints need to be away from the closest image
+            edge along any axis in order to be considered valid. For example, setting this to 0 will only
+            invalidate/remove keypoints outside of the image area, while a value of 1 will also remove keypoints
+            lying exactly on the edge.
+            Default is 0.
+        min_invalid_points (int or float, optional): Minimum number or fraction of invalid keypoints required
+            for a group of keypoints to be removed. For example, setting this to 1 will remove a group of keypoints
+            if any of its keypoints is invalid, while setting it to 2 will only remove groups with at least 2 invalid keypoints.
+            If a float in (0.0, 1.0) is passed, it represents a fraction of the total number of keypoints in
+            the group. For example, setting this to 0.3 will remove groups of keypoints with at least 30% invalid keypoints.
+            Note that a value of `1` (integer) is very different from `1.0` (float). The former will remove groups
+            with any invalid keypoint, while the latter will only remove groups where all keypoints are invalid.
+            Default is 1.
+
+    Returns:
+        out (tuple of Tensors): The subset of valid keypoints, and the corresponding indexing mask.
+        The mask can then be used to subset other tensors (e.g. labels) that are associated with the keypoints.
+    """
+    if torch.jit.is_scripting() or is_pure_tensor(key_points):
+        if canvas_size is None:
+            raise ValueError(
+                "canvas_size cannot be None if key_points is a pure tensor. "
+                "Set it to an appropriate value or pass key_points as a tv_tensors.KeyPoints object."
+            )
+        valid = _get_sanitize_keypoints_mask(
+            key_points,
+            canvas_size=canvas_size,
+            min_valid_edge_distance=min_valid_edge_distance,
+            min_invalid_points=min_invalid_points,
+        )
+        key_points = key_points[valid]
+    else:
+        if not isinstance(key_points, tv_tensors.KeyPoints):
+            raise ValueError("key_points must be a tv_tensors.KeyPoints instance or a pure tensor.")
+        if canvas_size is not None:
+            raise ValueError(
+                "canvas_size must be None when key_points is a tv_tensors.KeyPoints instance. "
+                f"Got canvas_size={canvas_size}. "
+                "Leave it to None or pass key_points as a pure tensor."
+            )
+        valid = _get_sanitize_keypoints_mask(
+            key_points,
+            canvas_size=key_points.canvas_size,
+            min_valid_edge_distance=min_valid_edge_distance,
+            min_invalid_points=min_invalid_points,
+        )
+        key_points = tv_tensors.wrap(key_points[valid], like=key_points)
+
+    return key_points, valid
+
+
+def _get_sanitize_keypoints_mask(
+    key_points: torch.Tensor,
+    canvas_size: tuple[int, int],
+    min_valid_edge_distance: int = 0,
+    min_invalid_points: int | float = 1,
+) -> torch.Tensor:
+
+    image_h, image_w = canvas_size
+
+    # Bring keypoints tensor into canonical shape [N_instances, N_points, 2]
+    if key_points.ndim == 2:
+        key_points = key_points.unsqueeze(dim=1)
+    elif key_points.ndim > 3:
+        key_points = key_points.flatten(start_dim=1, end_dim=-2)
+
+    # Convert min_invalid_points from relative to absolute number of points
+    if min_invalid_points <= 0:
+        raise ValueError(f"min_invalid_points must be > 0. Got {min_invalid_points}.")
+    if isinstance(min_invalid_points, float):
+        min_invalid_points = math.ceil(min_invalid_points * key_points.shape[1])
+    if min_invalid_points > 1 and key_points.shape[1] == 1:
+        raise ValueError(
+            f"min_invalid_points was set to {min_invalid_points}, but key_points only contains a single point per "
+            "instance, so min_invalid_points must be 1."
+        )
+
+    # Compute distance of each point to the closest image edge
+    dists = torch.stack(
+        [
+            key_points[..., 0],  # x
+            image_w - 1 - key_points[..., 0],  # image_w - x
+            key_points[..., 1],  # y
+            image_h - 1 - key_points[..., 1],  # image_h - y
+        ],
+        dim=-1,
+    )
+    dists = dists.min(dim=-1).values  # [N_instances, N_points]
+
+    # Determine invalid points
+    invalid_points = dists < min_valid_edge_distance  # [N_instances, N_points]
+
+    # Determine valid instances
+    valid = invalid_points.sum(dim=-1) < min_invalid_points  # [N_instances]
+    return valid


### PR DESCRIPTION
# Context

This PR proposes to add a `SanitizeKeyPoints` transform, similar to the existing `SanitizeBoundingBoxes` (#7246). This transform removes keypoints lying outside of the valid image area, which can happen after geometric transformations with the new default `clamping_mode` proposed in #9234, which allows for disabling automatic clamping of keypoints.

This implementation follows the proposal in issue #9223 as a solution for the issue that the previous default clamping of keypoints to the image edges modifies their position and creates a misalignment with the actual locations in the transformed image.

This PR hence only makes sense in combination with new clamping modes such as the one proposed in #9234.

# Implementation details

To understand the behavior of the proposed `SanitizeKeyPoints` transform, we need to distinguish two cases of keypoint formats:

- `tv_tensors.KeyPoints` contains a set of keypoints of shape `[N_points, 2]` or `[N_points, 1, 2]`. In this case, the transform will remove all keypoints lying outside of the valid image region.
- `tv_tensors.KeyPoints` contains groups of keypoints, i.e., several objects, each consisting of a certain number of keypoints (e.g., polygons, polygonal chains, skeletons etc.). It is a tensor of shape `[N_objects, N_points, 2]` or, in general, `[N_objects, ..., 2]`. In this case, the transform will remove all *objects* (first dimension) that have at least a certain number of keypoints lying outside of the valid image region.

The behavior of the transform can be controlled with the following arguments:

- `min_valid_edge_distance` (int): The minimum distance that keypoints need to be away from the closest image edge along any axis in order to be considered valid. For example, setting this to 0 will only invalidate/remove keypoints outside of the image area, while a value of 1 will also remove keypoints lying exactly on the edge. Default is 0.
- `min_invalid_points` (int or float): Minimum number or fraction of invalid keypoints required for a group of keypoints to be removed. For example, setting this to 1 will remove a group of keypoints if any of its keypoints is invalid, while setting it to 2 will only remove groups with at least 2 invalid keypoints. If a float in `(0.0, 1.0]` is passed, it represents a fraction of the total number of keypoints in the group. For example, setting this to 0.3 will remove groups of keypoints with at least 30% invalid keypoints. Note that a value of `1` (integer) is very different from `1.0` (float). The former will remove groups with any invalid keypoint, while the latter will only remove groups where all keypoints are invalid. Default is 1 (int).

In addition, the transform can also remove labels associated with the keypoints (or elements from any other tensors with the same first dimension as the keypoints). This can be achieved by setting the `labels_getter` argument, which follows the same logic as the homonymous argument of `SanitizeBoundingBoxes`. The only difference is, that the default for `SanitizeKeyPoints` is `None`, in order to avoid accidental conflicts with any additionally present bounding box labels.

# Illustration of the changes

The following example additionally requires PR #9234.

```python
orig_pts = KeyPoints(
    [
        [[445, 700]],  # nose
        [[320, 660]],
        [[370, 660]],
        [[420, 660]],  # left eye
        [[300, 620]],
        [[420, 620]],  # left eyebrow
        [[475, 665]],
        [[515, 665]],
        [[555, 655]],  # right eye
        [[460, 625]],
        [[560, 600]],  # right eyebrow
        [[370, 780]],
        [[450, 760]],
        [[540, 780]],
        [[450, 820]],  # mouth
    ],
    canvas_size=(orig_img.size[1], orig_img.size[0]),
    clamping_mode="soft",
)
cropper = v2.RandomCrop(size=(256, 256))
crops = [cropper((orig_img, orig_pts)) for _ in range(4)]
plot([(orig_img, orig_pts)] + crops)
```

<img width="990" height="262" alt="sanitize-keypoints-example" src="https://github.com/user-attachments/assets/4531a808-d591-489b-a2a9-574eea6e63fd" />

Unsanitized keypoint coordinates:

```python
for _, pts in crops:
    print(pts)
```

```
KeyPoints([[[   1, -109]],
           [[-124, -149]],
           [[ -74, -149]],
           [[ -24, -149]],
           [[-144, -189]],
           [[ -24, -189]],
           [[  31, -144]],
           [[  71, -144]],
           [[ 111, -154]],
           [[  16, -184]],
           [[ 116, -209]],
           [[ -74,  -29]],
           [[   6,  -49]],
           [[  96,  -29]],
           [[   6,   11]]], canvas_size=(256, 256), clamping_mode=soft)
KeyPoints([[[ -65, -238]],
           [[-190, -278]],
           [[-140, -278]],
           [[ -90, -278]],
           [[-210, -318]],
           [[ -90, -318]],
           [[ -35, -273]],
           [[   5, -273]],
           [[  45, -283]],
           [[ -50, -313]],
           [[  50, -338]],
           [[-140, -158]],
           [[ -60, -178]],
           [[  30, -158]],
           [[ -60, -118]]], canvas_size=(256, 256), clamping_mode=soft)
KeyPoints([[[301,  27]],
           [[176, -13]],
           [[226, -13]],
           [[276, -13]],
           [[156, -53]],
           [[276, -53]],
           [[331,  -8]],
           [[371,  -8]],
           [[411, -18]],
           [[316, -48]],
           [[416, -73]],
           [[226, 107]],
           [[306,  87]],
           [[396, 107]],
           [[306, 147]]], canvas_size=(256, 256), clamping_mode=soft)
KeyPoints([[[ 372,  -27]],
           [[ 247,  -67]],
           [[ 297,  -67]],
           [[ 347,  -67]],
           [[ 227, -107]],
           [[ 347, -107]],
           [[ 402,  -62]],
           [[ 442,  -62]],
           [[ 482,  -72]],
           [[ 387, -102]],
           [[ 487, -127]],
           [[ 297,   53]],
           [[ 377,   33]],
           [[ 467,   53]],
           [[ 377,   93]]], canvas_size=(256, 256), clamping_mode=soft)
```

Sanitization:

```python
sanitizer = v2.SanitizeKeyPoints()
sanitized_pts = [sanitizer(pts) for _, pts in crops]

for pts in sanitized_pts:
    print(pts)
```

```
KeyPoints([[[ 6, 11]]], canvas_size=(256, 256), clamping_mode=soft)
KeyPoints([], size=(0, 1, 2), dtype=torch.int64, canvas_size=(256, 256), clamping_mode=soft)
KeyPoints([[[226, 107]]], canvas_size=(256, 256), clamping_mode=soft)
KeyPoints([], size=(0, 1, 2), dtype=torch.int64, canvas_size=(256, 256), clamping_mode=soft)
```

# Testing

Please run the following unit tests:

```
pytest test/test_transforms_v2.py -vvv -k "SanitizeKeyPoints"
...
219 passed, 9718 deselected, 8 xfailed in 1.27s
```