### PR TITLE
ci: declare per-job permissions on tests-schedule workflow

### DIFF
--- a/.github/workflows/tests-schedule.yml
+++ b/.github/workflows/tests-schedule.yml
@@ -13,6 +13,9 @@ on:
 jobs:
   download:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write # JasonEtco/create-an-issue opens a tracking issue on schedule failure
 
     steps:
       - name: Set up python


### PR DESCRIPTION
The `tests-schedule` workflow runs nightly against the dataset-download tests and, on schedule failure, uses `JasonEtco/create-an-issue@v2.4.0` to open a tracking issue. Right now it doesn't declare a `permissions:` block.

The actual scope needed is small:

- `contents: read` for `actions/checkout`
- `issues: write` for `JasonEtco/create-an-issue` (POST `/repos/{owner}/{repo}/issues`)

This patch pins both at the job level, matching the per-job permission blocks already used by the reusable-test callers in this repo (`build-cmake.yml`, `build-conda-linux.yml`, `build-conda-m1.yml`, ...): typically `id-token: write` + `contents: read` for the OIDC + checkout pair.

With explicit scope:

- the workflow token can't be widened by a future change to the repo default
- the SLSA / OpenSSF Scorecard `Token-Permissions` check passes for this file
- a hypothetical compromise of `JasonEtco/create-an-issue` (cf. tj-actions/changed-files CVE-2025-30066) stays confined to "can open issues", not the broader default scope

`update-viablestrict.yml` is the other workflow in this repo that doesn't declare permissions, but it's deliberately small (one composite-action invocation, ~28 lines) and uses `UPDATEBOT_TOKEN` for any write path, so I left it out of this PR to keep the change focused.

No behavioural change.