### PR TITLE
Stand up dual stable-ABI build harness and port nms as the first op.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,8 +96,29 @@ FOREACH(DIR ${ALLOW_LISTED})
     file(GLOB ALL_SOURCES ${ALL_SOURCES} ${DIR}/*.*)
 ENDFOREACH()
 
+# These ops have been migrated to the stable ABI (torch::stable), the same set
+# setup.py builds into the _C_stable extension. It grows as each op is ported.
+set(TORCHVISION_STABLE_SOURCES
+  ${TVCPP}/ops/nms.cpp
+  ${TVCPP}/ops/cpu/nms_kernel.cpp
+  ${TVCPP}/ops/cuda/nms_kernel.cu
+  ${TVCPP}/vision_stable.cpp)
+# Pin them to torch 2.11. Per source, not library-wide: the pin makes ATen headers
+# error, and the legacy ops sharing this library still include them.
+# TODO(stable-abi): once every op is ported, drop this list and pin the whole
+# library target instead.
+set_source_files_properties(${TORCHVISION_STABLE_SOURCES} PROPERTIES
+  COMPILE_DEFINITIONS TORCH_TARGET_VERSION=0x020b000000000000)
+
 add_library(${PROJECT_NAME} SHARED ${ALL_SOURCES})
 target_link_libraries(${PROJECT_NAME} PRIVATE ${TORCH_LIBRARIES})
+
+if(WITH_CUDA)
+  # Some torch APIs like aoti_torch_get_current_cuda_stream (used by
+  # ops/cuda/nms_kernel.cu) are only exposed when USE_CUDA is defined.
+  # https://github.com/pytorch/pytorch/blob/98e36864e640023a716e058d894ea2d20e76e5f7/torch/csrc/inductor/aoti_torch/c/shim.h#L573-L602
+  target_compile_definitions(${PROJECT_NAME} PRIVATE USE_CUDA)
+endif()
 
 if(WITH_MPS)
   find_library(metal NAMES Metal)

--- a/setup.py
+++ b/setup.py
@@ -151,32 +151,68 @@ def get_macros_and_flags():
     return define_macros, extra_compile_args
 
 
+TORCH_TARGET_VERSION = "0x020b000000000000"
+
+# Files migrated to the stable ABI: subtracted from make_C_extension()'s globs and
+# built into _C_stable instead. Add an op's files here as it migrates.
+# TODO: when all ops migrate, drop make_C_extension()/STABLE_SOURCES and glob _C_stable.
+STABLE_SOURCES = {
+    CSRS_DIR / "ops/nms.cpp",
+    CSRS_DIR / "ops/cpu/nms_kernel.cpp",
+    CSRS_DIR / "ops/mps/nms_kernel.mm",
+    CSRS_DIR / "ops/quantized/cpu/qnms_kernel.cpp",
+}
+STABLE_SOURCES.add(CSRS_DIR / ("ops/hip/nms_kernel.hip" if IS_ROCM else "ops/cuda/nms_kernel.cu"))
+
+
+def _not_stable(paths):
+    return [p for p in paths if p not in STABLE_SOURCES]
+
+
+def _stable(paths):
+    return [p for p in paths if p in STABLE_SOURCES]
+
+
+_HIPIFIED = False
+
+
+def ensure_hipified():
+    # ROCm: rewrite ops/cuda/*.{cu,h} -> ops/hip/* once per build (no-op otherwise).
+    # Both _C and _C_stable consume ops/hip/*, so neither depends on the other's build
+    # order, and this survives make_C_extension() being dropped at the end state.
+    global _HIPIFIED
+    if _HIPIFIED or not IS_ROCM:
+        return
+    from torch.utils.hipify import hipify_python
+
+    hipify_python.hipify(
+        project_directory=str(ROOT_DIR),
+        output_directory=str(ROOT_DIR),
+        includes="torchvision/csrc/ops/cuda/*",
+        show_detailed=True,
+        is_pytorch_extension=True,
+    )
+    for header in CSRS_DIR.glob("ops/cuda/*.h"):
+        shutil.copy(str(header), str(CSRS_DIR / "ops/hip"))
+    _HIPIFIED = True
+
+
 def make_C_extension():
     print("Building _C extension")
 
+    ensure_hipified()
     sources = (
-        list(CSRS_DIR.glob("*.cpp"))
-        + list(CSRS_DIR.glob("ops/*.cpp"))
-        + list(CSRS_DIR.glob("ops/cpu/*.cpp"))
-        + list(CSRS_DIR.glob("ops/quantized/cpu/*.cpp"))
+        _not_stable(CSRS_DIR.glob("*.cpp"))
+        + _not_stable(CSRS_DIR.glob("ops/*.cpp"))
+        + _not_stable(CSRS_DIR.glob("ops/cpu/*.cpp"))
+        + _not_stable(CSRS_DIR.glob("ops/quantized/cpu/*.cpp"))
     )
-    mps_sources = list(CSRS_DIR.glob("ops/mps/*.mm"))
+    mps_sources = _not_stable(CSRS_DIR.glob("ops/mps/*.mm"))
 
     if IS_ROCM:
-        from torch.utils.hipify import hipify_python
-
-        hipify_python.hipify(
-            project_directory=str(ROOT_DIR),
-            output_directory=str(ROOT_DIR),
-            includes="torchvision/csrc/ops/cuda/*",
-            show_detailed=True,
-            is_pytorch_extension=True,
-        )
-        cuda_sources = list(CSRS_DIR.glob("ops/hip/*.hip"))
-        for header in CSRS_DIR.glob("ops/cuda/*.h"):
-            shutil.copy(str(header), str(CSRS_DIR / "ops/hip"))
+        cuda_sources = _not_stable(CSRS_DIR.glob("ops/hip/*.hip"))
     else:
-        cuda_sources = list(CSRS_DIR.glob("ops/cuda/*.cu"))
+        cuda_sources = _not_stable(CSRS_DIR.glob("ops/cuda/*.cu"))
 
     if BUILD_CUDA_SOURCES:
         Extension = CUDAExtension
@@ -189,6 +225,52 @@ def make_C_extension():
     define_macros, extra_compile_args = get_macros_and_flags()
     return Extension(
         name="torchvision._C",
+        sources=sorted(str(s) for s in sources),
+        include_dirs=[CSRS_DIR],
+        define_macros=define_macros,
+        extra_compile_args=extra_compile_args,
+    )
+
+
+def get_stable_macros_and_flags():
+    define_macros, extra_compile_args = get_macros_and_flags()
+    tv = f"-DTORCH_TARGET_VERSION={TORCH_TARGET_VERSION}"
+    extra_compile_args["cxx"].append(tv)
+    if "nvcc" in extra_compile_args:
+        extra_compile_args["nvcc"].append(tv)
+        if not IS_ROCM:
+            extra_compile_args["nvcc"].append("-DUSE_CUDA")
+    return define_macros, extra_compile_args
+
+
+def make_C_stable_extension():
+    print("Building _C_stable extension")
+
+    ensure_hipified()
+    sources = (
+        _stable(CSRS_DIR.glob("*.cpp"))
+        + _stable(CSRS_DIR.glob("ops/*.cpp"))
+        + _stable(CSRS_DIR.glob("ops/cpu/*.cpp"))
+        + _stable(CSRS_DIR.glob("ops/quantized/cpu/*.cpp"))
+    )
+    mps_sources = _stable(CSRS_DIR.glob("ops/mps/*.mm"))
+
+    if IS_ROCM:
+        cuda_sources = _stable(CSRS_DIR.glob("ops/hip/*.hip"))
+    else:
+        cuda_sources = _stable(CSRS_DIR.glob("ops/cuda/*.cu"))
+
+    if BUILD_CUDA_SOURCES:
+        Extension = CUDAExtension
+        sources += cuda_sources
+    else:
+        Extension = CppExtension
+        if torch.backends.mps.is_available() or FORCE_MPS:
+            sources += mps_sources
+
+    define_macros, extra_compile_args = get_stable_macros_and_flags()
+    return Extension(
+        name="torchvision._C_stable",
         sources=sorted(str(s) for s in sources),
         include_dirs=[CSRS_DIR],
         define_macros=define_macros,
@@ -394,6 +476,7 @@ if __name__ == "__main__":
 
     extensions = [
         make_C_extension(),
+        make_C_stable_extension(),
         make_image_extension(),
     ]
 

--- a/setup.py
+++ b/setup.py
@@ -155,8 +155,9 @@ TORCH_TARGET_VERSION = "0x020b000000000000"
 
 # Files migrated to the stable ABI: subtracted from make_C_extension()'s globs and
 # built into _C_stable instead. Add an op's files here as it migrates.
-# TODO: when all ops migrate, drop make_C_extension()/STABLE_SOURCES and glob _C_stable.
+# TODO(stable-abi): when all ops migrate, drop make_C_extension()/STABLE_SOURCES and glob _C_stable.
 STABLE_SOURCES = {
+    CSRS_DIR / "vision_stable.cpp",
     CSRS_DIR / "ops/nms.cpp",
     CSRS_DIR / "ops/cpu/nms_kernel.cpp",
     CSRS_DIR / "ops/mps/nms_kernel.mm",
@@ -233,6 +234,7 @@ def make_C_extension():
 
 
 def get_stable_macros_and_flags():
+    # TODO(stable-abi): merge into get_macros_and_flags() once the migration is done.
     define_macros, extra_compile_args = get_macros_and_flags()
     tv = f"-DTORCH_TARGET_VERSION={TORCH_TARGET_VERSION}"
     extra_compile_args["cxx"].append(tv)

--- a/torchvision/csrc/ops/StableABICompat.h
+++ b/torchvision/csrc/ops/StableABICompat.h
@@ -20,8 +20,8 @@
 //
 // Some ATen ops our kernels use have no torch::stable wrapper in
 // <torch/csrc/stable/ops.h> yet. The officially recommended approach is to call
-// them through torch_call_dispatcher -- an ABI-stable call into an op outside the
-// stable surface (the same pattern used by
+// them through torch_call_dispatcher -- an ABI-stable call into an op outside
+// the stable surface (the same pattern used by
 // https://github.com/meta-pytorch/torchcodec/blob/8bbce656797c4f2b00feb2784ffe76e408be1e4c/src/torchcodec/_core/StableABICompat.h).
 //
 // This file GROWS as operators migrate: add a helper the first time an op needs
@@ -36,7 +36,8 @@ namespace stable_helpers {
 
 using torch::stable::Tensor;
 
-// aten::sort.stable(Tensor self, bool? stable, int dim=-1, bool descending=False)
+// aten::sort.stable(Tensor self, bool? stable, int dim=-1, bool
+// descending=False)
 //     -> (Tensor values, Tensor indices)
 inline std::tuple<Tensor, Tensor> sort(
     const Tensor& self,
@@ -56,7 +57,10 @@ inline std::tuple<Tensor, Tensor> sort(
 }
 
 // aten::index_select(Tensor self, int dim, Tensor index) -> Tensor
-inline Tensor index_select(const Tensor& self, int64_t dim, const Tensor& index) {
+inline Tensor index_select(
+    const Tensor& self,
+    int64_t dim,
+    const Tensor& index) {
   std::array<StableIValue, 3> stack{
       torch::stable::detail::from(self),
       torch::stable::detail::from(dim),
@@ -69,8 +73,7 @@ inline Tensor index_select(const Tensor& self, int64_t dim, const Tensor& index)
 // aten::masked_select(Tensor self, Tensor mask) -> Tensor
 inline Tensor masked_select(const Tensor& self, const Tensor& mask) {
   std::array<StableIValue, 2> stack{
-      torch::stable::detail::from(self),
-      torch::stable::detail::from(mask)};
+      torch::stable::detail::from(self), torch::stable::detail::from(mask)};
   TORCH_ERROR_CODE_CHECK(torch_call_dispatcher(
       "aten::masked_select", "", stack.data(), TORCH_ABI_VERSION));
   return torch::stable::detail::to<Tensor>(stack[0]);

--- a/torchvision/csrc/ops/StableABICompat.h
+++ b/torchvision/csrc/ops/StableABICompat.h
@@ -1,4 +1,5 @@
-// Copyright (c) Soumith Chintala 2016, All rights reserved.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
 //
 // This source code is licensed under the BSD-style license found in the
 // LICENSE file in the root directory of this source tree.
@@ -20,8 +21,8 @@
 // Some ATen ops our kernels use have no torch::stable wrapper in
 // <torch/csrc/stable/ops.h> yet. The officially recommended approach is to call
 // them through torch_call_dispatcher -- an ABI-stable call into an op outside the
-// stable surface (the same pattern used by meta-pytorch/torchcodec's
-// StableABICompat.h and facebookresearch/xformers' pt_stable_utils.h).
+// stable surface (the same pattern used by
+// https://github.com/meta-pytorch/torchcodec/blob/8bbce656797c4f2b00feb2784ffe76e408be1e4c/src/torchcodec/_core/StableABICompat.h).
 //
 // This file GROWS as operators migrate: add a helper the first time an op needs
 // an ATen call with no stable wrapper. Each is a thin shim -- delete it once an

--- a/torchvision/csrc/ops/StableABICompat.h
+++ b/torchvision/csrc/ops/StableABICompat.h
@@ -1,0 +1,80 @@
+// Copyright (c) Soumith Chintala 2016, All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include <torch/csrc/stable/c/shim.h>
+#include <torch/csrc/stable/stableivalue_conversions.h>
+#include <torch/csrc/stable/tensor.h>
+#include <torch/headeronly/util/shim_utils.h>
+#include <torch/headeronly/version.h>
+
+#include <array>
+#include <optional>
+#include <tuple>
+
+// Stable-ABI compatibility shims for torchvision's C++ operators.
+//
+// Some ATen ops our kernels use have no torch::stable wrapper in
+// <torch/csrc/stable/ops.h> yet. The officially recommended approach is to call
+// them through torch_call_dispatcher -- an ABI-stable call into an op outside the
+// stable surface (the same pattern used by meta-pytorch/torchcodec's
+// StableABICompat.h and facebookresearch/xformers' pt_stable_utils.h).
+//
+// This file GROWS as operators migrate: add a helper the first time an op needs
+// an ATen call with no stable wrapper. Each is a thin shim -- delete it once an
+// upstream torch::stable wrapper lands.
+// TODO(stable-abi): upstream torch::stable wrappers for sort / index_select /
+// masked_select so these helpers can be removed.
+
+namespace vision {
+namespace ops {
+namespace stable_helpers {
+
+using torch::stable::Tensor;
+
+// aten::sort.stable(Tensor self, bool? stable, int dim=-1, bool descending=False)
+//     -> (Tensor values, Tensor indices)
+inline std::tuple<Tensor, Tensor> sort(
+    const Tensor& self,
+    bool stable,
+    int64_t dim,
+    bool descending) {
+  std::array<StableIValue, 4> stack{
+      torch::stable::detail::from(self),
+      torch::stable::detail::from(std::optional<bool>(stable)),
+      torch::stable::detail::from(dim),
+      torch::stable::detail::from(descending)};
+  TORCH_ERROR_CODE_CHECK(torch_call_dispatcher(
+      "aten::sort", "stable", stack.data(), TORCH_ABI_VERSION));
+  return {
+      torch::stable::detail::to<Tensor>(stack[0]),
+      torch::stable::detail::to<Tensor>(stack[1])};
+}
+
+// aten::index_select(Tensor self, int dim, Tensor index) -> Tensor
+inline Tensor index_select(const Tensor& self, int64_t dim, const Tensor& index) {
+  std::array<StableIValue, 3> stack{
+      torch::stable::detail::from(self),
+      torch::stable::detail::from(dim),
+      torch::stable::detail::from(index)};
+  TORCH_ERROR_CODE_CHECK(torch_call_dispatcher(
+      "aten::index_select", "", stack.data(), TORCH_ABI_VERSION));
+  return torch::stable::detail::to<Tensor>(stack[0]);
+}
+
+// aten::masked_select(Tensor self, Tensor mask) -> Tensor
+inline Tensor masked_select(const Tensor& self, const Tensor& mask) {
+  std::array<StableIValue, 2> stack{
+      torch::stable::detail::from(self),
+      torch::stable::detail::from(mask)};
+  TORCH_ERROR_CODE_CHECK(torch_call_dispatcher(
+      "aten::masked_select", "", stack.data(), TORCH_ABI_VERSION));
+  return torch::stable::detail::to<Tensor>(stack[0]);
+}
+
+} // namespace stable_helpers
+} // namespace ops
+} // namespace vision

--- a/torchvision/csrc/ops/cpu/nms_kernel.cpp
+++ b/torchvision/csrc/ops/cpu/nms_kernel.cpp
@@ -1,10 +1,7 @@
 #include "../StableABICompat.h"
 #include <torch/csrc/stable/library.h>
 #include <torch/csrc/stable/ops.h>
-#include <torch/csrc/stable/tensor.h>
 #include <torch/headeronly/core/Dispatch_v2.h>
-#include <torch/headeronly/core/ScalarType.h>
-#include <torch/headeronly/util/Exception.h>
 
 #include <algorithm>
 #include <cstdint>

--- a/torchvision/csrc/ops/cpu/nms_kernel.cpp
+++ b/torchvision/csrc/ops/cpu/nms_kernel.cpp
@@ -1,7 +1,7 @@
-#include "../StableABICompat.h"
 #include <torch/csrc/stable/library.h>
 #include <torch/csrc/stable/ops.h>
 #include <torch/headeronly/core/Dispatch_v2.h>
+#include "../StableABICompat.h"
 
 #include <algorithm>
 #include <cstdint>
@@ -26,7 +26,8 @@ Tensor nms_kernel_impl(
       "dets should have the same type as scores");
 
   if (dets.numel() == 0) {
-    return torch::stable::new_empty(dets, {0}, torch::headeronly::ScalarType::Long);
+    return torch::stable::new_empty(
+        dets, {0}, torch::headeronly::ScalarType::Long);
   }
 
   auto x1_t = torch::stable::contiguous(torch::stable::select(dets, 1, 0));
@@ -34,14 +35,14 @@ Tensor nms_kernel_impl(
   auto x2_t = torch::stable::contiguous(torch::stable::select(dets, 1, 2));
   auto y2_t = torch::stable::contiguous(torch::stable::select(dets, 1, 3));
 
-  auto order_t = std::get<1>(
-      stable_helpers::sort(scores, /*stable=*/true, /*dim=*/0, /*descending=*/true));
+  auto order_t = std::get<1>(stable_helpers::sort(
+      scores, /*stable=*/true, /*dim=*/0, /*descending=*/true));
 
   auto ndets = dets.size(0);
-  Tensor suppressed_t =
-      torch::stable::new_zeros(dets, {ndets}, torch::headeronly::ScalarType::Byte);
-  Tensor keep_t =
-      torch::stable::new_zeros(dets, {ndets}, torch::headeronly::ScalarType::Long);
+  Tensor suppressed_t = torch::stable::new_zeros(
+      dets, {ndets}, torch::headeronly::ScalarType::Byte);
+  Tensor keep_t = torch::stable::new_zeros(
+      dets, {ndets}, torch::headeronly::ScalarType::Long);
   Tensor areas_t = torch::stable::new_empty(dets, {ndets}, dets.scalar_type());
 
   auto suppressed = suppressed_t.mutable_data_ptr<uint8_t>();
@@ -89,7 +90,8 @@ Tensor nms_kernel_impl(
       }
     }
   }
-  return torch::stable::narrow(keep_t, /*dim=*/0, /*start=*/0, /*length=*/num_to_keep);
+  return torch::stable::narrow(
+      keep_t, /*dim=*/0, /*start=*/0, /*length=*/num_to_keep);
 }
 
 Tensor nms_kernel(
@@ -103,7 +105,10 @@ Tensor nms_kernel(
       "boxes should have 4 elements in dimension 1, got ",
       dets.size(1));
   STD_TORCH_CHECK(
-      scores.dim() == 1, "scores should be a 1d tensor, got ", scores.dim(), "D");
+      scores.dim() == 1,
+      "scores should be a 1d tensor, got ",
+      scores.dim(),
+      "D");
   STD_TORCH_CHECK(
       dets.size(0) == scores.size(0),
       "boxes and scores should have same number of elements in ",

--- a/torchvision/csrc/ops/cpu/nms_kernel.cpp
+++ b/torchvision/csrc/ops/cpu/nms_kernel.cpp
@@ -1,51 +1,66 @@
-#include <ATen/ATen.h>
-#include <torch/library.h>
+#include "../StableABICompat.h"
+#include <torch/csrc/stable/library.h>
+#include <torch/csrc/stable/ops.h>
+#include <torch/csrc/stable/tensor.h>
+#include <torch/headeronly/core/Dispatch_v2.h>
+#include <torch/headeronly/core/ScalarType.h>
+#include <torch/headeronly/util/Exception.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <tuple>
 
 namespace vision {
 namespace ops {
 
 namespace {
 
+using torch::stable::Tensor;
+
 template <typename scalar_t>
-at::Tensor nms_kernel_impl(
-    const at::Tensor& dets,
-    const at::Tensor& scores,
+Tensor nms_kernel_impl(
+    const Tensor& dets,
+    const Tensor& scores,
     double iou_threshold) {
-  TORCH_CHECK(dets.is_cpu(), "dets must be a CPU tensor");
-  TORCH_CHECK(scores.is_cpu(), "scores must be a CPU tensor");
-  TORCH_CHECK(
+  STD_TORCH_CHECK(dets.is_cpu(), "dets must be a CPU tensor");
+  STD_TORCH_CHECK(scores.is_cpu(), "scores must be a CPU tensor");
+  STD_TORCH_CHECK(
       dets.scalar_type() == scores.scalar_type(),
       "dets should have the same type as scores");
 
   if (dets.numel() == 0) {
-    return at::empty({0}, dets.options().dtype(at::kLong));
+    return torch::stable::new_empty(dets, {0}, torch::headeronly::ScalarType::Long);
   }
 
-  auto x1_t = dets.select(1, 0).contiguous();
-  auto y1_t = dets.select(1, 1).contiguous();
-  auto x2_t = dets.select(1, 2).contiguous();
-  auto y2_t = dets.select(1, 3).contiguous();
-
-  at::Tensor areas_t = (x2_t - x1_t) * (y2_t - y1_t);
+  auto x1_t = torch::stable::contiguous(torch::stable::select(dets, 1, 0));
+  auto y1_t = torch::stable::contiguous(torch::stable::select(dets, 1, 1));
+  auto x2_t = torch::stable::contiguous(torch::stable::select(dets, 1, 2));
+  auto y2_t = torch::stable::contiguous(torch::stable::select(dets, 1, 3));
 
   auto order_t = std::get<1>(
-      scores.sort(/*stable=*/true, /*dim=*/0, /* descending=*/true));
+      stable_helpers::sort(scores, /*stable=*/true, /*dim=*/0, /*descending=*/true));
 
   auto ndets = dets.size(0);
-  at::Tensor suppressed_t = at::zeros({ndets}, dets.options().dtype(at::kByte));
-  at::Tensor keep_t = at::zeros({ndets}, dets.options().dtype(at::kLong));
+  Tensor suppressed_t =
+      torch::stable::new_zeros(dets, {ndets}, torch::headeronly::ScalarType::Byte);
+  Tensor keep_t =
+      torch::stable::new_zeros(dets, {ndets}, torch::headeronly::ScalarType::Long);
+  Tensor areas_t = torch::stable::new_empty(dets, {ndets}, dets.scalar_type());
 
-  auto suppressed = suppressed_t.data_ptr<uint8_t>();
-  auto keep = keep_t.data_ptr<int64_t>();
-  auto order = order_t.data_ptr<int64_t>();
-  auto x1 = x1_t.data_ptr<scalar_t>();
-  auto y1 = y1_t.data_ptr<scalar_t>();
-  auto x2 = x2_t.data_ptr<scalar_t>();
-  auto y2 = y2_t.data_ptr<scalar_t>();
-  auto areas = areas_t.data_ptr<scalar_t>();
+  auto suppressed = suppressed_t.mutable_data_ptr<uint8_t>();
+  auto keep = keep_t.mutable_data_ptr<int64_t>();
+  auto order = order_t.const_data_ptr<int64_t>();
+  auto x1 = x1_t.const_data_ptr<scalar_t>();
+  auto y1 = y1_t.const_data_ptr<scalar_t>();
+  auto x2 = x2_t.const_data_ptr<scalar_t>();
+  auto y2 = y2_t.const_data_ptr<scalar_t>();
+  auto areas = areas_t.mutable_data_ptr<scalar_t>();
+
+  for (int64_t k = 0; k < ndets; k++) {
+    areas[k] = (x2[k] - x1[k]) * (y2[k] - y1[k]);
+  }
 
   int64_t num_to_keep = 0;
-
   for (int64_t _i = 0; _i < ndets; _i++) {
     auto i = order[_i];
     if (suppressed[i] == 1) {
@@ -77,25 +92,22 @@ at::Tensor nms_kernel_impl(
       }
     }
   }
-  return keep_t.narrow(/*dim=*/0, /*start=*/0, /*length=*/num_to_keep);
+  return torch::stable::narrow(keep_t, /*dim=*/0, /*start=*/0, /*length=*/num_to_keep);
 }
 
-at::Tensor nms_kernel(
-    const at::Tensor& dets,
-    const at::Tensor& scores,
+Tensor nms_kernel(
+    const Tensor& dets,
+    const Tensor& scores,
     double iou_threshold) {
-  TORCH_CHECK(
+  STD_TORCH_CHECK(
       dets.dim() == 2, "boxes should be a 2d tensor, got ", dets.dim(), "D");
-  TORCH_CHECK(
+  STD_TORCH_CHECK(
       dets.size(1) == 4,
       "boxes should have 4 elements in dimension 1, got ",
       dets.size(1));
-  TORCH_CHECK(
-      scores.dim() == 1,
-      "scores should be a 1d tensor, got ",
-      scores.dim(),
-      "D");
-  TORCH_CHECK(
+  STD_TORCH_CHECK(
+      scores.dim() == 1, "scores should be a 1d tensor, got ", scores.dim(), "D");
+  STD_TORCH_CHECK(
       dets.size(0) == scores.size(0),
       "boxes and scores should have same number of elements in ",
       "dimension 0, got ",
@@ -103,18 +115,22 @@ at::Tensor nms_kernel(
       " and ",
       scores.size(0));
 
-  auto result = at::empty({0}, dets.options());
+  Tensor result = torch::stable::new_empty(dets, {0}, dets.scalar_type());
 
-  AT_DISPATCH_FLOATING_TYPES(dets.scalar_type(), "nms_kernel", [&] {
-    result = nms_kernel_impl<scalar_t>(dets, scores, iou_threshold);
-  });
+  THO_DISPATCH_V2(
+      dets.scalar_type(),
+      "nms_kernel",
+      AT_WRAP([&]() {
+        result = nms_kernel_impl<scalar_t>(dets, scores, iou_threshold);
+      }),
+      AT_EXPAND(AT_FLOATING_TYPES));
   return result;
 }
 
 } // namespace
 
-TORCH_LIBRARY_IMPL(torchvision, CPU, m) {
-  m.impl(TORCH_SELECTIVE_NAME("torchvision::nms"), TORCH_FN(nms_kernel));
+STABLE_TORCH_LIBRARY_IMPL(torchvision, CPU, m) {
+  m.impl("nms", TORCH_BOX(&nms_kernel));
 }
 
 } // namespace ops

--- a/torchvision/csrc/ops/cuda/nms_kernel.cu
+++ b/torchvision/csrc/ops/cuda/nms_kernel.cu
@@ -25,6 +25,10 @@ using torch::stable::Tensor;
 
 int const threadsPerBlock = sizeof(unsigned long long) * 8;
 
+// Accumulate type for IoU. Only correct for the types we dispatch (float,
+// double, Half), not general: BFloat16 should accumulate in float but maps to
+// itself. Safe here since THO_DISPATCH_V2 controls the inputs.
+// TODO(stable-abi): drop once torch/headeronly ships an acc_type trait.
 template <typename T>
 struct AccType {
   using type = T;
@@ -143,7 +147,8 @@ __global__ static void gather_keep_from_mask(
   }
 }
 
-// Wrap the launch so the THO_DISPATCH_V2 body has no unprotected (launch-config) commas.
+// THO_DISPATCH_V2 splits its body on commas outside parens. The commas in
+// kernel<<<blocks, threads, 0, stream>>> would break it, so it goes through this wrapper.
 template <typename scalar_t>
 void launch_nms_kernel_impl(
     dim3 blocks,

--- a/torchvision/csrc/ops/cuda/nms_kernel.cu
+++ b/torchvision/csrc/ops/cuda/nms_kernel.cu
@@ -1,9 +1,19 @@
-#include <ATen/ATen.h>
-#include <ATen/AccumulateType.h>
-#include <ATen/cuda/CUDAContext.h>
-#include <c10/cuda/CUDAGuard.h>
-#include <torch/library.h>
+#include <torch/csrc/inductor/aoti_torch/c/shim.h>
+#include <torch/csrc/stable/accelerator.h>
+#include <torch/csrc/stable/library.h>
+#include <torch/csrc/stable/macros.h>
+#include <torch/csrc/stable/ops.h>
+#include <torch/csrc/stable/tensor.h>
+#include <torch/headeronly/core/Dispatch_v2.h>
+#include <torch/headeronly/core/ScalarType.h>
+#include <torch/headeronly/util/Exception.h>
+#include <torch/headeronly/util/Half.h>
 
+#include <cuda_runtime.h>
+
+#include <algorithm>
+
+#include "../StableABICompat.h"
 #include "cuda_helpers.h"
 
 namespace vision {
@@ -11,7 +21,18 @@ namespace ops {
 
 namespace {
 
+using torch::stable::Tensor;
+
 int const threadsPerBlock = sizeof(unsigned long long) * 8;
+
+template <typename T>
+struct AccType {
+  using type = T;
+};
+template <>
+struct AccType<torch::headeronly::Half> {
+  using type = float;
+};
 
 template <typename T>
 __device__ inline bool devIoU(
@@ -21,7 +42,7 @@ __device__ inline bool devIoU(
   T left = max(a[0], b[0]), right = min(a[2], b[2]);
   T top = max(a[1], b[1]), bottom = min(a[3], b[3]);
   T width = max(right - left, (T)0), height = max(bottom - top, (T)0);
-  using acc_T = at::acc_type<T, /*is_cuda=*/true>;
+  using acc_T = typename AccType<T>::type;
   acc_T interS = (acc_T)width * height;
   acc_T Sa = ((acc_T)a[2] - a[0]) * (a[3] - a[1]);
   acc_T Sb = ((acc_T)b[2] - b[0]) * (b[3] - b[1]);
@@ -122,64 +143,90 @@ __global__ static void gather_keep_from_mask(
   }
 }
 
-at::Tensor nms_kernel(
-    const at::Tensor& dets,
-    const at::Tensor& scores,
-    double iou_threshold) {
-  TORCH_CHECK(dets.is_cuda(), "dets must be a CUDA tensor");
-  TORCH_CHECK(scores.is_cuda(), "scores must be a CUDA tensor");
+// Wrap the launch so the THO_DISPATCH_V2 body has no unprotected (launch-config) commas.
+template <typename scalar_t>
+void launch_nms_kernel_impl(
+    dim3 blocks,
+    dim3 threads,
+    cudaStream_t stream,
+    int dets_num,
+    double iou_threshold,
+    const scalar_t* boxes,
+    unsigned long long* mask) {
+  nms_kernel_impl<scalar_t><<<blocks, threads, 0, stream>>>(
+      dets_num, iou_threshold, boxes, mask);
+}
 
-  TORCH_CHECK(
+Tensor nms_kernel(
+    const Tensor& dets,
+    const Tensor& scores,
+    double iou_threshold) {
+  STD_TORCH_CHECK(dets.is_cuda(), "dets must be a CUDA tensor");
+  STD_TORCH_CHECK(scores.is_cuda(), "scores must be a CUDA tensor");
+
+  STD_TORCH_CHECK(
       dets.dim() == 2, "boxes should be a 2d tensor, got ", dets.dim(), "D");
-  TORCH_CHECK(
+  STD_TORCH_CHECK(
       dets.size(1) == 4,
       "boxes should have 4 elements in dimension 1, got ",
       dets.size(1));
-  TORCH_CHECK(
-      scores.dim() == 1,
-      "scores should be a 1d tensor, got ",
-      scores.dim(),
-      "D");
-  TORCH_CHECK(
+  STD_TORCH_CHECK(
+      scores.dim() == 1, "scores should be a 1d tensor, got ", scores.dim(), "D");
+  STD_TORCH_CHECK(
       dets.size(0) == scores.size(0),
       "boxes and scores should have same number of elements in ",
       "dimension 0, got ",
       dets.size(0),
       " and ",
-      scores.size(0))
+      scores.size(0));
 
-  at::cuda::CUDAGuard device_guard(dets.device());
+  torch::stable::accelerator::DeviceGuard device_guard(dets.get_device_index());
 
   if (dets.numel() == 0) {
-    return at::empty({0}, dets.options().dtype(at::kLong));
+    return torch::stable::new_empty(dets, {0}, torch::headeronly::ScalarType::Long);
   }
 
   auto order_t = std::get<1>(
-      scores.sort(/*stable=*/true, /*dim=*/0, /* descending=*/true));
-  auto dets_sorted = dets.index_select(0, order_t).contiguous();
+      stable_helpers::sort(scores, /*stable=*/true, /*dim=*/0, /*descending=*/true));
+  auto dets_sorted =
+      torch::stable::contiguous(stable_helpers::index_select(dets, 0, order_t));
 
-  int dets_num = dets.size(0);
-
+  int dets_num = static_cast<int>(dets.size(0));
   const int col_blocks = ceil_div(dets_num, threadsPerBlock);
 
-  at::Tensor mask =
-      at::empty({dets_num * col_blocks}, dets.options().dtype(at::kLong));
+  Tensor mask = torch::stable::new_empty(
+      dets,
+      {static_cast<int64_t>(dets_num) * col_blocks},
+      torch::headeronly::ScalarType::Long);
 
   dim3 blocks(col_blocks, col_blocks);
   dim3 threads(threadsPerBlock);
-  cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-      dets_sorted.scalar_type(), "nms_kernel", [&] {
-        nms_kernel_impl<scalar_t><<<blocks, threads, 0, stream>>>(
+  void* stream_ptr = nullptr;
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_get_current_cuda_stream(dets.get_device_index(), &stream_ptr));
+  cudaStream_t stream = static_cast<cudaStream_t>(stream_ptr);
+
+  THO_DISPATCH_V2(
+      dets_sorted.scalar_type(),
+      "nms_kernel",
+      AT_WRAP([&]() {
+        launch_nms_kernel_impl<scalar_t>(
+            blocks,
+            threads,
+            stream,
             dets_num,
             iou_threshold,
-            dets_sorted.data_ptr<scalar_t>(),
-            (unsigned long long*)mask.data_ptr<int64_t>());
-      });
+            dets_sorted.const_data_ptr<scalar_t>(),
+            (unsigned long long*)mask.mutable_data_ptr<int64_t>());
+      }),
+      AT_EXPAND(AT_FLOATING_TYPES),
+      torch::headeronly::ScalarType::Half);
+  STD_CUDA_KERNEL_LAUNCH_CHECK();
 
-  at::Tensor keep =
-      at::zeros({dets_num}, dets.options().dtype(at::kBool).device(at::kCUDA));
+  Tensor keep =
+      torch::stable::new_zeros(dets, {static_cast<int64_t>(dets_num)},
+                               torch::headeronly::ScalarType::Bool);
 
   // Unwrap the mask to fill keep with proper values
   // Keeping the unwrap on device instead of applying iterative for loops on cpu
@@ -188,21 +235,21 @@ at::Tensor nms_kernel(
   // See https://github.com/pytorch/vision/issues/8713 for more details.
   gather_keep_from_mask<<<
       1,
-      min(col_blocks, threadsPerBlock),
+      std::min(col_blocks, threadsPerBlock),
       col_blocks * sizeof(unsigned long long),
       stream>>>(
-      keep.data_ptr<bool>(),
-      (unsigned long long*)mask.data_ptr<int64_t>(),
+      keep.mutable_data_ptr<bool>(),
+      (unsigned long long*)mask.mutable_data_ptr<int64_t>(),
       dets_num);
+  STD_CUDA_KERNEL_LAUNCH_CHECK();
 
-  AT_CUDA_CHECK(cudaGetLastError());
-  return order_t.masked_select(keep);
+  return stable_helpers::masked_select(order_t, keep);
 }
 
 } // namespace
 
-TORCH_LIBRARY_IMPL(torchvision, CUDA, m) {
-  m.impl(TORCH_SELECTIVE_NAME("torchvision::nms"), TORCH_FN(nms_kernel));
+STABLE_TORCH_LIBRARY_IMPL(torchvision, CUDA, m) {
+  m.impl("nms", TORCH_BOX(&nms_kernel));
 }
 
 } // namespace ops

--- a/torchvision/csrc/ops/cuda/nms_kernel.cu
+++ b/torchvision/csrc/ops/cuda/nms_kernel.cu
@@ -148,7 +148,8 @@ __global__ static void gather_keep_from_mask(
 }
 
 // THO_DISPATCH_V2 splits its body on commas outside parens. The commas in
-// kernel<<<blocks, threads, 0, stream>>> would break it, so it goes through this wrapper.
+// kernel<<<blocks, threads, 0, stream>>> would break it, so it goes through
+// this wrapper.
 template <typename scalar_t>
 void launch_nms_kernel_impl(
     dim3 blocks,
@@ -158,8 +159,8 @@ void launch_nms_kernel_impl(
     double iou_threshold,
     const scalar_t* boxes,
     unsigned long long* mask) {
-  nms_kernel_impl<scalar_t><<<blocks, threads, 0, stream>>>(
-      dets_num, iou_threshold, boxes, mask);
+  nms_kernel_impl<scalar_t>
+      <<<blocks, threads, 0, stream>>>(dets_num, iou_threshold, boxes, mask);
 }
 
 Tensor nms_kernel(
@@ -176,7 +177,10 @@ Tensor nms_kernel(
       "boxes should have 4 elements in dimension 1, got ",
       dets.size(1));
   STD_TORCH_CHECK(
-      scores.dim() == 1, "scores should be a 1d tensor, got ", scores.dim(), "D");
+      scores.dim() == 1,
+      "scores should be a 1d tensor, got ",
+      scores.dim(),
+      "D");
   STD_TORCH_CHECK(
       dets.size(0) == scores.size(0),
       "boxes and scores should have same number of elements in ",
@@ -188,11 +192,12 @@ Tensor nms_kernel(
   torch::stable::accelerator::DeviceGuard device_guard(dets.get_device_index());
 
   if (dets.numel() == 0) {
-    return torch::stable::new_empty(dets, {0}, torch::headeronly::ScalarType::Long);
+    return torch::stable::new_empty(
+        dets, {0}, torch::headeronly::ScalarType::Long);
   }
 
-  auto order_t = std::get<1>(
-      stable_helpers::sort(scores, /*stable=*/true, /*dim=*/0, /*descending=*/true));
+  auto order_t = std::get<1>(stable_helpers::sort(
+      scores, /*stable=*/true, /*dim=*/0, /*descending=*/true));
   auto dets_sorted =
       torch::stable::contiguous(stable_helpers::index_select(dets, 0, order_t));
 
@@ -229,9 +234,10 @@ Tensor nms_kernel(
       torch::headeronly::ScalarType::Half);
   STD_CUDA_KERNEL_LAUNCH_CHECK();
 
-  Tensor keep =
-      torch::stable::new_zeros(dets, {static_cast<int64_t>(dets_num)},
-                               torch::headeronly::ScalarType::Bool);
+  Tensor keep = torch::stable::new_zeros(
+      dets,
+      {static_cast<int64_t>(dets_num)},
+      torch::headeronly::ScalarType::Bool);
 
   // Unwrap the mask to fill keep with proper values
   // Keeping the unwrap on device instead of applying iterative for loops on cpu

--- a/torchvision/csrc/ops/mps/nms_kernel.mm
+++ b/torchvision/csrc/ops/mps/nms_kernel.mm
@@ -1,86 +1,177 @@
-#include <ATen/mps/MPSProfiler.h>
-#include <ATen/native/mps/OperationUtils.h>
-#include "mps_kernels.h"
+#include <torch/csrc/inductor/aoti_torch/c/shim_mps.h>
+#include <torch/csrc/stable/device.h>
+#include <torch/csrc/stable/library.h>
+#include <torch/csrc/stable/ops.h>
+#include <torch/csrc/stable/tensor.h>
+#include <torch/headeronly/core/DeviceType.h>
+#include <torch/headeronly/core/ScalarType.h>
+#include <torch/headeronly/util/Exception.h>
+
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include "../StableABICompat.h"
+#include "nms_metal_shader.h"
 
 namespace vision {
 namespace ops {
 
 namespace {
 
+using torch::stable::Tensor;
+
 // This should be in sync with `nmsThreadsPerBlock` in the metal kernel.
 constexpr int64_t nmsThreadsPerBlock = sizeof(uint64_t) * 8;
 
-at::Tensor nms_kernel(const at::Tensor& dets, const at::Tensor& scores, double iou_threshold) {
-  using namespace at::native::mps;
-  TORCH_CHECK(dets.is_mps(), "dets must be a MPS tensor");
-  TORCH_CHECK(scores.is_mps(), "scores must be a MPS tensor");
+// Lazily compile the nms Metal shader library once for the process, mirroring
+// the lazy-singleton the AOTInductor MPS backend generates. The handle lives
+// for the process lifetime (as the legacy static MetalShaderLibrary did).
+AOTIMetalShaderLibraryHandle nms_shader_library() {
+  static AOTIMetalShaderLibraryHandle library = []() {
+    AOTIMetalShaderLibraryHandle handle = nullptr;
+    TORCH_ERROR_CODE_CHECK(
+        aoti_torch_mps_create_shader_library(nms_metal_shader, &handle));
+    return handle;
+  }();
+  return library;
+}
 
-  TORCH_CHECK(dets.dim() == 2, "boxes should be a 2d tensor, got ", dets.dim(), "D");
-  TORCH_CHECK(dets.size(1) == 4, "boxes should have 4 elements in dimension 1, got ", dets.size(1));
-  TORCH_CHECK(scores.dim() == 1, "scores should be a 1d tensor, got ", scores.dim(), "D");
-  TORCH_CHECK(dets.size(0) == scores.size(0),
-              "boxes and scores should have same number of elements in ",
-              "dimension 0, got ",
-              dets.size(0),
-              " and ",
-              scores.size(0))
+// Mirrors at::native::mps::scalarToMetalTypeString for the dtypes nms registers
+// (nms_float / nms_half). An unsupported dtype yields a name with no matching
+// kernel, so the lookup in aoti_torch_mps_get_kernel_function fails -- as the
+// legacy visionPipelineState lookup did for unsupported types.
+const char* metal_type_string(torch::headeronly::ScalarType scalar_type) {
+  if (scalar_type == torch::headeronly::ScalarType::Float) {
+    return "float";
+  }
+  if (scalar_type == torch::headeronly::ScalarType::Half) {
+    return "half";
+  }
+  return "";
+}
+
+// Arguments bound to the nms kernel inside the command block. The tensors are
+// owned by the caller (nms_kernel) and outlive the synchronous dispatch.
+struct NmsLaunchArgs {
+  AtenTensorHandle dets_sorted;
+  AtenTensorHandle mask;
+  AtenTensorHandle iou_threshold;
+  int64_t dets_num;
+  uint64_t grid[2];
+  uint64_t threadgroup[2];
+};
+
+// Trampoline invoked on the MPS stream's queue by aoti_torch_mps_run_command_block.
+void nms_encode(AOTIMetalKernelFunctionHandle func, void* user_data) {
+  const auto* launch_args = static_cast<const NmsLaunchArgs*>(user_data);
+  TORCH_ERROR_CODE_CHECK(aoti_torch_mps_start_encoding(func));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_tensor(func, 0, launch_args->dets_sorted));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_tensor(func, 1, launch_args->mask));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_int(func, 2, launch_args->dets_num));
+  // The MPS shim has no scalar-float arg setter, so iou_threshold rides in as a
+  // 1-element float32 tensor bound at buffer(3).
+  // TODO(stable-abi): bind a float directly once aoti_torch_mps_set_arg_double /
+  // set_arg_bytes lands upstream (pytorch/pytorch).
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_tensor(func, 3, launch_args->iou_threshold));
+  TORCH_ERROR_CODE_CHECK(aoti_torch_mps_dispatch_array_with_group_size(
+      func,
+      launch_args->grid,
+      /*length_size=*/2,
+      launch_args->threadgroup,
+      /*group_size_size=*/2));
+}
+
+Tensor nms_kernel(
+    const Tensor& dets,
+    const Tensor& scores,
+    double iou_threshold) {
+  STD_TORCH_CHECK(
+      dets.device().type() == torch::headeronly::DeviceType::MPS,
+      "dets must be a MPS tensor");
+  STD_TORCH_CHECK(
+      scores.device().type() == torch::headeronly::DeviceType::MPS,
+      "scores must be a MPS tensor");
+
+  STD_TORCH_CHECK(
+      dets.dim() == 2, "boxes should be a 2d tensor, got ", dets.dim(), "D");
+  STD_TORCH_CHECK(
+      dets.size(1) == 4,
+      "boxes should have 4 elements in dimension 1, got ",
+      dets.size(1));
+  STD_TORCH_CHECK(
+      scores.dim() == 1, "scores should be a 1d tensor, got ", scores.dim(), "D");
+  STD_TORCH_CHECK(
+      dets.size(0) == scores.size(0),
+      "boxes and scores should have same number of elements in ",
+      "dimension 0, got ",
+      dets.size(0),
+      " and ",
+      scores.size(0));
 
   if (dets.numel() == 0) {
-    return at::empty({0}, dets.options().dtype(at::kLong));
+    return torch::stable::new_empty(dets, {0}, torch::headeronly::ScalarType::Long);
   }
 
-  auto order_t = std::get<1>(scores.sort(/*stable=*/true, /*dim=*/0, /* descending=*/true));
-  auto dets_sorted = dets.index_select(0, order_t).contiguous();
+  auto order_t = std::get<1>(
+      stable_helpers::sort(scores, /*stable=*/true, /*dim=*/0, /*descending=*/true));
+  auto dets_sorted =
+      torch::stable::contiguous(stable_helpers::index_select(dets, 0, order_t));
   int64_t dets_num = dets.size(0);
-  float iou_threshold_f = static_cast<float>(iou_threshold);
 
-  const int col_blocks = (dets_num + nmsThreadsPerBlock - 1) / nmsThreadsPerBlock;
-  at::Tensor mask = at::empty({dets_num * col_blocks}, dets.options().dtype(at::kLong));
+  const int64_t col_blocks =
+      (dets_num + nmsThreadsPerBlock - 1) / nmsThreadsPerBlock;
+  Tensor mask = torch::stable::new_empty(
+      dets, {dets_num * col_blocks}, torch::headeronly::ScalarType::Long);
 
-  id<MTLBuffer> inputBuffer = getMTLBufferStorage(dets_sorted);
-  id<MTLBuffer> outputBuffer = getMTLBufferStorage(mask);
-  id<MTLDevice> device = MPSDevice::getInstance()->device();
-  MPSStream* mpsStream = getCurrentMPSStream();
-  dispatch_sync(mpsStream->queue(), ^() {
-    @autoreleasepool {
-      id<MTLComputeCommandEncoder> computeEncoder = mpsStream->commandEncoder();
-      MTLSize threadgroupsPerGrid = MTLSizeMake(col_blocks, col_blocks, 1);
+  // The MPS kernel reads iou_threshold as a float; carry it in a 1-element
+  // float32 tensor (see note in nms_encode).
+  Tensor iou_threshold_t =
+      torch::stable::new_empty(dets, {1}, torch::headeronly::ScalarType::Float);
+  torch::stable::fill_(iou_threshold_t, iou_threshold);
 
-      const std::string kernel = "nms_" + scalarToMetalTypeString(dets_sorted.scalar_type());
-      id<MTLComputePipelineState> visionPSO = mps::visionPipelineState(device, kernel);
+  const std::string kernel =
+      "nms_" + std::string(metal_type_string(dets_sorted.scalar_type()));
+  AOTIMetalKernelFunctionHandle func = nullptr;
+  TORCH_ERROR_CODE_CHECK(aoti_torch_mps_get_kernel_function(
+      nms_shader_library(), kernel.c_str(), &func));
 
-      // this function call is a no-op if MPS Profiler is not enabled
-      getMPSProfiler().beginProfileKernel(visionPSO, kernel, {dets, scores});
-
-      [computeEncoder setComputePipelineState:visionPSO];
-      [computeEncoder setBuffer:inputBuffer offset:dets_sorted.storage_offset() * dets_sorted.element_size() atIndex:0];
-      [computeEncoder setBuffer:outputBuffer offset:mask.storage_offset() * mask.element_size() atIndex:1];
-      [computeEncoder setBytes:&dets_num length:sizeof(int64_t) atIndex:2];
-      [computeEncoder setBytes:&iou_threshold_f length:sizeof(float) atIndex:3];
-
-      // A threadGroup is equivalent to a cuda's block.
-      NSUInteger tgSize = visionPSO.maxTotalThreadsPerThreadgroup;
-      if (tgSize > nmsThreadsPerBlock) {
-        tgSize = nmsThreadsPerBlock;
-      }
-
-      MTLSize threadGroupSize = MTLSizeMake(tgSize, 1, 1);
-      [computeEncoder dispatchThreadgroups:threadgroupsPerGrid threadsPerThreadgroup:threadGroupSize];
-
-      getMPSProfiler().endProfileKernel(visionPSO);
-    }
-  });
+  // A threadGroup is equivalent to a cuda's block; dispatch col_blocks x
+  // col_blocks threadgroups of nmsThreadsPerBlock threads. The shim dispatches
+  // by total threads, so the x grid extent is scaled by the threadgroup width.
+  NmsLaunchArgs launch_args{
+      dets_sorted.get(),
+      mask.get(),
+      iou_threshold_t.get(),
+      dets_num,
+      {static_cast<uint64_t>(col_blocks) * nmsThreadsPerBlock,
+       static_cast<uint64_t>(col_blocks)},
+      {static_cast<uint64_t>(nmsThreadsPerBlock), 1}};
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_run_command_block(func, &nms_encode, &launch_args));
 
   int64_t num_to_keep = 0;
 
-  at::Tensor mask_cpu = mask.to(at::kCPU);
-  unsigned long long* mask_host = (unsigned long long*)mask_cpu.data_ptr<int64_t>();
+  Tensor mask_cpu = torch::stable::to(
+      mask, torch::stable::Device(torch::headeronly::DeviceType::CPU));
+  unsigned long long* mask_host =
+      (unsigned long long*)mask_cpu.const_data_ptr<int64_t>();
 
   std::vector<unsigned long long> remv(col_blocks);
   memset(&remv[0], 0, sizeof(unsigned long long) * col_blocks);
 
-  at::Tensor keep = at::empty({dets_num}, dets.options().dtype(at::kLong).device(at::kCPU));
-  int64_t* keep_out = keep.data_ptr<int64_t>();
+  Tensor keep = torch::stable::new_empty(
+      dets,
+      {dets_num},
+      torch::headeronly::ScalarType::Long,
+      /*layout=*/std::nullopt,
+      torch::stable::Device(torch::headeronly::DeviceType::CPU));
+  int64_t* keep_out = keep.mutable_data_ptr<int64_t>();
 
   for (int64_t i = 0; i < dets_num; i++) {
     int64_t nblock = i / nmsThreadsPerBlock;
@@ -95,14 +186,18 @@ at::Tensor nms_kernel(const at::Tensor& dets, const at::Tensor& scores, double i
     }
   }
 
-  return order_t.index(
-      {keep.narrow(/*dim=*/0, /*start=*/0, /*length=*/num_to_keep).to(order_t.device(), keep.scalar_type())});
+  return stable_helpers::index_select(
+      order_t,
+      0,
+      torch::stable::to(
+          torch::stable::narrow(keep, /*dim=*/0, /*start=*/0, /*length=*/num_to_keep),
+          order_t.device()));
 }
 
 } // namespace
 
-TORCH_LIBRARY_IMPL(torchvision, MPS, m) {
-  m.impl(TORCH_SELECTIVE_NAME("torchvision::nms"), TORCH_FN(nms_kernel));
+STABLE_TORCH_LIBRARY_IMPL(torchvision, MPS, m) {
+  m.impl("nms", TORCH_BOX(&nms_kernel));
 }
 
 } // namespace ops

--- a/torchvision/csrc/ops/mps/nms_metal_shader.h
+++ b/torchvision/csrc/ops/mps/nms_metal_shader.h
@@ -1,0 +1,112 @@
+#pragma once
+
+// Metal shader source for the nms MPS kernel.
+//
+// Carved out of the shared ops/mps/mps_kernels.h (which is still used by the
+// legacy _C ops) so it can be compiled into the stable-ABI _C_stable extension.
+// mps_kernels.h opens with #include <ATen/native/mps/OperationUtils.h> and
+// instantiates at::native::mps::MetalShaderLibrary, both unavailable under
+// -DTORCH_TARGET_VERSION. This header carries only the nms Metal source as a
+// plain string, handed to aoti_torch_mps_create_shader_library at runtime --
+// the same shape PyTorch's AOTInductor MPS backend emits.
+//
+// The kernel bodies below are copied verbatim from mps_kernels.h; keep them in
+// sync if that file changes.
+
+namespace vision {
+namespace ops {
+
+static const char* nms_metal_shader = R"VISION_METAL(
+
+#include <metal_stdlib>
+using namespace metal;
+
+/*----------Helpers--------*/
+
+template <typename T>
+inline T ceil_div(T n, T m) {
+  return (n + m - 1) / m;
+}
+
+template <typename T, typename scalar_t>
+inline bool IoU(
+  constant T & a,
+  threadgroup T & b,
+  const float threshold) {
+  auto xx1 = max(a.x, b.x);
+  auto yy1 = max(a.y, b.y);
+  auto xx2 = min(a.z, b.z);
+  auto yy2 = min(a.w, b.w);
+  auto w = max(static_cast<scalar_t>(0), xx2 - xx1);
+  auto h = max(static_cast<scalar_t>(0), yy2 - yy1);
+  // Upcast to float before multiplications to circumvent precision issues in half.
+  auto inter = static_cast<float>(w) * static_cast<float>(h);
+  auto area_b = static_cast<float>(b.z - b.x) * static_cast<float>(b.w - b.y);
+  auto area_a = static_cast<float>(a.z - a.x) * static_cast<float>(a.w - a.y);
+  return (inter / (area_a + area_b - inter)) > threshold;
+}
+
+/*----------Kernels----------*/
+
+// This should be in sync with the one in nms_kernel.mm.
+// Since metal does not support dynamic array,
+// we need to make it static instead of deriving it from [[threads_per_threadgroup]].
+constant int64_t nmsThreadsPerBlock = sizeof(uint64_t) * 8;
+
+template<typename T, typename scalar_t>
+kernel void nms(constant  T        * dev_boxes     [[buffer(0)]],
+                device    uint64_t * mask          [[buffer(1)]],
+                constant  int64_t  & n_boxes       [[buffer(2)]],
+                constant  float    & iou_threshold [[buffer(3)]],
+                uint2     tgid     [[threadgroup_position_in_grid]],
+                uint2     tid2     [[thread_position_in_threadgroup]]) {
+
+  const uint row_start = tgid.y;
+  const uint col_start = tgid.x;
+  const uint tid = tid2.x;
+  const uint row_size =
+      min(n_boxes - row_start * nmsThreadsPerBlock, nmsThreadsPerBlock);
+  const uint col_size =
+      min(n_boxes - col_start * nmsThreadsPerBlock, nmsThreadsPerBlock);
+
+  threadgroup T block_boxes[nmsThreadsPerBlock];
+  block_boxes[tid] = dev_boxes[nmsThreadsPerBlock * col_start + tid];
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  if (tid < row_size) {
+    const uint cur_box_idx = nmsThreadsPerBlock * row_start + tid;
+    uint64_t t = 0;
+    uint start = 0;
+
+    if (row_start == col_start) {
+      start = tid + 1;
+    }
+
+    for (uint i = start; i < col_size; i++){
+      if (IoU<T, scalar_t>(dev_boxes[cur_box_idx], block_boxes[i], iou_threshold)){
+        t |= static_cast<uint64_t>(1) << i;  // discard 1 keep 0
+      }
+    }
+    const uint col_blocks = ceil_div(n_boxes, nmsThreadsPerBlock);
+    mask[cur_box_idx * col_blocks + col_start] = t;
+  }
+}
+
+#define REGISTER_NMS_OP(DTYPE)                             \
+template                                                   \
+[[host_name("nms_" #DTYPE)]]                               \
+kernel void nms<DTYPE ## 4, DTYPE>(                        \
+  constant DTYPE ## 4 * dev_boxes         [[buffer(0)]],   \
+  device   uint64_t   * mask              [[buffer(1)]],   \
+  constant int64_t    & n_boxes           [[buffer(2)]],   \
+  constant float      & iou_threshold     [[buffer(3)]],   \
+  uint2    tgid   [[threadgroup_position_in_grid]],        \
+  uint2    tid2   [[thread_position_in_threadgroup]]);
+
+REGISTER_NMS_OP(float);
+REGISTER_NMS_OP(half);
+
+)VISION_METAL";
+
+} // namespace ops
+} // namespace vision

--- a/torchvision/csrc/ops/mps/nms_metal_shader.h
+++ b/torchvision/csrc/ops/mps/nms_metal_shader.h
@@ -7,11 +7,8 @@
 // mps_kernels.h opens with #include <ATen/native/mps/OperationUtils.h> and
 // instantiates at::native::mps::MetalShaderLibrary, both unavailable under
 // -DTORCH_TARGET_VERSION. This header carries only the nms Metal source as a
-// plain string, handed to aoti_torch_mps_create_shader_library at runtime --
+// plain string, handed to aoti_torch_mps_create_shader_library at runtime,
 // the same shape PyTorch's AOTInductor MPS backend emits.
-//
-// The kernel bodies below are copied verbatim from mps_kernels.h; keep them in
-// sync if that file changes.
 
 namespace vision {
 namespace ops {

--- a/torchvision/csrc/ops/nms.cpp
+++ b/torchvision/csrc/ops/nms.cpp
@@ -8,12 +8,6 @@
 
 #include <array>
 
-#if !defined(MOBILE) && defined(_WIN32)
-void* PyInit__C_stable(void) {
-  return nullptr;
-}
-#endif
-
 namespace vision {
 namespace ops {
 

--- a/torchvision/csrc/ops/nms.cpp
+++ b/torchvision/csrc/ops/nms.cpp
@@ -1,27 +1,36 @@
 #include "nms.h"
 
-#include <ATen/core/dispatch/Dispatcher.h>
-#include <torch/library.h>
-#include <torch/types.h>
+#include <torch/csrc/stable/c/shim.h>
+#include <torch/csrc/stable/library.h>
+#include <torch/csrc/stable/stableivalue_conversions.h>
+#include <torch/headeronly/util/shim_utils.h>
+#include <torch/headeronly/version.h>
+
+#include <array>
+
+#if !defined(MOBILE) && defined(_WIN32)
+void* PyInit__C_stable(void) {
+  return nullptr;
+}
+#endif
 
 namespace vision {
 namespace ops {
 
-at::Tensor nms(
-    const at::Tensor& dets,
-    const at::Tensor& scores,
-    double iou_threshold) {
-  C10_LOG_API_USAGE_ONCE("torchvision.csrc.ops.nms.nms");
-  static auto op = c10::Dispatcher::singleton()
-                       .findSchemaOrThrow("torchvision::nms", "")
-                       .typed<decltype(nms)>();
-  return op.call(dets, scores, iou_threshold);
+using torch::stable::Tensor;
+
+Tensor nms(const Tensor& dets, const Tensor& scores, double iou_threshold) {
+  std::array<StableIValue, 3> stack{
+      torch::stable::detail::from(dets),
+      torch::stable::detail::from(scores),
+      torch::stable::detail::from(iou_threshold)};
+  TORCH_ERROR_CODE_CHECK(torch_call_dispatcher(
+      "torchvision::nms", "", stack.data(), TORCH_ABI_VERSION));
+  return torch::stable::detail::to<Tensor>(stack[0]);
 }
 
-TORCH_LIBRARY_FRAGMENT(torchvision, m) {
-  m.set_python_module("torchvision._meta_registrations");
-  m.def(TORCH_SELECTIVE_SCHEMA(
-      "torchvision::nms(Tensor dets, Tensor scores, float iou_threshold) -> Tensor"));
+STABLE_TORCH_LIBRARY_FRAGMENT(torchvision, m) {
+  m.def("nms(Tensor dets, Tensor scores, float iou_threshold) -> Tensor");
 }
 
 } // namespace ops

--- a/torchvision/csrc/ops/nms.h
+++ b/torchvision/csrc/ops/nms.h
@@ -1,14 +1,14 @@
 #pragma once
 
-#include <ATen/ATen.h>
+#include <torch/csrc/stable/tensor.h>
 #include "../macros.h"
 
 namespace vision {
 namespace ops {
 
-VISION_API at::Tensor nms(
-    const at::Tensor& dets,
-    const at::Tensor& scores,
+VISION_API torch::stable::Tensor nms(
+    const torch::stable::Tensor& dets,
+    const torch::stable::Tensor& scores,
     double iou_threshold);
 
 } // namespace ops

--- a/torchvision/csrc/ops/quantized/cpu/qnms_kernel.cpp
+++ b/torchvision/csrc/ops/quantized/cpu/qnms_kernel.cpp
@@ -1,10 +1,10 @@
-#include "../../StableABICompat.h"
 #include <torch/csrc/stable/library.h>
 #include <torch/csrc/stable/ops.h>
 #include <torch/csrc/stable/tensor.h>
 #include <torch/headeronly/core/Dispatch_v2.h>
 #include <torch/headeronly/core/ScalarType.h>
 #include <torch/headeronly/util/Exception.h>
+#include "../../StableABICompat.h"
 
 #include <algorithm>
 #include <cstdint>
@@ -29,7 +29,8 @@ Tensor qnms_kernel_impl(
       "dets should have the same type as scores");
 
   if (dets.numel() == 0) {
-    return torch::stable::new_empty(dets, {0}, torch::headeronly::ScalarType::Long);
+    return torch::stable::new_empty(
+        dets, {0}, torch::headeronly::ScalarType::Long);
   }
 
   const auto ndets = dets.size(0);
@@ -38,14 +39,14 @@ Tensor qnms_kernel_impl(
   auto y1_t = torch::stable::contiguous(torch::stable::select(dets, 1, 1));
   auto x2_t = torch::stable::contiguous(torch::stable::select(dets, 1, 2));
   auto y2_t = torch::stable::contiguous(torch::stable::select(dets, 1, 3));
-  auto order_t = std::get<1>(
-      stable_helpers::sort(scores, /*stable=*/true, /*dim=*/0, /*descending=*/true));
-  Tensor suppressed_t =
-      torch::stable::new_zeros(dets, {ndets}, torch::headeronly::ScalarType::Byte);
-  Tensor keep_t =
-      torch::stable::new_zeros(dets, {ndets}, torch::headeronly::ScalarType::Long);
-  Tensor areas_t =
-      torch::stable::new_zeros(dets, {ndets}, torch::headeronly::ScalarType::Float);
+  auto order_t = std::get<1>(stable_helpers::sort(
+      scores, /*stable=*/true, /*dim=*/0, /*descending=*/true));
+  Tensor suppressed_t = torch::stable::new_zeros(
+      dets, {ndets}, torch::headeronly::ScalarType::Byte);
+  Tensor keep_t = torch::stable::new_zeros(
+      dets, {ndets}, torch::headeronly::ScalarType::Long);
+  Tensor areas_t = torch::stable::new_zeros(
+      dets, {ndets}, torch::headeronly::ScalarType::Float);
 
   auto suppressed = suppressed_t.mutable_data_ptr<uint8_t>();
   auto keep = keep_t.mutable_data_ptr<int64_t>();
@@ -103,7 +104,8 @@ Tensor qnms_kernel_impl(
       }
     }
   }
-  return torch::stable::narrow(keep_t, /*dim=*/0, /*start=*/0, /*length=*/num_to_keep);
+  return torch::stable::narrow(
+      keep_t, /*dim=*/0, /*start=*/0, /*length=*/num_to_keep);
 }
 
 Tensor qnms_kernel(
@@ -117,7 +119,10 @@ Tensor qnms_kernel(
       "boxes should have 4 elements in dimension 1, got ",
       dets.size(1));
   STD_TORCH_CHECK(
-      scores.dim() == 1, "scores should be a 1d tensor, got ", scores.dim(), "D");
+      scores.dim() == 1,
+      "scores should be a 1d tensor, got ",
+      scores.dim(),
+      "D");
   STD_TORCH_CHECK(
       dets.size(0) == scores.size(0),
       "boxes and scores should have same number of elements in ",

--- a/torchvision/csrc/ops/quantized/cpu/qnms_kernel.cpp
+++ b/torchvision/csrc/ops/quantized/cpu/qnms_kernel.cpp
@@ -1,46 +1,60 @@
-#include <ATen/ATen.h>
-#include <torch/library.h>
+#include "../../StableABICompat.h"
+#include <torch/csrc/stable/library.h>
+#include <torch/csrc/stable/ops.h>
+#include <torch/csrc/stable/tensor.h>
+#include <torch/headeronly/core/Dispatch_v2.h>
+#include <torch/headeronly/core/ScalarType.h>
+#include <torch/headeronly/util/Exception.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <tuple>
 
 namespace vision {
 namespace ops {
 
 namespace {
 
+using torch::stable::Tensor;
+
 template <typename scalar_t>
-at::Tensor qnms_kernel_impl(
-    const at::Tensor& dets,
-    const at::Tensor& scores,
+Tensor qnms_kernel_impl(
+    const Tensor& dets,
+    const Tensor& scores,
     double iou_threshold) {
-  TORCH_CHECK(!dets.is_cuda(), "dets must be a CPU tensor");
-  TORCH_CHECK(!scores.is_cuda(), "scores must be a CPU tensor");
-  TORCH_CHECK(
+  STD_TORCH_CHECK(!dets.is_cuda(), "dets must be a CPU tensor");
+  STD_TORCH_CHECK(!scores.is_cuda(), "scores must be a CPU tensor");
+  STD_TORCH_CHECK(
       dets.scalar_type() == scores.scalar_type(),
       "dets should have the same type as scores");
 
   if (dets.numel() == 0) {
-    return at::empty({0}, dets.options().dtype(at::kLong));
+    return torch::stable::new_empty(dets, {0}, torch::headeronly::ScalarType::Long);
   }
 
   const auto ndets = dets.size(0);
 
-  auto x1_t = dets.select(1, 0).contiguous();
-  auto y1_t = dets.select(1, 1).contiguous();
-  auto x2_t = dets.select(1, 2).contiguous();
-  auto y2_t = dets.select(1, 3).contiguous();
+  auto x1_t = torch::stable::contiguous(torch::stable::select(dets, 1, 0));
+  auto y1_t = torch::stable::contiguous(torch::stable::select(dets, 1, 1));
+  auto x2_t = torch::stable::contiguous(torch::stable::select(dets, 1, 2));
+  auto y2_t = torch::stable::contiguous(torch::stable::select(dets, 1, 3));
   auto order_t = std::get<1>(
-      scores.sort(/*stable=*/true, /*dim=*/0, /* descending=*/true));
-  at::Tensor suppressed_t = at::zeros({ndets}, dets.options().dtype(at::kByte));
-  at::Tensor keep_t = at::zeros({ndets}, dets.options().dtype(at::kLong));
-  at::Tensor areas_t = at::zeros({ndets}, dets.options().dtype(at::kFloat));
+      stable_helpers::sort(scores, /*stable=*/true, /*dim=*/0, /*descending=*/true));
+  Tensor suppressed_t =
+      torch::stable::new_zeros(dets, {ndets}, torch::headeronly::ScalarType::Byte);
+  Tensor keep_t =
+      torch::stable::new_zeros(dets, {ndets}, torch::headeronly::ScalarType::Long);
+  Tensor areas_t =
+      torch::stable::new_zeros(dets, {ndets}, torch::headeronly::ScalarType::Float);
 
-  auto suppressed = suppressed_t.data_ptr<uint8_t>();
-  auto keep = keep_t.data_ptr<int64_t>();
-  auto order = order_t.data_ptr<int64_t>();
-  auto x1 = x1_t.data_ptr<scalar_t>();
-  auto y1 = y1_t.data_ptr<scalar_t>();
-  auto x2 = x2_t.data_ptr<scalar_t>();
-  auto y2 = y2_t.data_ptr<scalar_t>();
-  auto areas = areas_t.data_ptr<float>();
+  auto suppressed = suppressed_t.mutable_data_ptr<uint8_t>();
+  auto keep = keep_t.mutable_data_ptr<int64_t>();
+  auto order = order_t.const_data_ptr<int64_t>();
+  auto x1 = x1_t.const_data_ptr<scalar_t>();
+  auto y1 = y1_t.const_data_ptr<scalar_t>();
+  auto x2 = x2_t.const_data_ptr<scalar_t>();
+  auto y2 = y2_t.const_data_ptr<scalar_t>();
+  auto areas = areas_t.mutable_data_ptr<float>();
 
   for (int64_t i = 0; i < ndets; i++) {
     // Note 1: To get the exact area we'd need to multiply by scale**2, but this
@@ -55,7 +69,6 @@ at::Tensor qnms_kernel_impl(
   }
 
   int64_t num_to_keep = 0;
-
   for (int64_t _i = 0; _i < ndets; _i++) {
     auto i = order[_i];
     if (suppressed[i] == 1) {
@@ -90,25 +103,22 @@ at::Tensor qnms_kernel_impl(
       }
     }
   }
-  return keep_t.narrow(/*dim=*/0, /*start=*/0, /*length=*/num_to_keep);
+  return torch::stable::narrow(keep_t, /*dim=*/0, /*start=*/0, /*length=*/num_to_keep);
 }
 
-at::Tensor qnms_kernel(
-    const at::Tensor& dets,
-    const at::Tensor& scores,
+Tensor qnms_kernel(
+    const Tensor& dets,
+    const Tensor& scores,
     double iou_threshold) {
-  TORCH_CHECK(
+  STD_TORCH_CHECK(
       dets.dim() == 2, "boxes should be a 2d tensor, got ", dets.dim(), "D");
-  TORCH_CHECK(
+  STD_TORCH_CHECK(
       dets.size(1) == 4,
       "boxes should have 4 elements in dimension 1, got ",
       dets.size(1));
-  TORCH_CHECK(
-      scores.dim() == 1,
-      "scores should be a 1d tensor, got ",
-      scores.dim(),
-      "D");
-  TORCH_CHECK(
+  STD_TORCH_CHECK(
+      scores.dim() == 1, "scores should be a 1d tensor, got ", scores.dim(), "D");
+  STD_TORCH_CHECK(
       dets.size(0) == scores.size(0),
       "boxes and scores should have same number of elements in ",
       "dimension 0, got ",
@@ -116,23 +126,26 @@ at::Tensor qnms_kernel(
       " and ",
       scores.size(0));
 
-  auto result = at::empty({0});
-
-  AT_DISPATCH_INTEGRAL_TYPES(dets.scalar_type(), "qnms_kernel", [&] {
-    result = qnms_kernel_impl<scalar_t>(dets, scores, iou_threshold);
-  });
+  Tensor result =
+      torch::stable::new_empty(dets, {0}, torch::headeronly::ScalarType::Long);
+  THO_DISPATCH_V2(
+      dets.scalar_type(),
+      "qnms_kernel",
+      AT_WRAP([&]() {
+        result = qnms_kernel_impl<scalar_t>(dets, scores, iou_threshold);
+      }),
+      AT_EXPAND(AT_INTEGRAL_TYPES));
   return result;
 }
 
 } // namespace
 
-TORCH_LIBRARY_FRAGMENT(torchvision, m) {
-  m.def(TORCH_SELECTIVE_SCHEMA(
-      "torchvision::qnms(Tensor dets, Tensor scores, float iou_threshold) -> Tensor"));
+STABLE_TORCH_LIBRARY_FRAGMENT(torchvision, m) {
+  m.def("qnms(Tensor dets, Tensor scores, float iou_threshold) -> Tensor");
 }
 
-TORCH_LIBRARY_IMPL(torchvision, CPU, m) {
-  m.impl(TORCH_SELECTIVE_NAME("torchvision::qnms"), TORCH_FN(qnms_kernel));
+STABLE_TORCH_LIBRARY_IMPL(torchvision, CPU, m) {
+  m.impl("qnms", TORCH_BOX(&qnms_kernel));
 }
 
 } // namespace ops

--- a/torchvision/csrc/vision_stable.cpp
+++ b/torchvision/csrc/vision_stable.cpp
@@ -1,0 +1,17 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+// Extension-level glue for the stable-ABI _C_stable extension -- the stable
+// counterpart of vision.cpp. Holds pieces that belong to the extension rather
+// than to any single operator, and grows as more ops migrate.
+
+// If we are in a Windows environment, we need to define
+// initialization functions for the _C_stable extension.
+#if !defined(MOBILE) && defined(_WIN32)
+void* PyInit__C_stable(void) {
+  return nullptr;
+}
+#endif // !defined(MOBILE) && defined(_WIN32)

--- a/torchvision/extension.py
+++ b/torchvision/extension.py
@@ -26,14 +26,10 @@ def _has_ops():
     return False
 
 
-if _load_library("_C"):
+if _load_library("_C") and _load_library("_C_stable"):
 
     def _has_ops():  # noqa: F811
         return True
-
-
-# Stable-ABI extension (migrated ops)
-_load_library("_C_stable")
 
 
 def _assert_has_ops():

--- a/torchvision/extension.py
+++ b/torchvision/extension.py
@@ -32,6 +32,10 @@ if _load_library("_C"):
         return True
 
 
+# Stable-ABI extension (migrated ops)
+_load_library("_C_stable")
+
+
 def _assert_has_ops():
     if not _has_ops():
         raise RuntimeError(


### PR DESCRIPTION
This PR stands up the stable-ABI build path and ports nms (CPU, CUDA, quantized-CPU, MPS) as the first op. The intent is to validate the harness/per-backend patterns on nms.

## Structure: Dual Extension
- `torchvision._C`: the existing extension, now built from all not-yet-ported sources.
- `torchvision._C_stable`: the new extension, built only from migrated sources (currently nms).

_Why two extensions?_ 
For a per op rollout a separate compilation unit helps to scope the pin and keep the tree buildable at every step of an incremental port (torchcodec migrated in place because it converted everything in one shot). Once all ops are stable remove legacy unstable compilation.

**Layout Changes**
`setup.py`: splits sources between the two extensions.
- `STABLE_SOURCES + _stable()/_not_stable()` helpers split the source globs, so migrated files compile into _C_stable and everything else stays in _C.
- `make_C_stable_extension()`: builds the new target with the -DTORCH_TARGET_VERSION pin.
- `ensure_hipified()` hoisted to a single idempotent step both extensions call (runs once/with no build-order dependency between them).

`Registration`: schema declaration/per-backend kernel binding.
- Schema via STABLE_TORCH_LIBRARY_FRAGMENT, which coexists with the classic TORCH_LIBRARY_FRAGMENT still in _C  both register into the same torchvision namespace across two .so.
- Per-backend kernels bound with STABLE_TORCH_LIBRARY_IMPL + TORCH_BOX.
- The nms() C++ entrypoint dispatches through torch_call_dispatcher.

`StableABICompat.h`: shared compat header one place for ATen ops not yet wrapped in stable ops.h (placeholder until upstream.
- Wraps sort, index_select, and masked_select through the dispatcher escape hatch, so each kernel doesn't re-roll the boilerplate.
- Mirrors torchcodec's header of the same name

`vision_stable.cpp`: extension-root file for `_C_stable`, the stable mirror of `vision.cpp`.
- Holds the Windows `PyInit__C_stable` stub. This is extension-level glue, not tied to any op, so it lives here rather than in a kernel file.
- Added to `STABLE_SOURCES` so it builds into `_C_stable` and stays out of `_C`.

## Missing Pytorch NMS MPS Stable-ABI Port Support
1. **MPS scalar arguments**:

    The [nms schema](https://github.com/adabeyta/vision/blob/65eb7b9e26750ae59e2748d340d8b0ff58b28bec/torchvision/csrc/ops/nms.cpp#L23-L24) takes a float [iou_threshold](https://github.com/adabeyta/vision/blob/829e95396dfa4e493269e661cc651a7ea932a331/torchvision/csrc/ops/mps/nms_metal_shader.h#L60), which the [Metal kernel](https://github.com/adabeyta/vision/blob/829e95396dfa4e493269e661cc651a7ea932a331/torchvision/csrc/ops/mps/nms_metal_shader.h#L56-L93) needs as a scalar argument (constant float & iou_threshold [[buffer(3)]]). With no scalar-arg setter in the shim, that float is currently carried as a 1-element float32 tensor bound via set_arg_tensor. shim_mps.h exposes only [aoti_torch_mps_set_arg_tensor and aoti_torch_mps_set_arg_int](https://github.com/pytorch/pytorch/blob/main/torch/csrc/inductor/aoti_torch/c/shim_mps.h#L33-L41)

     Missing:
     - aoti_torch_mps_set_arg_double
     - aoti_torch_mps_set_arg_float 
     - aoti_torch_mps_set_arg_bytes
     - aoti_torch_mps_set_arg_scalar. 

     TODO: Workaround (for now) packs iou_threshold into a [1-element float32 tensor](https://github.com/adabeyta/vision/blob/829e95396dfa4e493269e661cc651a7ea932a331/torchvision/csrc/ops/mps/nms_kernel.mm#L134-L136) (new_empty + fill_) and bind it at buffer(3) via set_arg_tensor. The kernel reads the same 4 bytes as constant float&, so it's behavior-identical. **_File PR for missing_** [mps_set_args](https://github.com/pytorch/pytorch/blob/main/torch/csrc/inductor/aoti_torch/c/shim_mps.h).

2. **Metal source isolation**.
     Made nms Metal source into a standalone nms_metal_shader.h. The shared mps_kernels.h can't be used under the pin because it pulls in ATen/native/mps/OperationUtils.h and instantiates at::native::mps::MetalShaderLibrary. Derives from same isolation rationale as the dual extension (legacy _C keeps using the full mps_kernels.h)
        
## Stable-ABI audit (`torch-abi-audit`)

  Ran [`torch-abi-audit`](https://github.com/Quansight/torch-abi-audit) against the built `torchvision` package to verify the migrated extension stays on the stable surface and never reaches into `at::` /  `c10::` / `torch::jit::` internals.

  **`_C_stable.so` audits as `STABLE` — 67 stable-shim symbols, 0 unstable.** The legacy `_C.so` and the
  unrelated `image.so` stay `UNSTABLE`, which is expected: only `nms` has migrated so far, so the
  package-level verdict remains `UNSTABLE` until the remaining ops move into `_C_stable` (same
  mid-migration shape as torchcodec).

  ```text
  Package: torchvision
    Torch ABI:   UNSTABLE
    CPython ABI: n/a
    Extensions:  0
    Bundled libs: 3
    -- bundled libs --
      [UNSTABLE] [not-abi3] _C.so         (stable_shim=0,  unstable=110)
      [STABLE  ] [not-abi3] _C_stable.so  (stable_shim=67, unstable=0)
      [UNSTABLE] [uses-private-api] image.so  (stable_shim=0,  unstable=36)
  ```