### PR TITLE
[roi_align] Fix XPU autocast precision in deterministic implementation

### DIFF
--- a/torchvision/ops/roi_align.py
+++ b/torchvision/ops/roi_align.py
@@ -99,10 +99,11 @@ def _bilinear_interpolate(
 # TODO: this doesn't actually cache
 # TODO: main library should make this easier to do
 def maybe_cast(tensor):
-    if torch.is_autocast_enabled() and tensor.is_cuda and tensor.dtype != torch.double:
+    if tensor.dtype != torch.double and (
+        (torch.is_autocast_enabled() and tensor.is_cuda) or (torch.is_autocast_enabled("xpu") and tensor.is_xpu)
+    ):
         return tensor.float()
-    else:
-        return tensor
+    return tensor
 
 
 # This is a pure Python and differentiable implementation of roi_align.  When


### PR DESCRIPTION
When torch.are_deterministic_algorithms_enabled() is True on XPU, roi_align() routes to the pure-Python _roi_align() implementation. _roi_align() calls maybe_cast() to promote low-precision inputs to float32 before coordinate arithmetic. However, maybe_cast() only handled CUDA autocast via torch.is_autocast_enabled(), which returns False inside a torch.amp.autocast("xpu") context. As a result, float16 inputs were not promoted on XPU, causing ~1e-3 numerical errors that exceeded the 1e-5 tolerance in test_autocast.

Fix: Promote to float32 when dtype != torch.double when XPU autocast is enabled.

Fixes: https://github.com/intel/torch-xpu-ops/issues/3518
