### PR TITLE
Restore the workflow to update vision repo viable/strict

### DIFF
--- a/.github/workflows/update-viablestrict.yml
+++ b/.github/workflows/update-viablestrict.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           repository: pytorch/vision
           stable-branch: viable/strict
-          requires: '[\"Build Linux Wheels\", \"Build M1 Wheels\", \"Tests\", \"CMake\", \"Lint\", \"Docs\"]'
+          requires: '[\"Build Linux Wheels\", \"Build M1 Wheels\", \"Tests\"]'
           secret-bot-token: ${{ secrets.UPDATEBOT_TOKEN }}
           clickhouse-url: ${{ secrets.CLICKHOUSE_URL }}
           clickhouse-username: ${{ secrets.CLICKHOUSE_VIABLESTRICT_USERNAME }}


### PR DESCRIPTION
Copy from https://github.com/pytorch/executorch/blob/main/.github/workflows/update-viablestrict.yml as used by ExecuTorch:

* Update the list of `requires` checks from https://github.com/pytorch/vision/pull/8676. @NicolasHug Please double check that they are what vision needs to promote `viable/strict`.  All the signals there need to be green for the promotion to happen.
* Add a new `update-viable-strict` env and populate with secrets for PyTorch update bot and ClickHouse.