### PR TITLE
Fix CPU segfault in roi_align when ROI contains NaN coordinates

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -475,6 +475,31 @@ class TestRoIAlign(RoIOpTester):
         self._helper_boxes_shape(ops.roi_align)
 
     @pytest.mark.parametrize("aligned", (True, False))
+    @pytest.mark.parametrize("sampling_ratio", (-1, 1))
+    def test_nan_roi_coordinates_do_not_crash(self, aligned, sampling_ratio):
+        # Non-regression test: a ROI with NaN coordinates used to bypass the
+        # out-of-bounds check in the CPU kernel (every comparison against NaN
+        # is False), get truncated to an undefined int index, and read out of
+        # bounds from the input feature map (can segfault under ASAN).
+        x = torch.zeros(2, 10, 15, 19, dtype=torch.float32)
+        rois = torch.tensor(
+            [[0.0, float("nan"), 0.0, float("nan"), 1.0]],
+            dtype=torch.float32,
+        )
+
+        y = ops.roi_align(
+            x,
+            rois,
+            output_size=(7, 7),
+            spatial_scale=0.1,
+            sampling_ratio=sampling_ratio,
+            aligned=aligned,
+        )
+
+        assert y.shape == (1, 10, 7, 7)
+        assert torch.isfinite(y).all() or torch.isnan(y).all()
+
+    @pytest.mark.parametrize("aligned", (True, False))
     @pytest.mark.parametrize("device", cpu_and_cuda_and_mps())
     @pytest.mark.parametrize("x_dtype", (torch.float16, torch.float32, torch.float64))  # , ids=str)
     @pytest.mark.parametrize("contiguous", (True, False))

--- a/torchvision/csrc/ops/cpu/roi_align_common.h
+++ b/torchvision/csrc/ops/cpu/roi_align_common.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ATen/ATen.h>
+#include <cmath>
 
 namespace vision {
 namespace ops {
@@ -57,7 +58,13 @@ void pre_calc_for_bilinear_interpolate(
           T x = xx;
           T y = yy;
           // deal with: inverse elements are out of feature map boundary
-          if (y < -1.0 || y > height || x < -1.0 || x > width) {
+          // NaN coordinates must be treated as out of bounds too, since every
+          // comparison against NaN is false and would otherwise fall through
+          // this check, get truncated to an undefined int value below, and
+          // produce an out-of-bounds pos1/pos2/pos3/pos4 index.
+          if (std::isnan(static_cast<double>(x)) ||
+              std::isnan(static_cast<double>(y)) || y < -1.0 || y > height ||
+              x < -1.0 || x > width) {
             // empty
             PreCalc<T> pc;
             pc.pos1 = 0;

--- a/torchvision/csrc/ops/cpu/roi_align_kernel.cpp
+++ b/torchvision/csrc/ops/cpu/roi_align_kernel.cpp
@@ -1,6 +1,8 @@
 #include <ATen/ATen.h>
 #include <torch/library.h>
 
+#include <cmath>
+
 #include "./roi_align_common.h"
 
 namespace vision {
@@ -123,7 +125,12 @@ void bilinear_interpolate_gradient(
     int& y_high,
     int index /* index for debug only*/) {
   // deal with cases that inverse elements are out of feature map boundary
-  if (y < -1.0 || y > height || x < -1.0 || x > width) {
+  // NaN coordinates must be treated as out of bounds too, since every
+  // comparison against NaN is false and would otherwise fall through this
+  // check and get truncated to an undefined int value below.
+  if (std::isnan(static_cast<double>(x)) ||
+      std::isnan(static_cast<double>(y)) || y < -1.0 || y > height ||
+      x < -1.0 || x > width) {
     // empty
     w1 = w2 = w3 = w4 = 0.;
     x_low = x_high = y_low = y_high = -1;


### PR DESCRIPTION
Fixes #9273

roi_align on CPU can segfault when a ROI has NaN coordinates. I tracked it down to the bounds check in `pre_calc_for_bilinear_interpolate` (torchvision/csrc/ops/cpu/roi_align_common.h) and the equivalent check in `bilinear_interpolate_gradient` (torchvision/csrc/ops/cpu/roi_align_kernel.cpp, used by the backward pass).

Both do something like:

```
if (y < -1.0 || y > height || x < -1.0 || x > width) {
  // treat as empty ROI
}
```

The problem is that any comparison against NaN is false, so a NaN coordinate slides right through this check instead of being caught as out of bounds. Right after that, the code does `(int)y` to compute the pixel index, and casting NaN to int is undefined behavior in C++. In practice it produces some garbage integer, which then gets used as `pos1/pos2/pos3/pos4` to read straight out of the input feature map buffer, which is exactly what the ASAN report in the issue shows.

I reproduced the crash locally with the repro script from the issue against the currently released torchvision (0.21.0) and it segfaults reliably.

Fix is small: add explicit `isnan` checks next to the existing range checks in both places, so a NaN ROI gets treated the same way as any other malformed/out-of-bounds ROI (zero weights, index -1, no memory read), instead of silently producing garbage.

Added a regression test (`test_nan_roi_coordinates_do_not_crash` in test/test_ops.py) that runs roi_align with a NaN ROI on CPU for both `aligned` values and both sampling_ratio modes.

One thing I want to be upfront about: I don't have a C++ toolchain available in the environment I used to write this patch, so I could not actually compile torchvision from source to run the new test against my fix. What I did verify:
- The crash is real: I reproduced the exact segfault from the issue against the released 0.21.0 wheel.
- The fix logic itself: I ported the exact before/after C++ conditions to Python and confirmed the old condition returns False for NaN inputs (bug) and the new one returns True (fixed), matching the intended behavior change.

If a maintainer or CI can confirm the actual build + test pass, that'd be great, happy to iterate if anything doesn't compile as expected (e.g. if isnan needs a different form for the Half/BFloat16 specializations dispatched via AT_DISPATCH_FLOATING_TYPES_AND_HALF).