### PR TITLE
Unblock CI after recent torch nightly changes.

### DIFF
--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -15,4 +15,4 @@ if(USE_TORCHVISION)
   target_link_libraries(run_model TorchVision::TorchVision)
 endif()
 
-set_property(TARGET run_model PROPERTY CXX_STANDARD 17)
+set_property(TARGET run_model PROPERTY CXX_STANDARD 20)

--- a/test/test_transforms_v2.py
+++ b/test/test_transforms_v2.py
@@ -67,6 +67,7 @@ pytestmark = [pytest.mark.filterwarnings("error")]
 
 # Since torchscript is deprecated, we are explicitly ignoring those warnings.
 # Otherwise we'd error on warnings due to the pytestmark filter above.
+pytestmark.append(pytest.mark.filterwarnings("ignore::DeprecationWarning"))
 pytestmark.append(pytest.mark.filterwarnings("ignore::FutureWarning"))
 
 

--- a/test/test_transforms_v2.py
+++ b/test/test_transforms_v2.py
@@ -67,7 +67,7 @@ pytestmark = [pytest.mark.filterwarnings("error")]
 
 # Since torchscript is deprecated, we are explicitly ignoring those warnings.
 # Otherwise we'd error on warnings due to the pytestmark filter above.
-pytestmark.append(pytest.mark.filterwarnings("ignore::DeprecationWarning"))
+pytestmark.append(pytest.mark.filterwarnings("ignore::FutureWarning"))
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
Unblocks CI after two unrelated torch nightly changes.

- pytorch/pytorch#189914 switched the torchscript deprecation warnings from `DeprecationWarning` to `FutureWarning` so they're visible by default, which slipped past this module's existing `ignore::DeprecationWarning` filter.
- pytorch/pytorch#178150 enforces a C++20 minimum in the ATen header guards, which broke the cmake job since `examples/cpp` still pinned `CXX_STANDARD 17`.
