### PR TITLE
Avoid torch.compile graph-break in functional normalize fn

### DIFF
--- a/torchvision/transforms/_functional_tensor.py
+++ b/torchvision/transforms/_functional_tensor.py
@@ -920,7 +920,7 @@ def normalize(tensor: Tensor, mean: list[float], std: list[float], inplace: bool
     mean = torch.as_tensor(mean, dtype=dtype, device=tensor.device)
     std = torch.as_tensor(std, dtype=dtype, device=tensor.device)
     std = torch.ops.aten._functional_assert_async.msg(
-        (std == 0).any(), f"std evaluated to zero after conversion to {dtype}, leading to division by zero.", std
+        (std != 0).all(), f"std evaluated to zero after conversion to {dtype}, leading to division by zero.", std
     )
     if mean.ndim == 1:
         mean = mean.view(-1, 1, 1)


### PR DESCRIPTION
The data-dependent check on the standard deviation (in case any of its elements is zero) caused a graph break when using torch.compile. Instead this can be replaced by an in-graph assert, which can even become a on-device assert in order to support CUDA graphs.
