### PR TITLE
Fix deform_conv2d kernels to use current CUDA stream

### DIFF
--- a/torchvision/csrc/ops/cuda/deform_conv2d_kernel.cu
+++ b/torchvision/csrc/ops/cuda/deform_conv2d_kernel.cu
@@ -247,10 +247,11 @@ void deformable_im2col(
            out_w >
        std::numeric_limits<int32_t>::max());
 
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
   if (use_64bits_indexing) {
     AT_DISPATCH_FLOATING_TYPES_AND_HALF(
         input.scalar_type(), "deformable_im2col", ([&] {
-          deformable_im2col_kernel<scalar_t, int64_t><<<blocks, threads>>>(
+          deformable_im2col_kernel<scalar_t, int64_t><<<blocks, threads, 0, stream>>>(
               num_kernels,
               input.data_ptr<scalar_t>(),
               data_offset.data_ptr<scalar_t>(),
@@ -277,7 +278,7 @@ void deformable_im2col(
   } else {
     AT_DISPATCH_FLOATING_TYPES_AND_HALF(
         input.scalar_type(), "deformable_im2col", ([&] {
-          deformable_im2col_kernel<scalar_t, int><<<blocks, threads>>>(
+          deformable_im2col_kernel<scalar_t, int><<<blocks, threads, 0, stream>>>(
               num_kernels,
               input.data_ptr<scalar_t>(),
               data_offset.data_ptr<scalar_t>(),
@@ -436,10 +437,11 @@ void compute_grad_input(
 
   at::globalContext().alertNotDeterministic("compute_grad_input");
 
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
   if (use_64bits_indexing) {
     AT_DISPATCH_FLOATING_TYPES_AND_HALF(
         columns.scalar_type(), "compute_grad_input", ([&] {
-          deformable_col2im_kernel<scalar_t, int64_t><<<blocks, threads>>>(
+          deformable_col2im_kernel<scalar_t, int64_t><<<blocks, threads, 0, stream>>>(
               num_kernels,
               columns.data_ptr<scalar_t>(),
               offset.data_ptr<scalar_t>(),
@@ -465,7 +467,7 @@ void compute_grad_input(
   } else {
     AT_DISPATCH_FLOATING_TYPES_AND_HALF(
         columns.scalar_type(), "compute_grad_input", ([&] {
-          deformable_col2im_kernel<scalar_t, int><<<blocks, threads>>>(
+          deformable_col2im_kernel<scalar_t, int><<<blocks, threads, 0, stream>>>(
               num_kernels,
               columns.data_ptr<scalar_t>(),
               offset.data_ptr<scalar_t>(),
@@ -678,11 +680,12 @@ void compute_grad_offset_and_mask(
       ((int64_t)channels * weight_h * weight_w * parallel_imgs * out_h * out_w >
        std::numeric_limits<int32_t>::max());
 
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
   if (use_64bits_indexing) {
     AT_DISPATCH_FLOATING_TYPES_AND_HALF(
         columns.scalar_type(), "compute_grad_offset_and_mask", ([&] {
           deformable_col2im_coord_kernel<scalar_t, int64_t>
-              <<<blocks, threads>>>(
+              <<<blocks, threads, 0, stream>>>(
                   num_kernels,
                   columns.data_ptr<scalar_t>(),
                   input.data_ptr<scalar_t>(),
@@ -711,7 +714,7 @@ void compute_grad_offset_and_mask(
   } else {
     AT_DISPATCH_FLOATING_TYPES_AND_HALF(
         columns.scalar_type(), "compute_grad_offset_and_mask", ([&] {
-          deformable_col2im_coord_kernel<scalar_t, int><<<blocks, threads>>>(
+          deformable_col2im_coord_kernel<scalar_t, int><<<blocks, threads, 0, stream>>>(
               num_kernels,
               columns.data_ptr<scalar_t>(),
               input.data_ptr<scalar_t>(),


### PR DESCRIPTION
Fixes #9513

## Problem

All 6 CUDA kernel launches in `deform_conv2d_kernel.cu` used `<<<blocks, threads>>>` with no stream argument, meaning they always ran on the **default CUDA stream**. This causes silent race conditions when users run deformable convolutions inside a non-default stream (e.g. with `torch.cuda.stream(s)` or in a multi-stream pipeline).

The same bug affects both the `int` and `int64_t` index variants of all three kernels:
- `deformable_im2col_kernel` (forward)
- `deformable_col2im_kernel` (backward grad input)
- `deformable_col2im_coord_kernel` (backward grad offset/mask)

## Fix

Add `const cudaStream_t stream = at::cuda::getCurrentCUDAStream();` once before each `if (use_64bits_indexing)` block, then pass `stream` as the fourth chevron argument to all 6 launches:

```cpp
// Before
deformable_im2col_kernel<scalar_t, int64_t><<<blocks, threads>>>(...)

// After
const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
deformable_im2col_kernel<scalar_t, int64_t><<<blocks, threads, 0, stream>>>(...)
```

This matches the existing pattern in `roi_pool_kernel.cu` and other ops in this repo.

## Testing

Stream sanity check (run locally with CUDA):

```python
import torch
from torchvision.ops import deform_conv2d

x = torch.randn(1, 3, 10, 10, device="cuda")
weight = torch.randn(3, 3, 3, 3, device="cuda")
offset = torch.randn(1, 18, 10, 10, device="cuda")

# Verify op works correctly on a non-default stream
s = torch.cuda.Stream()
with torch.cuda.stream(s):
    out = deform_conv2d(x, weight, offset)
s.synchronize()
print("OK")
```

Full test suite: `pytest test/test_ops.py::TestDeformConv2d -xvs`