### PR TITLE
Port CPU read_file and write_file to stable ABI.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,7 @@ set(TORCHVISION_STABLE_SOURCES
   ${TVCPP}/io/image/cuda/encode_jpegs_cuda.cpp
   ${TVCPP}/io/image/cpu/encode_png.cpp
   ${TVCPP}/io/image/cpu/encode_jpeg.cpp
+  ${TVCPP}/io/image/cpu/read_write_file.cpp
   ${TVCPP}/io/image/common_stable.cpp
   ${TVCPP}/vision_stable.cpp)
 # Pin them to torch 2.11. Per source, not library-wide: the pin makes ATen headers

--- a/setup.py
+++ b/setup.py
@@ -167,6 +167,7 @@ STABLE_SOURCES = {
     CSRS_DIR / "io/image/common_stable.cpp",
     CSRS_DIR / "io/image/cpu/encode_png.cpp",
     CSRS_DIR / "io/image/cpu/encode_jpeg.cpp",
+    CSRS_DIR / "io/image/cpu/read_write_file.cpp",
 }
 STABLE_SOURCES.add(CSRS_DIR / ("ops/hip/nms_kernel.hip" if IS_ROCM else "ops/cuda/nms_kernel.cu"))
 STABLE_SOURCES.add(

--- a/torchvision/csrc/io/image/cpu/read_write_file.cpp
+++ b/torchvision/csrc/io/image/cpu/read_write_file.cpp
@@ -1,5 +1,7 @@
 #include "read_write_file.h"
 
+#include <torch/csrc/stable/library.h>
+#include <torch/csrc/stable/ops.h>
 #include <torch/headeronly/util/Exception.h>
 
 #include <sys/stat.h>
@@ -11,6 +13,32 @@
 
 namespace vision {
 namespace image {
+
+#ifndef _WIN32
+namespace {
+// Shim for the from_file op missing in stable ABI.
+// TODO(stable-abi): remove once from_file lands in the stable ABI upstream.
+torch::stable::Tensor stable_from_file(
+    const std::string& filename,
+    bool shared,
+    int64_t size,
+    torch::headeronly::ScalarType dtype) {
+  const auto num_args = 7;
+  std::array<StableIValue, num_args> stack{
+      torch::stable::detail::from(filename),
+      torch::stable::detail::from(std::optional<bool>(shared)),
+      torch::stable::detail::from(std::optional<int64_t>(size)),
+      torch::stable::detail::from(
+          std::optional<torch::headeronly::ScalarType>(dtype)),
+      torch::stable::detail::from(std::nullopt), // layout
+      torch::stable::detail::from(std::nullopt), // device
+      torch::stable::detail::from(std::nullopt)}; // pin_memory
+  TORCH_ERROR_CODE_CHECK(torch_call_dispatcher(
+      "aten::from_file", "", stack.data(), TORCH_ABI_VERSION));
+  return torch::stable::detail::to<torch::stable::Tensor>(stack[0]);
+}
+} // namespace
+#endif
 
 #ifdef _WIN32
 namespace {
@@ -34,9 +62,7 @@ std::wstring utf8_decode(const std::string& str) {
 } // namespace
 #endif
 
-torch::Tensor read_file(const std::string& filename) {
-  C10_LOG_API_USAGE_ONCE(
-      "torchvision.csrc.io.image.cpu.read_write_file.read_file");
+torch::stable::Tensor read_file(const std::string& filename) {
 #ifdef _WIN32
   // According to
   // https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/stat-functions?view=vs-2019,
@@ -66,35 +92,38 @@ torch::Tensor read_file(const std::string& filename) {
 
   STD_TORCH_CHECK(infile != nullptr, "Error opening input file");
 
-  auto data = torch::empty({size}, torch::kU8);
-  auto dataBytes = data.data_ptr<uint8_t>();
+  auto data = torch::stable::empty({size}, torch::headeronly::ScalarType::Byte);
+  auto dataBytes = data.mutable_data_ptr<uint8_t>();
 
   fread(dataBytes, sizeof(uint8_t), size, infile);
   fclose(infile);
 #else
-  auto data =
-      torch::from_file(filename, /*shared=*/false, /*size=*/size, torch::kU8);
+  auto data = stable_from_file(
+      filename,
+      /*shared=*/false,
+      /*size=*/size,
+      torch::headeronly::ScalarType::Byte);
 #endif
 
   return data;
 }
 
-void write_file(const std::string& filename, torch::Tensor& data) {
-  C10_LOG_API_USAGE_ONCE(
-      "torchvision.csrc.io.image.cpu.read_write_file.write_file");
+torch::stable::Tensor write_file(
+    const std::string& filename,
+    torch::stable::Tensor& data) {
   // Check that the input tensor is on CPU
-  STD_TORCH_CHECK(
-      data.device() == torch::kCPU, "Input tensor should be on CPU");
+  STD_TORCH_CHECK(data.is_cpu(), "Input tensor should be on CPU");
 
   // Check that the input tensor dtype is uint8
   STD_TORCH_CHECK(
-      data.dtype() == torch::kU8, "Input tensor dtype should be uint8");
+      data.scalar_type() == torch::headeronly::ScalarType::Byte,
+      "Input tensor dtype should be uint8");
 
   // Check that the input tensor is 3-dimensional
   STD_TORCH_CHECK(
       data.dim() == 1, "Input data should be a 1-dimensional tensor");
 
-  auto fileBytes = data.data_ptr<uint8_t>();
+  auto fileBytes = data.const_data_ptr<uint8_t>();
   auto fileCStr = filename.c_str();
 #ifdef _WIN32
   auto fileW = utf8_decode(filename);
@@ -107,6 +136,21 @@ void write_file(const std::string& filename, torch::Tensor& data) {
 
   fwrite(fileBytes, sizeof(uint8_t), data.numel(), outfile);
   fclose(outfile);
+
+  return data;
+}
+
+STABLE_TORCH_LIBRARY_FRAGMENT(image, m) {
+  m.def("read_file(str filename) -> Tensor");
+  // write_file returns its input so TorchScript DCE keeps the call alive
+  // since a stable def cannot express AliasAnalysisKind::CONSERVATIVE:
+  // https://github.com/pytorch/pytorch/issues/189309
+  m.def("write_file(str filename, Tensor data) -> Tensor");
+}
+
+STABLE_TORCH_LIBRARY_IMPL(image, CompositeExplicitAutograd, m) {
+  m.impl("read_file", TORCH_BOX(&read_file));
+  m.impl("write_file", TORCH_BOX(&write_file));
 }
 
 } // namespace image

--- a/torchvision/csrc/io/image/cpu/read_write_file.h
+++ b/torchvision/csrc/io/image/cpu/read_write_file.h
@@ -1,13 +1,17 @@
 #pragma once
 
-#include <torch/types.h>
+#include <torch/csrc/stable/tensor.h>
+
+#include <string>
 
 namespace vision {
 namespace image {
 
-C10_EXPORT torch::Tensor read_file(const std::string& filename);
+torch::stable::Tensor read_file(const std::string& filename);
 
-C10_EXPORT void write_file(const std::string& filename, torch::Tensor& data);
+torch::stable::Tensor write_file(
+    const std::string& filename,
+    torch::stable::Tensor& data);
 
 } // namespace image
 } // namespace vision

--- a/torchvision/csrc/io/image/image.cpp
+++ b/torchvision/csrc/io/image/image.cpp
@@ -14,8 +14,6 @@ static auto registry =
             &decode_jpeg)
         .op("image::decode_webp(Tensor encoded_data, int mode) -> Tensor",
             &decode_webp)
-        .op("image::read_file", &read_file)
-        .op("image::write_file", &write_file)
         .op("image::decode_image(Tensor data, int mode, bool apply_exif_orientation=False) -> Tensor",
             &decode_image)
         .op("image::_jpeg_version", &_jpeg_version)

--- a/torchvision/csrc/io/image/image.h
+++ b/torchvision/csrc/io/image/image.h
@@ -5,4 +5,3 @@
 #include "cpu/decode_jpeg.h"
 #include "cpu/decode_png.h"
 #include "cpu/decode_webp.h"
-#include "cpu/read_write_file.h"

--- a/torchvision/io/image.py
+++ b/torchvision/io/image.py
@@ -77,18 +77,21 @@ def read_file(path: str) -> torch.Tensor:
     return data
 
 
-def write_file(filename: str, data: torch.Tensor) -> None:
+def write_file(filename: str, data: torch.Tensor) -> torch.Tensor:
     """
     Write the content of an uint8 1D tensor to a file.
 
     Args:
         filename (str or ``pathlib.Path``): the path to the file to be written
         data (Tensor): the contents to be written to the output file
+
+    Returns:
+        data (Tensor): the input data, returned as-is.
     """
     if not torch.jit.is_scripting() and not torch.jit.is_tracing():
         _log_api_usage_once(write_file)
     _assert_has_image_ops()
-    torch.ops.image.write_file(str(filename), data)
+    return torch.ops.image.write_file(str(filename), data)
 
 
 def decode_png(
@@ -150,7 +153,7 @@ def encode_png(input: torch.Tensor, compression_level: int = 6) -> torch.Tensor:
     return output
 
 
-def write_png(input: torch.Tensor, filename: str, compression_level: int = 6):
+def write_png(input: torch.Tensor, filename: str, compression_level: int = 6) -> torch.Tensor:
     """
     Takes an input tensor in CHW layout (or HW in the case of grayscale images)
     and saves it in a PNG file.
@@ -161,11 +164,14 @@ def write_png(input: torch.Tensor, filename: str, compression_level: int = 6):
         filename (str or ``pathlib.Path``): Path to save the image.
         compression_level (int): Compression factor for the resulting file, it must be a number
             between 0 and 9. Default: 6
+
+    Returns:
+        output (Tensor): the PNG-encoded data that was written to the file.
     """
     if not torch.jit.is_scripting() and not torch.jit.is_tracing():
         _log_api_usage_once(write_png)
     output = encode_png(input, compression_level)
-    write_file(filename, output)
+    return write_file(filename, output)
 
 
 def decode_jpeg(
@@ -276,7 +282,7 @@ def encode_jpeg(
             return torch.ops.image.encode_jpeg(input, quality)
 
 
-def write_jpeg(input: torch.Tensor, filename: str, quality: int = 75):
+def write_jpeg(input: torch.Tensor, filename: str, quality: int = 75) -> torch.Tensor:
     """
     Takes an input tensor in CHW layout and saves it in a JPEG file.
 
@@ -286,12 +292,15 @@ def write_jpeg(input: torch.Tensor, filename: str, quality: int = 75):
         filename (str or ``pathlib.Path``): Path to save the image.
         quality (int): Quality of the resulting JPEG file, it must be a number
             between 1 and 100. Default: 75
+
+    Returns:
+        output (Tensor): the JPEG-encoded data that was written to the file.
     """
     if not torch.jit.is_scripting() and not torch.jit.is_tracing():
         _log_api_usage_once(write_jpeg)
     output = encode_jpeg(input, quality)
     assert isinstance(output, torch.Tensor)  # Needed for torchscript
-    write_file(filename, output)
+    return write_file(filename, output)
 
 
 def decode_image(


### PR DESCRIPTION
Ports CPU `read_file` and `write_file` to stable ABI reusing image_stable extension.

## Notes: Missing StableABI `from_file` op
 - `read_file` needs `aten::from_file` for its mmap read path, but Stable-ABI does not expose it yet. Added a `stable_from_file` dispatcher shim following the same pattern as [`stable_permute`](https://github.com/pytorch/vision/blob/0bc41e67670d6a0ae5617c90e7b29a5c64ec0575/torchvision/csrc/io/image/common_stable.h#L18-L31) from #9539

## Stable-ABI audit (`torch-abi-audit`)
Ran [`torch-abi-audit`](https://github.com/Quansight/torch-abi-audit) against the built `torchvision` package.

**`image_stable.so` audits as `STABLE` — 72 stable-shim symbols, 0 unstable** The legacy `image.so` drops 45 → 43 unstable.
  ```text
    Package: torchvision
      Torch ABI:   UNSTABLE
      CPython ABI: n/a
      Bundled libs: 4
      -- bundled libs --
        [UNSTABLE] [not-abi3        ] _C.so            (stable_shim=0,  unstable=110)
        [STABLE  ] [not-abi3        ] _C_stable.so     (stable_shim=67, unstable=0)
        [UNSTABLE] [uses-private-api] image.so         (stable_shim=0,  unstable=43)
        [STABLE  ] [not-abi3        ] image_stable.so  (stable_shim=72, unstable=0)
  ```