### PR TITLE
Port box_iou_rotated to stable ABI.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,9 @@ set(TORCHVISION_STABLE_SOURCES
   ${TVCPP}/ops/nms.cpp
   ${TVCPP}/ops/cpu/nms_kernel.cpp
   ${TVCPP}/ops/cuda/nms_kernel.cu
+  ${TVCPP}/ops/box_iou_rotated.cpp
+  ${TVCPP}/ops/cpu/box_iou_rotated_kernel.cpp
+  ${TVCPP}/ops/cuda/box_iou_rotated_kernel.cu
   ${TVCPP}/io/image/cuda/decode_jpegs_cuda.cpp
   ${TVCPP}/io/image/cuda/encode_jpegs_cuda.cpp
   ${TVCPP}/io/image/cpu/encode_png.cpp

--- a/setup.py
+++ b/setup.py
@@ -164,8 +164,13 @@ STABLE_SOURCES = {
     CSRS_DIR / "ops/cpu/nms_kernel.cpp",
     CSRS_DIR / "ops/mps/nms_kernel.mm",
     CSRS_DIR / "ops/quantized/cpu/qnms_kernel.cpp",
+    CSRS_DIR / "ops/box_iou_rotated.cpp",
+    CSRS_DIR / "ops/cpu/box_iou_rotated_kernel.cpp",
 }
 STABLE_SOURCES.add(CSRS_DIR / ("ops/hip/nms_kernel.hip" if IS_ROCM else "ops/cuda/nms_kernel.cu"))
+STABLE_SOURCES.add(
+    CSRS_DIR / ("ops/hip/box_iou_rotated_kernel.hip" if IS_ROCM else "ops/cuda/box_iou_rotated_kernel.cu")
+)
 
 
 def _not_stable(paths):

--- a/torchvision/csrc/ops/box_iou_rotated.cpp
+++ b/torchvision/csrc/ops/box_iou_rotated.cpp
@@ -6,25 +6,29 @@
 
 #include "box_iou_rotated.h"
 
-#include <ATen/core/dispatch/Dispatcher.h>
-#include <torch/library.h>
-#include <torch/types.h>
+#include <torch/csrc/stable/c/shim.h>
+#include <torch/csrc/stable/library.h>
+#include <torch/csrc/stable/stableivalue_conversions.h>
+#include <torch/headeronly/util/shim_utils.h>
+#include <torch/headeronly/version.h>
+
+#include <array>
 
 namespace vision {
 namespace ops {
 
-at::Tensor box_iou_rotated(const at::Tensor& boxes1, const at::Tensor& boxes2) {
-  C10_LOG_API_USAGE_ONCE(
-      "torchvision.csrc.ops.box_iou_rotated.box_iou_rotated");
-  static auto op = c10::Dispatcher::singleton()
-                       .findSchemaOrThrow("torchvision::box_iou_rotated", "")
-                       .typed<decltype(box_iou_rotated)>();
-  return op.call(boxes1, boxes2);
+using torch::stable::Tensor;
+
+Tensor box_iou_rotated(const Tensor& boxes1, const Tensor& boxes2) {
+  std::array<StableIValue, 2> stack{
+      torch::stable::detail::from(boxes1), torch::stable::detail::from(boxes2)};
+  TORCH_ERROR_CODE_CHECK(torch_call_dispatcher(
+      "torchvision::box_iou_rotated", "", stack.data(), TORCH_ABI_VERSION));
+  return torch::stable::detail::to<Tensor>(stack[0]);
 }
 
-TORCH_LIBRARY_FRAGMENT(torchvision, m) {
-  m.def(TORCH_SELECTIVE_SCHEMA(
-      "torchvision::box_iou_rotated(Tensor boxes1, Tensor boxes2) -> Tensor"));
+STABLE_TORCH_LIBRARY_FRAGMENT(torchvision, m) {
+  m.def("box_iou_rotated(Tensor boxes1, Tensor boxes2) -> Tensor");
 }
 
 } // namespace ops

--- a/torchvision/csrc/ops/box_iou_rotated.h
+++ b/torchvision/csrc/ops/box_iou_rotated.h
@@ -6,15 +6,15 @@
 
 #pragma once
 
-#include <ATen/ATen.h>
+#include <torch/csrc/stable/tensor.h>
 #include "../macros.h"
 
 namespace vision {
 namespace ops {
 
-VISION_API at::Tensor box_iou_rotated(
-    const at::Tensor& boxes1,
-    const at::Tensor& boxes2);
+VISION_API torch::stable::Tensor box_iou_rotated(
+    const torch::stable::Tensor& boxes1,
+    const torch::stable::Tensor& boxes2);
 
 } // namespace ops
 } // namespace vision

--- a/torchvision/csrc/ops/cpu/box_iou_rotated_kernel.cpp
+++ b/torchvision/csrc/ops/cpu/box_iou_rotated_kernel.cpp
@@ -9,8 +9,13 @@
 // Original source: https://github.com/facebookresearch/detectron2
 // License: https://github.com/facebookresearch/detectron2/blob/main/LICENSE
 
-#include <ATen/ATen.h>
-#include <torch/library.h>
+#include <torch/csrc/stable/library.h>
+#include <torch/csrc/stable/ops.h>
+#include <torch/csrc/stable/tensor.h>
+#include <torch/headeronly/core/Dispatch_v2.h>
+#include <torch/headeronly/core/TensorAccessor.h>
+
+#include <cstdint>
 
 #include "../box_iou_rotated_utils.h"
 
@@ -19,18 +24,29 @@ namespace ops {
 
 namespace {
 
+using torch::stable::Tensor;
+
 template <typename T>
 void box_iou_rotated_cpu_kernel(
-    const at::Tensor& boxes1,
-    const at::Tensor& boxes2,
-    at::Tensor& ious) {
+    const Tensor& boxes1,
+    const Tensor& boxes2,
+    Tensor& ious) {
   auto num_boxes1 = boxes1.size(0);
   auto num_boxes2 = boxes2.size(0);
 
   // Use accessors for efficient element access
-  auto boxes1_a = boxes1.accessor<T, 2>();
-  auto boxes2_a = boxes2.accessor<T, 2>();
-  auto ious_a = ious.accessor<float, 1>();
+  auto boxes1_a = torch::headeronly::HeaderOnlyTensorAccessor<const T, 2>(
+      boxes1.const_data_ptr<T>(),
+      boxes1.sizes().data(),
+      boxes1.strides().data());
+  auto boxes2_a = torch::headeronly::HeaderOnlyTensorAccessor<const T, 2>(
+      boxes2.const_data_ptr<T>(),
+      boxes2.sizes().data(),
+      boxes2.strides().data());
+  auto ious_a = torch::headeronly::HeaderOnlyTensorAccessor<float, 1>(
+      ious.mutable_data_ptr<float>(),
+      ious.sizes().data(),
+      ious.strides().data());
 
   for (int64_t i = 0; i < num_boxes1; i++) {
     for (int64_t j = 0; j < num_boxes2; j++) {
@@ -40,21 +56,35 @@ void box_iou_rotated_cpu_kernel(
   }
 }
 
-at::Tensor box_iou_rotated_cpu(
+Tensor box_iou_rotated_cpu(
     // input must be contiguous:
-    const at::Tensor& boxes1,
-    const at::Tensor& boxes2) {
-  TORCH_CHECK(boxes1.is_cpu(), "boxes1 must be a CPU tensor");
-  TORCH_CHECK(boxes2.is_cpu(), "boxes2 must be a CPU tensor");
-  TORCH_CHECK(
-      boxes1.dim() == 2 && boxes1.size(1) == 5,
-      "boxes1 should have shape (N, 5), got ",
-      boxes1.sizes());
-  TORCH_CHECK(
-      boxes2.dim() == 2 && boxes2.size(1) == 5,
-      "boxes2 should have shape (M, 5), got ",
-      boxes2.sizes());
-  TORCH_CHECK(
+    const Tensor& boxes1,
+    const Tensor& boxes2) {
+  STD_TORCH_CHECK(boxes1.is_cpu(), "boxes1 must be a CPU tensor");
+  STD_TORCH_CHECK(boxes2.is_cpu(), "boxes2 must be a CPU tensor");
+  // Stable-ABI sizes() has no operator << to stream into STD_TORCH_CHECK.
+  // Modeled after torchcodec:
+  // https://github.com/meta-pytorch/torchcodec/blob/1dc85b7a7900d91fee207ccdc02f211a051688fe/src/torchcodec/_core/Encoder.cpp#L140-L147
+  // TODO(stable-abi): adopt << once it lands in the stable ABI upstream.
+  STD_TORCH_CHECK(
+      boxes1.dim() == 2,
+      "boxes1 should be a 2d tensor, got ",
+      boxes1.dim(),
+      "D");
+  STD_TORCH_CHECK(
+      boxes1.size(1) == 5,
+      "boxes1 should have 5 elements in dimension 1, got ",
+      boxes1.size(1));
+  STD_TORCH_CHECK(
+      boxes2.dim() == 2,
+      "boxes2 should be a 2d tensor, got ",
+      boxes2.dim(),
+      "D");
+  STD_TORCH_CHECK(
+      boxes2.size(1) == 5,
+      "boxes2 should have 5 elements in dimension 1, got ",
+      boxes2.size(1));
+  STD_TORCH_CHECK(
       boxes1.scalar_type() == boxes2.scalar_type(),
       "boxes1 and boxes2 must have the same dtype");
 
@@ -62,30 +92,32 @@ at::Tensor box_iou_rotated_cpu(
   auto num_boxes2 = boxes2.size(0);
 
   if (num_boxes1 == 0 || num_boxes2 == 0) {
-    return at::empty(
-        {num_boxes1, num_boxes2}, boxes1.options().dtype(at::kFloat));
+    return torch::stable::new_empty(
+        boxes1, {num_boxes1, num_boxes2}, torch::headeronly::ScalarType::Float);
   }
 
-  auto boxes1_contiguous = boxes1.contiguous();
-  auto boxes2_contiguous = boxes2.contiguous();
+  auto boxes1_contiguous = torch::stable::contiguous(boxes1);
+  auto boxes2_contiguous = torch::stable::contiguous(boxes2);
 
-  at::Tensor ious =
-      at::empty({num_boxes1 * num_boxes2}, boxes1.options().dtype(at::kFloat));
+  Tensor ious = torch::stable::new_empty(
+      boxes1, {num_boxes1 * num_boxes2}, torch::headeronly::ScalarType::Float);
 
-  AT_DISPATCH_FLOATING_TYPES(boxes1.scalar_type(), "box_iou_rotated_cpu", [&] {
-    box_iou_rotated_cpu_kernel<scalar_t>(
-        boxes1_contiguous, boxes2_contiguous, ious);
-  });
+  THO_DISPATCH_V2(
+      boxes1.scalar_type(),
+      "box_iou_rotated_cpu",
+      AT_WRAP([&]() {
+        box_iou_rotated_cpu_kernel<scalar_t>(
+            boxes1_contiguous, boxes2_contiguous, ious);
+      }),
+      AT_EXPAND(AT_FLOATING_TYPES));
 
-  return ious.reshape({num_boxes1, num_boxes2});
+  return torch::stable::reshape(ious, {num_boxes1, num_boxes2});
 }
 
 } // namespace
 
-TORCH_LIBRARY_IMPL(torchvision, CPU, m) {
-  m.impl(
-      TORCH_SELECTIVE_NAME("torchvision::box_iou_rotated"),
-      TORCH_FN(box_iou_rotated_cpu));
+STABLE_TORCH_LIBRARY_IMPL(torchvision, CPU, m) {
+  m.impl("box_iou_rotated", TORCH_BOX(&box_iou_rotated_cpu));
 }
 
 } // namespace ops

--- a/torchvision/csrc/ops/cpu/box_iou_rotated_kernel.cpp
+++ b/torchvision/csrc/ops/cpu/box_iou_rotated_kernel.cpp
@@ -62,10 +62,10 @@ Tensor box_iou_rotated_cpu(
     const Tensor& boxes2) {
   STD_TORCH_CHECK(boxes1.is_cpu(), "boxes1 must be a CPU tensor");
   STD_TORCH_CHECK(boxes2.is_cpu(), "boxes2 must be a CPU tensor");
-  // Stable-ABI sizes() has no operator << to stream into STD_TORCH_CHECK.
-  // Modeled after torchcodec:
+  // Stable-ABI sizes() is not streamable so the checks split to guard size(1):
   // https://github.com/meta-pytorch/torchcodec/blob/1dc85b7a7900d91fee207ccdc02f211a051688fe/src/torchcodec/_core/Encoder.cpp#L140-L147
-  // TODO(stable-abi): adopt << once it lands in the stable ABI upstream.
+  // TODO(stable-abi): print sizes() in the error message once it can be
+  // streamed.
   STD_TORCH_CHECK(
       boxes1.dim() == 2,
       "boxes1 should be a 2d tensor, got ",

--- a/torchvision/csrc/ops/cuda/box_iou_rotated_kernel.cu
+++ b/torchvision/csrc/ops/cuda/box_iou_rotated_kernel.cu
@@ -9,18 +9,30 @@
 // Original source: https://github.com/facebookresearch/detectron2
 // License: https://github.com/facebookresearch/detectron2/blob/main/LICENSE
 
-#include <ATen/ATen.h>
-#include <ATen/cuda/CUDAContext.h>
-#include <c10/cuda/CUDAGuard.h>
-#include <torch/library.h>
-#include <ATen/cuda/CUDAApplyUtils.cuh>
+#include <torch/csrc/inductor/aoti_torch/c/shim.h>
+#include <torch/csrc/stable/accelerator.h>
+#include <torch/csrc/stable/library.h>
+#include <torch/csrc/stable/macros.h>
+#include <torch/csrc/stable/ops.h>
+#include <torch/csrc/stable/tensor.h>
+#include <torch/headeronly/core/Dispatch_v2.h>
+#include <torch/headeronly/core/ScalarType.h>
+#include <torch/headeronly/util/Exception.h>
+
+#include <cuda_runtime.h>
+
+#include <utility>
+#include <vector>
 
 #include "../box_iou_rotated_utils.h"
+#include "cuda_helpers.h"
 
 namespace vision {
 namespace ops {
 
 namespace {
+
+using torch::stable::Tensor;
 
 // 2D block with 32 * 16 = 512 threads per block
 const int BLOCK_DIM_X = 32;
@@ -77,27 +89,45 @@ __global__ void box_iou_rotated_cuda_kernel(
   }
 }
 
-at::Tensor box_iou_rotated_cuda(
+// THO_DISPATCH_V2 splits its body on commas outside parens. The commas in
+// kernel<<<blocks, threads, 0, stream>>> would break it, so it goes through
+// this wrapper.
+template <typename scalar_t>
+void launch_box_iou_rotated_cuda_kernel(
+    dim3 blocks,
+    dim3 threads,
+    cudaStream_t stream,
+    int n_boxes1,
+    int n_boxes2,
+    const scalar_t* boxes1,
+    const scalar_t* boxes2,
+    float* ious) {
+  box_iou_rotated_cuda_kernel<scalar_t><<<blocks, threads, 0, stream>>>(
+      n_boxes1, n_boxes2, boxes1, boxes2, ious);
+}
+
+Tensor box_iou_rotated_cuda(
     // input must be contiguous
-    const at::Tensor& boxes1,
-    const at::Tensor& boxes2) {
-  TORCH_CHECK(boxes1.is_cuda(), "boxes1 must be a CUDA tensor");
-  TORCH_CHECK(boxes2.is_cuda(), "boxes2 must be a CUDA tensor");
-  TORCH_CHECK(
+    const Tensor& boxes1,
+    const Tensor& boxes2) {
+  STD_TORCH_CHECK(boxes1.is_cuda(), "boxes1 must be a CUDA tensor");
+  STD_TORCH_CHECK(boxes2.is_cuda(), "boxes2 must be a CUDA tensor");
+  STD_TORCH_CHECK(
       boxes1.scalar_type() == boxes2.scalar_type(),
       "boxes1 and boxes2 must have the same dtype");
-  at::cuda::CUDAGuard device_guard(boxes1.device());
+  torch::stable::accelerator::DeviceGuard device_guard(
+      boxes1.get_device_index());
 
   auto num_boxes1 = boxes1.size(0);
   auto num_boxes2 = boxes2.size(0);
 
-  at::Tensor ious =
-      at::empty({num_boxes1 * num_boxes2}, boxes1.options().dtype(at::kFloat));
+  Tensor ious = torch::stable::new_empty(
+      boxes1, {num_boxes1 * num_boxes2}, torch::headeronly::ScalarType::Float);
 
   bool transpose = false;
   if (num_boxes1 > 0 && num_boxes2 > 0) {
     if (num_boxes2 > 65535 * BLOCK_DIM_Y) {
-      TORCH_CHECK(
+      STD_TORCH_CHECK(
           num_boxes1 <= 65535 * BLOCK_DIM_Y,
           "Too many boxes for box_iou_rotated_cuda!");
       // x dim is allowed to be large, but y dim cannot,
@@ -108,48 +138,59 @@ at::Tensor box_iou_rotated_cuda(
       transpose = true;
     }
 
-    const int blocks_x =
-        at::cuda::ATenCeilDiv(static_cast<int>(num_boxes1), BLOCK_DIM_X);
-    const int blocks_y =
-        at::cuda::ATenCeilDiv(static_cast<int>(num_boxes2), BLOCK_DIM_Y);
+    const int blocks_x = ceil_div(static_cast<int>(num_boxes1), BLOCK_DIM_X);
+    const int blocks_y = ceil_div(static_cast<int>(num_boxes2), BLOCK_DIM_Y);
 
     dim3 blocks(blocks_x, blocks_y);
     dim3 threads(BLOCK_DIM_X, BLOCK_DIM_Y);
-    cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
-    AT_DISPATCH_FLOATING_TYPES(
-        boxes1.scalar_type(), "box_iou_rotated_cuda", [&] {
-          scalar_t *data1, *data2;
+    void* stream_ptr = nullptr;
+    TORCH_ERROR_CODE_CHECK(aoti_torch_get_current_cuda_stream(
+        boxes1.get_device_index(), &stream_ptr));
+    cudaStream_t stream = static_cast<cudaStream_t>(stream_ptr);
+
+    THO_DISPATCH_V2(
+        boxes1.scalar_type(),
+        "box_iou_rotated_cuda",
+        AT_WRAP([&]() {
+          const scalar_t* data1;
+          const scalar_t* data2;
           if (transpose) {
-            data1 = boxes2.data_ptr<scalar_t>();
-            data2 = boxes1.data_ptr<scalar_t>();
+            data1 = boxes2.const_data_ptr<scalar_t>();
+            data2 = boxes1.const_data_ptr<scalar_t>();
           } else {
-            data1 = boxes1.data_ptr<scalar_t>();
-            data2 = boxes2.data_ptr<scalar_t>();
+            data1 = boxes1.const_data_ptr<scalar_t>();
+            data2 = boxes2.const_data_ptr<scalar_t>();
           }
 
-          box_iou_rotated_cuda_kernel<scalar_t><<<blocks, threads, 0, stream>>>(
-              num_boxes1, num_boxes2, data1, data2, ious.data_ptr<float>());
-        });
+          launch_box_iou_rotated_cuda_kernel<scalar_t>(
+              blocks,
+              threads,
+              stream,
+              num_boxes1,
+              num_boxes2,
+              data1,
+              data2,
+              ious.mutable_data_ptr<float>());
+        }),
+        AT_EXPAND(AT_FLOATING_TYPES));
 
-    AT_CUDA_CHECK(cudaGetLastError());
+    STD_CUDA_KERNEL_LAUNCH_CHECK();
   }
 
   // reshape from 1d array to 2d array
   auto shape = std::vector<int64_t>{num_boxes1, num_boxes2};
   if (transpose) {
-    return ious.view(shape).t();
+    return torch::stable::transpose(torch::stable::view(ious, shape), 0, 1);
   } else {
-    return ious.view(shape);
+    return torch::stable::view(ious, shape);
   }
 }
 
 } // namespace
 
-TORCH_LIBRARY_IMPL(torchvision, CUDA, m) {
-  m.impl(
-      TORCH_SELECTIVE_NAME("torchvision::box_iou_rotated"),
-      TORCH_FN(box_iou_rotated_cuda));
+STABLE_TORCH_LIBRARY_IMPL(torchvision, CUDA, m) {
+  m.impl("box_iou_rotated", TORCH_BOX(&box_iou_rotated_cuda));
 }
 
 } // namespace ops


### PR DESCRIPTION
Ports `box_iou_rotated` (CPU + CUDA/ROCm) to the stable ABI. 

## Notes
- CUDA launch goes through a `launch_*` wrapper, `THO_DISPATCH_V2` splits its body on commas outside parens. Same pattern as [`nms_kernel.cu`](https://github.com/pytorch/vision/blob/f23f832d090c868691855cc1261ed907e400c2a2/torchvision/csrc/ops/cuda/nms_kernel.cu#L150-L164).

## Stable-ABI audit (`torch-abi-audit`)
Ran [`torch-abi-audit`](https://github.com/Quansight/torch-abi-audit) against the built `torchvision` package. The legacy `_C.so` drops 110 → 107 unstable as `box_iou_rotated` moves over.

```text
      Package: torchvision
        Torch ABI:   UNSTABLE
        CPython ABI: n/a
        Bundled libs: 3
        -- bundled libs --
          [UNSTABLE] [not-abi3        ] _C.so            (stable_shim=0,  unstable=107)
          [STABLE  ] [not-abi3        ] _C_stable.so     (stable_shim=69, unstable=0)
          [STABLE  ] [not-abi3        ] image_stable.so  (stable_shim=76, unstable=0)

---