### PR TITLE
gh-8952: Added `zero or` to `chain_depth` explanation of AugMix in _auto_augment.py

### DIFF
--- a/torchvision/transforms/v2/_auto_augment.py
+++ b/torchvision/transforms/v2/_auto_augment.py
@@ -517,7 +517,7 @@ class AugMix(_AutoAugmentBase):
     Args:
         severity (int, optional): The severity of base augmentation operators. Default is ``3``.
         mixture_width (int, optional): The number of augmentation chains. Default is ``3``.
-        chain_depth (int, optional): The depth of augmentation chains. A negative value denotes stochastic depth sampled from the interval [1, 3].
+        chain_depth (int, optional): The depth of augmentation chains. A zero or negative value denotes stochastic depth sampled from the interval [1, 3].
             Default is ``-1``.
         alpha (float, optional): The hyperparameter for the probability distributions. Default is ``1.0``.
         all_ops (bool, optional): Use all operations (including brightness, contrast, color and sharpness). Default is ``True``.


### PR DESCRIPTION
I added `zero or` to `chain_depth` to solve [the doc issue](https://github.com/pytorch/vision/issues/8952).

Because according to [the source code](https://pytorch.org/vision/main/_modules/torchvision/transforms/v2/_auto_augment.html#AugMix) which is `self.chain_depth > 0` , it also includes `0` just not a negative value:

```python
depth = self.chain_depth if self.chain_depth > 0 else int(torch.randint(low=1, high=4, size=(1,)).item())
```