### PR TITLE
Fix vertical_flip_bounding_boxes wrong corner reorder for XYXYXYXY format

### DIFF
--- a/torchvision/transforms/v2/functional/_geometry.py
+++ b/torchvision/transforms/v2/functional/_geometry.py
@@ -195,7 +195,7 @@ def vertical_flip_bounding_boxes(
         bounding_boxes[:, 1].sub_(canvas_size[0]).neg_()
     elif format == tv_tensors.BoundingBoxFormat.XYXYXYXY:
         bounding_boxes[:, 1::2].sub_(canvas_size[0]).neg_()
-        bounding_boxes = bounding_boxes[:, [2, 3, 0, 1, 6, 7, 4, 5]]
+        bounding_boxes = bounding_boxes[:, [6, 7, 4, 5, 2, 3, 0, 1]]
     elif format == tv_tensors.BoundingBoxFormat.XYWHR:
         angle_rad = bounding_boxes[:, 4].mul(torch.pi).div(180)
         bounding_boxes[:, 1].sub_(bounding_boxes[:, 2].mul(angle_rad.sin())).sub_(canvas_size[0]).neg_()


### PR DESCRIPTION
## Summary

`vertical_flip_bounding_boxes` used the same corner reordering index as
`horizontal_flip_bounding_boxes` for the `XYXYXYXY` format — a copy-paste
error that produces corners in the wrong order after a vertical flip.

## Root Cause

`XYXYXYXY` stores four corners as `[TL, TR, BR, BL]` (indices 0–7, pairs of xy).
After flipping all y-coordinates:

- **Horizontal flip** swaps TL↔TR and BL↔BR → reorder `[2,3, 0,1, 6,7, 4,5]` ✓
- **Vertical flip** swaps TL↔BL and TR↔BR → reorder must be `[6,7, 4,5, 2,3, 0,1]`

The vertical-flip path was incorrectly reusing the horizontal-flip index
`[2, 3, 0, 1, 6, 7, 4, 5]`, returning corners as `[old-TR, old-TL, old-BL, old-BR]`
instead of the correct `[new-TL, new-TR, new-BR, new-BL]`.

## Fix

```python
# Before (wrong — copy-pasted from horizontal_flip)
bounding_boxes = bounding_boxes[:, [2, 3, 0, 1, 6, 7, 4, 5]]

# After (correct for vertical flip)
bounding_boxes = bounding_boxes[:, [6, 7, 4, 5, 2, 3, 0, 1]]