### PR TITLE
Fix DTD partition validation using `and` instead of `or`

### DIFF
--- a/torchvision/datasets/dtd.py
+++ b/torchvision/datasets/dtd.py
@@ -46,7 +46,7 @@ class DTD(VisionDataset):
         loader: Callable[[Union[str, pathlib.Path]], Any] = default_loader,
     ) -> None:
         self._split = verify_str_arg(split, "split", ("train", "val", "test"))
-        if not isinstance(partition, int) and not (1 <= partition <= 10):
+        if not isinstance(partition, int) or not (1 <= partition <= 10):
             raise ValueError(
                 f"Parameter 'partition' should be an integer with `1 <= partition <= 10`, "
                 f"but got {partition} instead"


### PR DESCRIPTION
## Problem

`DTD.__init__` (`torchvision/datasets/dtd.py`) validates the `partition` argument with `and`:

```python
if not isinstance(partition, int) and not (1 <= partition <= 10):
    raise ValueError(
        f"Parameter 'partition' should be an integer with `1 <= partition <= 10`, "
        f"but got {partition} instead"
    )
```

The intent is to reject any value that isn't an int in `[1, 10]`. The correct predicate is `not (isinstance(partition, int) and 1 <= partition <= 10)`, which by De Morgan is `not isinstance(...) or not (1 <= ... <= 10)`. With `and`, the error fires only when the value is *both* a non-int *and* out of range — so a normal out-of-range int like `11` (`not isinstance(11, int)` → `False`) short-circuits the `and` to `False` and passes validation.

## Impact

`DTD(root, partition=11)` (or `0`, `-3`) slips past the check and then dies later at:

```python
open(self._meta_folder / f"{self._split}{self._partition}.txt")
```

with an opaque `FileNotFoundError: ...train11.txt` instead of the documented `ValueError`. A `str` partition like `"1"` raises `TypeError` from `1 <= "1"` for the same reason (the `or` fix short-circuits before the comparison and handles that too). `torchvision.datasets.DTD` is public and `partition` is a documented constructor arg; the error message in this very statement documents the contract the guard fails to enforce.

## Reproduction

| partition | before (`and`) | after (`or`) |
|---|---|---|
| 1, 10 | accepted | accepted |
| 11, 0, -3 | **accepted** ❌ (later `FileNotFoundError`) | `ValueError` ✅ |
| `"1"` | `TypeError` | `ValueError` ✅ |

## Fix

```python
if not isinstance(partition, int) or not (1 <= partition <= 10):
```
