### PR TITLE
Updating decode_gif to default to DISPOSE_DO_NOT to fix animated gif loading

### DIFF
--- a/torchvision/csrc/io/image/cpu/decode_gif.cpp
+++ b/torchvision/csrc/io/image/cpu/decode_gif.cpp
@@ -128,9 +128,10 @@ torch::Tensor decode_gif(const torch::Tensor& encoded_data) {
     // (https://giflib.sourceforge.net/whatsinagif/animation_and_transparency.html).
     // This is consistent with default behaviour in the majority of web browsers
     // and image libraries like Pillow.
-    if (i > 0 && (gcb.DisposalMode == DISPOSAL_UNSPECIFIED || 
-                  gcb.DisposalMode == DISPOSE_DO_NOT       ||
-                  gcb.DisposalMode == DISPOSE_PREVIOUS)) {
+    if (i > 0 &&
+        (gcb.DisposalMode == DISPOSAL_UNSPECIFIED ||
+         gcb.DisposalMode == DISPOSE_DO_NOT ||
+         gcb.DisposalMode == DISPOSE_PREVIOUS)) {
       out[i] = out[i - 1];
     } else {
       // Background. If bg wasn't defined, it will be (0, 0, 0)


### PR DESCRIPTION
There are errors loading animated gifs where the frame disposal method is set to DISPOSAL_UNSPECIFIED #9009 

This is because when an animated gif has disposal mode `DISPOSAL_UNSPECIFIED`, `decode_gif` is defaulting to "background" drawing mode. It needs to be `DISPOSE_DO_NOT` instead where changes are overwritten onto the previous canvas. This is the default behaviour of web browsers and libraries like [Pillow - GifImagePlugin.py](https://github.com/python-pillow/Pillow/blob/6b4bb79b44b3bde6a25a33b6733358d409930854/src/PIL/GifImagePlugin.py#L366).

After this the example gif subsequent frames display correctly

``` python
import cv2
import torchvision

gif = torchvision.io.read_image('jake.gif').numpy().transpose(0, 2, 3, 1)
image = cv2.cvtColor(gif[5], cv2.COLOR_RGB2BGR)
cv2.imshow(f'Frame 5', image)
cv2.waitKey()
```

<img width="814" height="696" alt="image" src="https://github.com/user-attachments/assets/46d6bf50-be9e-46a8-90e5-204df9d7dcff" />



