### PR TITLE
Port CPU decode_image to stable ABI.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,7 @@ set(TORCHVISION_STABLE_SOURCES
   ${TVCPP}/io/image/cpu/encode_png.cpp
   ${TVCPP}/io/image/cpu/encode_jpeg.cpp
   ${TVCPP}/io/image/cpu/read_write_file.cpp
+  ${TVCPP}/io/image/cpu/decode_image.cpp
   ${TVCPP}/io/image/common_stable.cpp
   ${TVCPP}/vision_stable.cpp)
 # Pin them to torch 2.11. Per source, not library-wide: the pin makes ATen headers

--- a/setup.py
+++ b/setup.py
@@ -168,6 +168,7 @@ STABLE_SOURCES = {
     CSRS_DIR / "io/image/cpu/encode_png.cpp",
     CSRS_DIR / "io/image/cpu/encode_jpeg.cpp",
     CSRS_DIR / "io/image/cpu/read_write_file.cpp",
+    CSRS_DIR / "io/image/cpu/decode_image.cpp",
 }
 STABLE_SOURCES.add(CSRS_DIR / ("ops/hip/nms_kernel.hip" if IS_ROCM else "ops/cuda/nms_kernel.cu"))
 STABLE_SOURCES.add(

--- a/torchvision/csrc/io/image/cpu/decode_image.cpp
+++ b/torchvision/csrc/io/image/cpu/decode_image.cpp
@@ -1,21 +1,77 @@
 #include "decode_image.h"
 
-#include "decode_gif.h"
-#include "decode_jpeg.h"
-#include "decode_png.h"
-#include "decode_webp.h"
+#include <torch/csrc/stable/library.h>
+#include <torch/headeronly/util/Exception.h>
+
+#include <cstring>
 
 namespace vision {
 namespace image {
 
-torch::Tensor decode_image(
-    const torch::Tensor& data,
+namespace {
+
+// Shims over the legacy image::decode_jpeg, decode_png, decode_gif and
+// decode_webp ops not yet on the stable ABI.
+// TODO(stable-abi): remove each shim once its decoder is ported.
+torch::stable::Tensor decode_jpeg(
+    const torch::stable::Tensor& data,
+    ImageReadMode mode,
+    bool apply_exif_orientation) {
+  const auto num_args = 3;
+  std::array<StableIValue, num_args> stack{
+      torch::stable::detail::from(data),
+      torch::stable::detail::from(mode),
+      torch::stable::detail::from(apply_exif_orientation)};
+  TORCH_ERROR_CODE_CHECK(torch_call_dispatcher(
+      "image::decode_jpeg", "", stack.data(), TORCH_ABI_VERSION));
+  return torch::stable::detail::to<torch::stable::Tensor>(stack[0]);
+}
+
+torch::stable::Tensor decode_png(
+    const torch::stable::Tensor& data,
+    ImageReadMode mode,
+    bool apply_exif_orientation) {
+  const auto num_args = 3;
+  std::array<StableIValue, num_args> stack{
+      torch::stable::detail::from(data),
+      torch::stable::detail::from(mode),
+      torch::stable::detail::from(apply_exif_orientation)};
+  TORCH_ERROR_CODE_CHECK(torch_call_dispatcher(
+      "image::decode_png", "", stack.data(), TORCH_ABI_VERSION));
+  return torch::stable::detail::to<torch::stable::Tensor>(stack[0]);
+}
+
+torch::stable::Tensor decode_gif(const torch::stable::Tensor& data) {
+  const auto num_args = 1;
+  std::array<StableIValue, num_args> stack{torch::stable::detail::from(data)};
+  TORCH_ERROR_CODE_CHECK(torch_call_dispatcher(
+      "image::decode_gif", "", stack.data(), TORCH_ABI_VERSION));
+  return torch::stable::detail::to<torch::stable::Tensor>(stack[0]);
+}
+
+torch::stable::Tensor decode_webp(
+    const torch::stable::Tensor& data,
+    ImageReadMode mode) {
+  const auto num_args = 2;
+  std::array<StableIValue, num_args> stack{
+      torch::stable::detail::from(data), torch::stable::detail::from(mode)};
+  TORCH_ERROR_CODE_CHECK(torch_call_dispatcher(
+      "image::decode_webp", "", stack.data(), TORCH_ABI_VERSION));
+  return torch::stable::detail::to<torch::stable::Tensor>(stack[0]);
+}
+
+} // namespace
+
+torch::stable::Tensor decode_image(
+    const torch::stable::Tensor& data,
     ImageReadMode mode,
     bool apply_exif_orientation) {
   // Check that tensor is a CPU tensor
-  STD_TORCH_CHECK(data.device() == torch::kCPU, "Expected a CPU tensor");
+  STD_TORCH_CHECK(data.is_cpu(), "Expected a CPU tensor");
   // Check that the input tensor dtype is uint8
-  STD_TORCH_CHECK(data.dtype() == torch::kU8, "Expected a torch.uint8 tensor");
+  STD_TORCH_CHECK(
+      data.scalar_type() == torch::headeronly::ScalarType::Byte,
+      "Expected a torch.uint8 tensor");
   // Check that the input tensor is 1-dimensional
   STD_TORCH_CHECK(
       data.dim() == 1 && data.numel() > 0,
@@ -24,7 +80,7 @@ torch::Tensor decode_image(
   auto err_msg =
       "Unsupported image file. Only jpeg, png, webp and gif are currently supported. For avif and heic format, please rely on `decode_avif` and `decode_heic` directly.";
 
-  auto datap = data.data_ptr<uint8_t>();
+  auto datap = data.const_data_ptr<uint8_t>();
 
   const uint8_t jpeg_signature[3] = {255, 216, 255}; // == "\xFF\xD8\xFF"
   STD_TORCH_CHECK(data.numel() >= 3, err_msg);
@@ -58,6 +114,15 @@ torch::Tensor decode_image(
   }
 
   STD_TORCH_CHECK(false, err_msg);
+}
+
+STABLE_TORCH_LIBRARY_FRAGMENT(image, m) {
+  m.def(
+      "decode_image(Tensor data, int mode, bool apply_exif_orientation=False) -> Tensor");
+}
+
+STABLE_TORCH_LIBRARY_IMPL(image, CompositeExplicitAutograd, m) {
+  m.impl("decode_image", TORCH_BOX(&decode_image));
 }
 
 } // namespace image

--- a/torchvision/csrc/io/image/cpu/decode_image.h
+++ b/torchvision/csrc/io/image/cpu/decode_image.h
@@ -1,13 +1,13 @@
 #pragma once
 
-#include <torch/types.h>
-#include "../common.h"
+#include <torch/csrc/stable/tensor.h>
+#include "../common_stable.h"
 
 namespace vision {
 namespace image {
 
-C10_EXPORT torch::Tensor decode_image(
-    const torch::Tensor& data,
+torch::stable::Tensor decode_image(
+    const torch::stable::Tensor& data,
     ImageReadMode mode = IMAGE_READ_MODE_UNCHANGED,
     bool apply_exif_orientation = false);
 

--- a/torchvision/csrc/io/image/image.cpp
+++ b/torchvision/csrc/io/image/image.cpp
@@ -14,8 +14,6 @@ static auto registry =
             &decode_jpeg)
         .op("image::decode_webp(Tensor encoded_data, int mode) -> Tensor",
             &decode_webp)
-        .op("image::decode_image(Tensor data, int mode, bool apply_exif_orientation=False) -> Tensor",
-            &decode_image)
         .op("image::_jpeg_version", &_jpeg_version)
         .op("image::_is_compiled_against_turbo", &_is_compiled_against_turbo);
 

--- a/torchvision/csrc/io/image/image.h
+++ b/torchvision/csrc/io/image/image.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "cpu/decode_gif.h"
-#include "cpu/decode_image.h"
 #include "cpu/decode_jpeg.h"
 #include "cpu/decode_png.h"
 #include "cpu/decode_webp.h"


### PR DESCRIPTION
Ports CPU `decode_image` to stable ABI.

## Notes: Missing stable ABI shims
- `decode_image` selects between the four CPU decoders (jpeg,png,gif,webp), which are still on the unstable extension. Until each one is ported it calls them through torch_call_dispatcher on the registered `image::decode_*` ops, following the same pattern as [`stable_permute`](https://github.com/pytorch/vision/blob/0bc41e67670d6a0ae5617c90e7b29a5c64ec0575/torchvision/csrc/io/image/common_stable.h#L18-L31) from #9539. 

## Stable-ABI audit (`torch-abi-audit`)
 Ran [`torch-abi-audit`](https://github.com/Quansight/torch-abi-audit) against the built `torchvision` package. **`image_stable.so` audits as `STABLE` — 68 stable-shim symbols, 0 unstable** The legacy `image.so` stays at 45 unstable.
```text
    Package: torchvision
      Torch ABI:   UNSTABLE
      CPython ABI: n/a
      Bundled libs: 4
      -- bundled libs --
        [UNSTABLE] [not-abi3        ] _C.so            (stable_shim=0,  unstable=110)
        [STABLE  ] [not-abi3        ] _C_stable.so     (stable_shim=67, unstable=0)
        [UNSTABLE] [uses-private-api] image.so         (stable_shim=0,  unstable=45)
        [STABLE  ] [not-abi3        ] image_stable.so  (stable_shim=68, unstable=0)
```  