### PR TITLE
[xrpilot_vision] Add AMD GPU (HIP/ROCm) support to torchvision ops

### DIFF
--- a/torchvision/csrc/ops/cuda/ps_roi_align_kernel.cu
+++ b/torchvision/csrc/ops/cuda/ps_roi_align_kernel.cu
@@ -384,7 +384,7 @@ std::tuple<at::Tensor, at::Tensor> ps_roi_align_forward_kernel(
             channel_mapping.data_ptr<int>());
       });
   AT_CUDA_CHECK(cudaGetLastError());
-  cudaDeviceSynchronize();
+  AT_CUDA_CHECK(cudaDeviceSynchronize());
   return std::make_tuple(output, channel_mapping);
 }
 


### PR DESCRIPTION
Summary:
Adapted from D94284807 by Dave Driver (changes-planned, not landed). I
needed it as a prerequisite for the SAM 3 spike on MI300X — SAM 3 calls
torchvision::roi_align which has no HIP kernel today — so re-submitting
under my name for landing.

**Why torchvision custom ops need this:** torchvision CUDA ops (NMS,
ROI align/pool, deform_conv2d, PS ROI align/pool) were compiled only
for NVIDIA GPUs. This change adds AMD GPU support by hipifying the CUDA
kernels at build time using fbcode//compilers/amd:hipify.

**Changes:**
- Add a custom_rule genrule that runs the hipify tool on the CUDA .cu and
  .h files, producing .hip and .h outputs under torchvision/csrc/ops/hip/
- Update OPS_SRCS_GPU, OPS_H_GPU, and GPU_FLAGS to use select_accelerator()
  to route hipified sources and HIP preprocessor defines on AMD builds
- Add hip_flags = get_rocm_arch_args() to compile for the correct AMD GPU
  architecture (e.g. gfx942 for MI300X)
- Add ("rocm", None, "amdhip64-lazy") to exported_external_deps for AMD
- Fix unused return value of cudaDeviceSynchronize() in ps_roi_align_kernel.cu
  — wrap with AT_CUDA_CHECK() to satisfy HIP's [[nodiscard]] attribute
- box_iou_rotated_kernel.cu is excluded from the AMD glob because it
  includes a parent-dir header (`../box_iou_rotated_utils.h`) which the
  hipify pass doesn't carry into the generated tree. Callers needing
  rotated-box IoU on AMD use torch.ops.detectron2.box_iou_rotated.

Differential Revision: D101543952




cc @jeffdaily @jithunnair-amd