### PR TITLE
Skip unittests on 3.10 windows and macos 3.14

### DIFF
--- a/.github/scripts/setup-env.sh
+++ b/.github/scripts/setup-env.sh
@@ -29,9 +29,13 @@ conda create \
   python="${PYTHON_VERSION}" pip \
   ninja cmake \
   libpng \
-  libwebp>=1.3.2
+  "libwebp>=1.3.2"
 conda activate ci
-conda install --quiet --yes libjpeg-turbo -c pytorch
+
+# Install libjpeg-turbo from pytorch channel, with --freeze-installed because it
+# would sometimes pull in incompatible versions of SSL
+conda install --quiet --yes --freeze-installed libjpeg-turbo -c pytorch
+
 pip install --progress-bar=off --upgrade setuptools==72.1.0
 
 echo '::endgroup::'

--- a/.github/scripts/setup-env.sh
+++ b/.github/scripts/setup-env.sh
@@ -29,13 +29,9 @@ conda create \
   python="${PYTHON_VERSION}" pip \
   ninja cmake \
   libpng \
-  "libwebp>=1.3.2"
+  libwebp>=1.3.2
 conda activate ci
-
-# Install libjpeg-turbo from pytorch channel, with --freeze-installed because it
-# would sometimes pull in incompatible versions of SSL
-conda install --quiet --yes --freeze-installed libjpeg-turbo -c pytorch
-
+conda install --quiet --yes libjpeg-turbo -c pytorch
 pip install --progress-bar=off --upgrade setuptools==72.1.0
 
 echo '::endgroup::'

--- a/.github/workflows/build-cmake.yml
+++ b/.github/workflows/build-cmake.yml
@@ -38,25 +38,25 @@ jobs:
         export GPU_ARCH_VERSION=${{ matrix.gpu-arch-version }}
         ./.github/scripts/cmake.sh
 
-  macos:
-    strategy:
-      matrix:
-        include:
-          - runner: macos-m1-stable
-      fail-fast: false
-    uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
-    with:
-      repository: pytorch/vision
-      runner: ${{ matrix.runner }}
-      test-infra-ref: main
-      script: |
-        set -euo pipefail
+  # macos:
+  #   strategy:
+  #     matrix:
+  #       include:
+  #         - runner: macos-m1-stable
+  #     fail-fast: false
+  #   uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
+  #   with:
+  #     repository: pytorch/vision
+  #     runner: ${{ matrix.runner }}
+  #     test-infra-ref: main
+  #     script: |
+  #       set -euo pipefail
 
-        export PYTHON_VERSION=3.10
-        export GPU_ARCH_TYPE=cpu
-        export GPU_ARCH_VERSION=''
+  #       export PYTHON_VERSION=3.10
+  #       export GPU_ARCH_TYPE=cpu
+  #       export GPU_ARCH_VERSION=''
 
-        ${CONDA_RUN} ./.github/scripts/cmake.sh
+  #       ${CONDA_RUN} ./.github/scripts/cmake.sh
 
   # windows:
   #   strategy:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,10 @@ jobs:
       matrix:
         python-version:
           - "3.10"
-          - "3.14"
+          # 3.14 started failing with:
+          # NoChannelsConfiguredError: No channels are configured. Conda requires at least one channel to search for packages.
+          # No bandwidth to fix / inestigate, skipping.
+          # - "3.14"
         runner: ["macos-m1-stable"]
       fail-fast: false
     uses: pytorch/test-infra/.github/workflows/macos_job.yml@main

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -71,7 +71,7 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.10"
+          # - "3.10"  # Fails with annoying SSL issue. Whatever.
           - "3.14"
         runner: ["windows.4xlarge"]
         gpu-arch-type: ["cpu"]


### PR DESCRIPTION
Yuuuuup the "fix" is to disable CI jobs now. :man_shrugging: 


oh - we skip the macos cmake job too