### PR TITLE
Port CPU decode_png to stable ABI.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,7 @@ set(TORCHVISION_STABLE_SOURCES
   ${TVCPP}/io/image/cpu/encode_jpeg.cpp
   ${TVCPP}/io/image/cpu/read_write_file.cpp
   ${TVCPP}/io/image/cpu/decode_image.cpp
+  ${TVCPP}/io/image/cpu/decode_png.cpp
   ${TVCPP}/io/image/common_stable.cpp
   ${TVCPP}/vision_stable.cpp)
 # Pin them to torch 2.11. Per source, not library-wide: the pin makes ATen headers

--- a/setup.py
+++ b/setup.py
@@ -169,6 +169,7 @@ STABLE_SOURCES = {
     CSRS_DIR / "io/image/cpu/encode_jpeg.cpp",
     CSRS_DIR / "io/image/cpu/read_write_file.cpp",
     CSRS_DIR / "io/image/cpu/decode_image.cpp",
+    CSRS_DIR / "io/image/cpu/decode_png.cpp",
 }
 STABLE_SOURCES.add(CSRS_DIR / ("ops/hip/nms_kernel.hip" if IS_ROCM else "ops/cuda/nms_kernel.cu"))
 STABLE_SOURCES.add(
@@ -402,19 +403,6 @@ def make_image_extension():
         sources += _not_stable(image_dir.glob("cuda/*.cpp"))
 
     Extension = CppExtension
-
-    if USE_PNG:
-        png_found, png_include_dir, png_library_dir, png_library = find_libpng()
-        if png_found:
-            print("Building torchvision with PNG support")
-            print(f"{png_include_dir = }")
-            print(f"{png_library_dir = }")
-            include_dirs.append(png_include_dir)
-            library_dirs.append(png_library_dir)
-            libraries.append(png_library)
-            define_macros += [("PNG_FOUND", 1)]
-        else:
-            warnings.warn("Building torchvision without PNG support")
 
     if USE_JPEG:
         jpeg_found, jpeg_include_dir, jpeg_library_dir = find_library(header="jpeglib.h")

--- a/torchvision/csrc/io/image/common_stable.cpp
+++ b/torchvision/csrc/io/image/common_stable.cpp
@@ -8,6 +8,10 @@
 // counterpart of common.cpp. Holds pieces that belong to the extension rather
 // than to any single operator, and grows as more ops migrate.
 
+#include "common_stable.h"
+
+#include <torch/headeronly/util/Exception.h>
+
 // If we are in a Windows environment, we need to define
 // initialization functions for the image_stable extension.
 #if !defined(MOBILE) && defined(_WIN32)
@@ -15,3 +19,25 @@ void* PyInit_image_stable(void) {
   return nullptr;
 }
 #endif // !defined(MOBILE) && defined(_WIN32)
+
+namespace vision {
+namespace image {
+
+void validate_encoded_data(const torch::stable::Tensor& encoded_data) {
+  STD_TORCH_CHECK(
+      encoded_data.is_contiguous(), "Input tensor must be contiguous.");
+  STD_TORCH_CHECK(
+      encoded_data.scalar_type() == torch::headeronly::ScalarType::Byte,
+      "Input tensor must have uint8 data type, got ",
+      torch::headeronly::toString(encoded_data.scalar_type()));
+  STD_TORCH_CHECK(
+      encoded_data.dim() == 1 && encoded_data.numel() > 0,
+      "Input tensor must be 1-dimensional and non-empty, got ",
+      encoded_data.dim(),
+      " dims  and ",
+      encoded_data.numel(),
+      " numels.");
+}
+
+} // namespace image
+} // namespace vision

--- a/torchvision/csrc/io/image/common_stable.h
+++ b/torchvision/csrc/io/image/common_stable.h
@@ -29,5 +29,21 @@ inline torch::stable::Tensor stable_permute(
   return torch::stable::detail::to<torch::stable::Tensor>(stack[0]);
 }
 
+// Stable-ABI missing flip op, shimmed with the same dispatcher idiom as
+// stable_permute.
+// TODO(stable-abi): remove once flip lands in the stable ABI upstream.
+inline torch::stable::Tensor stable_flip(
+    const torch::stable::Tensor& self,
+    std::vector<int64_t> dims) {
+  const auto num_args = 2;
+  std::array<StableIValue, num_args> stack{
+      torch::stable::detail::from(self), torch::stable::detail::from(dims)};
+  TORCH_ERROR_CODE_CHECK(
+      torch_call_dispatcher("aten::flip", "", stack.data(), TORCH_ABI_VERSION));
+  return torch::stable::detail::to<torch::stable::Tensor>(stack[0]);
+}
+
+void validate_encoded_data(const torch::stable::Tensor& encoded_data);
+
 } // namespace image
 } // namespace vision

--- a/torchvision/csrc/io/image/cpu/decode_image.cpp
+++ b/torchvision/csrc/io/image/cpu/decode_image.cpp
@@ -5,13 +5,15 @@
 
 #include <cstring>
 
+#include "decode_png.h"
+
 namespace vision {
 namespace image {
 
 namespace {
 
-// Shims over the legacy image::decode_jpeg, decode_png, decode_gif and
-// decode_webp ops not yet on the stable ABI.
+// Shims over the legacy image::decode_jpeg, decode_gif and decode_webp ops
+// not yet on the stable ABI.
 // TODO(stable-abi): remove each shim once its decoder is ported.
 torch::stable::Tensor decode_jpeg(
     const torch::stable::Tensor& data,
@@ -24,20 +26,6 @@ torch::stable::Tensor decode_jpeg(
       torch::stable::detail::from(apply_exif_orientation)};
   TORCH_ERROR_CODE_CHECK(torch_call_dispatcher(
       "image::decode_jpeg", "", stack.data(), TORCH_ABI_VERSION));
-  return torch::stable::detail::to<torch::stable::Tensor>(stack[0]);
-}
-
-torch::stable::Tensor decode_png(
-    const torch::stable::Tensor& data,
-    ImageReadMode mode,
-    bool apply_exif_orientation) {
-  const auto num_args = 3;
-  std::array<StableIValue, num_args> stack{
-      torch::stable::detail::from(data),
-      torch::stable::detail::from(mode),
-      torch::stable::detail::from(apply_exif_orientation)};
-  TORCH_ERROR_CODE_CHECK(torch_call_dispatcher(
-      "image::decode_png", "", stack.data(), TORCH_ABI_VERSION));
   return torch::stable::detail::to<torch::stable::Tensor>(stack[0]);
 }
 

--- a/torchvision/csrc/io/image/cpu/decode_png.cpp
+++ b/torchvision/csrc/io/image/cpu/decode_png.cpp
@@ -1,9 +1,15 @@
 #include "decode_png.h"
-#include "../common.h"
+
+#include <torch/csrc/stable/library.h>
+#include <torch/csrc/stable/ops.h>
+#include <torch/headeronly/util/Exception.h>
+
+#include <algorithm>
+#include <optional>
+
+#include "../common_stable.h"
 #include "common_png.h"
 #include "exif.h"
-
-#include <optional>
 
 namespace vision {
 namespace image {
@@ -11,8 +17,8 @@ namespace image {
 using namespace exif_private;
 
 #if !PNG_FOUND
-torch::Tensor decode_png(
-    const torch::Tensor& data,
+torch::stable::Tensor decode_png(
+    const torch::stable::Tensor& data,
     ImageReadMode mode,
     bool apply_exif_orientation) {
   STD_TORCH_CHECK(
@@ -25,12 +31,10 @@ bool is_little_endian() {
   return *(uint8_t*)&x;
 }
 
-torch::Tensor decode_png(
-    const torch::Tensor& data,
+torch::stable::Tensor decode_png(
+    const torch::stable::Tensor& data,
     ImageReadMode mode,
     bool apply_exif_orientation) {
-  C10_LOG_API_USAGE_ONCE("torchvision.csrc.io.image.cpu.decode_png.decode_png");
-
   validate_encoded_data(data);
 
   auto png_ptr =
@@ -43,15 +47,14 @@ torch::Tensor decode_png(
     STD_TORCH_CHECK(info_ptr, "libpng info structure allocation failed!")
   }
 
-  auto accessor = data.accessor<unsigned char, 1>();
-  auto datap = accessor.data();
-  auto datap_len = accessor.size(0);
+  auto datap = data.const_data_ptr<uint8_t>();
+  auto datap_len = data.numel();
 
   // NOTE: libpng uses setjmp/longjmp for error handling. longjmp does not
   // unwind C++ stack frames, so destructors of objects created after setjmp
   // won't run. We use std::optional to declare tensors before setjmp while
   // deferring construction, and explicitly reset them on the error path.
-  std::optional<torch::Tensor> tensor;
+  std::optional<torch::stable::Tensor> tensor;
 
   if (setjmp(png_jmpbuf(png_ptr)) != 0) {
     tensor.reset();
@@ -206,19 +209,20 @@ torch::Tensor decode_png(
 
   auto num_pixels_per_row = width * channels;
   auto is_16_bits = bit_depth == 16;
-  tensor = torch::empty(
+  tensor = torch::stable::empty(
       {int64_t(height), int64_t(width), channels},
-      is_16_bits ? at::kUInt16 : torch::kU8);
+      is_16_bits ? torch::headeronly::ScalarType::UInt16
+                 : torch::headeronly::ScalarType::Byte);
   if (is_little_endian()) {
     png_set_swap(png_ptr);
   }
-  auto t_ptr = (uint8_t*)tensor->data_ptr();
+  auto t_ptr = (uint8_t*)tensor->mutable_data_ptr();
   for (int pass = 0; pass < number_of_passes; pass++) {
     for (png_uint_32 i = 0; i < height; ++i) {
       png_read_row(png_ptr, t_ptr, nullptr);
       t_ptr += num_pixels_per_row * (is_16_bits ? 2 : 1);
     }
-    t_ptr = (uint8_t*)tensor->data_ptr();
+    t_ptr = (uint8_t*)tensor->mutable_data_ptr();
   }
 
   int exif_orientation = -1;
@@ -228,13 +232,22 @@ torch::Tensor decode_png(
 
   png_destroy_read_struct(&png_ptr, &info_ptr, nullptr);
 
-  auto output = tensor->permute({2, 0, 1});
+  auto output = stable_permute(*tensor, {2, 0, 1});
   if (apply_exif_orientation) {
     return exif_orientation_transform(output, exif_orientation);
   }
   return output;
 }
 #endif
+
+STABLE_TORCH_LIBRARY_FRAGMENT(image, m) {
+  m.def(
+      "decode_png(Tensor data, int mode, bool apply_exif_orientation=False) -> Tensor");
+}
+
+STABLE_TORCH_LIBRARY_IMPL(image, CompositeExplicitAutograd, m) {
+  m.impl("decode_png", TORCH_BOX(&decode_png));
+}
 
 } // namespace image
 } // namespace vision

--- a/torchvision/csrc/io/image/cpu/decode_png.h
+++ b/torchvision/csrc/io/image/cpu/decode_png.h
@@ -1,13 +1,13 @@
 #pragma once
 
-#include <torch/types.h>
-#include "../common.h"
+#include <torch/csrc/stable/tensor.h>
+#include "../common_stable.h"
 
 namespace vision {
 namespace image {
 
-C10_EXPORT torch::Tensor decode_png(
-    const torch::Tensor& data,
+torch::stable::Tensor decode_png(
+    const torch::stable::Tensor& data,
     ImageReadMode mode = IMAGE_READ_MODE_UNCHANGED,
     bool apply_exif_orientation = false);
 

--- a/torchvision/csrc/io/image/cpu/exif.h
+++ b/torchvision/csrc/io/image/cpu/exif.h
@@ -59,7 +59,16 @@ direct,
 #endif
 
 #include <torch/headeronly/util/Exception.h>
+
+// Header-only code compiles per-TU, so stable TUs (which both build systems
+// compile with the TORCH_TARGET_VERSION pin) get stable-typed torch pieces.
+// TODO(stable-abi): drop the legacy branch once decode_jpeg migrates.
+#ifdef TORCH_TARGET_VERSION
+#include <torch/csrc/stable/ops.h>
+#include "../common_stable.h"
+#else
 #include <torch/types.h>
+#endif
 
 namespace vision {
 namespace image {
@@ -228,6 +237,34 @@ constexpr uint16_t IMAGE_ORIENTATION_RB =
     7; // mirrored horizontal & rotate 90 CW
 constexpr uint16_t IMAGE_ORIENTATION_LB = 8; // needs 270 CW rotation
 
+// Stable-typed twin of the legacy transform below for stable TUs.
+// TODO(stable-abi): drop the legacy branch once decode_jpeg migrates.
+#ifdef TORCH_TARGET_VERSION
+inline torch::stable::Tensor exif_orientation_transform(
+    const torch::stable::Tensor& image,
+    int orientation) {
+  if (orientation == IMAGE_ORIENTATION_TL) {
+    return image;
+  } else if (orientation == IMAGE_ORIENTATION_TR) {
+    return stable_flip(image, {-1});
+  } else if (orientation == IMAGE_ORIENTATION_BR) {
+    // needs 180 rotation equivalent to
+    // flip both horizontally and vertically
+    return stable_flip(image, {-2, -1});
+  } else if (orientation == IMAGE_ORIENTATION_BL) {
+    return stable_flip(image, {-2});
+  } else if (orientation == IMAGE_ORIENTATION_LT) {
+    return torch::stable::transpose(image, -1, -2);
+  } else if (orientation == IMAGE_ORIENTATION_RT) {
+    return stable_flip(torch::stable::transpose(image, -1, -2), {-1});
+  } else if (orientation == IMAGE_ORIENTATION_RB) {
+    return stable_flip(torch::stable::transpose(image, -1, -2), {-2, -1});
+  } else if (orientation == IMAGE_ORIENTATION_LB) {
+    return stable_flip(torch::stable::transpose(image, -1, -2), {-2});
+  }
+  return image;
+}
+#else
 inline torch::Tensor exif_orientation_transform(
     const torch::Tensor& image,
     int orientation) {
@@ -252,6 +289,7 @@ inline torch::Tensor exif_orientation_transform(
   }
   return image;
 }
+#endif
 
 } // namespace exif_private
 } // namespace image

--- a/torchvision/csrc/io/image/image.cpp
+++ b/torchvision/csrc/io/image/image.cpp
@@ -8,8 +8,6 @@ namespace image {
 static auto registry =
     torch::RegisterOperators()
         .op("image::decode_gif", &decode_gif)
-        .op("image::decode_png(Tensor data, int mode, bool apply_exif_orientation=False) -> Tensor",
-            &decode_png)
         .op("image::decode_jpeg(Tensor data, int mode, bool apply_exif_orientation=False) -> Tensor",
             &decode_jpeg)
         .op("image::decode_webp(Tensor encoded_data, int mode) -> Tensor",

--- a/torchvision/csrc/io/image/image.h
+++ b/torchvision/csrc/io/image/image.h
@@ -2,5 +2,4 @@
 
 #include "cpu/decode_gif.h"
 #include "cpu/decode_jpeg.h"
-#include "cpu/decode_png.h"
 #include "cpu/decode_webp.h"


### PR DESCRIPTION
Ports CPU png decoder to stable ABI.

## Notes: 
**_Missing StableABI ops_**
- The EXIF orientation transform needs `flip`, which Stable-ABI does not expose yet. Added a `stable_flip` shim to `common_stable.h` following the same pattern as [`stable_permute`](https://github.com/pytorch/vision/blob/0bc41e67670d6a0ae5617c90e7b29a5c64ec0575/torchvision/csrc/io/image/common_stable.h#L18-L31) from #9539.

**_Shared exif.h_**
- `exif.h` is shared with the unstable `decode_jpeg`, and its orientation transform returns tensors, so the header gains a stable-typed gated on the existing `TORCH_TARGET_VERSION`. The unstable branch is removed when `decode_jpeg` is ported.

## Notes: libpng leaves the unstable extension
- `decode_png` was the last libpng consumer in the unstable  `image` extension (`encode_png` moved in #9539), so libpng detection/linking now applies only to `image_stable`.

 ## Stable-ABI audit (`torch-abi-audit`)
 Ran [`torch-abi-audit`](https://github.com/Quansight/torch-abi-audit) against the built `torchvision` package. **`image_stable.so` audits as `STABLE` 73 stable-shim symbols, 0 unstable** The legacy `image.so` drops 45 → 37 unstable.
```text
    Package: torchvision
      Torch ABI:   UNSTABLE
      CPython ABI: n/a
      Bundled libs: 4
      -- bundled libs --
        [UNSTABLE] [not-abi3        ] _C.so            (stable_shim=0,  unstable=110)
        [STABLE  ] [not-abi3        ] _C_stable.so     (stable_shim=67, unstable=0)
        [UNSTABLE] [uses-private-api] image.so         (stable_shim=0,  unstable=37)
        [STABLE  ] [not-abi3        ] image_stable.so  (stable_shim=73, unstable=0)
  ```