### PR TITLE
Document Inception3 transform_input override for pretrained weights

### DIFF
--- a/torchvision/models/inception.py
+++ b/torchvision/models/inception.py
@@ -26,6 +26,43 @@ _InceptionOutputs = InceptionOutputs
 
 
 class Inception3(nn.Module):
+    """Inception v3 model architecture from
+    `Rethinking the Inception Architecture for Computer Vision <http://arxiv.org/abs/1512.00567>`_.
+
+    .. note::
+        When loading pretrained weights via :func:`~torchvision.models.inception_v3`
+        (i.e. by passing a non-``None`` ``weights`` argument), ``transform_input``
+        is silently set to ``True`` regardless of the value passed to this
+        constructor. This is required because the pretrained weights expect
+        inputs normalized to ImageNet statistics. See :func:`inception_v3`
+        for details.
+
+    Args:
+        num_classes (int, optional): Number of classes for the classification
+            head. Default is 1000.
+        aux_logits (bool, optional): If ``True``, attach an auxiliary classifier
+            (``AuxLogits``) on top of an intermediate feature map. The auxiliary
+            output is only returned during training. Default is ``True``.
+        transform_input (bool, optional): If ``True``, pre-process the input
+            according to the method used in the original paper (rescale from
+            ``mean=0.5, std=0.5`` to the ImageNet ``mean``/``std``). This option
+            is intended for use with pretrained weights that were trained with
+            this preprocessing. Default is ``False``. Note that this argument
+            is overridden to ``True`` by :func:`inception_v3` when pretrained
+            weights are loaded (see note above).
+        inception_blocks (list of callable, optional): A list of 7 callables
+            used to build the model's inception blocks, in the following order:
+            ``[BasicConv2d, InceptionA, InceptionB, InceptionC, InceptionD,
+            InceptionE, InceptionAux]``. If ``None``, the default torchvision
+            implementations are used.
+        init_weights (bool, optional): If ``True``, initialize the model
+            weights using truncated normal initialization. If ``None``, defaults
+            to ``True`` and emits a ``FutureWarning``: this default will change
+            in a future release.
+        dropout (float, optional): Dropout probability applied before the final
+            fully-connected layer. Default is ``0.5``.
+    """
+
     def __init__(
         self,
         num_classes: int = 1000,
@@ -440,6 +477,15 @@ def inception_v3(*, weights: Optional[Inception_V3_Weights] = None, progress: bo
     .. note::
         **Important**: In contrast to the other models the inception_v3 expects tensors with a size of
         N x 3 x 299 x 299, so ensure your images are sized accordingly.
+
+    .. note::
+        When ``weights`` is not ``None`` (i.e. pretrained weights are requested),
+        ``transform_input`` is forced to ``True`` regardless of any value passed
+        via ``kwargs``. The pretrained weights expect inputs normalized to
+        ImageNet statistics, and the input transform inside
+        :class:`Inception3` rescales the input accordingly. If you need to
+        bypass this transform when using pretrained weights, set
+        ``model.transform_input = False`` on the returned model.
 
     Args:
         weights (:class:`~torchvision.models.Inception_V3_Weights`, optional): The


### PR DESCRIPTION
## Summary

Fixes #1709.

`Inception3` had no class docstring. The constructor exposes `transform_input` with default `False`, but `inception_v3(weights=...)` silently calls `_ovewrite_named_param(kwargs, "transform_input", True)` and forces it to `True` whenever pretrained weights are loaded (the weights expect ImageNet-normalised inputs). Users reading the source see `transform_input: bool = False` and reasonably assume the constructor default holds, when in practice it does not.

This is a pure docs change. No behaviour is modified.

## Changes

- Add a class docstring to `Inception3` documenting all constructor arguments (`num_classes`, `aux_logits`, `transform_input`, `inception_blocks`, `init_weights`, `dropout`) in the torchvision style.
- Add a `.. note::` to the class docstring describing the `transform_input` override applied by the factory when pretrained weights are loaded, and pointing readers to `inception_v3`.
- Add a matching `.. note::` to the `inception_v3` factory docstring, explaining the override and showing the escape hatch (`model.transform_input = False` after construction) for users who need it.

## Test plan

- [x] `python3 -c "import ast; ast.parse(open('torchvision/models/inception.py').read())"` succeeds (no syntax regressions).
- [x] No behaviour change: only docstrings were added; the constructor signature, defaults, factory logic, and `_ovewrite_named_param` call are untouched.
- [ ] Sphinx render of the updated docstrings looks clean (CI on this PR exercises the docs build).