### PR TITLE
Port CPU png encoder to stable ABI.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,7 @@ set(TORCHVISION_STABLE_SOURCES
   ${TVCPP}/ops/cuda/nms_kernel.cu
   ${TVCPP}/io/image/cuda/decode_jpegs_cuda.cpp
   ${TVCPP}/io/image/cuda/encode_jpegs_cuda.cpp
+  ${TVCPP}/io/image/cpu/encode_png.cpp
   ${TVCPP}/io/image/common_stable.cpp
   ${TVCPP}/vision_stable.cpp)
 # Pin them to torch 2.11. Per source, not library-wide: the pin makes ATen headers

--- a/setup.py
+++ b/setup.py
@@ -165,6 +165,7 @@ STABLE_SOURCES = {
     CSRS_DIR / "ops/mps/nms_kernel.mm",
     CSRS_DIR / "ops/quantized/cpu/qnms_kernel.cpp",
     CSRS_DIR / "io/image/common_stable.cpp",
+    CSRS_DIR / "io/image/cpu/encode_png.cpp",
 }
 STABLE_SOURCES.add(CSRS_DIR / ("ops/hip/nms_kernel.hip" if IS_ROCM else "ops/cuda/nms_kernel.cu"))
 STABLE_SOURCES.add(
@@ -471,6 +472,18 @@ def make_image_stable_extension():
     )
 
     Extension = CppExtension
+
+    if USE_PNG:
+        png_found, png_include_dir, png_library_dir, png_library = find_libpng()
+        if png_found:
+            print("Building torchvision with PNG image support")
+            include_dirs.append(png_include_dir)
+            library_dirs.append(png_library_dir)
+            libraries.append(png_library)
+            define_macros += [("PNG_FOUND", 1)]
+        else:
+            warnings.warn("Building torchvision without PNG support")
+
     if USE_NVJPEG and (torch.cuda.is_available() or FORCE_CUDA):
         nvjpeg_found = CUDA_HOME is not None and (Path(CUDA_HOME) / "include/nvjpeg.h").exists()
         if nvjpeg_found:

--- a/torchvision/csrc/io/image/common_stable.h
+++ b/torchvision/csrc/io/image/common_stable.h
@@ -2,6 +2,8 @@
 
 #include <cstdint>
 
+#include <torch/csrc/stable/tensor.h>
+
 namespace vision {
 namespace image {
 
@@ -12,6 +14,20 @@ const ImageReadMode IMAGE_READ_MODE_GRAY = 1;
 const ImageReadMode IMAGE_READ_MODE_GRAY_ALPHA = 2;
 const ImageReadMode IMAGE_READ_MODE_RGB = 3;
 const ImageReadMode IMAGE_READ_MODE_RGB_ALPHA = 4;
+
+// Stable-ABI missing permute op; shim mirrors torchcodec's stablePermute:
+// https://github.com/meta-pytorch/torchcodec/blob/1dc85b7a7900d91fee207ccdc02f211a051688fe/src/torchcodec/_core/StableABICompat.h#L81-L90
+// TODO(stable-abi): remove once permute lands in the stable ABI upstream.
+inline torch::stable::Tensor stable_permute(
+    const torch::stable::Tensor& self,
+    std::vector<int64_t> dims) {
+  const auto num_args = 2;
+  std::array<StableIValue, num_args> stack{
+      torch::stable::detail::from(self), torch::stable::detail::from(dims)};
+  TORCH_ERROR_CODE_CHECK(torch_call_dispatcher(
+      "aten::permute", "", stack.data(), TORCH_ABI_VERSION));
+  return torch::stable::detail::to<torch::stable::Tensor>(stack[0]);
+}
 
 } // namespace image
 } // namespace vision

--- a/torchvision/csrc/io/image/cpu/encode_png.cpp
+++ b/torchvision/csrc/io/image/cpu/encode_png.cpp
@@ -1,9 +1,12 @@
-#include "encode_jpeg.h"
+#include "encode_png.h"
 
+#include <torch/csrc/stable/library.h>
+#include <torch/csrc/stable/ops.h>
 #include <torch/headeronly/util/Exception.h>
 
 #include <optional>
 
+#include "../common_stable.h"
 #include "common_png.h"
 
 namespace vision {
@@ -11,7 +14,9 @@ namespace image {
 
 #if !PNG_FOUND
 
-torch::Tensor encode_png(const torch::Tensor& data, int64_t compression_level) {
+torch::stable::Tensor encode_png(
+    const torch::stable::Tensor& data,
+    int64_t compression_level) {
   STD_TORCH_CHECK(
       false, "encode_png: torchvision not compiled with libpng support");
 }
@@ -68,8 +73,9 @@ void torch_png_write_data(
 
 } // namespace
 
-torch::Tensor encode_png(const torch::Tensor& data, int64_t compression_level) {
-  C10_LOG_API_USAGE_ONCE("torchvision.csrc.io.image.cpu.encode_png.encode_png");
+torch::stable::Tensor encode_png(
+    const torch::stable::Tensor& data,
+    int64_t compression_level) {
   // Define compression structures and error handling
   png_structp png_write;
   png_infop info_ptr;
@@ -84,7 +90,7 @@ torch::Tensor encode_png(const torch::Tensor& data, int64_t compression_level) {
   // unwind C++ stack frames, so destructors of objects created after setjmp
   // won't run. We use std::optional to declare tensors before setjmp while
   // deferring construction, and explicitly reset them on the error path.
-  std::optional<torch::Tensor> input;
+  std::optional<torch::stable::Tensor> input;
 
   /* Establish the setjmp return context for my_error_exit to use. */
   if (setjmp(err_ptr.setjmp_buffer)) {
@@ -114,12 +120,12 @@ torch::Tensor encode_png(const torch::Tensor& data, int64_t compression_level) {
       "Compression level should be between 0 and 9");
 
   // Check that the input tensor is on CPU
-  STD_TORCH_CHECK(
-      data.device() == torch::kCPU, "Input tensor should be on CPU");
+  STD_TORCH_CHECK(data.is_cpu(), "Input tensor should be on CPU");
 
   // Check that the input tensor dtype is uint8
   STD_TORCH_CHECK(
-      data.dtype() == torch::kU8, "Input tensor dtype should be uint8");
+      data.scalar_type() == torch::headeronly::ScalarType::Byte,
+      "Input tensor dtype should be uint8");
 
   // Check that the input tensor is 3-dimensional
   STD_TORCH_CHECK(
@@ -129,7 +135,7 @@ torch::Tensor encode_png(const torch::Tensor& data, int64_t compression_level) {
   int channels = data.size(0);
   int height = data.size(1);
   int width = data.size(2);
-  input = data.permute({1, 2, 0}).contiguous();
+  input = torch::stable::contiguous(stable_permute(data, {1, 2, 0}));
 
   STD_TORCH_CHECK(
       channels == 1 || channels == 3,
@@ -165,7 +171,7 @@ torch::Tensor encode_png(const torch::Tensor& data, int64_t compression_level) {
   png_write_info(png_write, info_ptr);
 
   auto stride = width * channels;
-  auto ptr = input->data_ptr<uint8_t>();
+  auto ptr = input->const_data_ptr<uint8_t>();
 
   // Encode PNG file
   for (int y = 0; y < height; ++y) {
@@ -179,12 +185,13 @@ torch::Tensor encode_png(const torch::Tensor& data, int64_t compression_level) {
   // Destroy structures
   png_destroy_write_struct(&png_write, &info_ptr);
 
-  torch::TensorOptions options = torch::TensorOptions{torch::kU8};
-  auto outTensor = torch::empty({(long)buf_info.size}, options);
+  auto outTensor = torch::stable::empty(
+      {static_cast<int64_t>(buf_info.size)},
+      torch::headeronly::ScalarType::Byte);
 
   // Copy memory from png buffer, since torch cannot get ownership of it via
   // `from_blob`
-  auto outPtr = outTensor.data_ptr<uint8_t>();
+  auto outPtr = outTensor.mutable_data_ptr<uint8_t>();
   std::memcpy(outPtr, buf_info.buffer, sizeof(uint8_t) * outTensor.numel());
   free(buf_info.buffer);
 
@@ -192,6 +199,14 @@ torch::Tensor encode_png(const torch::Tensor& data, int64_t compression_level) {
 }
 
 #endif
+
+STABLE_TORCH_LIBRARY_FRAGMENT(image, m) {
+  m.def("encode_png(Tensor data, int compression_level) -> Tensor");
+}
+
+STABLE_TORCH_LIBRARY_IMPL(image, CompositeExplicitAutograd, m) {
+  m.impl("encode_png", TORCH_BOX(&encode_png));
+}
 
 } // namespace image
 } // namespace vision

--- a/torchvision/csrc/io/image/cpu/encode_png.h
+++ b/torchvision/csrc/io/image/cpu/encode_png.h
@@ -1,12 +1,12 @@
 #pragma once
 
-#include <torch/types.h>
+#include <torch/csrc/stable/tensor.h>
 
 namespace vision {
 namespace image {
 
-C10_EXPORT torch::Tensor encode_png(
-    const torch::Tensor& data,
+torch::stable::Tensor encode_png(
+    const torch::stable::Tensor& data,
     int64_t compression_level);
 
 } // namespace image

--- a/torchvision/csrc/io/image/image.cpp
+++ b/torchvision/csrc/io/image/image.cpp
@@ -10,7 +10,6 @@ static auto registry =
         .op("image::decode_gif", &decode_gif)
         .op("image::decode_png(Tensor data, int mode, bool apply_exif_orientation=False) -> Tensor",
             &decode_png)
-        .op("image::encode_png", &encode_png)
         .op("image::decode_jpeg(Tensor data, int mode, bool apply_exif_orientation=False) -> Tensor",
             &decode_jpeg)
         .op("image::decode_webp(Tensor encoded_data, int mode) -> Tensor",

--- a/torchvision/csrc/io/image/image.h
+++ b/torchvision/csrc/io/image/image.h
@@ -6,5 +6,4 @@
 #include "cpu/decode_png.h"
 #include "cpu/decode_webp.h"
 #include "cpu/encode_jpeg.h"
-#include "cpu/encode_png.h"
 #include "cpu/read_write_file.h"


### PR DESCRIPTION
Ports the CPU png encoder to stable ABI.

## Notes: Missing StableABI `stable_permute` shim
-  `encode_png` needs `permute` for its HWC↔CHW conversion, but Stable-ABI does not expose it yet. Followed [torchcodec's stablePermute`](https://github.com/meta-pytorch/torchcodec/blob/1dc85b7a7900d91fee207ccdc02f211a051688fe/src/torchcodec/_core/StableABICompat.h#L81-L90).

 ## Stable-ABI audit (`torch-abi-audit`)

Ran [`torch-abi-audit`](https://github.com/Quansight/torch-abi-audit) against the built `torchvision` package to verify the migrated extension stays on the stable surface. **`image_stable.so` audits as `STABLE` — 67 stable-shim symbols, 0 unstable** The legacy `image.so` / `_C.so` stay `UNSTABLE` (expected: their remaining ops still use the same private APIs), so the package-level verdict stays `UNSTABLE` until the rest move.

  ```text
  Package: torchvision
    Torch ABI:   UNSTABLE
    CPython ABI: n/a
    Bundled libs: 4
    -- bundled libs --
      [UNSTABLE] [not-abi3        ] _C.so            (stable_shim=0,  unstable=110)
      [STABLE  ] [not-abi3        ] _C_stable.so     (stable_shim=67, unstable=0)
      [UNSTABLE] [uses-private-api] image.so         (stable_shim=0,  unstable=48)
      [STABLE  ] [not-abi3        ] image_stable.so  (stable_shim=67, unstable=0)
  ```