### PR TITLE
Fix vision install for all files

### DIFF
--- a/packaging/windows/internal/vc_env_helper.bat
+++ b/packaging/windows/internal/vc_env_helper.bat
@@ -23,7 +23,6 @@ if "%VSDEVCMD_ARGS%" == "" (
 if "%CU_VERSION%" == "xpu" call "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
 
 set DISTUTILS_USE_SDK=1
-set CL=%CL% /Zc:preprocessor
 
 set args=%1
 shift

--- a/setup.py
+++ b/setup.py
@@ -128,6 +128,7 @@ def get_macros_and_flags():
     if sys.platform == "win32":
         define_macros += [("torchvision_EXPORTS", None)]
         extra_compile_args["cxx"].append("/MP")
+        extra_compile_args["cxx"].append("/Zc:preprocessor")
         if sysconfig.get_config_var("Py_GIL_DISABLED"):
             extra_compile_args["cxx"].append("-DPy_GIL_DISABLED")
 

--- a/setup.py
+++ b/setup.py
@@ -129,6 +129,8 @@ def get_macros_and_flags():
         define_macros += [("torchvision_EXPORTS", None)]
         extra_compile_args["cxx"].append("/MP")
         extra_compile_args["cxx"].append("/Zc:preprocessor")
+        if "nvcc" in extra_compile_args:
+            extra_compile_args["nvcc"].append("-DCCCL_IGNORE_MSVC_TRADITIONAL_PREPROCESSOR_WARNING")
         if sysconfig.get_config_var("Py_GIL_DISABLED"):
             extra_compile_args["cxx"].append("-DPy_GIL_DISABLED")
 

--- a/setup.py
+++ b/setup.py
@@ -130,6 +130,8 @@ def get_macros_and_flags():
         extra_compile_args["cxx"].append("/MP")
         extra_compile_args["cxx"].append("/Zc:preprocessor")
         if "nvcc" in extra_compile_args:
+            extra_compile_args["nvcc"].append("-Xcompiler")
+            extra_compile_args["nvcc"].append("/Zc:preprocessor")
             extra_compile_args["nvcc"].append("-DCCCL_IGNORE_MSVC_TRADITIONAL_PREPROCESSOR_WARNING")
         if sysconfig.get_config_var("Py_GIL_DISABLED"):
             extra_compile_args["cxx"].append("-DPy_GIL_DISABLED")


### PR DESCRIPTION
```
2026-04-02T12:26:57.0297276Z C:/actions-runner/_work/_temp/conda_environment_23898900289/lib/site-packages/torch/include\c10/cuda/CUDACachingAllocator.h(105): error: invalid combination of type specifiers
2026-04-02T12:26:57.1656746Z     StreamSegmentSize(cudaStream_t s, bool char , size_t sz)
2026-04-02T12:26:57.2674865Z                                            ^
2026-04-02T12:26:57.4435273Z 
2026-04-02T12:26:57.5852644Z C:/actions-runner/_work/_temp/conda_environment_23898900289/lib/site-packages/torch/include\c10/cuda/CUDACachingAllocator.h(106): error: type name is not allowed
2026-04-02T12:26:57.7023246Z         : stream(s), is_small_pool(char ), total_size(sz) {}
2026-04-02T12:26:57.8187869Z                                    ^
2026-04-02T12:26:57.9261140Z 
2026-04-02T12:26:58.7092980Z 2 errors detected in the compilation of "C:/actions-runner/_work/vision/vision/pytorch/vision/torchvision/csrc/ops/cuda/nms_kernel.cu".
```
Previous fix https://github.com/pytorch/vision/pull/9464 only applies to the .cpp files compiled directly by cl.exe, not .cu files via nvcc. Need to change it in the setup.py.

cc @atalman 