### PR TITLE
Revert CV-CUDA

### DIFF
--- a/.github/scripts/setup-env.sh
+++ b/.github/scripts/setup-env.sh
@@ -82,12 +82,6 @@ echo '::group::Install TorchVision'
 pip install -e . -v --no-build-isolation
 echo '::endgroup::'
 
-if [[ "${CVCUDA:-}" == "1" ]]; then
-  echo '::group::Install CV-CUDA'
-  pip install --progress-bar=off cvcuda-cu12
-  echo '::endgroup::'
-fi
-
 echo '::group::Install torchvision-extra-decoders'
 # This can be done after torchvision was built
 if [[ "$(uname)" == "Linux" && "$(uname -m)" != "aarch64" ]]; then

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,36 +44,6 @@ jobs:
 
         ./.github/scripts/unittest.sh
 
-  unittests-linux-cvcuda:
-    strategy:
-      matrix:
-        python-version:
-          - "3.10"
-        runner: ["linux.g5.4xlarge.nvidia.gpu"]
-        gpu-arch-type: ["cuda"]
-        gpu-arch-version: ["12.6"]
-      fail-fast: false
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
-    permissions:
-      id-token: write
-      contents: read
-    with:
-      repository: pytorch/vision
-      runner: ${{ matrix.runner }}
-      gpu-arch-type: ${{ matrix.gpu-arch-type }}
-      gpu-arch-version: ${{ matrix.gpu-arch-version }}
-      timeout: 120
-      test-infra-ref: main
-      script: |
-        set -euo pipefail
-
-        export PYTHON_VERSION=${{ matrix.python-version }}
-        export GPU_ARCH_TYPE=${{ matrix.gpu-arch-type }}
-        export GPU_ARCH_VERSION=${{ matrix.gpu-arch-version }}
-        export CVCUDA="1"
-
-        ./.github/scripts/unittest.sh
-
   unittests-macos:
     strategy:
       matrix:

--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -29,7 +29,6 @@ IN_OSS_CI = any(os.getenv(var) == "true" for var in ["CIRCLECI", "GITHUB_ACTIONS
 IN_RE_WORKER = os.environ.get("INSIDE_RE_WORKER") is not None
 IN_FBCODE = os.environ.get("IN_FBCODE_TORCHVISION") == "1"
 CUDA_NOT_AVAILABLE_MSG = "CUDA device not available"
-CVCUDA_NOT_AVAILABLE_MSG = "CV-CUDA not available"
 MPS_NOT_AVAILABLE_MSG = "MPS device not available"
 OSS_CI_GPU_NO_CUDA_MSG = "We're in an OSS GPU machine, and this test doesn't need cuda."
 
@@ -133,12 +132,6 @@ def needs_cuda(test_func):
     import pytest  # noqa
 
     return pytest.mark.needs_cuda(test_func)
-
-
-def needs_cvcuda(test_func):
-    import pytest  # noqa
-
-    return pytest.mark.needs_cvcuda(test_func)
 
 
 def needs_mps(test_func):

--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -20,8 +20,7 @@ import torch.testing
 from torch.testing._comparison import BooleanPair, NonePair, not_close_error_metas, NumberPair, TensorLikePair
 from torchvision import io, tv_tensors
 from torchvision.transforms._functional_tensor import _max_value as get_max_value
-from torchvision.transforms.v2.functional import cvcuda_to_tensor, to_cvcuda_tensor, to_image, to_pil_image
-from torchvision.transforms.v2.functional._utils import _is_cvcuda_available, _is_cvcuda_tensor
+from torchvision.transforms.v2.functional import to_cvcuda_tensor, to_image, to_pil_image
 from torchvision.utils import _Image_fromarray
 
 
@@ -285,24 +284,8 @@ class ImagePair(TensorLikePair):
         mae=False,
         **other_parameters,
     ):
-        # Convert PIL images to tv_tensors.Image (regardless of what the other is)
-        if isinstance(actual, PIL.Image.Image):
-            actual = to_image(actual)
-        if isinstance(expected, PIL.Image.Image):
-            expected = to_image(expected)
-
-        if _is_cvcuda_available():
-            if _is_cvcuda_tensor(actual):
-                actual = cvcuda_to_tensor(actual)
-                # Remove batch dimension if it's 1 for easier comparison against 3D PIL images
-                if actual.shape[0] == 1:
-                    actual = actual[0]
-                actual = actual.cpu()
-            if _is_cvcuda_tensor(expected):
-                expected = cvcuda_to_tensor(expected)
-                if expected.shape[0] == 1:
-                    expected = expected[0]
-                expected = expected.cpu()
+        if all(isinstance(input, PIL.Image.Image) for input in [actual, expected]):
+            actual, expected = (to_image(input) for input in [actual, expected])
 
         super().__init__(actual, expected, **other_parameters)
         self.mae = mae
@@ -417,8 +400,8 @@ def make_image_pil(*args, **kwargs):
     return to_pil_image(make_image(*args, **kwargs))
 
 
-def make_image_cvcuda(*args, batch_dims=(1,), **kwargs):
-    return to_cvcuda_tensor(make_image(*args, batch_dims=batch_dims, **kwargs))
+def make_image_cvcuda(*args, **kwargs):
+    return to_cvcuda_tensor(make_image(*args, **kwargs))
 
 
 def make_keypoints(canvas_size=DEFAULT_SIZE, *, num_points=4, dtype=None, device="cpu"):
@@ -558,9 +541,5 @@ def ignore_jit_no_profile_information_warning():
     # with varying `INT1` and `INT2`. Since these are uninteresting for us and only clutter the test summary, we ignore
     # them.
     with warnings.catch_warnings():
-        warnings.filterwarnings(
-            "ignore",
-            message=re.escape("operator() profile_node %"),
-            category=UserWarning,
-        )
+        warnings.filterwarnings("ignore", message=re.escape("operator() profile_node %"), category=UserWarning)
         yield

--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -20,7 +20,7 @@ import torch.testing
 from torch.testing._comparison import BooleanPair, NonePair, not_close_error_metas, NumberPair, TensorLikePair
 from torchvision import io, tv_tensors
 from torchvision.transforms._functional_tensor import _max_value as get_max_value
-from torchvision.transforms.v2.functional import to_cvcuda_tensor, to_image, to_pil_image
+from torchvision.transforms.v2.functional import to_image, to_pil_image
 from torchvision.utils import _Image_fromarray
 
 
@@ -398,10 +398,6 @@ def make_image_tensor(*args, **kwargs):
 
 def make_image_pil(*args, **kwargs):
     return to_pil_image(make_image(*args, **kwargs))
-
-
-def make_image_cvcuda(*args, **kwargs):
-    return to_cvcuda_tensor(make_image(*args, **kwargs))
 
 
 def make_keypoints(canvas_size=DEFAULT_SIZE, *, num_points=4, dtype=None, device="cpu"):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -5,9 +5,7 @@ import pytest
 import torch
 
 from common_utils import (
-    _is_cvcuda_available,
     CUDA_NOT_AVAILABLE_MSG,
-    CVCUDA_NOT_AVAILABLE_MSG,
     IN_FBCODE,
     IN_OSS_CI,
     IN_RE_WORKER,
@@ -19,7 +17,6 @@ from common_utils import (
 def pytest_configure(config):
     # register an additional marker (see pytest_collection_modifyitems)
     config.addinivalue_line("markers", "needs_cuda: mark for tests that rely on a CUDA device")
-    config.addinivalue_line("markers", "needs_cvcuda: mark for tests that rely on CV-CUDA")
     config.addinivalue_line("markers", "needs_mps: mark for tests that rely on a MPS device")
     config.addinivalue_line("markers", "dont_collect: mark for tests that should not be collected")
     config.addinivalue_line("markers", "opcheck_only_one: only opcheck one parametrization")
@@ -44,9 +41,6 @@ def pytest_collection_modifyitems(items):
         # @pytest.mark.parametrize('device', cpu_and_cuda())
         # the "instances" of the tests where device == 'cuda' will have the 'needs_cuda' mark,
         # and the ones with device == 'cpu' won't have the mark.
-        needs_cvcuda = item.get_closest_marker("needs_cvcuda") is not None
-        if needs_cvcuda:
-            item.add_marker(pytest.mark.needs_cuda)
         needs_cuda = item.get_closest_marker("needs_cuda") is not None
         needs_mps = item.get_closest_marker("needs_mps") is not None
 
@@ -57,9 +51,6 @@ def pytest_collection_modifyitems(items):
 
         if needs_mps and not torch.backends.mps.is_available():
             item.add_marker(pytest.mark.skip(reason=MPS_NOT_AVAILABLE_MSG))
-
-        if needs_cvcuda and not _is_cvcuda_available():
-            item.add_marker(pytest.mark.skip(reason=CVCUDA_NOT_AVAILABLE_MSG))
 
         if IN_FBCODE:
             # fbcode doesn't like skipping tests, so instead we  just don't collect the test

--- a/test/test_transforms_v2.py
+++ b/test/test_transforms_v2.py
@@ -37,7 +37,6 @@ from common_utils import (
     make_video,
     make_video_tensor,
     needs_cuda,
-    needs_cvcuda,
     set_rng_seed,
 )
 
@@ -53,6 +52,7 @@ from torchvision.transforms.functional import pil_modes_mapping, to_pil_image
 from torchvision.transforms.v2 import functional as F
 from torchvision.transforms.v2._utils import check_type, is_pure_tensor
 from torchvision.transforms.v2.functional._geometry import _get_perspective_coeffs, _parallelogram_to_bounding_boxes
+
 from torchvision.transforms.v2.functional._meta import (
     _cxcywh_to_xywh,
     _cxcywh_to_xyxy,
@@ -61,8 +61,12 @@ from torchvision.transforms.v2.functional._meta import (
     _xyxy_to_cxcywh,
     _xyxy_to_xywh,
 )
-from torchvision.transforms.v2.functional._utils import _get_kernel, _import_cvcuda, _register_kernel_internal
+from torchvision.transforms.v2.functional._utils import _get_kernel, _register_kernel_internal
 
+
+CVCUDA_AVAILABLE = _is_cvcuda_available()
+if CVCUDA_AVAILABLE:
+    cvcuda = _import_cvcuda()
 
 # turns all warnings into errors for this module
 pytestmark = [pytest.mark.filterwarnings("error")]
@@ -1269,7 +1273,7 @@ class TestHorizontalFlip:
             make_image,
             pytest.param(
                 make_image_cvcuda,
-                marks=pytest.mark.needs_cvcuda,
+                marks=pytest.mark.skipif(not CVCUDA_AVAILABLE, reason="CVCUDA is not available"),
             ),
             make_bounding_boxes,
             make_segmentation_mask,
@@ -1289,7 +1293,7 @@ class TestHorizontalFlip:
             pytest.param(
                 F._geometry._horizontal_flip_image_cvcuda,
                 None,
-                marks=pytest.mark.needs_cvcuda,
+                marks=pytest.mark.skipif(not CVCUDA_AVAILABLE, reason="CVCUDA is not available"),
             ),
             (F.horizontal_flip_bounding_boxes, tv_tensors.BoundingBoxes),
             (F.horizontal_flip_mask, tv_tensors.Mask),
@@ -1310,7 +1314,7 @@ class TestHorizontalFlip:
             make_image,
             pytest.param(
                 make_image_cvcuda,
-                marks=pytest.mark.needs_cvcuda,
+                marks=pytest.mark.skipif(not CVCUDA_AVAILABLE, reason="CVCUDA is not available"),
             ),
             make_bounding_boxes,
             make_segmentation_mask,
@@ -1331,7 +1335,7 @@ class TestHorizontalFlip:
             make_image,
             pytest.param(
                 make_image_cvcuda,
-                marks=pytest.mark.needs_cvcuda,
+                marks=pytest.mark.skipif(not CVCUDA_AVAILABLE, reason="CVCUDA is not available"),
             ),
         ],
     )
@@ -1399,7 +1403,7 @@ class TestHorizontalFlip:
             make_image,
             pytest.param(
                 make_image_cvcuda,
-                marks=pytest.mark.needs_cvcuda,
+                marks=pytest.mark.skipif(not CVCUDA_AVAILABLE, reason="CVCUDA is not available"),
             ),
             make_bounding_boxes,
             make_segmentation_mask,
@@ -1911,7 +1915,7 @@ class TestVerticalFlip:
             make_image,
             pytest.param(
                 make_image_cvcuda,
-                marks=pytest.mark.needs_cvcuda,
+                marks=pytest.mark.skipif(not CVCUDA_AVAILABLE, reason="CVCUDA is not available"),
             ),
             make_bounding_boxes,
             make_segmentation_mask,
@@ -1931,7 +1935,7 @@ class TestVerticalFlip:
             pytest.param(
                 F._geometry._vertical_flip_image_cvcuda,
                 None,
-                marks=pytest.mark.needs_cvcuda,
+                marks=pytest.mark.skipif(not CVCUDA_AVAILABLE, reason="CVCUDA is not available"),
             ),
             (F.vertical_flip_bounding_boxes, tv_tensors.BoundingBoxes),
             (F.vertical_flip_mask, tv_tensors.Mask),
@@ -1952,7 +1956,7 @@ class TestVerticalFlip:
             make_image,
             pytest.param(
                 make_image_cvcuda,
-                marks=pytest.mark.needs_cvcuda,
+                marks=pytest.mark.skipif(not CVCUDA_AVAILABLE, reason="CVCUDA is not available"),
             ),
             make_bounding_boxes,
             make_segmentation_mask,
@@ -1971,7 +1975,7 @@ class TestVerticalFlip:
             make_image,
             pytest.param(
                 make_image_cvcuda,
-                marks=pytest.mark.needs_cvcuda,
+                marks=pytest.mark.skipif(not CVCUDA_AVAILABLE, reason="CVCUDA is not available"),
             ),
         ],
     )
@@ -2035,7 +2039,7 @@ class TestVerticalFlip:
             make_image,
             pytest.param(
                 make_image_cvcuda,
-                marks=pytest.mark.needs_cvcuda,
+                marks=pytest.mark.skipif(not CVCUDA_AVAILABLE, reason="CVCUDA is not available"),
             ),
             make_bounding_boxes,
             make_segmentation_mask,
@@ -6879,7 +6883,8 @@ class TestPILToTensor:
             F.pil_to_tensor(object())
 
 
-@needs_cvcuda
+@pytest.mark.skipif(not CVCUDA_AVAILABLE, reason="test requires CVCUDA")
+@needs_cuda
 class TestToCVCUDATensor:
     @pytest.mark.parametrize("image_type", (torch.Tensor, tv_tensors.Image))
     @pytest.mark.parametrize("dtype", [torch.uint8, torch.uint16, torch.float32, torch.float64])
@@ -6897,7 +6902,7 @@ class TestToCVCUDATensor:
             assert is_pure_tensor(image)
         output = fn(image)
 
-        assert isinstance(output, _import_cvcuda().Tensor)
+        assert isinstance(output, cvcuda.Tensor)
         assert F.get_size(output) == F.get_size(image)
         assert output is not None
 
@@ -6940,8 +6945,9 @@ class TestToCVCUDATensor:
         assert result_tensor.shape[0] == batch_size
 
 
-@needs_cvcuda
-class TestCVCUDAToTensor:
+@pytest.mark.skipif(not CVCUDA_AVAILABLE, reason="test requires CVCUDA")
+@needs_cuda
+class TestCVDUDAToTensor:
     @pytest.mark.parametrize("dtype", [torch.uint8, torch.uint16, torch.float32, torch.float64])
     @pytest.mark.parametrize("device", cpu_and_cuda())
     @pytest.mark.parametrize("color_space", ["RGB", "GRAY"])

--- a/test/test_transforms_v2.py
+++ b/test/test_transforms_v2.py
@@ -6914,7 +6914,7 @@ class TestCVDUDAToTensor:
         assert F.get_size(output) == F.get_size(input_tensor)
 
     def test_functional_error(self):
-        with pytest.raises(TypeError, match=r"cvcuda_img should be ``cvcuda\.Tensor``\. Got .+\."):
+        with pytest.raises(TypeError, match="cvcuda_img should be `cvcuda.Tensor`"):
             F.cvcuda_to_tensor(object())
 
 

--- a/test/test_transforms_v2.py
+++ b/test/test_transforms_v2.py
@@ -29,7 +29,6 @@ from common_utils import (
     make_bounding_boxes,
     make_detection_masks,
     make_image,
-    make_image_cvcuda,
     make_image_pil,
     make_image_tensor,
     make_keypoints,
@@ -52,7 +51,6 @@ from torchvision.transforms.functional import pil_modes_mapping, to_pil_image
 from torchvision.transforms.v2 import functional as F
 from torchvision.transforms.v2._utils import check_type, is_pure_tensor
 from torchvision.transforms.v2.functional._geometry import _get_perspective_coeffs, _parallelogram_to_bounding_boxes
-
 from torchvision.transforms.v2.functional._meta import (
     _cxcywh_to_xywh,
     _cxcywh_to_xyxy,
@@ -63,10 +61,6 @@ from torchvision.transforms.v2.functional._meta import (
 )
 from torchvision.transforms.v2.functional._utils import _get_kernel, _register_kernel_internal
 
-
-CVCUDA_AVAILABLE = _is_cvcuda_available()
-if CVCUDA_AVAILABLE:
-    cvcuda = _import_cvcuda()
 
 # turns all warnings into errors for this module
 pytestmark = [pytest.mark.filterwarnings("error")]
@@ -6829,93 +6823,6 @@ class TestPILToTensor:
     def test_functional_error(self):
         with pytest.raises(TypeError, match="pic should be PIL Image"):
             F.pil_to_tensor(object())
-
-
-@pytest.mark.skipif(not CVCUDA_AVAILABLE, reason="test requires CVCUDA")
-@needs_cuda
-class TestToCVCUDATensor:
-    @pytest.mark.parametrize("image_type", (torch.Tensor, tv_tensors.Image))
-    @pytest.mark.parametrize("dtype", [torch.uint8, torch.uint16, torch.float32, torch.float64])
-    @pytest.mark.parametrize("device", cpu_and_cuda())
-    @pytest.mark.parametrize("color_space", ["RGB", "GRAY"])
-    @pytest.mark.parametrize("batch_dims", [(1,), (2,), (4,)])
-    @pytest.mark.parametrize(
-        "fn",
-        [F.to_cvcuda_tensor, transform_cls_to_functional(transforms.ToCVCUDATensor)],
-    )
-    def test_functional_and_transform(self, image_type, dtype, device, color_space, batch_dims, fn):
-        image = make_image(dtype=dtype, device=device, color_space=color_space, batch_dims=batch_dims)
-        if image_type is torch.Tensor:
-            image = image.as_subclass(torch.Tensor)
-            assert is_pure_tensor(image)
-        output = fn(image)
-
-        assert isinstance(output, cvcuda.Tensor)
-        assert F.get_size(output) == F.get_size(image)
-        assert output is not None
-
-    def test_invalid_input_type(self):
-        with pytest.raises(TypeError, match=r"inpt should be ``torch.Tensor``"):
-            F.to_cvcuda_tensor("invalid_input")
-
-    def test_invalid_dimensions(self):
-        with pytest.raises(ValueError, match=r"pic should be 4 dimensional"):
-            img_data = torch.randint(0, 256, (3, 1, 3), dtype=torch.uint8)
-            img_data = img_data.cuda()
-            F.to_cvcuda_tensor(img_data)
-
-        with pytest.raises(ValueError, match=r"pic should be 4 dimensional"):
-            img_data = torch.randint(0, 256, (4,), dtype=torch.uint8)
-            img_data = img_data.cuda()
-            F.to_cvcuda_tensor(img_data)
-
-        with pytest.raises(ValueError, match=r"pic should be 4 dimensional"):
-            img_data = torch.randint(0, 256, (4, 4), dtype=torch.uint8)
-            img_data = img_data.cuda()
-            F.to_cvcuda_tensor(img_data)
-
-        with pytest.raises(ValueError, match=r"pic should be 4 dimensional"):
-            img_data = torch.randint(0, 256, (1, 1, 3, 4, 4), dtype=torch.uint8)
-            img_data = img_data.cuda()
-            F.to_cvcuda_tensor(img_data)
-
-    @pytest.mark.parametrize("dtype", [torch.uint8, torch.uint16, torch.float32, torch.float64])
-    @pytest.mark.parametrize("device", cpu_and_cuda())
-    @pytest.mark.parametrize("color_space", ["RGB", "GRAY"])
-    @pytest.mark.parametrize("batch_size", [1, 2, 4])
-    def test_round_trip(self, dtype, device, color_space, batch_size):
-        original_tensor = make_image_tensor(
-            dtype=dtype, device=device, color_space=color_space, batch_dims=(batch_size,)
-        )
-        cvcuda_tensor = F.to_cvcuda_tensor(original_tensor)
-        result_tensor = F.cvcuda_to_tensor(cvcuda_tensor)
-        torch.testing.assert_close(result_tensor.to(device), original_tensor, rtol=0, atol=0)
-        assert result_tensor.shape[0] == batch_size
-
-
-@pytest.mark.skipif(not CVCUDA_AVAILABLE, reason="test requires CVCUDA")
-@needs_cuda
-class TestCVDUDAToTensor:
-    @pytest.mark.parametrize("dtype", [torch.uint8, torch.uint16, torch.float32, torch.float64])
-    @pytest.mark.parametrize("device", cpu_and_cuda())
-    @pytest.mark.parametrize("color_space", ["RGB", "GRAY"])
-    @pytest.mark.parametrize("batch_dims", [(1,), (2,), (4,)])
-    @pytest.mark.parametrize(
-        "fn",
-        [F.cvcuda_to_tensor, transform_cls_to_functional(transforms.CVCUDAToTensor)],
-    )
-    def test_functional_and_transform(self, dtype, device, color_space, batch_dims, fn):
-        input = make_image_cvcuda(dtype=dtype, device=device, color_space=color_space, batch_dims=batch_dims)
-
-        output = fn(input)
-
-        assert isinstance(output, torch.Tensor)
-        input_tensor = F.cvcuda_to_tensor(input)
-        assert F.get_size(output) == F.get_size(input_tensor)
-
-    def test_functional_error(self):
-        with pytest.raises(TypeError, match="cvcuda_img should be `cvcuda.Tensor`"):
-            F.cvcuda_to_tensor(object())
 
 
 class TestLambda:

--- a/test/test_transforms_v2.py
+++ b/test/test_transforms_v2.py
@@ -1271,10 +1271,6 @@ class TestHorizontalFlip:
             make_image_tensor,
             make_image_pil,
             make_image,
-            pytest.param(
-                make_image_cvcuda,
-                marks=pytest.mark.skipif(not CVCUDA_AVAILABLE, reason="CVCUDA is not available"),
-            ),
             make_bounding_boxes,
             make_segmentation_mask,
             make_video,
@@ -1290,11 +1286,6 @@ class TestHorizontalFlip:
             (F.horizontal_flip_image, torch.Tensor),
             (F._geometry._horizontal_flip_image_pil, PIL.Image.Image),
             (F.horizontal_flip_image, tv_tensors.Image),
-            pytest.param(
-                F._geometry._horizontal_flip_image_cvcuda,
-                None,
-                marks=pytest.mark.skipif(not CVCUDA_AVAILABLE, reason="CVCUDA is not available"),
-            ),
             (F.horizontal_flip_bounding_boxes, tv_tensors.BoundingBoxes),
             (F.horizontal_flip_mask, tv_tensors.Mask),
             (F.horizontal_flip_video, tv_tensors.Video),
@@ -1302,8 +1293,6 @@ class TestHorizontalFlip:
         ],
     )
     def test_functional_signature(self, kernel, input_type):
-        if kernel is F._geometry._horizontal_flip_image_cvcuda:
-            input_type = _import_cvcuda().Tensor
         check_functional_kernel_signature_match(F.horizontal_flip, kernel=kernel, input_type=input_type)
 
     @pytest.mark.parametrize(
@@ -1312,10 +1301,6 @@ class TestHorizontalFlip:
             make_image_tensor,
             make_image_pil,
             make_image,
-            pytest.param(
-                make_image_cvcuda,
-                marks=pytest.mark.skipif(not CVCUDA_AVAILABLE, reason="CVCUDA is not available"),
-            ),
             make_bounding_boxes,
             make_segmentation_mask,
             make_video,
@@ -1329,23 +1314,13 @@ class TestHorizontalFlip:
     @pytest.mark.parametrize(
         "fn", [F.horizontal_flip, transform_cls_to_functional(transforms.RandomHorizontalFlip, p=1)]
     )
-    @pytest.mark.parametrize(
-        "make_input",
-        [
-            make_image,
-            pytest.param(
-                make_image_cvcuda,
-                marks=pytest.mark.skipif(not CVCUDA_AVAILABLE, reason="CVCUDA is not available"),
-            ),
-        ],
-    )
-    def test_image_correctness(self, fn, make_input):
-        image = make_input()
+    def test_image_correctness(self, fn):
+        image = make_image(dtype=torch.uint8, device="cpu")
+
         actual = fn(image)
-        if make_input is make_image_cvcuda:
-            image = F.cvcuda_to_tensor(image)[0].cpu()
-        expected = F.horizontal_flip(F.to_pil_image(image))
-        assert_equal(actual, expected)
+        expected = F.to_image(F.horizontal_flip(F.to_pil_image(image)))
+
+        torch.testing.assert_close(actual, expected)
 
     def _reference_horizontal_flip_bounding_boxes(self, bounding_boxes: tv_tensors.BoundingBoxes):
         affine_matrix = np.array(
@@ -1401,10 +1376,6 @@ class TestHorizontalFlip:
             make_image_tensor,
             make_image_pil,
             make_image,
-            pytest.param(
-                make_image_cvcuda,
-                marks=pytest.mark.skipif(not CVCUDA_AVAILABLE, reason="CVCUDA is not available"),
-            ),
             make_bounding_boxes,
             make_segmentation_mask,
             make_video,
@@ -1414,8 +1385,11 @@ class TestHorizontalFlip:
     @pytest.mark.parametrize("device", cpu_and_cuda())
     def test_transform_noop(self, make_input, device):
         input = make_input(device=device)
+
         transform = transforms.RandomHorizontalFlip(p=0)
+
         output = transform(input)
+
         assert_equal(output, input)
 
 
@@ -1913,10 +1887,6 @@ class TestVerticalFlip:
             make_image_tensor,
             make_image_pil,
             make_image,
-            pytest.param(
-                make_image_cvcuda,
-                marks=pytest.mark.skipif(not CVCUDA_AVAILABLE, reason="CVCUDA is not available"),
-            ),
             make_bounding_boxes,
             make_segmentation_mask,
             make_video,
@@ -1932,11 +1902,6 @@ class TestVerticalFlip:
             (F.vertical_flip_image, torch.Tensor),
             (F._geometry._vertical_flip_image_pil, PIL.Image.Image),
             (F.vertical_flip_image, tv_tensors.Image),
-            pytest.param(
-                F._geometry._vertical_flip_image_cvcuda,
-                None,
-                marks=pytest.mark.skipif(not CVCUDA_AVAILABLE, reason="CVCUDA is not available"),
-            ),
             (F.vertical_flip_bounding_boxes, tv_tensors.BoundingBoxes),
             (F.vertical_flip_mask, tv_tensors.Mask),
             (F.vertical_flip_video, tv_tensors.Video),
@@ -1944,8 +1909,6 @@ class TestVerticalFlip:
         ],
     )
     def test_functional_signature(self, kernel, input_type):
-        if kernel is F._geometry._vertical_flip_image_cvcuda:
-            input_type = _import_cvcuda().Tensor
         check_functional_kernel_signature_match(F.vertical_flip, kernel=kernel, input_type=input_type)
 
     @pytest.mark.parametrize(
@@ -1954,10 +1917,6 @@ class TestVerticalFlip:
             make_image_tensor,
             make_image_pil,
             make_image,
-            pytest.param(
-                make_image_cvcuda,
-                marks=pytest.mark.skipif(not CVCUDA_AVAILABLE, reason="CVCUDA is not available"),
-            ),
             make_bounding_boxes,
             make_segmentation_mask,
             make_video,
@@ -1969,23 +1928,13 @@ class TestVerticalFlip:
         check_transform(transforms.RandomVerticalFlip(p=1), make_input(device=device))
 
     @pytest.mark.parametrize("fn", [F.vertical_flip, transform_cls_to_functional(transforms.RandomVerticalFlip, p=1)])
-    @pytest.mark.parametrize(
-        "make_input",
-        [
-            make_image,
-            pytest.param(
-                make_image_cvcuda,
-                marks=pytest.mark.skipif(not CVCUDA_AVAILABLE, reason="CVCUDA is not available"),
-            ),
-        ],
-    )
-    def test_image_correctness(self, fn, make_input):
-        image = make_input()
+    def test_image_correctness(self, fn):
+        image = make_image(dtype=torch.uint8, device="cpu")
+
         actual = fn(image)
-        if make_input is make_image_cvcuda:
-            image = F.cvcuda_to_tensor(image)[0].cpu()
-        expected = F.vertical_flip(F.to_pil_image(image))
-        assert_equal(actual, expected)
+        expected = F.to_image(F.vertical_flip(F.to_pil_image(image)))
+
+        torch.testing.assert_close(actual, expected)
 
     def _reference_vertical_flip_bounding_boxes(self, bounding_boxes: tv_tensors.BoundingBoxes):
         affine_matrix = np.array(
@@ -2037,10 +1986,6 @@ class TestVerticalFlip:
             make_image_tensor,
             make_image_pil,
             make_image,
-            pytest.param(
-                make_image_cvcuda,
-                marks=pytest.mark.skipif(not CVCUDA_AVAILABLE, reason="CVCUDA is not available"),
-            ),
             make_bounding_boxes,
             make_segmentation_mask,
             make_video,
@@ -2050,8 +1995,11 @@ class TestVerticalFlip:
     @pytest.mark.parametrize("device", cpu_and_cuda())
     def test_transform_noop(self, make_input, device):
         input = make_input(device=device)
+
         transform = transforms.RandomVerticalFlip(p=0)
+
         output = transform(input)
+
         assert_equal(output, input)
 
 

--- a/torchvision/transforms/v2/__init__.py
+++ b/torchvision/transforms/v2/__init__.py
@@ -55,7 +55,7 @@ from ._misc import (
     ToDtype,
 )
 from ._temporal import UniformTemporalSubsample
-from ._type_conversion import CVCUDAToTensor, PILToTensor, ToCVCUDATensor, ToImage, ToPILImage, ToPureTensor
+from ._type_conversion import PILToTensor, ToImage, ToPILImage, ToPureTensor
 from ._utils import check_type, get_bounding_boxes, get_keypoints, has_all, has_any, query_chw, query_size
 
 from ._deprecated import ToTensor  # usort: skip

--- a/torchvision/transforms/v2/_geometry.py
+++ b/torchvision/transforms/v2/_geometry.py
@@ -11,7 +11,7 @@ from torchvision import transforms as _transforms, tv_tensors
 from torchvision.ops.boxes import box_iou
 from torchvision.transforms.functional import _get_perspective_coeffs
 from torchvision.transforms.v2 import functional as F, InterpolationMode, Transform
-from torchvision.transforms.v2.functional._utils import _FillType, _is_cvcuda_available, _is_cvcuda_tensor
+from torchvision.transforms.v2.functional._utils import _FillType
 
 from ._transform import _RandomApplyTransform
 from ._utils import (
@@ -30,8 +30,6 @@ from ._utils import (
     query_size,
 )
 
-CVCUDA_AVAILABLE = _is_cvcuda_available()
-
 
 class RandomHorizontalFlip(_RandomApplyTransform):
     """Horizontally flip the input with a given probability.
@@ -46,9 +44,6 @@ class RandomHorizontalFlip(_RandomApplyTransform):
     """
 
     _v1_transform_cls = _transforms.RandomHorizontalFlip
-
-    if CVCUDA_AVAILABLE:
-        _transformed_types = _RandomApplyTransform._transformed_types + (_is_cvcuda_tensor,)
 
     def transform(self, inpt: Any, params: dict[str, Any]) -> Any:
         return self._call_kernel(F.horizontal_flip, inpt)
@@ -67,9 +62,6 @@ class RandomVerticalFlip(_RandomApplyTransform):
     """
 
     _v1_transform_cls = _transforms.RandomVerticalFlip
-
-    if CVCUDA_AVAILABLE:
-        _transformed_types = _RandomApplyTransform._transformed_types + (_is_cvcuda_tensor,)
 
     def transform(self, inpt: Any, params: dict[str, Any]) -> Any:
         return self._call_kernel(F.vertical_flip, inpt)

--- a/torchvision/transforms/v2/_type_conversion.py
+++ b/torchvision/transforms/v2/_type_conversion.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, TYPE_CHECKING, Union
+from typing import Any, Optional, Union
 
 import numpy as np
 import PIL.Image
@@ -6,11 +6,8 @@ import torch
 
 from torchvision import tv_tensors
 from torchvision.transforms.v2 import functional as F, Transform
-from torchvision.transforms.v2._utils import is_pure_tensor
-from torchvision.transforms.v2.functional._utils import _import_cvcuda
 
-if TYPE_CHECKING:
-    import cvcuda  # type: ignore[import-not-found]
+from torchvision.transforms.v2._utils import is_pure_tensor
 
 
 class PILToTensor(Transform):
@@ -93,31 +90,3 @@ class ToPureTensor(Transform):
 
     def transform(self, inpt: Any, params: dict[str, Any]) -> torch.Tensor:
         return inpt.as_subclass(torch.Tensor)
-
-
-class ToCVCUDATensor(Transform):
-    """Convert a ``torch.Tensor`` with NCHW shape to a ``cvcuda.Tensor``.
-    If the input tensor is on CPU, it will automatically be transferred to GPU.
-    Only 1-channel and 3-channel images are supported.
-
-    This transform does not support torchscript.
-    """
-
-    def transform(self, inpt: torch.Tensor, params: dict[str, Any]) -> "cvcuda.Tensor":
-        return F.to_cvcuda_tensor(inpt)
-
-
-class CVCUDAToTensor(Transform):
-    """Convert a ``cvcuda.Tensor`` to a ``torch.Tensor`` with NCHW shape.
-
-    This function does not support torchscript.
-    """
-
-    try:
-        cvcuda = _import_cvcuda()
-        _transformed_types = (cvcuda.Tensor,)
-    except ImportError:
-        pass
-
-    def transform(self, inpt: Any, params: dict[str, Any]) -> torch.Tensor:
-        return F.cvcuda_to_tensor(inpt)

--- a/torchvision/transforms/v2/functional/__init__.py
+++ b/torchvision/transforms/v2/functional/__init__.py
@@ -162,6 +162,6 @@ from ._misc import (
     to_dtype_video,
 )
 from ._temporal import uniform_temporal_subsample, uniform_temporal_subsample_video
-from ._type_conversion import cvcuda_to_tensor, pil_to_tensor, to_cvcuda_tensor, to_image, to_pil_image
+from ._type_conversion import pil_to_tensor, to_image, to_pil_image
 
 from ._deprecated import get_image_size, to_tensor  # usort: skip

--- a/torchvision/transforms/v2/functional/_geometry.py
+++ b/torchvision/transforms/v2/functional/_geometry.py
@@ -3,7 +3,7 @@ import numbers
 import platform
 import warnings
 from collections.abc import Sequence
-from typing import Any, Optional, TYPE_CHECKING, Union
+from typing import Any, Optional, Union
 
 import PIL.Image
 import torch
@@ -27,18 +27,7 @@ from torchvision.utils import _log_api_usage_once
 
 from ._meta import _get_size_image_pil, clamp_bounding_boxes, convert_bounding_box_format
 
-from ._utils import (
-    _FillTypeJIT,
-    _get_kernel,
-    _import_cvcuda,
-    _is_cvcuda_available,
-    _register_five_ten_crop_kernel_internal,
-    _register_kernel_internal,
-)
-
-CVCUDA_AVAILABLE = _is_cvcuda_available()
-if TYPE_CHECKING:
-    import cvcuda  # type: ignore[import-not-found]
+from ._utils import _FillTypeJIT, _get_kernel, _register_five_ten_crop_kernel_internal, _register_kernel_internal
 
 
 def _check_interpolation(interpolation: Union[InterpolationMode, int]) -> InterpolationMode:
@@ -72,14 +61,6 @@ def horizontal_flip_image(image: torch.Tensor) -> torch.Tensor:
 @_register_kernel_internal(horizontal_flip, PIL.Image.Image)
 def _horizontal_flip_image_pil(image: PIL.Image.Image) -> PIL.Image.Image:
     return _FP.hflip(image)
-
-
-def _horizontal_flip_image_cvcuda(image: "cvcuda.Tensor") -> "cvcuda.Tensor":
-    return _import_cvcuda().flip(image, flipCode=1)
-
-
-if CVCUDA_AVAILABLE:
-    _register_kernel_internal(horizontal_flip, _import_cvcuda().Tensor)(_horizontal_flip_image_cvcuda)
 
 
 @_register_kernel_internal(horizontal_flip, tv_tensors.Mask)
@@ -168,14 +149,6 @@ def vertical_flip_image(image: torch.Tensor) -> torch.Tensor:
 @_register_kernel_internal(vertical_flip, PIL.Image.Image)
 def _vertical_flip_image_pil(image: PIL.Image.Image) -> PIL.Image.Image:
     return _FP.vflip(image)
-
-
-def _vertical_flip_image_cvcuda(image: "cvcuda.Tensor") -> "cvcuda.Tensor":
-    return _import_cvcuda().flip(image, flipCode=0)
-
-
-if CVCUDA_AVAILABLE:
-    _register_kernel_internal(vertical_flip, _import_cvcuda().Tensor)(_vertical_flip_image_cvcuda)
 
 
 @_register_kernel_internal(vertical_flip, tv_tensors.Mask)

--- a/torchvision/transforms/v2/functional/_meta.py
+++ b/torchvision/transforms/v2/functional/_meta.py
@@ -1,4 +1,4 @@
-from typing import Optional, TYPE_CHECKING, Union
+from typing import Optional, Union
 
 import PIL.Image
 import torch
@@ -9,14 +9,7 @@ from torchvision.tv_tensors._bounding_boxes import CLAMPING_MODE_TYPE
 
 from torchvision.utils import _log_api_usage_once
 
-from ._utils import _get_kernel, _import_cvcuda, _is_cvcuda_available, _register_kernel_internal, is_pure_tensor
-
-CVCUDA_AVAILABLE = _is_cvcuda_available()
-
-if TYPE_CHECKING:
-    import cvcuda  # type: ignore[import-not-found]
-if CVCUDA_AVAILABLE:
-    cvcuda = _import_cvcuda()  # noqa: F811
+from ._utils import _get_kernel, _register_kernel_internal, is_pure_tensor
 
 
 def get_dimensions(inpt: torch.Tensor) -> list[int]:
@@ -112,20 +105,6 @@ def get_size_image(image: torch.Tensor) -> list[int]:
 def _get_size_image_pil(image: PIL.Image.Image) -> list[int]:
     width, height = _FP.get_image_size(image)
     return [height, width]
-
-
-def get_size_image_cvcuda(image: "cvcuda.Tensor") -> list[int]:
-    """Get size of `cvcuda.Tensor` with NHWC layout."""
-    hw = list(image.shape[-3:-1])
-    ndims = len(hw)
-    if ndims == 2:
-        return hw
-    else:
-        raise TypeError(f"Input tensor should have at least two dimensions, but got {ndims}")
-
-
-if CVCUDA_AVAILABLE:
-    _get_size_image_cvcuda = _register_kernel_internal(get_size, cvcuda.Tensor)(get_size_image_cvcuda)
 
 
 @_register_kernel_internal(get_size, tv_tensors.Video, tv_tensor_wrapper=False)

--- a/torchvision/transforms/v2/functional/_type_conversion.py
+++ b/torchvision/transforms/v2/functional/_type_conversion.py
@@ -1,16 +1,10 @@
-from typing import TYPE_CHECKING, Union
+from typing import Union
 
 import numpy as np
 import PIL.Image
 import torch
 from torchvision import tv_tensors
 from torchvision.transforms import functional as _F
-from torchvision.utils import _log_api_usage_once
-
-from ._utils import _import_cvcuda
-
-if TYPE_CHECKING:
-    import cvcuda  # type: ignore[import-not-found]
 
 
 @torch.jit.unused
@@ -31,34 +25,3 @@ def to_image(inpt: Union[torch.Tensor, PIL.Image.Image, np.ndarray]) -> tv_tenso
 
 to_pil_image = _F.to_pil_image
 pil_to_tensor = _F.pil_to_tensor
-
-
-@torch.jit.unused
-def to_cvcuda_tensor(inpt: torch.Tensor) -> "cvcuda.Tensor":
-    """See :class:``~torchvision.transforms.v2.ToCVCUDATensor`` for details."""
-    cvcuda = _import_cvcuda()
-    if not torch.jit.is_scripting() and not torch.jit.is_tracing():
-        _log_api_usage_once(to_cvcuda_tensor)
-    if not isinstance(inpt, (torch.Tensor, tv_tensors.Image)):
-        raise TypeError(f"inpt should be ``torch.Tensor`` or ``tv_tensors.Image``. Got {type(inpt)}.")
-    if inpt.ndim != 4:
-        raise ValueError(f"pic should be 4 dimensional. Got {inpt.ndim} dimensions.")
-    # Convert to NHWC as CVCUDA transforms do not support NCHW
-    inpt = inpt.permute(0, 2, 3, 1)
-    return cvcuda.as_tensor(inpt.cuda().contiguous(), cvcuda.TensorLayout.NHWC)
-
-
-@torch.jit.unused
-def cvcuda_to_tensor(cvcuda_img: "cvcuda.Tensor") -> torch.Tensor:
-    """See :class:``~torchvision.transforms.v2.CVCUDAToTensor`` for details."""
-    cvcuda = _import_cvcuda()
-    if not torch.jit.is_scripting() and not torch.jit.is_tracing():
-        _log_api_usage_once(cvcuda_to_tensor)
-    if not isinstance(cvcuda_img, cvcuda.Tensor):
-        raise TypeError(f"cvcuda_img should be ``cvcuda.Tensor``. Got {type(cvcuda_img)}.")
-    cuda_tensor = torch.as_tensor(cvcuda_img.cuda(), device="cuda")
-    if cvcuda_img.ndim != 4:
-        raise ValueError(f"Image should be 4 dimensional. Got {cuda_tensor.ndim} dimensions.")
-    # Convert to NCHW shape from CVCUDA default NHWC
-    img = cuda_tensor.permute(0, 3, 1, 2)
-    return img

--- a/torchvision/transforms/v2/functional/_utils.py
+++ b/torchvision/transforms/v2/functional/_utils.py
@@ -140,32 +140,3 @@ def _register_five_ten_crop_kernel_internal(functional, input_type):
         return kernel
 
     return decorator
-
-
-def _import_cvcuda():
-    """Import CV-CUDA modules with informative error message if not installed.
-
-    Returns:
-        cvcuda module.
-
-    Raises:
-        RuntimeError: If CV-CUDA is not installed.
-    """
-    try:
-        import cvcuda  # type: ignore[import-not-found]
-
-        return cvcuda
-    except ImportError as e:
-        raise ImportError(
-            "CV-CUDA is required but not installed. "
-            "Please install it following the instructions at "
-            "https://github.com/CVCUDA/CV-CUDA."
-        ) from e
-
-
-def _is_cvcuda_available():
-    try:
-        _ = _import_cvcuda()
-        return True
-    except ImportError:
-        return False

--- a/torchvision/transforms/v2/functional/_utils.py
+++ b/torchvision/transforms/v2/functional/_utils.py
@@ -169,11 +169,3 @@ def _is_cvcuda_available():
         return True
     except ImportError:
         return False
-
-
-def _is_cvcuda_tensor(inpt: Any) -> bool:
-    try:
-        cvcuda = _import_cvcuda()
-        return isinstance(inpt, cvcuda.Tensor)
-    except ImportError:
-        return False


### PR DESCRIPTION
This is hopefully temporary. We haven't made progress on the CV-CUDA intergration for a while, and I've had to revert the CV-CUDA stuff in all past 3 release branches so far, so I'm removing them from `main` for the time being.

Since they're mostly orthogonal to the rest of the codebase, it'll be easy to bring these commits back when we need to.