### PR TITLE
Fix docs gh-pages push hanging until job timeout

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -131,4 +131,13 @@ jobs:
         git config user.email 'soumith+bot@pytorch.org'
         git config http.postBuffer 524288000
         git commit -m "auto-generating sphinx docs" || true
-        git push
+
+        # The credentials persisted by actions/checkout are scoped (via
+        # includeIf.gitdir) to the runner-host checkout path and are NOT
+        # visible to git inside this container (repo is mounted at
+        # /pytorch/vision), so a bare `git push` is unauthenticated and
+        # hangs on a credential prompt until the job times out. Push with
+        # an explicit token and disable interactive prompts so any auth
+        # failure surfaces immediately instead of hanging.
+        export GIT_TERMINAL_PROMPT=0
+        git push "https://x-access-token:${SECRET_GITHUB_TOKEN}@github.com/pytorch/vision" HEAD:gh-pages


### PR DESCRIPTION
## Summary

The `upload` job's docs push to `gh-pages` has been **hanging until the 60-minute job timeout** on tag/main pushes (deterministic, not a flake): both the `v0.27.0` and `v0.28.0` runs show `build` succeeding and `upload` cancelled ~59 min into a silent `git push`. Automated `pytorchbot` "auto-generating sphinx docs" commits on `gh-pages` stop at **2026-01-21**; every release since was pushed **manually**.

## Root cause

The `git push` runs **inside the build container** (repo mounted at `/pytorch/vision`). `actions/checkout` stores the auth header in a temp file wired via path-scoped `includeIf.gitdir` for the runner-host path and `/github/workspace/...` — **neither matches `/pytorch/vision/.git`**. So the push is **unauthenticated**; with a TTY and no credential helper, git blocks on an interactive credential prompt until the timeout.

## Fix — this authenticates the push so it *succeeds*

The real fix is giving the push valid credentials. `SECRET_GITHUB_TOKEN` is already present in the container and the job has `contents: write`, so we push with an explicit token:

```bash
export GIT_TERMINAL_PROMPT=0
git push "https://x-access-token:${SECRET_GITHUB_TOKEN}@github.com/pytorch/vision" HEAD:gh-pages
```

`GIT_TERMINAL_PROMPT=0` is only a safety net (turns any future auth problem into an immediate error instead of a 60-min hang); the authenticated URL is what makes the push actually complete.

## Verification that the push succeeds (not just fails fast)

- The tokenized-URL form authenticates against `pytorch/vision`: `git ls-remote https://x-access-token:<token>@github.com/pytorch/vision gh-pages` returns the ref, no prompt.
- `gh-pages` is **not** a protected branch, and the token has push/`contents: write`, so the push is authorized to write.
- `SECRET_GITHUB_TOKEN` is confirmed populated in the container (the failing 0.28 run logged `ALL_SECRETS: {"github_token":"***"}`), and `run_with_env_secrets.py` exports it as `SECRET_GITHUB_TOKEN`.
- After merge, the first push to `main` will exercise this path and should land a fresh `auto-generating sphinx docs` commit on `gh-pages` within minutes (instead of timing out) — the authoritative end-to-end confirmation.

AI assistance (Claude) was used for this change.