### PR TITLE
Relax tolerance for TestAffine::test_kernel_bounding_boxes

### DIFF
--- a/test/test_transforms_v2.py
+++ b/test/test_transforms_v2.py
@@ -1439,6 +1439,7 @@ class TestAffine:
             canvas_size=bounding_boxes.canvas_size,
             **{param: value},
             check_scripted_vs_eager=not (param == "shear" and isinstance(value, (int, float))),
+            check_cuda_vs_cpu=dict(atol=1e-5, rtol=1e-5),
         )
 
     @param_value_parametrization(


### PR DESCRIPTION
Summary: The following test "TestAffine::test_kernel_bounding_boxes" produce approximation errors between GPU and CPU and could fail for some random values. We are relaxing the tolerance with values inline with what is set for other tests (e.g. `test_transform_bounding_boxes_correctness`) to ensure the test is not flaky.

Differential Revision: D85890420


