### PR TITLE
Support inplace in ConvertBoundingBoxFormat transform

### DIFF
--- a/test/test_transforms_v2.py
+++ b/test/test_transforms_v2.py
@@ -4371,6 +4371,31 @@ class TestConvertBoundingBoxFormat:
         )
 
     @pytest.mark.parametrize(("old_format", "new_format"), old_new_formats)
+    @pytest.mark.parametrize("dtype", [torch.float32, torch.int64])
+    def test_transform_inplace(self, old_format, new_format, dtype):
+        if not dtype.is_floating_point and (
+            tv_tensors.is_rotated_bounding_format(old_format) or tv_tensors.is_rotated_bounding_format(new_format)
+        ):
+            pytest.xfail("Rotated bounding boxes should be floating point tensors")
+
+        input = make_bounding_boxes(format=old_format, dtype=dtype)
+        input_data_ptr = input.data_ptr()
+        input_version = input._version
+
+        out_of_place = transforms.ConvertBoundingBoxFormat(new_format, inplace=False)(input.clone())
+        in_place = transforms.ConvertBoundingBoxFormat(new_format, inplace=True)(input)
+
+        if old_format != tv_tensors.BoundingBoxFormat.XYXYXYXY and new_format != tv_tensors.BoundingBoxFormat.XYXYXYXY:
+            # NOTE: BoundingBox format conversion from and to XYXYXYXY format
+            # cannot modify the input tensor inplace as it requires a dimension
+            # change.
+            assert in_place.data_ptr() == input_data_ptr
+            assert in_place._version > input_version
+
+        assert in_place.format == new_format
+        assert_equal(in_place, out_of_place)
+
+    @pytest.mark.parametrize(("old_format", "new_format"), old_new_formats)
     def test_strings(self, old_format, new_format):
         # Non-regression test for https://github.com/pytorch/vision/issues/8258
         input = make_bounding_boxes(format=old_format, canvas_size=(50, 50))

--- a/torchvision/transforms/v2/_meta.py
+++ b/torchvision/transforms/v2/_meta.py
@@ -12,16 +12,21 @@ class ConvertBoundingBoxFormat(Transform):
         format (str or tv_tensors.BoundingBoxFormat): output bounding box format.
             Possible values are defined by :class:`~torchvision.tv_tensors.BoundingBoxFormat` and
             string values match the enums, e.g. "XYXY" or "XYWH" etc.
+        inplace (bool, optional): Whether to convert the bounding boxes in-place.
+            Note that conversions from or to the ``XYXYXYXY`` format always
+            allocate a new tensor because they change the size of the last
+            dimension. Default is ``False``.
     """
 
     _transformed_types = (tv_tensors.BoundingBoxes,)
 
-    def __init__(self, format: Union[str, tv_tensors.BoundingBoxFormat]) -> None:
+    def __init__(self, format: Union[str, tv_tensors.BoundingBoxFormat], inplace: bool = False) -> None:
         super().__init__()
         self.format = format
+        self.inplace = inplace
 
     def transform(self, inpt: tv_tensors.BoundingBoxes, params: dict[str, Any]) -> tv_tensors.BoundingBoxes:
-        return F.convert_bounding_box_format(inpt, new_format=self.format)  # type: ignore[return-value, arg-type]
+        return F.convert_bounding_box_format(inpt, new_format=self.format, inplace=self.inplace)  # type: ignore[return-value, arg-type]
 
 
 class ClampBoundingBoxes(Transform):


### PR DESCRIPTION
Fixes #8923

## Root cause

The functional `convert_bounding_box_format` already accepts an `inplace` argument:

https://github.com/pytorch/vision/blob/main/torchvision/transforms/v2/functional/_meta.py

However the `ConvertBoundingBoxFormat` transform class never exposed it, so there was no way to request an in-place conversion through the class-based transform API. The issue notes this gap and asks that we wire it through.

## Fix

This adds an `inplace` parameter to `ConvertBoundingBoxFormat.__init__`, stores it on the instance, and forwards it to the functional in `transform`. This mirrors exactly how `Normalize` already exposes its own `inplace` argument (stored on the instance and passed straight to the kernel), so the pattern is consistent with the rest of the v2 transforms.

The docstring is updated to document the new argument, including the existing caveat that conversions from or to the `XYXYXYXY` format always allocate a new tensor because they change the size of the last dimension.

## Verification

I extended `TestConvertBoundingBoxFormat` with a `test_transform_inplace` case that runs over every old/new format permutation and over `float32` and `int64`. It checks that:

- with `inplace=True` the output reuses the input storage (same `data_ptr`) and bumps the tensor version for conversions that do not involve `XYXYXYXY`
- the result is identical to the out-of-place path
- the output format is updated correctly

The new test follows the same structure as the existing `test_kernel_inplace`, including the same xfail for rotated boxes with integer dtype.

Targeted run of the whole class against a torchvision build:

```
python -m pytest test/test_transforms_v2.py -k "TestConvertBoundingBoxFormat" -q
154 passed, 56 skipped, 24 xfailed
```

The new test alone:

```
python -m pytest test/test_transforms_v2.py -k "TestConvertBoundingBoxFormat and test_transform_inplace" -q
18 passed, 6 xfailed
```

`black` (line length 120) reports both changed files unchanged, and `flake8 --config=setup.cfg` is clean on the changed source.