### PR TITLE
Fix `resize_mask` to honor `NEAREST_EXACT` interpolation

### DIFF
--- a/test/test_transforms_v2.py
+++ b/test/test_transforms_v2.py
@@ -808,8 +808,17 @@ class TestResize:
         )
 
     @pytest.mark.parametrize("make_mask", [make_segmentation_mask, make_detection_masks])
-    def test_kernel_mask(self, make_mask):
-        check_kernel(F.resize_mask, make_mask(self.INPUT_SIZE), size=self.OUTPUT_SIZES[-1])
+    @pytest.mark.parametrize(
+        "interpolation",
+        [transforms.InterpolationMode.NEAREST, transforms.InterpolationMode.NEAREST_EXACT],
+    )
+    def test_kernel_mask(self, make_mask, interpolation):
+        check_kernel(
+            F.resize_mask,
+            make_mask(self.INPUT_SIZE),
+            size=self.OUTPUT_SIZES[-1],
+            interpolation=interpolation,
+        )
 
     def test_kernel_video(self):
         check_kernel(F.resize_video, make_video(self.INPUT_SIZE), size=self.OUTPUT_SIZES[-1], antialias=True)

--- a/torchvision/transforms/v2/functional/_geometry.py
+++ b/torchvision/transforms/v2/functional/_geometry.py
@@ -396,14 +396,26 @@ def __resize_image_pil_dispatch(
     return _resize_image_pil(image, size=size, interpolation=interpolation, max_size=max_size)
 
 
-def resize_mask(mask: torch.Tensor, size: Optional[list[int]], max_size: Optional[int] = None) -> torch.Tensor:
+def resize_mask(
+    mask: torch.Tensor,
+    size: Optional[list[int]],
+    interpolation: Union[str, InterpolationMode, int] = InterpolationMode.BILINEAR,
+    max_size: Optional[int] = None,
+) -> torch.Tensor:
     if mask.ndim < 3:
         mask = mask.unsqueeze(0)
         needs_squeeze = True
     else:
         needs_squeeze = False
 
-    output = resize_image(mask, size=size, interpolation=InterpolationMode.NEAREST, max_size=max_size)
+    interpolation = _check_interpolation(interpolation)
+    # Masks only support nearest-neighbor interpolations. Any other mode is
+    # silently coerced to NEAREST so the historical behavior of ignoring the
+    # signature-level default (BILINEAR) is preserved.
+    if interpolation != InterpolationMode.NEAREST and interpolation != InterpolationMode.NEAREST_EXACT:
+        interpolation = InterpolationMode.NEAREST
+
+    output = resize_image(mask, size=size, interpolation=interpolation, max_size=max_size)
 
     if needs_squeeze:
         output = output.squeeze(0)
@@ -413,9 +425,13 @@ def resize_mask(mask: torch.Tensor, size: Optional[list[int]], max_size: Optiona
 
 @_register_kernel_internal(resize, tv_tensors.Mask, tv_tensor_wrapper=False)
 def _resize_mask_dispatch(
-    inpt: tv_tensors.Mask, size: list[int], max_size: Optional[int] = None, **kwargs: Any
+    inpt: tv_tensors.Mask,
+    size: list[int],
+    interpolation: Union[str, InterpolationMode, int] = InterpolationMode.BILINEAR,
+    max_size: Optional[int] = None,
+    **kwargs: Any,
 ) -> tv_tensors.Mask:
-    output = resize_mask(inpt.as_subclass(torch.Tensor), size, max_size=max_size)
+    output = resize_mask(inpt.as_subclass(torch.Tensor), size, interpolation=interpolation, max_size=max_size)
     return tv_tensors.wrap(output, like=inpt)
 
 


### PR DESCRIPTION
<!-- Before submitting a PR, please make sure to check our contributing guidelines regarding code formatting, tests, and documentation: https://github.com/pytorch/vision/blob/main/CONTRIBUTING.md -->

Closes #9188.

The `interpolation` argument was effectively ignored for `tv_tensors.Mask` inputs. `resize_mask` hardcoded `InterpolationMode.NEAREST` when calling `resize_image`, so `F.resize(mask, size, interpolation=InterpolationMode.NEAREST_EXACT)` produced the same output as plain `NEAREST`, contrary to what the docs imply.

**Reproduction (before this PR):**

```python
import torch
from torchvision import tv_tensors
from torchvision.transforms.v2 import functional as F, InterpolationMode

mask = tv_tensors.Mask(torch.randint(0, 4, (1, 7, 11)))
a = F.resize(mask, size=[14, 22], interpolation=InterpolationMode.NEAREST)
b = F.resize(mask, size=[14, 22], interpolation=InterpolationMode.NEAREST_EXACT)
assert torch.equal(a, b)   # passes — bug: NEAREST_EXACT was a no-op
```

After this PR, `b` is computed with `nearest-exact` and the two tensors differ on inputs where the two algorithms disagree.

### What changed

- Add an `interpolation` parameter to `resize_mask` and `_resize_mask_dispatch`, in the position expected by `F.resize` (`mask, size, interpolation, max_size`) and with the same annotation and default (`Union[str, InterpolationMode, int] = InterpolationMode.BILINEAR`) so `test_functional_signature[F.resize_mask-Mask]` passes.
- Validate through the existing `_check_interpolation` helper. Anything other than `NEAREST` / `NEAREST_EXACT` is silently coerced to `NEAREST`, preserving the historical behavior of callers that previously relied on the argument being ignored. Comparisons are chained `!=` / `and` (no set literals) so the function stays TorchScript-compatible.
- Extend `TestResize.test_kernel_mask` to parametrize over `NEAREST` and `NEAREST_EXACT`, exercising eager / scripted / batched / CUDA via `check_kernel`.

A prior attempt at the same fix is open as #9384; the maintainer review there spelled out the signature ordering, set-literal, and default-value issues that this PR addresses from scratch.

### Test plan

- `pytest test/test_transforms_v2.py -k "TestResize and (test_kernel_mask or test_functional_signature)" -v` covers the new parametrization and the signature contract (to be exercised on CI).
- Existing call sites of `resize_mask` (`resized_crop_mask` at `_geometry.py:2845`) pass `(mask, size)` positionally and are backward-compatible with the new signature.

cc @vfdev-5