### PR TITLE
fix windows install for vision

### DIFF
--- a/packaging/windows/internal/vc_env_helper.bat
+++ b/packaging/windows/internal/vc_env_helper.bat
@@ -23,6 +23,7 @@ if "%VSDEVCMD_ARGS%" == "" (
 if "%CU_VERSION%" == "xpu" call "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
 
 set DISTUTILS_USE_SDK=1
+set CL=%CL% /Zc:preprocessor
 
 set args=%1
 shift


### PR DESCRIPTION
fix the build failure in https://github.com/pytorch/test-infra/pull/7865
link: https://github.com/pytorch/test-infra/actions/runs/23821498605/job/69435368907?pr=7865

The problem: CUDA 13.2 ships with CCCL (CUDA C++ Core Libraries) headers that check how MSVC's preprocessor works. MSVC has two preprocessor modes:

Traditional (default): has quirks and doesn't fully conform to the C++ standard
Standard conforming (/Zc:preprocessor): follows the C++ standard properly
CCCL's header (preprocessor.h) does a compile-time check and throws a #error if MSVC is using the traditional preprocessor, because CCCL's macros rely on standard-conforming behavior and would silently produce wrong results otherwise.

The fix: The CL environment variable is special to MSVC — it's automatically prepended to every cl.exe invocation.

```
[11/24] cl /showIncludes /nologo /O2 /W3 /GL /DNDEBUG /MD -DWITH_CUDA -Dtorchvision_EXPORTS -IC:\actions-runner\_work\test-infra\test-infra\pytorch\vision\torchvision\csrc -IC:\actions-runner\_work\_temp\conda_environment_23821498605\lib\site-packages\torch\include -IC:\actions-runner\_work\_temp\conda_environment_23821498605\lib\site-packages\torch\include\torch\csrc\api\include "-IC:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.2\include" -IC:\actions-runner\_work\_temp\conda_environment_23821498605\include -IC:\actions-runner\_work\_temp\conda_environment_23821498605\Include "-IC:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.42.34433\include" "-IC:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\VS\include" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.19041.0\ucrt" "-IC:\Program Files (x86)\Windows Kits\10\\include\10.0.19041.0\\um" "-IC:\Program Files (x86)\Windows Kits\10\\include\10.0.19041.0\\shared" "-IC:\Program Files (x86)\Windows Kits\10\\include\10.0.19041.0\\winrt" "-IC:\Program Files (x86)\Windows Kits\10\\include\10.0.19041.0\\cppwinrt" "-IC:\Program Files (x86)\Windows Kits\NETFXSDK\4.8\include\um" /MD /wd4819 /wd4251 /wd4244 /wd4267 /wd4275 /wd4018 /wd4190 /wd4624 /wd4067 /wd4068 /EHsc -c C:\actions-runner\_work\test-infra\test-infra\pytorch\vision\torchvision\csrc\ops\cpu\roi_align_kernel.cpp /FoC:\actions-runner\_work\test-infra\test-infra\pytorch\vision\build\temp.win-amd64-cpython-310\Release\actions-runner\_work\test-infra\test-infra\pytorch\vision\torchvision\csrc\ops\cpu\roi_align_kernel.obj /MP -g0 -DTORCH_API_INCLUDE_EXTENSION_H -DTORCH_EXTENSION_NAME=_C /std:c++20
cl : Command line warning D9002 : ignoring unknown option '-g0'
```
cc @atalman 