### PR TITLE
Fix run pre-script for python 3.13t installation process

### DIFF
--- a/packaging/pre_build_script.sh
+++ b/packaging/pre_build_script.sh
@@ -12,13 +12,13 @@ if [[ "$(uname)" == Darwin ]]; then
   conda install -y wget
 fi
 
-if [[ "${PYTHON_VERSION:-}" == *t || "${PYTHON_VERSION:-}" == 3.13* ]]; then
-  # downgrade conda version for python 3.13t, 3.13t install.
-  conda install -y conda=24.7.1
+# workaround for conda install failure on 3.13t 
+if [[ "${PYTHON_VERSION:-}" == 3.13t ]]; then
+  CONDA_SUFFIX="-c conda-forge"
 fi
 
 if [[ "$(uname)" == Darwin || "$OSTYPE" == "msys" ]]; then
-  conda install libpng libwebp -y
+  conda install -y libpng libwebp $CONDA_SUFFIX
   # Installing webp also installs a non-turbo jpeg, so we uninstall jpeg stuff
   # before re-installing them
   conda uninstall libjpeg-turbo libjpeg -y
@@ -37,7 +37,7 @@ else
     conda install -y libjpeg-turbo -c pytorch-nightly
   fi
 
-  conda install -y libwebp 
+  conda install -y libwebp $CONDA_SUFFIX
   conda install libjpeg-turbo -c pytorch
   yum install -y freetype gnutls
   pip install "auditwheel<6.3.0"


### PR DESCRIPTION
Linux failure : https://github.com/pytorch/vision/actions/runs/22097230572/job/63857381286 
```
Could not solve for environment specs
The following packages are incompatible
├─ libwebp =* * is installable with the potential options
│  ├─ libwebp [1.0.0|1.0.1] would require
│  │  └─ libtiff >=4.0.9,<4.7.0 * with the potential options
│  │     ├─ libtiff [4.0.10|4.0.9|4.1.0|4.5.0|4.5.1] would require
│  │     │  └─ xz >=5.2.4,<6.0a0 *, which can be installed;
│  │     ├─ libtiff 4.0.9 would require
│  │     │  └─ xz >=5.2.3,<6.0a0 *, which can be installed;
│  │     ├─ libtiff [4.1.0|4.2.0|4.4.0] would require
│  │     │  └─ xz >=5.2.5,<6.0a0 *, which can be installed;
│  │     ├─ libtiff 4.4.0 would require
│  │     │  └─ xz >=5.2.6,<6.0a0 *, which can be installed;
│  │     ├─ libtiff 4.5.0 would require
│  │     │  └─ xz >=5.2.8,<6.0a0 *, which can be installed;
│  │     └─ libtiff 4.5.1 would require
│  │        └─ xz >=5.2.10,<6.0a0 *, which can be installed;
│  ├─ libwebp [1.1.0|1.2.0|1.2.2|1.2.4|1.3.2] would require
│  │  └─ libtiff >=4.1.0,<4.7.0 *, which can be installed (as previously explained);
│  └─ libwebp [1.3.2|1.6.0] would require
│     └─ libtiff [>=4.7.0,<5.0a0 *|>=4.7.1,<5.0a0 *], which requires
│        └─ xz >=5.6.4,<6.0a0 *, which can be installed;
├─ pin on python 3.13.* =* * is installable and it requires
│  └─ python =3.13 *, which can be installed;
├─ python-freethreading =* * is installable with the potential options
│  ├─ python-freethreading 3.13.12 would require
│  │  └─ python_abi =* *_cp313t, which requires
│  │     └─ python =3.13 *_cp313t, which can be installed;
│  ├─ python-freethreading 3.14.0 would require
│  │  └─ python =3.14.0 *, which conflicts with any installable versions previously reported;
│  ├─ python-freethreading 3.14.1 would require
│  │  └─ python =3.14.1 *, which conflicts with any installable versions previously reported;
│  └─ python-freethreading 3.14.2 would require
│     └─ python =3.14.2 *, which conflicts with any installable versions previously reported;
└─ wheel =0.37 * is not installable because it requires
   └─ python [!=3.0,(!=3.1,(!=3.2,(!=3.3,!=3.4))) *|=* *] but there are no viable options
      ├─ python [2.7.13|2.7.14|...|3.9.7] conflicts with any installable versions previously reported;
      ├─ python 3.14.0 conflicts with any installable versions previously reported;
      ├─ python 3.14.1 conflicts with any installable versions previously reported;
      ├─ python 3.14.2 conflicts with any installable versions previously reported;
      └─ python 3.13.12 would require
         └─ liblzma >=5.8.2,<6.0a0 *, which requires
            └─ xz =5.8.2 *, which conflicts with any installable versions previously reported
```

MacOS failure: https://github.com/pytorch/vision/actions/runs/22097230534/job/63857777891
```
LibMambaUnsatisfiableError: Encountered problems while solving:
  - package python-3.13.12-h76e3b2d_0_cp313t requires liblzma >=5.8.2,<6.0a0, but none of the providers can be installed

Could not solve for environment specs
The following packages are incompatible
├─ libwebp =* * is installable with the potential options
│  ├─ libwebp [1.2.0|1.2.2|1.2.4|1.3.2] would require
│  │  └─ libtiff >=4.2.0,<4.7.0 * with the potential options
│  │     ├─ libtiff [4.2.0|4.4.0] would require
│  │     │  └─ xz >=5.2.5,<6.0a0 *, which can be installed;
│  │     ├─ libtiff 4.4.0 would require
│  │     │  └─ xz >=5.2.6,<6.0a0 *, which can be installed;
│  │     ├─ libtiff 4.5.0 would require
│  │     │  └─ xz >=5.2.8,<6.0a0 *, which can be installed;
│  │     ├─ libtiff [4.5.0|4.5.1] would require
│  │     │  └─ xz >=5.2.4,<6.0a0 *, which can be installed;
│  │     └─ libtiff 4.5.1 would require
│  │        └─ xz >=5.2.10,<6.0a0 *, which can be installed;
│  └─ libwebp [1.3.2|1.6.0] would require
│     └─ libtiff [>=4.7.0,<5.0a0 *|>=4.7.1,<5.0a0 *], which requires
│        └─ xz >=5.6.4,<6.0a0 *, which can be installed;
├─ pin on python =3.13 * is installable and it requires
│  └─ python =3.13 *, which can be installed;
├─ python-freethreading =* * is installable with the potential options
│  ├─ python-freethreading 3.13.12 would require
│  │  └─ python_abi =* *_cp313t, which requires
│  │     └─ python =3.13 *_cp313t, which can be installed;
│  ├─ python-freethreading 3.14.0 would require
│  │  └─ python =3.14.0 *, which conflicts with any installable versions previously reported;
│  ├─ python-freethreading 3.14.1 would require
│  │  └─ python =3.14.1 *, which conflicts with any installable versions previously reported;
│  └─ python-freethreading 3.14.2 would require
│     └─ python =3.14.2 *, which conflicts with any installable versions previously reported;
└─ wheel =0.37 * is not installable because it requires
   └─ python [!=3.0,(!=3.1,(!=3.2,(!=3.3,!=3.4))) *|=* *] but there are no viable options
      ├─ python [3.10.0|3.10.10|...|3.9.7] conflicts with any installable versions previously reported;
      ├─ python 3.14.0 conflicts with any installable versions previously reported;
      ├─ python 3.14.1 conflicts with any installable versions previously reported;
      ├─ python 3.14.2 conflicts with any installable versions previously reported;
      └─ python 3.13.12 would require
         └─ liblzma >=5.8.2,<6.0a0 *, which requires
            └─ xz =5.8.2 *, which conflicts with any installable versions previously reported.


...
PackagesNotFoundError: The following packages are missing from the target environment:
  - libjpeg-turbo
  - libjpeg


```

Failure started to happen after merging https://github.com/pytorch/test-infra/pull/7753 - conda version was unpinned

Related PR for 3.13t we use environment created with conda-forge: https://github.com/pytorch/test-infra/pull/7769
And looks like with conda version 25.3.0 has issues resolving the install for ``libwebp`` and ``libpng``  I believe this is related to the fact that 3.13t builds use conda-forge environment