### PR TITLE
Fix typo in anchor_utils.py documentation

### DIFF
--- a/torchvision/models/detection/anchor_utils.py
+++ b/torchvision/models/detection/anchor_utils.py
@@ -12,7 +12,7 @@ class AnchorGenerator(nn.Module):
     Module that generates anchors for a set of feature maps and
     image sizes.
 
-    The module support computing anchors at multiple sizes and aspect ratios
+    The module supports computing anchors at multiple sizes and aspect ratios
     per feature map. This module assumes aspect ratio = height / width for
     each anchor.
 


### PR DESCRIPTION
<!-- Before submitting a PR, please make sure to check our contributing guidelines regarding code formatting, tests, and documentation: https://github.com/pytorch/vision/blob/main/CONTRIBUTING.md -->

Minor typo in `torchvision.models.detection.anchor_utils.AnchorGenerator`:
`The module support computing anchors...`
Should be:
`The module supports computing anchors`