### PR TITLE
Fix: Expand tilde (~) in home directory paths for GTSRB dataset

### DIFF
--- a/torchvision/datasets/gtsrb.py
+++ b/torchvision/datasets/gtsrb.py
@@ -35,7 +35,7 @@ class GTSRB(VisionDataset):
         super().__init__(root, transform=transform, target_transform=target_transform)
 
         self._split = verify_str_arg(split, "split", ("train", "test"))
-        self._base_folder = pathlib.Path(root) / "gtsrb"
+        self._base_folder = pathlib.Path(self.root) / "gtsrb"
         self._target_folder = (
             self._base_folder / "GTSRB" / ("Training" if self._split == "train" else "Final_Test/Images")
         )


### PR DESCRIPTION
## Description

This PR fixes an issue where the GTSRB dataset fails to recognize existing data when the root path contains a tilde (`~`) for the home directory.

## Problem

Within `torchvision/datasets/gtsrb.py`, due to the root path not being correctly inherited from the VisionDataset class, `pathlib.Path` failed to automatically expand a path containing a tilde (e.g., `~/data`) into its corresponding absolute home directory path (e.g., `/home/username/data`). Consequently, the `_check_exists()` method would incorrectly return `False` even when the dataset was already present, leading to superfluous downloads or runtime errors.

This issue was not observed in other classes, such as OxfordIIITPet, which correctly inherit and utilize the root path from the VisionDataset class.

## Changes

- Rewrite to `self.root` to ensure proper inheritance from the `VisonDataset` class.
- This ensures that paths like `~/data/gtsrb` are correctly resolved to absolute paths