### PR TITLE
Fix dead PhotoTour dataset docstring link

### DIFF
--- a/torchvision/datasets/phototour.py
+++ b/torchvision/datasets/phototour.py
@@ -11,7 +11,7 @@ from .vision import VisionDataset
 
 
 class PhotoTour(VisionDataset):
-    """`Multi-view Stereo Correspondence <http://matthewalunbrown.com/patchdata/patchdata.html>`_ Dataset.
+    """`Multi-view Stereo Correspondence <https://phototour.cs.washington.edu/patches/default.htm>`_ Dataset.
 
     .. note::
 


### PR DESCRIPTION
## Summary

The ``PhotoTour`` dataset class's docstring linked to ``http://matthewalunbrown.com/patchdata/patchdata.html``, which no longer hosts the dataset. The domain ``matthewalunbrown.com`` 301-redirects all ``patchdata/`` paths to the site root, which currently serves unrelated commercial content.

This patch updates the ``Multi-view Stereo Correspondence`` link in the ``PhotoTour`` docstring to point at the original UW project page ``https://phototour.cs.washington.edu/patches/default.htm``, which still serves and which the existing note in the same docstring already references as the original dataset page.

Scope is limited to the docstring link. The download URLs in the ``urls`` dict also appear to be broken (see #8722), but per the maintainer comment on that issue there is no known working replacement for the actual ``*_harris.zip`` archives, so those are intentionally left alone in this PR.

Fixes #8722

## Test plan

- [x] ``curl -I https://phototour.cs.washington.edu/patches/default.htm`` returns ``HTTP/1.1 200 OK``
- [x] One-line change, docstring only, no behavior change