### PR TITLE
[split] Remove LEGACY template parameter from callers of fbgemm::Quantize in pytorch/vision (extracted from D101871199) (#9484)

### DIFF
--- a/torchvision/csrc/ops/quantized/cpu/qroi_align_kernel.cpp
+++ b/torchvision/csrc/ops/quantized/cpu/qroi_align_kernel.cpp
@@ -35,7 +35,7 @@ T quantize_val(double scale, int64_t zero_point, float value) {
   // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   int32_t qvalue;
   // NOLINTNEXTLINE(bugprone-signed-char-misuse)
-  qvalue = fbgemm::Quantize<typename T::underlying, false /*LEGACY*/>(
+  qvalue = fbgemm::Quantize<typename T::underlying>(
       value,
       static_cast<int32_t>(zero_point),
       static_cast<float>(scale),


### PR DESCRIPTION
Summary:

Remove the `LEGACY` template parameter from `fbgemm::Quantize` call sites in pytorch/vision

This diff removes the now-unnecessary `false /*LEGACY*/` template argument from the `fbgemm::Quantize<T>` call in torchvision's quantized RoI Align kernel. This is a follow-up to D100683749, which removed the `LEGACY` template parameter from the `fbgemm::Quantize` API entirely. Specifically:

1. **Template parameter cleanup**: Removes the explicit `false /*LEGACY*/` second template argument, relying on the simplified single-parameter `fbgemm::Quantize<T>()` signature
2. **Both fbcode and xplat copies**: Updates the mirrored file in both `fbcode/` and `xplat/` paths

## Detailed Changes

### `fbcode/pytorch/vision/torchvision/csrc/ops/quantized/cpu/qroi_align_kernel.cpp`
- Removes `false /*LEGACY*/` template parameter from `fbgemm::Quantize<typename T::underlying, false /*LEGACY*/>()` in `quantize_val<T>()`, simplifying to `fbgemm::Quantize<typename T::underlying>()`

### `xplat/pytorch/vision/torchvision/csrc/ops/quantized/cpu/qroi_align_kernel.cpp`
- Same change as above in the xplat mirror

Reviewed By: gchalump

Differential Revision: D101874472


