### PR TITLE
Fix typo in LFWPairs docstring

### DIFF
--- a/torchvision/datasets/lfw.py
+++ b/torchvision/datasets/lfw.py
@@ -257,7 +257,7 @@ class LFWPairs(_LFW):
             index (int): Index
 
         Returns:
-            tuple: (image1, image2, target) where target is `0` for different indentities and `1` for same identities.
+            tuple: (image1, image2, target) where target is `0` for different identities and `1` for same identities.
         """
         img1, img2 = self.data[index]
         img1, img2 = self._loader(img1), self._loader(img2)


### PR DESCRIPTION
## Summary

Fixes a typo in the `LFWPairs` return-value docstring: `indentities` -> `identities`.

## Proof

Source proof:
- Upstream repo: `pytorch/vision`
- Base branch: `main`
- Base commit checked before editing: `0bc41e67670d6a0ae5617c90e7b29a5c64ec0575`
- Current source line before the fix: `torchvision/datasets/lfw.py:260` said `different indentities`.

Duplicate-search proof before editing:
- `gh pr list --repo pytorch/vision --state open --search 'indentities' --json ... --limit 30` returned `[]`.
- `gh pr list --repo pytorch/vision --state open --search 'LFW identities' --json ... --limit 20` returned `[]`.
- `gh pr list --repo pytorch/vision --state all --search 'indentities' --json ... --limit 30` returned `[]`.
- `gh issue list --repo pytorch/vision --state all --search 'indentities' --json ... --limit 30` returned `[]`.

Failing-first proof:
- Before the change, `python3 - <<'PY' ... assert 'different identities' in text ... PY` failed with `AssertionError`.
- After the change, the same assertion passed and also asserted `different indentities` is absent.

## Verification

- `python3 - <<'PY' ... assert 'different identities' in text; assert 'different indentities' not in text; compile(text, str(path), 'exec') ... PY`
- `git diff --check`
- `git status --short -uno`

All commands passed after the commit.
