### PR TITLE
Fix not exporting encode_png on windows

### DIFF
--- a/torchvision/csrc/io/image/cpu/encode_png.cpp
+++ b/torchvision/csrc/io/image/cpu/encode_png.cpp
@@ -1,4 +1,4 @@
-#include "encode_jpeg.h"
+#include "encode_png.h"
 
 #include <torch/headeronly/util/Exception.h>
 


### PR DESCRIPTION
As `encode_png.h` was not included `encode_png` in `encode_png.cpp` becomes the definition of a new function not the definition of the function declared in `encode_png.h`, therefore it is not decorated with `C10_EXPORT` and is not exported to the DLL on Windows.
