### PR TITLE
[Pillow] pytorch: flip pillow 9.4.0 -> 12.2.0 (#9559)

### DIFF
--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -175,7 +175,7 @@ class TestAccImage:
     def test_accimage_resize(self):
         trans = transforms.Compose(
             [
-                transforms.Resize(256, interpolation=Image.LINEAR),
+                transforms.Resize(256, interpolation=Image.Resampling.BILINEAR),
                 transforms.PILToTensor(),
                 transforms.ConvertImageDtype(dtype=torch.float),
             ]


### PR DESCRIPTION
Summary:

Flips the `pypi/pillow` pin from 9.4.0 to the repo default 12.2.0 for `fbcode/pytorch/`, part of the Pillow default-flip enablement (T274839644), and migrates the removed Pillow APIs in the vendored tensorboardX lib and a torchvision test: `Image.ANTIALIAS` -> `Image.Resampling.LANCZOS` and `ImageFont.getsize` -> `getbbox` in `tensorboardX/summary.py`, and `Image.LINEAR` -> `Image.Resampling.BILINEAR` in `vision/test/test_transforms.py`.

Reviewed By: itamaro

Differential Revision: D112190260


