### PR TITLE
Port CPU decode_gif to stable ABI.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,7 @@ set(TORCHVISION_STABLE_SOURCES
   ${TVCPP}/io/image/cpu/decode_png.cpp
   ${TVCPP}/io/image/cpu/decode_jpeg.cpp
   ${TVCPP}/io/image/cpu/common_jpeg.cpp
+  ${TVCPP}/io/image/cpu/decode_gif.cpp
   ${TVCPP}/io/image/common_stable.cpp
   ${TVCPP}/vision_stable.cpp)
 # Pin them to torch 2.11. Per source, not library-wide: the pin makes ATen headers

--- a/setup.py
+++ b/setup.py
@@ -172,6 +172,11 @@ STABLE_SOURCES = {
     CSRS_DIR / "io/image/cpu/decode_png.cpp",
     CSRS_DIR / "io/image/cpu/decode_jpeg.cpp",
     CSRS_DIR / "io/image/cpu/common_jpeg.cpp",
+    CSRS_DIR / "io/image/cpu/decode_gif.cpp",
+    CSRS_DIR / "io/image/cpu/giflib/dgif_lib.c",
+    CSRS_DIR / "io/image/cpu/giflib/gif_hash.c",
+    CSRS_DIR / "io/image/cpu/giflib/gifalloc.c",
+    CSRS_DIR / "io/image/cpu/giflib/openbsd-reallocarray.c",
 }
 STABLE_SOURCES.add(CSRS_DIR / ("ops/hip/nms_kernel.hip" if IS_ROCM else "ops/cuda/nms_kernel.cu"))
 STABLE_SOURCES.add(
@@ -446,6 +451,7 @@ def make_image_stable_extension():
     sources = (
         _stable(image_dir.glob("*.cpp"))
         + _stable(image_dir.glob("cpu/*.cpp"))
+        + _stable(image_dir.glob("cpu/giflib/*.c"))
         + _stable(image_dir.glob("hip/*.cpp" if IS_ROCM else "cuda/*.cpp"))
     )
 

--- a/torchvision/csrc/io/image/cpu/decode_gif.cpp
+++ b/torchvision/csrc/io/image/cpu/decode_gif.cpp
@@ -1,6 +1,14 @@
 #include "decode_gif.h"
+
+#include <torch/csrc/stable/library.h>
+#include <torch/csrc/stable/ops.h>
+#include <torch/headeronly/core/TensorAccessor.h>
+#include <torch/headeronly/util/Exception.h>
+
+#include <algorithm>
 #include <cstring>
-#include "../common.h"
+
+#include "../common_stable.h"
 #include "giflib/gif_lib.h"
 
 namespace vision {
@@ -32,7 +40,7 @@ int read_from_tensor(GifFileType* gifFile, GifByteType* buf, int len) {
   return num_bytes_to_read;
 }
 
-torch::Tensor decode_gif(const torch::Tensor& encoded_data) {
+torch::stable::Tensor decode_gif(const torch::stable::Tensor& encoded_data) {
   // LibGif docs: https://giflib.sourceforge.net/intro.html
   // Refer over there for more details on the libgif API, API ref, and a
   // detailed description of the GIF format.
@@ -59,7 +67,7 @@ torch::Tensor decode_gif(const torch::Tensor& encoded_data) {
   // If we do that, we'd have to make sure the buffers are never written to by
   // GIFLIB, otherwise we'd be overriding the tensor data.
   reader_helper_t reader_helper;
-  reader_helper.encoded_data = encoded_data.data_ptr<uint8_t>();
+  reader_helper.encoded_data = encoded_data.const_data_ptr<uint8_t>();
   reader_helper.encoded_data_size = encoded_data.numel();
   reader_helper.num_bytes_read = 0;
   GifFileType* gifFile =
@@ -97,12 +105,16 @@ torch::Tensor decode_gif(const torch::Tensor& encoded_data) {
 
   // We output a channels-last tensor for consistency with other image decoders.
   // Torchvision's resize tends to be is faster on uint8 channels-last tensors.
-  auto options = torch::TensorOptions()
-                     .dtype(torch::kU8)
-                     .memory_format(torch::MemoryFormat::ChannelsLast);
-  auto out = torch::empty(
-      {int64_t(num_images), 3, int64_t(out_h), int64_t(out_w)}, options);
-  auto out_a = out.accessor<uint8_t, 4>();
+  auto out = torch::stable::empty(
+      {int64_t(num_images), 3, int64_t(out_h), int64_t(out_w)},
+      torch::headeronly::ScalarType::Byte,
+      std::nullopt,
+      std::nullopt,
+      std::nullopt,
+      torch::headeronly::MemoryFormat::ChannelsLast);
+  auto out_data = out.mutable_data_ptr<uint8_t>();
+  auto out_a = torch::headeronly::HeaderOnlyTensorAccessor<uint8_t, 4>(
+      out_data, out.sizes().data(), out.strides().data());
   for (int i = 0; i < num_images; i++) {
     const SavedImage& img = gifFile->SavedImages[i];
 
@@ -135,7 +147,8 @@ torch::Tensor decode_gif(const torch::Tensor& encoded_data) {
         (gcb.DisposalMode == DISPOSAL_UNSPECIFIED ||
          gcb.DisposalMode == DISPOSE_DO_NOT ||
          gcb.DisposalMode == DISPOSE_PREVIOUS)) {
-      out[i] = out[i - 1];
+      auto dst = torch::stable::select(out, 0, i);
+      torch::stable::copy_(dst, torch::stable::select(out, 0, i - 1));
     } else {
       // Background. If bg wasn't defined, it will be (0, 0, 0)
       for (int h = 0; h < gifFile->SHeight; h++) {
@@ -174,12 +187,21 @@ torch::Tensor decode_gif(const torch::Tensor& encoded_data) {
     }
   }
 
-  out = out.squeeze(0); // remove batch dim if there's only one image
+  out = torch::stable::squeeze(
+      out, 0); // remove batch dim if there's only one image
 
   DGifCloseFile(gifFile, &error);
   STD_TORCH_CHECK(error == D_GIF_SUCCEEDED, "DGifCloseFile() failed - ", error);
 
   return out;
+}
+
+STABLE_TORCH_LIBRARY_FRAGMENT(image, m) {
+  m.def("decode_gif(Tensor data) -> Tensor");
+}
+
+STABLE_TORCH_LIBRARY_IMPL(image, CompositeExplicitAutograd, m) {
+  m.impl("decode_gif", TORCH_BOX(&decode_gif));
 }
 
 } // namespace image

--- a/torchvision/csrc/io/image/cpu/decode_gif.h
+++ b/torchvision/csrc/io/image/cpu/decode_gif.h
@@ -1,12 +1,12 @@
 #pragma once
 
-#include <torch/types.h>
+#include <torch/csrc/stable/tensor.h>
 
 namespace vision {
 namespace image {
 
 // encoded_data tensor must be 1D uint8 and contiguous
-C10_EXPORT torch::Tensor decode_gif(const torch::Tensor& encoded_data);
+torch::stable::Tensor decode_gif(const torch::stable::Tensor& encoded_data);
 
 } // namespace image
 } // namespace vision

--- a/torchvision/csrc/io/image/cpu/decode_image.cpp
+++ b/torchvision/csrc/io/image/cpu/decode_image.cpp
@@ -5,6 +5,7 @@
 
 #include <cstring>
 
+#include "decode_gif.h"
 #include "decode_jpeg.h"
 #include "decode_png.h"
 
@@ -13,17 +14,9 @@ namespace image {
 
 namespace {
 
-// Shims over the legacy image::decode_gif and decode_webp ops
+// Shim over the legacy image::decode_webp op
 // not yet on the stable ABI.
-// TODO(stable-abi): remove each shim once its decoder is ported.
-torch::stable::Tensor decode_gif(const torch::stable::Tensor& data) {
-  const auto num_args = 1;
-  std::array<StableIValue, num_args> stack{torch::stable::detail::from(data)};
-  TORCH_ERROR_CODE_CHECK(torch_call_dispatcher(
-      "image::decode_gif", "", stack.data(), TORCH_ABI_VERSION));
-  return torch::stable::detail::to<torch::stable::Tensor>(stack[0]);
-}
-
+// TODO(stable-abi): remove the shim once the decoder is ported.
 torch::stable::Tensor decode_webp(
     const torch::stable::Tensor& data,
     ImageReadMode mode) {

--- a/torchvision/csrc/io/image/image.cpp
+++ b/torchvision/csrc/io/image/image.cpp
@@ -5,11 +5,9 @@
 namespace vision {
 namespace image {
 
-static auto registry =
-    torch::RegisterOperators()
-        .op("image::decode_gif", &decode_gif)
-        .op("image::decode_webp(Tensor encoded_data, int mode) -> Tensor",
-            &decode_webp);
+static auto registry = torch::RegisterOperators().op(
+    "image::decode_webp(Tensor encoded_data, int mode) -> Tensor",
+    &decode_webp);
 
 } // namespace image
 } // namespace vision

--- a/torchvision/csrc/io/image/image.h
+++ b/torchvision/csrc/io/image/image.h
@@ -1,4 +1,3 @@
 #pragma once
 
-#include "cpu/decode_gif.h"
 #include "cpu/decode_webp.h"


### PR DESCRIPTION
Ports CPU gif decoder to stable ABI.

## Notes
- Vendored giflib C sources build into `image_stable` now.

## Stable-ABI audit (`torch-abi-audit`)
Ran [`torch-abi-audit`](https://github.com/Quansight/torch-abi-audit) against the built `torchvision` package. **`image_stable.so` audits as `STABLE` — 75 stable-shim symbols, 0 unstable** The legacy `image.so` drops 34 → 29 unstable.
```text
    Package: torchvision
      Torch ABI:   UNSTABLE
      CPython ABI: n/a
      Bundled libs: 4
      -- bundled libs --
        [UNSTABLE] [not-abi3        ] _C.so            (stable_shim=0,  unstable=110)
        [STABLE  ] [not-abi3        ] _C_stable.so     (stable_shim=67, unstable=0)
        [UNSTABLE] [uses-private-api] image.so         (stable_shim=0,  unstable=29)
        [STABLE  ] [not-abi3        ] image_stable.so  (stable_shim=75, unstable=0)
```