### PR TITLE
Remove obsolete FIXME in autoaugment.py

### DIFF
--- a/torchvision/transforms/autoaugment.py
+++ b/torchvision/transforms/autoaugment.py
@@ -100,7 +100,6 @@ class AutoAugmentPolicy(Enum):
     SVHN = "svhn"
 
 
-# FIXME: Eliminate copy-pasted code for fill standardization and _augmentation_space() by moving stuff on a base class
 class AutoAugment(torch.nn.Module):
     r"""AutoAugment data augmentation method based on
     `"AutoAugment: Learning Augmentation Strategies from Data" <https://arxiv.org/pdf/1805.09501.pdf>`_.


### PR DESCRIPTION
## Summary

Removes the FIXME comment at `torchvision/transforms/autoaugment.py:103`:

> `# FIXME: Eliminate copy-pasted code for fill standardization and _augmentation_space() by moving stuff on a base class`

The FIXME proposed extracting a shared `_AutoAugmentBase` to deduplicate the fill-standardization logic that `AutoAugment`, `RandAugment`, `TrivialAugmentWide`, and `AugMix` each implement in v1. The v2 transforms in `torchvision/transforms/v2/_auto_augment.py` already have this base class, so the refactor only ever made sense for v1.

Per maintainer guidance in #9447:

> We won't be merging the changes in this PR as-is, since we're focusing on V2 going forward and aren't planning to make further changes to V1. [...] If you update this PR to only remove the FIXME comment and adjust the PR description accordingly, I'm happy to approve and merge it.

Since #9447 has been inactive for over a month after that follow-up, opening this as a minimal alternative that matches exactly what the maintainer asked for: removing the FIXME to reflect that the refactor will not be done in v1. Happy to defer to #9447 if it becomes active again.

## Changes

- Delete one comment line in `torchvision/transforms/autoaugment.py`. No code or behavior changes.

Closes #9446.

## Test plan

- [x] Confirmed the change is comment-only — no Python source, no behavior, no tests affected.