### PR TITLE
Port CPU decode_jpeg to stable ABI.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,8 @@ set(TORCHVISION_STABLE_SOURCES
   ${TVCPP}/io/image/cpu/read_write_file.cpp
   ${TVCPP}/io/image/cpu/decode_image.cpp
   ${TVCPP}/io/image/cpu/decode_png.cpp
+  ${TVCPP}/io/image/cpu/decode_jpeg.cpp
+  ${TVCPP}/io/image/cpu/common_jpeg.cpp
   ${TVCPP}/io/image/common_stable.cpp
   ${TVCPP}/vision_stable.cpp)
 # Pin them to torch 2.11. Per source, not library-wide: the pin makes ATen headers

--- a/setup.py
+++ b/setup.py
@@ -170,6 +170,8 @@ STABLE_SOURCES = {
     CSRS_DIR / "io/image/cpu/read_write_file.cpp",
     CSRS_DIR / "io/image/cpu/decode_image.cpp",
     CSRS_DIR / "io/image/cpu/decode_png.cpp",
+    CSRS_DIR / "io/image/cpu/decode_jpeg.cpp",
+    CSRS_DIR / "io/image/cpu/common_jpeg.cpp",
 }
 STABLE_SOURCES.add(CSRS_DIR / ("ops/hip/nms_kernel.hip" if IS_ROCM else "ops/cuda/nms_kernel.cu"))
 STABLE_SOURCES.add(
@@ -404,21 +406,6 @@ def make_image_extension():
 
     Extension = CppExtension
 
-    if USE_JPEG:
-        jpeg_found, jpeg_include_dir, jpeg_library_dir = find_library(header="jpeglib.h")
-        if jpeg_found:
-            print("Building torchvision with JPEG support")
-            print(f"{jpeg_include_dir = }")
-            print(f"{jpeg_library_dir = }")
-            if jpeg_include_dir is not None and jpeg_library_dir is not None:
-                # if those are None it means they come from standard paths that are already in the search paths, which we don't need to re-add.
-                include_dirs.append(jpeg_include_dir)
-                library_dirs.append(jpeg_library_dir)
-            libraries.append("jpeg")
-            define_macros += [("JPEG_FOUND", 1)]
-        else:
-            warnings.warn("Building torchvision without JPEG support")
-
     if USE_WEBP:
         webp_found, webp_include_dir, webp_library_dir = find_library(header="webp/decode.h")
         if webp_found:
@@ -461,8 +448,6 @@ def make_image_stable_extension():
         + _stable(image_dir.glob("cpu/*.cpp"))
         + _stable(image_dir.glob("hip/*.cpp" if IS_ROCM else "cuda/*.cpp"))
     )
-    # Shared libjpeg glue. Legacy decode_jpeg still needs it, so it builds into both extensions.
-    sources.append(image_dir / "cpu/common_jpeg.cpp")
 
     Extension = CppExtension
 

--- a/torchvision/csrc/io/image/cpu/decode_image.cpp
+++ b/torchvision/csrc/io/image/cpu/decode_image.cpp
@@ -5,6 +5,7 @@
 
 #include <cstring>
 
+#include "decode_jpeg.h"
 #include "decode_png.h"
 
 namespace vision {
@@ -12,23 +13,9 @@ namespace image {
 
 namespace {
 
-// Shims over the legacy image::decode_jpeg, decode_gif and decode_webp ops
+// Shims over the legacy image::decode_gif and decode_webp ops
 // not yet on the stable ABI.
 // TODO(stable-abi): remove each shim once its decoder is ported.
-torch::stable::Tensor decode_jpeg(
-    const torch::stable::Tensor& data,
-    ImageReadMode mode,
-    bool apply_exif_orientation) {
-  const auto num_args = 3;
-  std::array<StableIValue, num_args> stack{
-      torch::stable::detail::from(data),
-      torch::stable::detail::from(mode),
-      torch::stable::detail::from(apply_exif_orientation)};
-  TORCH_ERROR_CODE_CHECK(torch_call_dispatcher(
-      "image::decode_jpeg", "", stack.data(), TORCH_ABI_VERSION));
-  return torch::stable::detail::to<torch::stable::Tensor>(stack[0]);
-}
-
 torch::stable::Tensor decode_gif(const torch::stable::Tensor& data) {
   const auto num_args = 1;
   std::array<StableIValue, num_args> stack{torch::stable::detail::from(data)};

--- a/torchvision/csrc/io/image/cpu/decode_jpeg.cpp
+++ b/torchvision/csrc/io/image/cpu/decode_jpeg.cpp
@@ -1,16 +1,23 @@
 #include "decode_jpeg.h"
-#include "../common.h"
+
+#include <torch/csrc/stable/library.h>
+#include <torch/csrc/stable/ops.h>
+#include <torch/headeronly/util/Exception.h>
+
+#include <algorithm>
+#include <cstring>
+#include <optional>
+
+#include "../common_stable.h"
 #include "common_jpeg.h"
 #include "exif.h"
-
-#include <optional>
 
 namespace vision {
 namespace image {
 
 #if !JPEG_FOUND
-torch::Tensor decode_jpeg(
-    const torch::Tensor& data,
+torch::stable::Tensor decode_jpeg(
+    const torch::stable::Tensor& data,
     ImageReadMode mode,
     bool apply_exif_orientation) {
   STD_TORCH_CHECK(
@@ -131,13 +138,10 @@ void convert_line_cmyk_to_gray(
 
 } // namespace
 
-torch::Tensor decode_jpeg(
-    const torch::Tensor& data,
+torch::stable::Tensor decode_jpeg(
+    const torch::stable::Tensor& data,
     ImageReadMode mode,
     bool apply_exif_orientation) {
-  C10_LOG_API_USAGE_ONCE(
-      "torchvision.csrc.io.image.cpu.decode_jpeg.decode_jpeg");
-
   validate_encoded_data(data);
 
   struct jpeg_decompress_struct cinfo;
@@ -147,10 +151,10 @@ torch::Tensor decode_jpeg(
   // unwind C++ stack frames, so destructors of objects created after setjmp
   // won't run. We use std::optional to declare tensors before setjmp while
   // deferring construction, and explicitly reset them on the error path.
-  std::optional<torch::Tensor> tensor;
-  std::optional<torch::Tensor> cmyk_line_tensor;
+  std::optional<torch::stable::Tensor> tensor;
+  std::optional<torch::stable::Tensor> cmyk_line_tensor;
 
-  auto datap = data.data_ptr<uint8_t>();
+  auto datap = data.const_data_ptr<uint8_t>();
   // Setup decompression structure
   cinfo.err = jpeg_std_error(&jerr.pub);
   jerr.pub.error_exit = torch_jpeg_error_exit;
@@ -223,12 +227,14 @@ torch::Tensor decode_jpeg(
   int width = cinfo.output_width;
 
   int stride = width * channels;
-  tensor =
-      torch::empty({int64_t(height), int64_t(width), channels}, torch::kU8);
-  auto ptr = tensor->data_ptr<uint8_t>();
+  tensor = torch::stable::empty(
+      {int64_t(height), int64_t(width), channels},
+      torch::headeronly::ScalarType::Byte);
+  auto ptr = tensor->mutable_data_ptr<uint8_t>();
 
   if (cmyk_to_rgb_or_gray) {
-    cmyk_line_tensor = torch::empty({int64_t(width), 4}, torch::kU8);
+    cmyk_line_tensor = torch::stable::empty(
+        {int64_t(width), 4}, torch::headeronly::ScalarType::Byte);
   }
 
   while (cinfo.output_scanline < cinfo.output_height) {
@@ -237,7 +243,7 @@ torch::Tensor decode_jpeg(
      * more than one scanline at a time if that's more convenient.
      */
     if (cmyk_to_rgb_or_gray) {
-      auto cmyk_line_ptr = cmyk_line_tensor->data_ptr<uint8_t>();
+      auto cmyk_line_ptr = cmyk_line_tensor->mutable_data_ptr<uint8_t>();
       jpeg_read_scanlines(&cinfo, &cmyk_line_ptr, 1);
 
       if (channels == 3) {
@@ -253,7 +259,7 @@ torch::Tensor decode_jpeg(
 
   jpeg_finish_decompress(&cinfo);
   jpeg_destroy_decompress(&cinfo);
-  auto output = tensor->permute({2, 0, 1});
+  auto output = stable_permute(*tensor, {2, 0, 1});
 
   if (apply_exif_orientation) {
     return exif_orientation_transform(output, exif_orientation);
@@ -276,6 +282,19 @@ bool _is_compiled_against_turbo() {
 #else
   return false;
 #endif
+}
+
+STABLE_TORCH_LIBRARY_FRAGMENT(image, m) {
+  m.def(
+      "decode_jpeg(Tensor data, int mode, bool apply_exif_orientation=False) -> Tensor");
+  m.def("_jpeg_version() -> int");
+  m.def("_is_compiled_against_turbo() -> bool");
+}
+
+STABLE_TORCH_LIBRARY_IMPL(image, CompositeExplicitAutograd, m) {
+  m.impl("decode_jpeg", TORCH_BOX(&decode_jpeg));
+  m.impl("_jpeg_version", TORCH_BOX(&_jpeg_version));
+  m.impl("_is_compiled_against_turbo", TORCH_BOX(&_is_compiled_against_turbo));
 }
 
 } // namespace image

--- a/torchvision/csrc/io/image/cpu/decode_jpeg.h
+++ b/torchvision/csrc/io/image/cpu/decode_jpeg.h
@@ -1,18 +1,18 @@
 #pragma once
 
-#include <torch/types.h>
-#include "../common.h"
+#include <torch/csrc/stable/tensor.h>
+#include "../common_stable.h"
 
 namespace vision {
 namespace image {
 
-C10_EXPORT torch::Tensor decode_jpeg(
-    const torch::Tensor& data,
+torch::stable::Tensor decode_jpeg(
+    const torch::stable::Tensor& data,
     ImageReadMode mode = IMAGE_READ_MODE_UNCHANGED,
     bool apply_exif_orientation = false);
 
-C10_EXPORT int64_t _jpeg_version();
-C10_EXPORT bool _is_compiled_against_turbo();
+int64_t _jpeg_version();
+bool _is_compiled_against_turbo();
 
 } // namespace image
 } // namespace vision

--- a/torchvision/csrc/io/image/cpu/exif.h
+++ b/torchvision/csrc/io/image/cpu/exif.h
@@ -60,15 +60,8 @@ direct,
 
 #include <torch/headeronly/util/Exception.h>
 
-// Header-only code compiles per-TU, so stable TUs (which both build systems
-// compile with the TORCH_TARGET_VERSION pin) get stable-typed torch pieces.
-// TODO(stable-abi): drop the legacy branch once decode_jpeg migrates.
-#ifdef TORCH_TARGET_VERSION
 #include <torch/csrc/stable/ops.h>
 #include "../common_stable.h"
-#else
-#include <torch/types.h>
-#endif
 
 namespace vision {
 namespace image {
@@ -237,9 +230,6 @@ constexpr uint16_t IMAGE_ORIENTATION_RB =
     7; // mirrored horizontal & rotate 90 CW
 constexpr uint16_t IMAGE_ORIENTATION_LB = 8; // needs 270 CW rotation
 
-// Stable-typed twin of the legacy transform below for stable TUs.
-// TODO(stable-abi): drop the legacy branch once decode_jpeg migrates.
-#ifdef TORCH_TARGET_VERSION
 inline torch::stable::Tensor exif_orientation_transform(
     const torch::stable::Tensor& image,
     int orientation) {
@@ -264,32 +254,6 @@ inline torch::stable::Tensor exif_orientation_transform(
   }
   return image;
 }
-#else
-inline torch::Tensor exif_orientation_transform(
-    const torch::Tensor& image,
-    int orientation) {
-  if (orientation == IMAGE_ORIENTATION_TL) {
-    return image;
-  } else if (orientation == IMAGE_ORIENTATION_TR) {
-    return image.flip(-1);
-  } else if (orientation == IMAGE_ORIENTATION_BR) {
-    // needs 180 rotation equivalent to
-    // flip both horizontally and vertically
-    return image.flip({-2, -1});
-  } else if (orientation == IMAGE_ORIENTATION_BL) {
-    return image.flip(-2);
-  } else if (orientation == IMAGE_ORIENTATION_LT) {
-    return image.transpose(-1, -2);
-  } else if (orientation == IMAGE_ORIENTATION_RT) {
-    return image.transpose(-1, -2).flip(-1);
-  } else if (orientation == IMAGE_ORIENTATION_RB) {
-    return image.transpose(-1, -2).flip({-2, -1});
-  } else if (orientation == IMAGE_ORIENTATION_LB) {
-    return image.transpose(-1, -2).flip(-2);
-  }
-  return image;
-}
-#endif
 
 } // namespace exif_private
 } // namespace image

--- a/torchvision/csrc/io/image/image.cpp
+++ b/torchvision/csrc/io/image/image.cpp
@@ -8,12 +8,8 @@ namespace image {
 static auto registry =
     torch::RegisterOperators()
         .op("image::decode_gif", &decode_gif)
-        .op("image::decode_jpeg(Tensor data, int mode, bool apply_exif_orientation=False) -> Tensor",
-            &decode_jpeg)
         .op("image::decode_webp(Tensor encoded_data, int mode) -> Tensor",
-            &decode_webp)
-        .op("image::_jpeg_version", &_jpeg_version)
-        .op("image::_is_compiled_against_turbo", &_is_compiled_against_turbo);
+            &decode_webp);
 
 } // namespace image
 } // namespace vision

--- a/torchvision/csrc/io/image/image.h
+++ b/torchvision/csrc/io/image/image.h
@@ -1,5 +1,4 @@
 #pragma once
 
 #include "cpu/decode_gif.h"
-#include "cpu/decode_jpeg.h"
 #include "cpu/decode_webp.h"


### PR DESCRIPTION
Ports CPU jpeg decoder to stable ABI.

## Notes: 
- `exif.h` becomes stable-only, `decode_jpeg` was the last legacy consumer of `exif.h`.
- `common_jpeg.cpp` stops dual-compiling, with the decoder migrated it builds only into `image_stable`.
- libjpeg leaves the legacy extension no unstable TU uses libjpeg anymore, so its detection/linking now applies only to `image_stable`.

## Stable-ABI audit (`torch-abi-audit`)
Ran [`torch-abi-audit`](https://github.com/Quansight/torch-abi-audit) against the built `torchvision` package. **`image_stable.so` audits as `STABLE` — 73 stable-shim symbols, 0 unstable. ** The legacy `image.so` drops 37 → 34 unstable.
```text
    Package: torchvision
      Torch ABI:   UNSTABLE
      CPython ABI: n/a
      Bundled libs: 4
      -- bundled libs --
        [UNSTABLE] [not-abi3        ] _C.so            (stable_shim=0,  unstable=110)
        [STABLE  ] [not-abi3        ] _C_stable.so     (stable_shim=67, unstable=0)
        [UNSTABLE] [uses-private-api] image.so         (stable_shim=0,  unstable=34)
        [STABLE  ] [not-abi3        ] image_stable.so  (stable_shim=73, unstable=0)
```