### PR TITLE
Fix the dataset test failures

### DIFF
--- a/torchvision/datasets/_optical_flow.py
+++ b/torchvision/datasets/_optical_flow.py
@@ -503,8 +503,8 @@ def _read_flo(file_name: str) -> np.ndarray:
         if magic != b"PIEH":
             raise ValueError("Magic number incorrect. Invalid .flo file")
 
-        w = int(np.fromfile(f, "<i4", count=1))
-        h = int(np.fromfile(f, "<i4", count=1))
+        w = np.fromfile(f, "<i4", count=1).item()
+        h = np.fromfile(f, "<i4", count=1).item()
         data = np.fromfile(f, "<f4", count=2 * w * h)
         return data.reshape(h, w, 2).transpose(2, 0, 1)
 


### PR DESCRIPTION
<!-- Before submitting a PR, please make sure to check our contributing guidelines regarding code formatting, tests, and documentation: https://github.com/pytorch/vision/blob/main/CONTRIBUTING.md -->

Summary:
Fixed the test failures in [#9317](https://github.com/pytorch/vision/pull/9317):
2026-01-05T15:58:40.1734062Z FAILED test/test_datasets.py::SintelTestCase::test_feature_types - TypeError: only 0-dimensional arrays can be converted to Python scalars
2026-01-05T15:58:40.1735400Z FAILED test/test_datasets.py::SintelTestCase::test_flow - TypeError: only 0-dimensional arrays can be converted to Python scalars
2026-01-05T15:58:40.1736711Z FAILED test/test_datasets.py::SintelTestCase::test_num_examples - TypeError: only 0-dimensional arrays can be converted to Python scalars
2026-01-05T15:58:40.1738053Z FAILED test/test_datasets.py::SintelTestCase::test_transforms - TypeError: only 0-dimensional arrays can be converted to Python scalars
2026-01-05T15:58:40.1739427Z FAILED test/test_datasets.py::SintelTestCase::test_tv_decode_image_support - TypeError: only 0-dimensional arrays can be converted to Python scalars
2026-01-05T15:58:40.1740948Z FAILED test/test_datasets.py::FlyingChairsTestCase::test_feature_types - TypeError: only 0-dimensional arrays can be converted to Python scalars
2026-01-05T15:58:40.1742330Z FAILED test/test_datasets.py::FlyingChairsTestCase::test_flow - TypeError: only 0-dimensional arrays can be converted to Python scalars
2026-01-05T15:58:40.1743690Z FAILED test/test_datasets.py::FlyingChairsTestCase::test_num_examples - TypeError: only 0-dimensional arrays can be converted to Python scalars
2026-01-05T15:58:40.1745092Z FAILED test/test_datasets.py::FlyingChairsTestCase::test_transforms - TypeError: only 0-dimensional arrays can be converted to Python scalars



In the latest NumPy, `int() `no longer accepts 1-dimensional arrays. `np.fromfile(f, "<i4", count=1)` returns a 1-dimensional array with one element (shape (1,)), not a 0-dimensional scalar. In old Numpy, calling int() on a 1-element array worked implicitly, but in newer versions, this raises `TypeError: only 0-dimensional arrays can be converted to Python scalars`. Thus, using `.item()` to extract the scalar value from the array can fix the test failures.



