### PR TITLE
Fix Windows CI: ninja PATH and SSL certificate issues

### DIFF
--- a/.github/scripts/unittest.sh
+++ b/.github/scripts/unittest.sh
@@ -7,6 +7,11 @@ set -euo pipefail
 # Activate conda environment
 eval "$($(which conda) shell.bash hook)" && conda deactivate && conda activate ci
 
+# Fix SSL certificate verification on Windows by using certifi's CA bundle
+if [[ "$(uname)" == MSYS* ]]; then
+    export SSL_CERT_FILE=$(python -c "import certifi; print(certifi.where())")
+fi
+
 echo '::group::Install testing utilities'
 # TODO: remove the <8 constraint on pytest when https://github.com/pytorch/vision/issues/8238 is closed
 pip install --progress-bar=off "pytest<8" pytest-mock pytest-cov expecttest!=0.2.0 requests

--- a/packaging/pre_build_script.sh
+++ b/packaging/pre_build_script.sh
@@ -38,5 +38,13 @@ else
   pip install "auditwheel<6.3.0"
 fi
 
-pip install numpy pyyaml future ninja
+pip install numpy pyyaml future
 pip install --upgrade setuptools==72.1.0
+
+# Use conda ninja on Windows to avoid "ReadFile: The handle is invalid" errors
+# with pip-installed ninja. On other platforms, pip ninja works fine.
+if [[ "$OSTYPE" == "msys" ]]; then
+    conda install -y ninja
+else
+    pip install ninja
+fi

--- a/packaging/windows/internal/vc_env_helper.bat
+++ b/packaging/windows/internal/vc_env_helper.bat
@@ -24,7 +24,9 @@ if "%CU_VERSION%" == "xpu" call "C:\Program Files (x86)\Intel\oneAPI\setvars.bat
 
 set DISTUTILS_USE_SDK=1
 
-set MAX_JOBS=4
+REM Limit parallel jobs to avoid ninja "ReadFile: The handle is invalid" errors
+REM See: https://github.com/pytorch/pytorch/issues/22450
+set MAX_JOBS=1
 
 set args=%1
 shift

--- a/packaging/windows/internal/vc_env_helper.bat
+++ b/packaging/windows/internal/vc_env_helper.bat
@@ -24,6 +24,8 @@ if "%CU_VERSION%" == "xpu" call "C:\Program Files (x86)\Intel\oneAPI\setvars.bat
 
 set DISTUTILS_USE_SDK=1
 
+set MAX_JOBS=4
+
 set args=%1
 shift
 :start

--- a/packaging/windows/internal/vc_env_helper.bat
+++ b/packaging/windows/internal/vc_env_helper.bat
@@ -24,10 +24,6 @@ if "%CU_VERSION%" == "xpu" call "C:\Program Files (x86)\Intel\oneAPI\setvars.bat
 
 set DISTUTILS_USE_SDK=1
 
-REM Ensure pip-installed tools (like ninja) are accessible
-for /f "delims=" %%i in ('python -c "import sys; print(sys.prefix + r'\Scripts')"') do set PYTHON_SCRIPTS=%%i
-if exist "%PYTHON_SCRIPTS%\ninja.exe" set PATH=%PYTHON_SCRIPTS%;%PATH%
-
 set args=%1
 shift
 :start

--- a/packaging/windows/internal/vc_env_helper.bat
+++ b/packaging/windows/internal/vc_env_helper.bat
@@ -24,6 +24,10 @@ if "%CU_VERSION%" == "xpu" call "C:\Program Files (x86)\Intel\oneAPI\setvars.bat
 
 set DISTUTILS_USE_SDK=1
 
+REM Ensure pip-installed tools (like ninja) are accessible
+for /f "delims=" %%i in ('python -c "import sys; print(sys.prefix + r'\Scripts')"') do set PYTHON_SCRIPTS=%%i
+if exist "%PYTHON_SCRIPTS%\ninja.exe" set PATH=%PYTHON_SCRIPTS%;%PATH%
+
 set args=%1
 shift
 :start


### PR DESCRIPTION
- Add Python Scripts dir to PATH in vc_env_helper.bat for ninja access
- Set SSL_CERT_FILE on Windows to fix urllib certificate verification

<!-- Before submitting a PR, please make sure to check our contributing guidelines regarding code formatting, tests, and documentation: https://github.com/pytorch/vision/blob/main/CONTRIBUTING.md -->
