### PR TITLE
Port CUDA jpeg decoder to stable ABI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,8 @@ set(TORCHVISION_STABLE_SOURCES
   ${TVCPP}/ops/nms.cpp
   ${TVCPP}/ops/cpu/nms_kernel.cpp
   ${TVCPP}/ops/cuda/nms_kernel.cu
+  ${TVCPP}/io/image/cuda/decode_jpegs_cuda.cpp
+  ${TVCPP}/io/image/common_stable.cpp
   ${TVCPP}/vision_stable.cpp)
 # Pin them to torch 2.11. Per source, not library-wide: the pin makes ATen headers
 # error, and the legacy ops sharing this library still include them.

--- a/setup.py
+++ b/setup.py
@@ -162,6 +162,8 @@ STABLE_SOURCES = {
     CSRS_DIR / "ops/cpu/nms_kernel.cpp",
     CSRS_DIR / "ops/mps/nms_kernel.mm",
     CSRS_DIR / "ops/quantized/cpu/qnms_kernel.cpp",
+    CSRS_DIR / "io/image/cuda/decode_jpegs_cuda.cpp",
+    CSRS_DIR / "io/image/common_stable.cpp",
 }
 STABLE_SOURCES.add(CSRS_DIR / ("ops/hip/nms_kernel.hip" if IS_ROCM else "ops/cuda/nms_kernel.cu"))
 
@@ -241,7 +243,13 @@ def get_stable_macros_and_flags():
     if "nvcc" in extra_compile_args:
         extra_compile_args["nvcc"].append(tv)
         if not IS_ROCM:
+            # Some torch APIs like aoti_torch_get_current_cuda_stream (used by
+            # ops/cuda/nms_kernel.cu) are only exposed when USE_CUDA is defined.
+            # https://github.com/pytorch/pytorch/blob/98e36864e640023a716e058d894ea2d20e76e5f7/torch/csrc/inductor/aoti_torch/c/shim.h#L573-L602
             extra_compile_args["nvcc"].append("-DUSE_CUDA")
+            # The jpeg decode .cpp also calls these shims (incl.
+            # torch_get_cuda_stream_from_pool), so cxx needs USE_CUDA too.
+            extra_compile_args["cxx"].append("-DUSE_CUDA")
     return define_macros, extra_compile_args
 
 
@@ -373,14 +381,18 @@ def make_image_extension():
     define_macros, extra_compile_args = get_macros_and_flags()
 
     image_dir = CSRS_DIR / "io/image"
-    sources = list(image_dir.glob("*.cpp")) + list(image_dir.glob("cpu/*.cpp")) + list(image_dir.glob("cpu/giflib/*.c"))
+    sources = (
+        _not_stable(image_dir.glob("*.cpp"))
+        + _not_stable(image_dir.glob("cpu/*.cpp"))
+        + _not_stable(image_dir.glob("cpu/giflib/*.c"))
+    )
 
     if IS_ROCM:
-        sources += list(image_dir.glob("hip/*.cpp"))
+        sources += _not_stable(image_dir.glob("hip/*.cpp"))
         # we need to exclude this in favor of the hipified source
         sources.remove(image_dir / "image.cpp")
     else:
-        sources += list(image_dir.glob("cuda/*.cpp"))
+        sources += _not_stable(image_dir.glob("cuda/*.cpp"))
 
     Extension = CppExtension
 
@@ -452,6 +464,41 @@ def make_image_extension():
     )
 
 
+def make_image_stable_extension():
+    # Stable-ABI sibling of make_image_extension(): only the migrated (_stable) image TUs.
+    print("Building image_stable extension")
+
+    include_dirs = TORCHVISION_INCLUDE.copy()
+    library_dirs = TORCHVISION_LIBRARY.copy()
+    libraries = []
+    define_macros, extra_compile_args = get_stable_macros_and_flags()
+
+    image_dir = CSRS_DIR / "io/image"
+    sources = (
+        _stable(image_dir.glob("*.cpp"))
+        + _stable(image_dir.glob("cpu/*.cpp"))
+        + _stable(image_dir.glob("hip/*.cpp" if IS_ROCM else "cuda/*.cpp"))
+    )
+
+    Extension = CppExtension
+    if USE_NVJPEG and (torch.cuda.is_available() or FORCE_CUDA):
+        nvjpeg_found = CUDA_HOME is not None and (Path(CUDA_HOME) / "include/nvjpeg.h").exists()
+        if nvjpeg_found:
+            libraries.append("nvjpeg")
+            define_macros += [("NVJPEG_FOUND", 1)]
+            Extension = CUDAExtension
+
+    return Extension(
+        name="torchvision.image_stable",
+        sources=sorted(str(s) for s in sources),
+        include_dirs=include_dirs,
+        library_dirs=library_dirs,
+        define_macros=define_macros,
+        libraries=libraries,
+        extra_compile_args=extra_compile_args,
+    )
+
+
 class clean(distutils.command.clean.clean):
     def run(self):
         with open(".gitignore") as f:
@@ -480,6 +527,7 @@ if __name__ == "__main__":
         make_C_extension(),
         make_C_stable_extension(),
         make_image_extension(),
+        make_image_stable_extension(),
     ]
 
     setup(

--- a/torchvision/csrc/io/image/common_stable.cpp
+++ b/torchvision/csrc/io/image/common_stable.cpp
@@ -1,0 +1,17 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+// Extension-level glue for the stable-ABI image_stable extension -- the stable
+// counterpart of common.cpp. Holds pieces that belong to the extension rather
+// than to any single operator, and grows as more ops migrate.
+
+// If we are in a Windows environment, we need to define
+// initialization functions for the image_stable extension.
+#if !defined(MOBILE) && defined(_WIN32)
+void* PyInit_image_stable(void) {
+  return nullptr;
+}
+#endif // !defined(MOBILE) && defined(_WIN32)

--- a/torchvision/csrc/io/image/common_stable.h
+++ b/torchvision/csrc/io/image/common_stable.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <cstdint>
+
+namespace vision {
+namespace image {
+
+/* Should be kept in-sync with Python ImageReadMode enum */
+using ImageReadMode = int64_t;
+const ImageReadMode IMAGE_READ_MODE_UNCHANGED = 0;
+const ImageReadMode IMAGE_READ_MODE_GRAY = 1;
+const ImageReadMode IMAGE_READ_MODE_GRAY_ALPHA = 2;
+const ImageReadMode IMAGE_READ_MODE_RGB = 3;
+const ImageReadMode IMAGE_READ_MODE_RGB_ALPHA = 4;
+
+} // namespace image
+} // namespace vision

--- a/torchvision/csrc/io/image/cuda/decode_jpegs_cuda.cpp
+++ b/torchvision/csrc/io/image/cuda/decode_jpegs_cuda.cpp
@@ -237,6 +237,66 @@ CUDAJpegDecoder::~CUDAJpegDecoder() {
   that the CUDA runtime handles cleanup for us.
   Please send a PR if you have a solution for this problem.
   */
+
+  // nvjpegStatus_t status;
+
+  // status = nvjpegDecodeParamsDestroy(nvjpeg_decode_params);
+  // STD_TORCH_CHECK(
+  //     status == NVJPEG_STATUS_SUCCESS,
+  //     "Failed to destroy nvjpeg decode params: ",
+  //     status);
+
+  // status = nvjpegJpegStreamDestroy(jpeg_streams[0]);
+  // STD_TORCH_CHECK(
+  //     status == NVJPEG_STATUS_SUCCESS,
+  //     "Failed to destroy jpeg stream: ",
+  //     status);
+
+  // status = nvjpegJpegStreamDestroy(jpeg_streams[1]);
+  // STD_TORCH_CHECK(
+  //     status == NVJPEG_STATUS_SUCCESS,
+  //     "Failed to destroy jpeg stream: ",
+  //     status);
+
+  // status = nvjpegBufferPinnedDestroy(pinned_buffers[0]);
+  // STD_TORCH_CHECK(
+  //     status == NVJPEG_STATUS_SUCCESS,
+  //     "Failed to destroy pinned buffer[0]: ",
+  //     status);
+
+  // status = nvjpegBufferPinnedDestroy(pinned_buffers[1]);
+  // STD_TORCH_CHECK(
+  //     status == NVJPEG_STATUS_SUCCESS,
+  //     "Failed to destroy pinned buffer[1]: ",
+  //     status);
+
+  // status = nvjpegBufferDeviceDestroy(device_buffer);
+  // STD_TORCH_CHECK(
+  //     status == NVJPEG_STATUS_SUCCESS,
+  //     "Failed to destroy device buffer: ",
+  //     status);
+
+  // status = nvjpegJpegStateDestroy(nvjpeg_decoupled_state);
+  // STD_TORCH_CHECK(
+  //     status == NVJPEG_STATUS_SUCCESS,
+  //     "Failed to destroy nvjpeg decoupled state: ",
+  //     status);
+
+  // status = nvjpegDecoderDestroy(nvjpeg_decoder);
+  // STD_TORCH_CHECK(
+  //     status == NVJPEG_STATUS_SUCCESS,
+  //     "Failed to destroy nvjpeg decoder: ",
+  //     status);
+
+  // status = nvjpegJpegStateDestroy(nvjpeg_state);
+  // STD_TORCH_CHECK(
+  //     status == NVJPEG_STATUS_SUCCESS,
+  //     "Failed to destroy nvjpeg state: ",
+  //     status);
+
+  // status = nvjpegDestroy(nvjpeg_handle);
+  // STD_TORCH_CHECK(
+  //     status == NVJPEG_STATUS_SUCCESS, "nvjpegDestroy failed: ", status);
 }
 
 std::tuple<

--- a/torchvision/csrc/io/image/cuda/decode_jpegs_cuda.cpp
+++ b/torchvision/csrc/io/image/cuda/decode_jpegs_cuda.cpp
@@ -1,11 +1,15 @@
 #include "decode_jpegs_cuda.h"
+
+#include <torch/csrc/stable/library.h>
+#include <torch/headeronly/util/Exception.h>
+
 #if !NVJPEG_FOUND
 namespace vision {
 namespace image {
-std::vector<torch::Tensor> decode_jpegs_cuda(
-    const std::vector<torch::Tensor>& encoded_images,
+std::vector<torch::stable::Tensor> decode_jpegs_cuda(
+    const std::vector<torch::stable::Tensor>& encoded_images,
     vision::image::ImageReadMode mode,
-    torch::Device device) {
+    torch::stable::Device device) {
   STD_TORCH_CHECK(
       false, "decode_jpegs_cuda: torchvision not compiled with nvJPEG support");
 }
@@ -13,33 +17,49 @@ std::vector<torch::Tensor> decode_jpegs_cuda(
 } // namespace vision
 
 #else
-#include <ATen/cuda/CUDAContext.h>
-#include <ATen/cuda/CUDAEvent.h>
-#include <c10/cuda/CUDAGuard.h>
-#include <cuda_runtime_api.h>
-#include <algorithm>
-#include <fstream>
-#include <iostream>
+#include <torch/csrc/inductor/aoti_torch/c/shim.h>
+#include <torch/csrc/stable/accelerator.h>
+#include <torch/csrc/stable/c/shim.h>
+#include <torch/csrc/stable/ops.h>
+#include <torch/headeronly/core/DeviceType.h>
+#include <torch/headeronly/core/ScalarType.h>
+#include <torch/headeronly/util/shim_utils.h>
 #include <memory>
 #include <mutex>
-#include <sstream>
-#include <string>
-#include <typeinfo>
+#include <optional>
 namespace vision {
 namespace image {
 
 std::mutex decoderMutex;
 std::unique_ptr<CUDAJpegDecoder> cudaJpegDecoder;
 
-std::vector<torch::Tensor> decode_jpegs_cuda(
-    const std::vector<torch::Tensor>& encoded_images,
-    vision::image::ImageReadMode mode,
-    torch::Device device) {
-  C10_LOG_API_USAGE_ONCE(
-      "torchvision.csrc.io.image.cuda.decode_jpegs_cuda.decode_jpegs_cuda");
+// Make `waitingStream` wait on work in `runningStream` without blocking the
+// host, via a CUDA event.
+// https://github.com/meta-pytorch/torchcodec/blob/1dc85b7a7900d91fee207ccdc02f211a051688fe/src/torchcodec/_core/CUDACommon.cpp#L30-L47
+static void syncStreams(
+    cudaStream_t runningStream,
+    cudaStream_t waitingStream) {
+  cudaEvent_t event;
+  cudaError_t err = cudaEventCreate(&event);
+  STD_TORCH_CHECK(
+      err == cudaSuccess, "cudaEventCreate failed: ", cudaGetErrorString(err));
+  err = cudaEventRecord(event, runningStream);
+  STD_TORCH_CHECK(
+      err == cudaSuccess, "cudaEventRecord failed: ", cudaGetErrorString(err));
+  err = cudaStreamWaitEvent(waitingStream, event, 0);
+  STD_TORCH_CHECK(
+      err == cudaSuccess,
+      "cudaStreamWaitEvent failed: ",
+      cudaGetErrorString(err));
+  cudaEventDestroy(event);
+}
 
+std::vector<torch::stable::Tensor> decode_jpegs_cuda(
+    const std::vector<torch::stable::Tensor>& encoded_images,
+    vision::image::ImageReadMode mode,
+    torch::stable::Device device) {
   std::lock_guard<std::mutex> lock(decoderMutex);
-  std::vector<torch::Tensor> contig_images;
+  std::vector<torch::stable::Tensor> contig_images;
   contig_images.reserve(encoded_images.size());
 
   STD_TORCH_CHECK(
@@ -47,7 +67,8 @@ std::vector<torch::Tensor> decode_jpegs_cuda(
 
   for (auto& encoded_image : encoded_images) {
     STD_TORCH_CHECK(
-        encoded_image.dtype() == torch::kU8, "Expected a torch.uint8 tensor");
+        encoded_image.scalar_type() == torch::headeronly::ScalarType::Byte,
+        "Expected a torch.uint8 tensor");
 
     STD_TORCH_CHECK(
         !encoded_image.is_cuda(),
@@ -58,35 +79,10 @@ std::vector<torch::Tensor> decode_jpegs_cuda(
         "Expected a non empty 1-dimensional tensor");
 
     // nvjpeg requires images to be contiguous
-    if (encoded_image.is_contiguous()) {
-      contig_images.push_back(encoded_image);
-    } else {
-      contig_images.push_back(encoded_image.contiguous());
-    }
+    contig_images.push_back(torch::stable::contiguous(encoded_image));
   }
 
-  int major_version;
-  int minor_version;
-  nvjpegStatus_t get_major_property_status =
-      nvjpegGetProperty(MAJOR_VERSION, &major_version);
-  nvjpegStatus_t get_minor_property_status =
-      nvjpegGetProperty(MINOR_VERSION, &minor_version);
-
-  STD_TORCH_CHECK(
-      get_major_property_status == NVJPEG_STATUS_SUCCESS,
-      "nvjpegGetProperty failed: ",
-      get_major_property_status);
-  STD_TORCH_CHECK(
-      get_minor_property_status == NVJPEG_STATUS_SUCCESS,
-      "nvjpegGetProperty failed: ",
-      get_minor_property_status);
-  if ((major_version < 11) || ((major_version == 11) && (minor_version < 6))) {
-    TORCH_WARN_ONCE(
-        "There is a memory leak issue in the nvjpeg library for CUDA versions < 11.6. "
-        "Make sure to rely on CUDA 11.6 or above before using decode_jpeg(..., device='cuda').");
-  }
-
-  at::cuda::CUDAGuard device_guard(device);
+  torch::stable::accelerator::DeviceGuard device_guard(device.index());
 
   if (cudaJpegDecoder == nullptr || device != cudaJpegDecoder->target_device) {
     if (cudaJpegDecoder != nullptr) {
@@ -119,27 +115,33 @@ std::vector<torch::Tensor> decode_jpegs_cuda(
   }
 
   try {
-    at::cuda::CUDAEvent event;
     auto result = cudaJpegDecoder->decode_images(contig_images, output_format);
-    auto current_stream{
-        device.has_index() ? at::cuda::getCurrentCUDAStream(
-                                 cudaJpegDecoder->original_device.index())
-                           : at::cuda::getCurrentCUDAStream()};
-    event.record(cudaJpegDecoder->stream);
-    event.block(current_stream);
+    // Caller's current stream waits on the decoder's private stream before use.
+    // https://github.com/pytorch/pytorch/blob/98e36864e640023a716e058d894ea2d20e76e5f7/torch/csrc/inductor/aoti_torch/c/shim.h#L573-L602
+    void* current_stream_ptr = nullptr;
+    TORCH_ERROR_CODE_CHECK(aoti_torch_get_current_cuda_stream(
+        cudaJpegDecoder->original_device.index(), &current_stream_ptr));
+    cudaStream_t current_stream = static_cast<cudaStream_t>(current_stream_ptr);
+    syncStreams(cudaJpegDecoder->stream, current_stream);
     return result;
   } catch (const std::exception& e) {
     STD_TORCH_CHECK(false, "Error while decoding JPEG images: ", e.what());
   }
 }
 
-CUDAJpegDecoder::CUDAJpegDecoder(const torch::Device& target_device)
-    : original_device{torch::kCUDA, c10::cuda::current_device()},
-      target_device{target_device},
-      stream{
-          target_device.has_index()
-              ? at::cuda::getStreamFromPool(false, target_device.index())
-              : at::cuda::getStreamFromPool(false)} {
+CUDAJpegDecoder::CUDAJpegDecoder(const torch::stable::Device& target_device)
+    : original_device(
+          torch::headeronly::DeviceType::CUDA,
+          torch::stable::accelerator::getCurrentDeviceIndex()),
+      target_device(target_device) {
+  torch::stable::accelerator::DeviceGuard device_guard(target_device.index());
+  // Pool-owned (not a raw leaked) stream; avoids a cross-DSO teardown hazard.
+  // https://github.com/pytorch/pytorch/blob/98e36864e640023a716e058d894ea2d20e76e5f7/torch/csrc/stable/c/shim.h#L127-L130
+  void* stream_ptr = nullptr;
+  TORCH_ERROR_CODE_CHECK(torch_get_cuda_stream_from_pool(
+      false, target_device.index(), &stream_ptr));
+  stream = static_cast<cudaStream_t>(stream_ptr);
+
   nvjpegStatus_t status;
 
   hw_decode_available = true;
@@ -235,81 +237,21 @@ CUDAJpegDecoder::~CUDAJpegDecoder() {
   that the CUDA runtime handles cleanup for us.
   Please send a PR if you have a solution for this problem.
   */
-
-  // nvjpegStatus_t status;
-
-  // status = nvjpegDecodeParamsDestroy(nvjpeg_decode_params);
-  // STD_TORCH_CHECK(
-  //     status == NVJPEG_STATUS_SUCCESS,
-  //     "Failed to destroy nvjpeg decode params: ",
-  //     status);
-
-  // status = nvjpegJpegStreamDestroy(jpeg_streams[0]);
-  // STD_TORCH_CHECK(
-  //     status == NVJPEG_STATUS_SUCCESS,
-  //     "Failed to destroy jpeg stream: ",
-  //     status);
-
-  // status = nvjpegJpegStreamDestroy(jpeg_streams[1]);
-  // STD_TORCH_CHECK(
-  //     status == NVJPEG_STATUS_SUCCESS,
-  //     "Failed to destroy jpeg stream: ",
-  //     status);
-
-  // status = nvjpegBufferPinnedDestroy(pinned_buffers[0]);
-  // STD_TORCH_CHECK(
-  //     status == NVJPEG_STATUS_SUCCESS,
-  //     "Failed to destroy pinned buffer[0]: ",
-  //     status);
-
-  // status = nvjpegBufferPinnedDestroy(pinned_buffers[1]);
-  // STD_TORCH_CHECK(
-  //     status == NVJPEG_STATUS_SUCCESS,
-  //     "Failed to destroy pinned buffer[1]: ",
-  //     status);
-
-  // status = nvjpegBufferDeviceDestroy(device_buffer);
-  // STD_TORCH_CHECK(
-  //     status == NVJPEG_STATUS_SUCCESS,
-  //     "Failed to destroy device buffer: ",
-  //     status);
-
-  // status = nvjpegJpegStateDestroy(nvjpeg_decoupled_state);
-  // STD_TORCH_CHECK(
-  //     status == NVJPEG_STATUS_SUCCESS,
-  //     "Failed to destroy nvjpeg decoupled state: ",
-  //     status);
-
-  // status = nvjpegDecoderDestroy(nvjpeg_decoder);
-  // STD_TORCH_CHECK(
-  //     status == NVJPEG_STATUS_SUCCESS,
-  //     "Failed to destroy nvjpeg decoder: ",
-  //     status);
-
-  // status = nvjpegJpegStateDestroy(nvjpeg_state);
-  // STD_TORCH_CHECK(
-  //     status == NVJPEG_STATUS_SUCCESS,
-  //     "Failed to destroy nvjpeg state: ",
-  //     status);
-
-  // status = nvjpegDestroy(nvjpeg_handle);
-  // STD_TORCH_CHECK(
-  //     status == NVJPEG_STATUS_SUCCESS, "nvjpegDestroy failed: ", status);
 }
 
 std::tuple<
     std::vector<nvjpegImage_t>,
-    std::vector<torch::Tensor>,
+    std::vector<torch::stable::Tensor>,
     std::vector<int>>
 CUDAJpegDecoder::prepare_buffers(
-    const std::vector<torch::Tensor>& encoded_images,
+    const std::vector<torch::stable::Tensor>& encoded_images,
     const nvjpegOutputFormat_t& output_format) {
   /*
     This function scans the encoded images' jpeg headers and
     allocates decoding buffers based on the metadata found
 
     Args:
-    - encoded_images (std::vector<torch::Tensor>): a vector of tensors
+    - encoded_images (std::vector<torch::stable::Tensor>): a vector of tensors
     containing the jpeg bitstreams to be decoded. Each tensor must have dtype
     torch.uint8 and device cpu
     - output_format (nvjpegOutputFormat_t): NVJPEG_OUTPUT_RGB, NVJPEG_OUTPUT_Y
@@ -318,7 +260,7 @@ CUDAJpegDecoder::prepare_buffers(
     Returns:
     - decoded_images (std::vector<nvjpegImage_t>): a vector of nvjpegImages
     containing pointers to the memory of the decoded images
-    - output_tensors (std::vector<torch::Tensor>): a vector of Tensors
+    - output_tensors (std::vector<torch::stable::Tensor>): a vector of Tensors
     containing the decoded images. `decoded_images` points to the memory of
     output_tensors
     - channels (std::vector<int>): a vector of ints containing the number of
@@ -331,16 +273,18 @@ CUDAJpegDecoder::prepare_buffers(
   nvjpegChromaSubsampling_t subsampling;
   nvjpegStatus_t status;
 
-  std::vector<torch::Tensor> output_tensors{encoded_images.size()};
+  std::vector<torch::stable::Tensor> output_tensors;
+  output_tensors.reserve(encoded_images.size());
   std::vector<nvjpegImage_t> decoded_images{encoded_images.size()};
 
-  for (std::vector<at::Tensor>::size_type i = 0; i < encoded_images.size();
+  for (std::vector<torch::stable::Tensor>::size_type i = 0;
+       i < encoded_images.size();
        i++) {
     // extract bitstream meta data to figure out the number of channels, height,
     // width for every image
     status = nvjpegGetImageInfo(
         nvjpeg_handle,
-        (unsigned char*)encoded_images[i].data_ptr(),
+        (unsigned char*)encoded_images[i].const_data_ptr<uint8_t>(),
         encoded_images[i].numel(),
         &channels[i],
         &subsampling,
@@ -364,26 +308,29 @@ CUDAJpegDecoder::prepare_buffers(
     }
 
     // reserve output buffer
-    auto output_tensor = torch::empty(
+    auto output_tensor = torch::stable::empty(
         {int64_t(output_channels), int64_t(height[0]), int64_t(width[0])},
-        torch::dtype(torch::kU8).device(target_device));
-    output_tensors[i] = output_tensor;
+        torch::headeronly::ScalarType::Byte,
+        std::nullopt,
+        target_device);
 
     // fill nvjpegImage_t struct
     for (int c = 0; c < output_channels; c++) {
-      decoded_images[i].channel[c] = output_tensor[c].data_ptr<uint8_t>();
+      decoded_images[i].channel[c] = torch::stable::select(output_tensor, 0, c)
+                                         .mutable_data_ptr<uint8_t>();
       decoded_images[i].pitch[c] = width[0];
     }
     for (int c = output_channels; c < NVJPEG_MAX_COMPONENT; c++) {
       decoded_images[i].channel[c] = NULL;
       decoded_images[i].pitch[c] = 0;
     }
+    output_tensors.push_back(output_tensor);
   }
   return {decoded_images, output_tensors, channels};
 }
 
-std::vector<torch::Tensor> CUDAJpegDecoder::decode_images(
-    const std::vector<torch::Tensor>& encoded_images,
+std::vector<torch::stable::Tensor> CUDAJpegDecoder::decode_images(
+    const std::vector<torch::stable::Tensor>& encoded_images,
     const nvjpegOutputFormat_t& output_format) {
   /*
     This function decodes a batch of jpeg bitstreams.
@@ -398,14 +345,15 @@ std::vector<torch::Tensor> CUDAJpegDecoder::decode_images(
     for reference.
 
     Args:
-    - encoded_images (std::vector<torch::Tensor>): a vector of tensors
+    - encoded_images (std::vector<torch::stable::Tensor>): a vector of tensors
     containing the jpeg bitstreams to be decoded
     - output_format (nvjpegOutputFormat_t): NVJPEG_OUTPUT_RGB, NVJPEG_OUTPUT_Y
     or NVJPEG_OUTPUT_UNCHANGED
-    - device (torch::Device): The desired CUDA device for the returned Tensors
+    - device (torch::stable::Device): The desired CUDA device for the returned
+    Tensors
 
     Returns:
-    - output_tensors (std::vector<torch::Tensor>): a vector of Tensors
+    - output_tensors (std::vector<torch::stable::Tensor>): a vector of Tensors
     containing the decoded images
   */
 
@@ -434,13 +382,14 @@ std::vector<torch::Tensor> CUDAJpegDecoder::decode_images(
   std::vector<nvjpegImage_t> sw_output_buffer;
 
   if (hw_decode_available) {
-    for (std::vector<at::Tensor>::size_type i = 0; i < encoded_images.size();
+    for (std::vector<torch::stable::Tensor>::size_type i = 0;
+         i < encoded_images.size();
          ++i) {
       // extract bitstream meta data to figure out whether a bit-stream can be
       // decoded
       nvjpegJpegStreamParseHeader(
           nvjpeg_handle,
-          encoded_images[i].data_ptr<uint8_t>(),
+          encoded_images[i].const_data_ptr<uint8_t>(),
           encoded_images[i].numel(),
           jpeg_streams[0]);
       int isSupported = -1;
@@ -448,19 +397,20 @@ std::vector<torch::Tensor> CUDAJpegDecoder::decode_images(
           nvjpeg_handle, jpeg_streams[0], &isSupported);
 
       if (isSupported == 0) {
-        hw_input_buffer.push_back(encoded_images[i].data_ptr<uint8_t>());
+        hw_input_buffer.push_back(encoded_images[i].const_data_ptr<uint8_t>());
         hw_input_buffer_size.push_back(encoded_images[i].numel());
         hw_output_buffer.push_back(decoded_imgs_buf[i]);
       } else {
-        sw_input_buffer.push_back(encoded_images[i].data_ptr<uint8_t>());
+        sw_input_buffer.push_back(encoded_images[i].const_data_ptr<uint8_t>());
         sw_input_buffer_size.push_back(encoded_images[i].numel());
         sw_output_buffer.push_back(decoded_imgs_buf[i]);
       }
     }
   } else {
-    for (std::vector<at::Tensor>::size_type i = 0; i < encoded_images.size();
+    for (std::vector<torch::stable::Tensor>::size_type i = 0;
+         i < encoded_images.size();
          ++i) {
-      sw_input_buffer.push_back(encoded_images[i].data_ptr<uint8_t>());
+      sw_input_buffer.push_back(encoded_images[i].const_data_ptr<uint8_t>());
       sw_input_buffer_size.push_back(encoded_images[i].numel());
       sw_output_buffer.push_back(decoded_imgs_buf[i]);
     }
@@ -508,7 +458,8 @@ std::vector<torch::Tensor> CUDAJpegDecoder::decode_images(
         status == NVJPEG_STATUS_SUCCESS,
         "Failed to set output format: ",
         status);
-    for (std::vector<at::Tensor>::size_type i = 0; i < sw_input_buffer.size();
+    for (std::vector<torch::stable::Tensor>::size_type i = 0;
+         i < sw_input_buffer.size();
          ++i) {
       status = nvjpegJpegStreamParse(
           nvjpeg_handle,
@@ -581,10 +532,12 @@ std::vector<torch::Tensor> CUDAJpegDecoder::decode_images(
 
   // prune extraneous channels from single channel images
   if (output_format == NVJPEG_OUTPUT_UNCHANGED) {
-    for (std::vector<at::Tensor>::size_type i = 0; i < output_tensors.size();
+    for (std::vector<torch::stable::Tensor>::size_type i = 0;
+         i < output_tensors.size();
          ++i) {
       if (channels[i] == 1) {
-        output_tensors[i] = output_tensors[i][0].unsqueeze(0).clone();
+        output_tensors[i] = torch::stable::clone(torch::stable::unsqueeze(
+            torch::stable::select(output_tensors[i], 0, 0), 0));
       }
     }
   }
@@ -596,3 +549,18 @@ std::vector<torch::Tensor> CUDAJpegDecoder::decode_images(
 } // namespace vision
 
 #endif
+
+namespace vision {
+namespace image {
+
+STABLE_TORCH_LIBRARY_FRAGMENT(image, m) {
+  m.def(
+      "decode_jpegs_cuda(Tensor[] encoded_images, int mode, Device device) -> Tensor[]");
+}
+
+STABLE_TORCH_LIBRARY_IMPL(image, CompositeExplicitAutograd, m) {
+  m.impl("decode_jpegs_cuda", TORCH_BOX(&decode_jpegs_cuda));
+}
+
+} // namespace image
+} // namespace vision

--- a/torchvision/csrc/io/image/cuda/decode_jpegs_cuda.h
+++ b/torchvision/csrc/io/image/cuda/decode_jpegs_cuda.h
@@ -1,34 +1,36 @@
 #pragma once
-#include <torch/types.h>
+#include <torch/csrc/stable/device.h>
+#include <torch/csrc/stable/tensor.h>
+#include <tuple>
 #include <vector>
-#include "../common.h"
+#include "../common_stable.h"
 
 #if NVJPEG_FOUND
-#include <c10/cuda/CUDAStream.h>
+#include <cuda_runtime.h>
 #include <nvjpeg.h>
 
 namespace vision {
 namespace image {
 class CUDAJpegDecoder {
  public:
-  CUDAJpegDecoder(const torch::Device& target_device);
+  CUDAJpegDecoder(const torch::stable::Device& target_device);
   ~CUDAJpegDecoder();
 
-  std::vector<torch::Tensor> decode_images(
-      const std::vector<torch::Tensor>& encoded_images,
+  std::vector<torch::stable::Tensor> decode_images(
+      const std::vector<torch::stable::Tensor>& encoded_images,
       const nvjpegOutputFormat_t& output_format);
 
-  const torch::Device original_device;
-  const torch::Device target_device;
-  const c10::cuda::CUDAStream stream;
+  const torch::stable::Device original_device;
+  const torch::stable::Device target_device;
+  cudaStream_t stream;
 
  private:
   std::tuple<
       std::vector<nvjpegImage_t>,
-      std::vector<torch::Tensor>,
+      std::vector<torch::stable::Tensor>,
       std::vector<int>>
   prepare_buffers(
-      const std::vector<torch::Tensor>& encoded_images,
+      const std::vector<torch::stable::Tensor>& encoded_images,
       const nvjpegOutputFormat_t& output_format);
   nvjpegJpegState_t nvjpeg_state;
   nvjpegJpegState_t nvjpeg_decoupled_state;
@@ -40,6 +42,12 @@ class CUDAJpegDecoder {
   bool hw_decode_available{false};
   nvjpegHandle_t nvjpeg_handle;
 };
+
+std::vector<torch::stable::Tensor> decode_jpegs_cuda(
+    const std::vector<torch::stable::Tensor>& encoded_images,
+    ImageReadMode mode,
+    torch::stable::Device device);
+
 } // namespace image
 } // namespace vision
 #endif

--- a/torchvision/csrc/io/image/cuda/encode_decode_jpegs_cuda.h
+++ b/torchvision/csrc/io/image/cuda/encode_decode_jpegs_cuda.h
@@ -2,38 +2,10 @@
 
 #include <torch/types.h>
 #include "../common.h"
-#include "decode_jpegs_cuda.h"
 #include "encode_jpegs_cuda.h"
 
 namespace vision {
 namespace image {
-
-/*
-
-Fast jpeg decoding with CUDA.
-A100+ GPUs have dedicated hardware support for jpeg decoding.
-
-Args:
-    - encoded_images (const std::vector<torch::Tensor>&): a vector of tensors
-    containing the jpeg bitstreams to be decoded. Each tensor must have dtype
-    torch.uint8 and device cpu
-    - mode (ImageReadMode): IMAGE_READ_MODE_UNCHANGED, IMAGE_READ_MODE_GRAY and
-IMAGE_READ_MODE_RGB are supported
-    - device (torch::Device): The desired CUDA device to run the decoding on and
-which will contain the output tensors
-
-Returns:
-    - decoded_images (std::vector<torch::Tensor>): a vector of torch::Tensors of
-dtype torch.uint8 on the specified <device> containing the decoded images
-
-Notes:
-    - If a single image fails, the whole batch fails.
-    - This function is thread-safe
-*/
-C10_EXPORT std::vector<torch::Tensor> decode_jpegs_cuda(
-    const std::vector<torch::Tensor>& encoded_images,
-    vision::image::ImageReadMode mode,
-    torch::Device device);
 
 /*
 Fast jpeg encoding with CUDA.

--- a/torchvision/csrc/io/image/image.cpp
+++ b/torchvision/csrc/io/image/image.cpp
@@ -20,7 +20,6 @@ static auto registry =
         .op("image::write_file", &write_file)
         .op("image::decode_image(Tensor data, int mode, bool apply_exif_orientation=False) -> Tensor",
             &decode_image)
-        .op("image::decode_jpegs_cuda", &decode_jpegs_cuda)
         .op("image::encode_jpegs_cuda", &encode_jpegs_cuda)
         .op("image::_jpeg_version", &_jpeg_version)
         .op("image::_is_compiled_against_turbo", &_is_compiled_against_turbo);

--- a/torchvision/io/image.py
+++ b/torchvision/io/image.py
@@ -17,6 +17,10 @@ if _load_library("image"):
         return True
 
 
+# Stable-ABI image extension (migrated ops)
+_load_library("image_stable")
+
+
 def _assert_has_image_ops():
     if not _has_image_ops():
         raise RuntimeError(


### PR DESCRIPTION
Ports the CUDA jpeg decoder to stable ABI. The CUDA jpeg decoder lives in the image extension, so this also stands up image_stable (same dual-extension pattern to `_C` / `_C_stable`).

## Structure: Image_stable Extension
Mirrors the _C / _C_stable split. 
  - `torchvision.image`: the existing extension, now built from all not-yet-ported image sources.
  - `torchvision.image_stable`: the new extension, built only from migrated image sources (currently the jpeg decoder + its extension glue).



**Layout Changes**

  - `setup.py`: splits the image sources between the two extensions. Migrated files added to STABLE_SOURCES, the existing _stable()/_not_stable() helpers route them into image_stable and keep everything else in image.
  
  - `make_image_stable_extension()`: stable sibling of make_image_extension()).

  - `CMakeLists.txt`: migrated files added to `TORCHVISION_STABLE_SOURCES` so the cmake build pins them identically.
  
  - `io/image.py`: loads image_stable after image.
 
  - Schema via `STABLE_TORCH_LIBRARY_FRAGMENT(image)`, this extends the image namespace co-owned with the legacy .so.

  - `common_stable.h`: torch-free ImageReadMode constants, so the stable TU doesn't pull full libtorch in via common.h.

  - `common_stable.cpp`: extension-level glue for image_stable, the stable counterpart of common.cpp. Holds the Windows PyInit_image_stable stub extension glue, not tied to any op,  it lives there instead of in a kernel file.
 

## CUDA Stream/Event Model
  - Decode runs on a dedicated stream, the caller's current stream then waits on it via the exact `cudaEventCreate → Record → cudaStreamWaitEvent → Destroy` sequence.
  -  `syncStreams` (extracted into a `syncStreams` helper). Current stream via `aoti_torch_get_current_cuda_stream`.

## Stable-ABI audit (`torch-abi-audit`)

Ran [`torch-abi-audit`](https://github.com/Quansight/torch-abi-audit) against the built `torchvision` package to verify the migrated extension stays on the stable surface and never reaches into `at::` / `c10::` / `torch::jit::` internals.

**`image_stable.so` audits as `STABLE` — 65 stable-shim symbols, 0 unstable.** The legacy `image.so` / `_C.so` stay `UNSTABLE` (expected: only nms and the jpeg decoder have
  migrated), so the package-level verdict stays `UNSTABLE` until the rest move — same mid-migration shape as torchcodec.
 
 ```text
  Package: torchvision
    Torch ABI:   UNSTABLE
    CPython ABI: n/a
    Bundled libs: 4
    -- bundled libs --
      [UNSTABLE] [not-abi3        ] _C.so            (stable_shim=0,  unstable=110)
      [STABLE  ] [not-abi3        ] _C_stable.so     (stable_shim=67, unstable=0)
      [UNSTABLE] [uses-private-api] image.so         (stable_shim=0,  unstable=71)
      [STABLE  ] [not-abi3        ] image_stable.so  (stable_shim=65, unstable=0) 
 ```