### PR TITLE
Fix warning message to show up on the LFW dataset webpages

### DIFF
--- a/torchvision/datasets/lfw.py
+++ b/torchvision/datasets/lfw.py
@@ -96,7 +96,7 @@ class _LFW(VisionDataset):
 class LFWPeople(_LFW):
     """`LFW <http://vis-www.cs.umass.edu/lfw/>`_ Dataset.
 
-    .. warning:
+    .. warning::
 
         The LFW dataset is no longer available for automatic download. Please
         download it manually and place it in the specified directory.
@@ -185,7 +185,7 @@ class LFWPeople(_LFW):
 class LFWPairs(_LFW):
     """`LFW <http://vis-www.cs.umass.edu/lfw/>`_ Dataset.
 
-    .. warning:
+    .. warning::
 
         The LFW dataset is no longer available for automatic download. Please
         download it manually and place it in the specified directory.


### PR DESCRIPTION
<!-- Before submitting a PR, please make sure to check our contributing guidelines regarding code formatting, tests, and documentation: https://github.com/pytorch/vision/blob/main/CONTRIBUTING.md -->

Based on comment [here](https://github.com/pytorch/vision/pull/9463#discussion_r3056308523), this PR is trying to fix a bug that warning message does not show up on the LFW dataset webpages.

cc: @zy1git