### PR TITLE
Rotated IOU Implementation

### DIFF
--- a/torchvision/ops/__init__.py
+++ b/torchvision/ops/__init__.py
@@ -11,6 +11,7 @@ from .boxes import (
     masks_to_boxes,
     nms,
     remove_small_boxes,
+    rotated_box_iou,
 )
 from .ciou_loss import complete_box_iou_loss
 from .deform_conv import deform_conv2d, DeformConv2d
@@ -41,6 +42,7 @@ __all__ = [
     "box_convert",
     "box_area",
     "box_iou",
+    "rotated_box_iou",
     "generalized_box_iou",
     "distance_box_iou",
     "complete_box_iou",


### PR DESCRIPTION
<!-- Before submitting a PR, please make sure to check our contributing guidelines regarding code formatting, tests, and documentation: https://github.com/pytorch/vision/blob/main/CONTRIBUTING.md -->
Summary:
Implemented rotated_box_iou function to compute Intersection over Union (IoU) between rotated bounding boxes. The public API follows the existing box_iou pattern and supports all three rotated box formats: cxcywhr, xywhr, and xyxyxyxy.

Test Plan:
Added TestRotatedBoxIou test class with comprehensive tests:

- Core IoU test with 4 boxes (including 45° rotated box) across all three formats

- Rotation behavior tests (90°, 180°, 45°, negative angles)

- Edge case tests (containment, zero area)

- API contract tests (output shape, invalid format, format consistency)

All tests pass locally.