### PR TITLE
[MPS] Fix overaccumulation in ROI ops

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -729,6 +729,34 @@ class TestPSRoIAlign(RoIOpTester):
 
 
 @pytest.mark.parametrize(
+    "device",
+    (
+        pytest.param("cuda", marks=pytest.mark.needs_cuda),
+        pytest.param("mps", marks=pytest.mark.needs_mps),
+    ),
+)
+@pytest.mark.parametrize(
+    "op", (ops.roi_pool, ops.ps_roi_pool, ops.ps_roi_align), ids=("roi_pool", "ps_roi_pool", "ps_roi_align")
+)
+def test_roi_pooling_grad_sum(device, op):
+    pool_size = 4
+
+    def run(device):
+        x = torch.ones(1, 64, 8, 8, dtype=torch.float32, device=device, requires_grad=True)
+        # 17 RoIs make the PS outputs 1,088 elements, forcing a partial tail threadgroup.
+        rois = torch.tensor([[0.0, 0, 0, 7, 7]], device=device).repeat(17, 1)
+        output = op(x, rois, [pool_size, pool_size])
+        output.sum().backward()
+        return output.detach().cpu(), x.grad.detach().cpu()
+
+    output, grad = run(device)
+    _, expected_grad = run("cpu")
+    torch.testing.assert_close(output, torch.ones_like(output))
+    torch.testing.assert_close(grad, expected_grad)
+    torch.testing.assert_close(grad.sum(), output.new_tensor(output.numel()))
+
+
+@pytest.mark.parametrize(
     "op",
     (
         torch.ops.torchvision.roi_pool,

--- a/torchvision/csrc/ops/mps/mps_kernels.h
+++ b/torchvision/csrc/ops/mps/mps_kernels.h
@@ -614,61 +614,66 @@ kernel void roi_pool(
     constant T       * rois          [[buffer(1)]],
     device   T       * output        [[buffer(2)]],
     device   int64_t * argmax        [[buffer(3)]],
-    constant int64_t & channels      [[buffer(4)]],
-    constant int64_t & height        [[buffer(5)]],
-    constant int64_t & width         [[buffer(6)]],
-    constant int64_t & pooled_height [[buffer(7)]],
-    constant int64_t & pooled_width  [[buffer(8)]],
-    constant float   & spatial_scale [[buffer(9)]],
-    uint     index   [[thread_position_in_grid]]){
-  // (n, c, ph, pw) is an element in the pooled output
-  integer_t pw = index % pooled_width;
-  integer_t ph = (index / pooled_width) % pooled_height;
-  integer_t c = (index / pooled_width / pooled_height) % channels;
-  integer_t n = index / pooled_width / pooled_height / channels;
+    constant int64_t & output_size   [[buffer(4)]],
+    constant int64_t & channels      [[buffer(5)]],
+    constant int64_t & height        [[buffer(6)]],
+    constant int64_t & width         [[buffer(7)]],
+    constant int64_t & pooled_height [[buffer(8)]],
+    constant int64_t & pooled_width  [[buffer(9)]],
+    constant float   & spatial_scale [[buffer(10)]],
+    uint2     tgid   [[threadgroup_position_in_grid]],
+    uint2     tptg   [[threads_per_threadgroup]],
+    uint2     tid2   [[thread_position_in_threadgroup]]){
+  MPS_1D_KERNEL_LOOP(index, output_size, 1) {
+    // (n, c, ph, pw) is an element in the pooled output
+    integer_t pw = index % pooled_width;
+    integer_t ph = (index / pooled_width) % pooled_height;
+    integer_t c = (index / pooled_width / pooled_height) % channels;
+    integer_t n = index / pooled_width / pooled_height / channels;
 
-  constant T* offset_rois = rois + n * 5;
-  integer_t roi_batch_ind = offset_rois[0];
-  integer_t roi_start_w = round(offset_rois[1] * spatial_scale);
-  integer_t roi_start_h = round(offset_rois[2] * spatial_scale);
-  integer_t roi_end_w = round(offset_rois[3] * spatial_scale);
-  integer_t roi_end_h = round(offset_rois[4] * spatial_scale);
+    constant T* offset_rois = rois + n * 5;
+    integer_t roi_batch_ind = offset_rois[0];
+    integer_t roi_start_w = round(offset_rois[1] * spatial_scale);
+    integer_t roi_start_h = round(offset_rois[2] * spatial_scale);
+    integer_t roi_end_w = round(offset_rois[3] * spatial_scale);
+    integer_t roi_end_h = round(offset_rois[4] * spatial_scale);
 
-  // Force malformed ROIs to be 1x1
-  integer_t roi_width = max(roi_end_w - roi_start_w + 1, static_cast<integer_t>(1));
-  integer_t roi_height = max(roi_end_h - roi_start_h + 1, static_cast<integer_t>(1));
-  T bin_size_h = static_cast<T>(roi_height) / static_cast<T>(pooled_height);
-  T bin_size_w = static_cast<T>(roi_width) / static_cast<T>(pooled_width);
+    // Force malformed ROIs to be 1x1
+    integer_t roi_width = max(roi_end_w - roi_start_w + 1, static_cast<integer_t>(1));
+    integer_t roi_height = max(roi_end_h - roi_start_h + 1, static_cast<integer_t>(1));
+    T bin_size_h = static_cast<T>(roi_height) / static_cast<T>(pooled_height);
+    T bin_size_w = static_cast<T>(roi_width) / static_cast<T>(pooled_width);
 
-  integer_t hstart = static_cast<integer_t>(floor(static_cast<T>(ph) * bin_size_h));
-  integer_t wstart = static_cast<integer_t>(floor(static_cast<T>(pw) * bin_size_w));
-  integer_t hend = static_cast<integer_t>(ceil(static_cast<T>(ph + 1) * bin_size_h));
-  integer_t wend = static_cast<integer_t>(ceil(static_cast<T>(pw + 1) * bin_size_w));
+    integer_t hstart = static_cast<integer_t>(floor(static_cast<T>(ph) * bin_size_h));
+    integer_t wstart = static_cast<integer_t>(floor(static_cast<T>(pw) * bin_size_w));
+    integer_t hend = static_cast<integer_t>(ceil(static_cast<T>(ph + 1) * bin_size_h));
+    integer_t wend = static_cast<integer_t>(ceil(static_cast<T>(pw + 1) * bin_size_w));
 
-  // Add roi offsets and clip to input boundaries
-  hstart = min(max(hstart + roi_start_h, static_cast<integer_t>(0)), static_cast<integer_t>(height));
-  hend = min(max(hend + roi_start_h, static_cast<integer_t>(0)), static_cast<integer_t>(height));
-  wstart = min(max(wstart + roi_start_w, static_cast<integer_t>(0)), static_cast<integer_t>(width));
-  wend = min(max(wend + roi_start_w, static_cast<integer_t>(0)), static_cast<integer_t>(width));
-  bool is_empty = (hend <= hstart) || (wend <= wstart);
+    // Add roi offsets and clip to input boundaries
+    hstart = min(max(hstart + roi_start_h, static_cast<integer_t>(0)), static_cast<integer_t>(height));
+    hend = min(max(hend + roi_start_h, static_cast<integer_t>(0)), static_cast<integer_t>(height));
+    wstart = min(max(wstart + roi_start_w, static_cast<integer_t>(0)), static_cast<integer_t>(width));
+    wend = min(max(wend + roi_start_w, static_cast<integer_t>(0)), static_cast<integer_t>(width));
+    bool is_empty = (hend <= hstart) || (wend <= wstart);
 
-  // Define an empty pooling region to be zero
-  T maxval = is_empty ? 0 : -FLT_MAX;
-  // If nothing is pooled, argmax = -1 causes nothing to be backprop'd
-  integer_t maxidx = -1;
-  constant T* offset_input =
-      input + (roi_batch_ind * channels + c) * height * width;
-  for (integer_t h = hstart; h < hend; ++h) {
-    for (integer_t w = wstart; w < wend; ++w) {
-      integer_t input_index = h * width + w;
-      if (offset_input[input_index] > maxval) {
-        maxval = offset_input[input_index];
-        maxidx = input_index;
+    // Define an empty pooling region to be zero
+    T maxval = is_empty ? 0 : -FLT_MAX;
+    // If nothing is pooled, argmax = -1 causes nothing to be backprop'd
+    integer_t maxidx = -1;
+    constant T* offset_input =
+        input + (roi_batch_ind * channels + c) * height * width;
+    for (integer_t h = hstart; h < hend; ++h) {
+      for (integer_t w = wstart; w < wend; ++w) {
+        integer_t input_index = h * width + w;
+        if (offset_input[input_index] > maxval) {
+          maxval = offset_input[input_index];
+          maxidx = input_index;
+        }
       }
     }
+    output[index] = maxval;
+    argmax[index] = maxidx;
   }
-  output[index] = maxval;
-  argmax[index] = maxidx;
 }
 
 #define REGISTER_ROI_POOL_OP(DTYPE, INT_DTYPE)          \
@@ -679,13 +684,16 @@ kernel void roi_pool<DTYPE, INT_DTYPE>(                 \
   constant DTYPE * rois            [[buffer(1)]],       \
   device   DTYPE * output          [[buffer(2)]],       \
   device   int64_t * argmax_data   [[buffer(3)]],       \
-  constant int64_t & channels      [[buffer(4)]],       \
-  constant int64_t & height        [[buffer(5)]],       \
-  constant int64_t & width         [[buffer(6)]],       \
-  constant int64_t & pooled_height [[buffer(7)]],       \
-  constant int64_t & pooled_width  [[buffer(8)]],       \
-  constant float   & spatial_scale [[buffer(9)]],       \
-  uint     index   [[thread_position_in_grid]]);
+  constant int64_t & output_size   [[buffer(4)]],       \
+  constant int64_t & channels      [[buffer(5)]],       \
+  constant int64_t & height        [[buffer(6)]],       \
+  constant int64_t & width         [[buffer(7)]],       \
+  constant int64_t & pooled_height [[buffer(8)]],       \
+  constant int64_t & pooled_width  [[buffer(9)]],       \
+  constant float   & spatial_scale [[buffer(10)]],      \
+  uint2     tgid   [[threadgroup_position_in_grid]],    \
+  uint2     tptg   [[threads_per_threadgroup]],         \
+  uint2     tid2   [[thread_position_in_threadgroup]]);
 
 template<typename T, typename integer_t>
 kernel void roi_pool_backward(
@@ -693,35 +701,46 @@ kernel void roi_pool_backward(
     constant T       * rois          [[buffer(1)]],
     constant int64_t * argmax_data   [[buffer(2)]],
     device   T       * grad_input    [[buffer(3)]],
-    constant int64_t & channels      [[buffer(4)]],
-    constant int64_t & height        [[buffer(5)]],
-    constant int64_t & width         [[buffer(6)]],
-    constant int64_t & pooled_height [[buffer(7)]],
-    constant int64_t & pooled_width  [[buffer(8)]],
-    constant float   & spatial_scale [[buffer(9)]],
-    constant int64_t & n_stride      [[buffer(10)]],
-    constant int64_t & c_stride      [[buffer(11)]],
-    constant int64_t & h_stride      [[buffer(12)]],
-    constant int64_t & w_stride      [[buffer(13)]],
+    constant int64_t & output_size   [[buffer(4)]],
+    constant int64_t & channels      [[buffer(5)]],
+    constant int64_t & height        [[buffer(6)]],
+    constant int64_t & width         [[buffer(7)]],
+    constant int64_t & pooled_height [[buffer(8)]],
+    constant int64_t & pooled_width  [[buffer(9)]],
+    constant float   & spatial_scale [[buffer(10)]],
+    constant int64_t & n_stride      [[buffer(11)]],
+    constant int64_t & c_stride      [[buffer(12)]],
+    constant int64_t & h_stride      [[buffer(13)]],
+    constant int64_t & w_stride      [[buffer(14)]],
     uint     index   [[thread_position_in_grid]]){
-  // (n, c, ph, pw) is an element in the pooled output
-  integer_t pw = index % pooled_width;
-  integer_t ph = (index / pooled_width) % pooled_height;
-  integer_t c = (index / pooled_width / pooled_height) % channels;
-  integer_t n = index / pooled_width / pooled_height / channels;
 
-  constant T* offset_rois = rois + n * 5;
-  integer_t roi_batch_ind = offset_rois[0];
-
-  const integer_t output_offset = n * n_stride + c * c_stride;
-  constant integer_t * argmax_data_offset =
-      argmax_data + (n * channels + c) * pooled_height * pooled_width;
-  const integer_t argmax = argmax_data_offset[ph * pooled_width + pw];
-  const integer_t offset = (roi_batch_ind * channels + c) * height * width;
-
-  if (argmax != -1) {
-    atomic_add_float(grad_input + offset + argmax, static_cast<T>(grad_output[output_offset + ph * h_stride + pw * w_stride]));
+  // One thread per pooled-output element. Dispatched via dispatchThreads, so
+  // each element is processed exactly once; redundant passes would otherwise
+  // be silently summed by the atomic_add below (overlapping RoIs share pixels).
+  if (index >= static_cast<uint>(output_size)) {
+    return;
   }
+  {
+    // (n, c, ph, pw) is an element in the pooled output
+    integer_t pw = index % pooled_width;
+    integer_t ph = (index / pooled_width) % pooled_height;
+    integer_t c = (index / pooled_width / pooled_height) % channels;
+    integer_t n = index / pooled_width / pooled_height / channels;
+
+    constant T* offset_rois = rois + n * 5;
+    integer_t roi_batch_ind = offset_rois[0];
+
+    const integer_t output_offset = n * n_stride + c * c_stride;
+    constant integer_t * argmax_data_offset =
+        argmax_data + (n * channels + c) * pooled_height * pooled_width;
+    const integer_t argmax = argmax_data_offset[ph * pooled_width + pw];
+    const integer_t offset = (roi_batch_ind * channels + c) * height * width;
+
+    if (argmax != -1) {
+      atomic_add_float(grad_input + offset + argmax, static_cast<T>(grad_output[output_offset + ph * h_stride + pw * w_stride]));
+    }
+    
+  } // MPS_1D_KERNEL_LOOP
 }
 
 #define REGISTER_ROI_POOL_BACKWARD_OP(DTYPE, INT_DTYPE)   \
@@ -732,16 +751,17 @@ kernel void roi_pool_backward<DTYPE, INT_DTYPE>(          \
     constant DTYPE   * rois          [[buffer(1)]],       \
     constant int64_t * argmax_data   [[buffer(2)]],       \
     device   DTYPE   * grad_input    [[buffer(3)]],       \
-    constant int64_t & channels      [[buffer(4)]],       \
-    constant int64_t & height        [[buffer(5)]],       \
-    constant int64_t & width         [[buffer(6)]],       \
-    constant int64_t & pooled_height [[buffer(7)]],       \
-    constant int64_t & pooled_width  [[buffer(8)]],       \
-    constant float   & spatial_scale [[buffer(9)]],       \
-    constant int64_t & n_stride      [[buffer(10)]],      \
-    constant int64_t & c_stride      [[buffer(11)]],      \
-    constant int64_t & h_stride      [[buffer(12)]],      \
-    constant int64_t & w_stride      [[buffer(13)]],      \
+    constant int64_t & output_size   [[buffer(4)]],       \
+    constant int64_t & channels      [[buffer(5)]],       \
+    constant int64_t & height        [[buffer(6)]],       \
+    constant int64_t & width         [[buffer(7)]],       \
+    constant int64_t & pooled_height [[buffer(8)]],       \
+    constant int64_t & pooled_width  [[buffer(9)]],       \
+    constant float   & spatial_scale [[buffer(10)]],      \
+    constant int64_t & n_stride      [[buffer(11)]],      \
+    constant int64_t & c_stride      [[buffer(12)]],      \
+    constant int64_t & h_stride      [[buffer(13)]],      \
+    constant int64_t & w_stride      [[buffer(14)]],      \
     uint     index   [[thread_position_in_grid]]);
 
 template<typename T, typename integer_t>
@@ -750,70 +770,75 @@ kernel void ps_roi_align(
     constant T       * rois            [[buffer(1)]],
     device   T       * output          [[buffer(2)]],
     device   int64_t * channel_mapping [[buffer(3)]],
-    constant int64_t & channels        [[buffer(4)]],
-    constant int64_t & height          [[buffer(5)]],
-    constant int64_t & width           [[buffer(6)]],
-    constant int64_t & pooled_height   [[buffer(7)]],
-    constant int64_t & pooled_width    [[buffer(8)]],
-    constant int64_t & sampling_ratio  [[buffer(9)]],
-    constant int64_t & channels_out    [[buffer(10)]],
-    constant float   & spatial_scale   [[buffer(11)]],
-    uint     index   [[thread_position_in_grid]]){
-  // (n, c_out, ph, pw) is an element in the pooled output
-  integer_t pw = index % pooled_width;
-  integer_t ph = (index / pooled_width) % pooled_height;
-  integer_t c_out = (index / pooled_width / pooled_height) % channels_out;
-  integer_t n = index / pooled_width / pooled_height / channels_out;
+    constant int64_t & output_size     [[buffer(4)]],
+    constant int64_t & channels        [[buffer(5)]],
+    constant int64_t & height          [[buffer(6)]],
+    constant int64_t & width           [[buffer(7)]],
+    constant int64_t & pooled_height   [[buffer(8)]],
+    constant int64_t & pooled_width    [[buffer(9)]],
+    constant int64_t & sampling_ratio  [[buffer(10)]],
+    constant int64_t & channels_out    [[buffer(11)]],
+    constant float   & spatial_scale   [[buffer(12)]],
+    uint2     tgid   [[threadgroup_position_in_grid]],
+    uint2     tptg   [[threads_per_threadgroup]],
+    uint2     tid2   [[thread_position_in_threadgroup]]){
+  MPS_1D_KERNEL_LOOP(index, output_size, 1) {
+    // (n, c_out, ph, pw) is an element in the pooled output
+    integer_t pw = index % pooled_width;
+    integer_t ph = (index / pooled_width) % pooled_height;
+    integer_t c_out = (index / pooled_width / pooled_height) % channels_out;
+    integer_t n = index / pooled_width / pooled_height / channels_out;
 
-  // (n, c_in, ph, pw) is the associated element in the input
-  integer_t c_in = (c_out * pooled_height + ph) * pooled_width + pw;
+    // (n, c_in, ph, pw) is the associated element in the input
+    integer_t c_in = (c_out * pooled_height + ph) * pooled_width + pw;
 
-  // [start, end) interval for spatial sampling
-  constant T* offset_rois = rois + n * 5;
-  integer_t roi_batch_ind = offset_rois[0];
+    // [start, end) interval for spatial sampling
+    constant T* offset_rois = rois + n * 5;
+    integer_t roi_batch_ind = offset_rois[0];
 
-  // Do not using rounding; this implementation detail is critical
-  T roi_start_w = offset_rois[1] * spatial_scale - static_cast<T>(0.5);
-  T roi_start_h = offset_rois[2] * spatial_scale - static_cast<T>(0.5);
-  T roi_end_w = offset_rois[3] * spatial_scale - static_cast<T>(0.5);
-  T roi_end_h = offset_rois[4] * spatial_scale - static_cast<T>(0.5);
+    // Do not using rounding; this implementation detail is critical
+    T roi_start_w = offset_rois[1] * spatial_scale - static_cast<T>(0.5);
+    T roi_start_h = offset_rois[2] * spatial_scale - static_cast<T>(0.5);
+    T roi_end_w = offset_rois[3] * spatial_scale - static_cast<T>(0.5);
+    T roi_end_h = offset_rois[4] * spatial_scale - static_cast<T>(0.5);
 
-  T roi_width = roi_end_w - roi_start_w;
-  T roi_height = roi_end_h - roi_start_h;
-  T bin_size_h = static_cast<T>(roi_height) / static_cast<T>(pooled_height);
-  T bin_size_w = static_cast<T>(roi_width) / static_cast<T>(pooled_width);
+    T roi_width = roi_end_w - roi_start_w;
+    T roi_height = roi_end_h - roi_start_h;
+    T bin_size_h = static_cast<T>(roi_height) / static_cast<T>(pooled_height);
+    T bin_size_w = static_cast<T>(roi_width) / static_cast<T>(pooled_width);
 
-  // Do not using floor/ceil; this implementation detail is critical
-  T hstart = static_cast<T>(ph) * bin_size_h + roi_start_h;
-  T wstart = static_cast<T>(pw) * bin_size_w + roi_start_w;
+    // Do not using floor/ceil; this implementation detail is critical
+    T hstart = static_cast<T>(ph) * bin_size_h + roi_start_h;
+    T wstart = static_cast<T>(pw) * bin_size_w + roi_start_w;
 
-  // We use roi_bin_grid to sample the grid and mimic integral
-  integer_t roi_bin_grid_h = (sampling_ratio > 0)
-      ? sampling_ratio
-      : ceil(roi_height / pooled_height);
-  integer_t roi_bin_grid_w =
-      (sampling_ratio > 0) ? sampling_ratio : ceil(roi_width / pooled_width);
-  const T count = roi_bin_grid_h * roi_bin_grid_w;
+    // We use roi_bin_grid to sample the grid and mimic integral
+    integer_t roi_bin_grid_h = (sampling_ratio > 0)
+        ? sampling_ratio
+        : ceil(roi_height / pooled_height);
+    integer_t roi_bin_grid_w =
+        (sampling_ratio > 0) ? sampling_ratio : ceil(roi_width / pooled_width);
+    const T count = roi_bin_grid_h * roi_bin_grid_w;
 
-  constant T* offset_input =
-      input + (roi_batch_ind * channels + c_in) * height * width;
-  T out_sum = 0;
-  for (integer_t iy = 0; iy < roi_bin_grid_h; iy++) {
-    const T y = hstart +
-        static_cast<T>(iy + .5f) * bin_size_h /
-            static_cast<T>(roi_bin_grid_h);
-    for (integer_t ix = 0; ix < roi_bin_grid_w; ix++) {
-      const T x = wstart +
-          static_cast<T>(ix + .5f) * bin_size_w /
-              static_cast<T>(roi_bin_grid_w);
-      T val = bilinear_interpolate(offset_input, height, width, y, x, index);
-      out_sum += val;
+    constant T* offset_input =
+        input + (roi_batch_ind * channels + c_in) * height * width;
+    T out_sum = 0;
+    for (integer_t iy = 0; iy < roi_bin_grid_h; iy++) {
+      const T y = hstart +
+          static_cast<T>(iy + .5f) * bin_size_h /
+              static_cast<T>(roi_bin_grid_h);
+      for (integer_t ix = 0; ix < roi_bin_grid_w; ix++) {
+        const T x = wstart +
+            static_cast<T>(ix + .5f) * bin_size_w /
+                static_cast<T>(roi_bin_grid_w);
+        T val = bilinear_interpolate(offset_input, height, width, y, x, index);
+        out_sum += val;
+      }
     }
-  }
 
-  out_sum /= count;
-  output[index] = out_sum;
-  channel_mapping[index] = c_in;
+    out_sum /= count;
+    output[index] = out_sum;
+    channel_mapping[index] = c_in;
+  }
 }
 
 #define REGISTER_PS_ROI_ALIGN_OP(DTYPE, INT_DTYPE)      \
@@ -824,15 +849,18 @@ kernel void ps_roi_align<DTYPE, INT_DTYPE>(             \
   constant DTYPE   * rois            [[buffer(1)]],     \
   device   DTYPE   * output          [[buffer(2)]],     \
   device   int64_t * channel_mapping [[buffer(3)]],     \
-  constant int64_t & channels        [[buffer(4)]],     \
-  constant int64_t & height          [[buffer(5)]],     \
-  constant int64_t & width           [[buffer(6)]],     \
-  constant int64_t & pooled_height   [[buffer(7)]],     \
-  constant int64_t & pooled_width    [[buffer(8)]],     \
-  constant int64_t & sampling_ratio  [[buffer(9)]],     \
-  constant int64_t & channels_out    [[buffer(10)]],    \
-  constant float   & spatial_scale   [[buffer(11)]],    \
-  uint     index   [[thread_position_in_grid]]);
+  constant int64_t & output_size     [[buffer(4)]],     \
+  constant int64_t & channels        [[buffer(5)]],     \
+  constant int64_t & height          [[buffer(6)]],     \
+  constant int64_t & width           [[buffer(7)]],     \
+  constant int64_t & pooled_height   [[buffer(8)]],     \
+  constant int64_t & pooled_width    [[buffer(9)]],     \
+  constant int64_t & sampling_ratio  [[buffer(10)]],    \
+  constant int64_t & channels_out    [[buffer(11)]],    \
+  constant float   & spatial_scale   [[buffer(12)]],    \
+  uint2     tgid   [[threadgroup_position_in_grid]],    \
+  uint2     tptg   [[threads_per_threadgroup]],         \
+  uint2     tid2   [[thread_position_in_threadgroup]]);
 
 template<typename T, typename integer_t>
 kernel void ps_roi_align_backward(
@@ -840,93 +868,103 @@ kernel void ps_roi_align_backward(
     constant T       * rois            [[buffer(1)]],
     constant int64_t * channel_mapping [[buffer(2)]],
     device   T       * grad_input      [[buffer(3)]],
-    constant int64_t & channels        [[buffer(4)]],
-    constant int64_t & height          [[buffer(5)]],
-    constant int64_t & width           [[buffer(6)]],
-    constant int64_t & pooled_height   [[buffer(7)]],
-    constant int64_t & pooled_width    [[buffer(8)]],
-    constant int64_t & sampling_ratio  [[buffer(9)]],
-    constant int64_t & channels_out    [[buffer(10)]],
-    constant float   & spatial_scale   [[buffer(11)]],
+    constant int64_t & output_size     [[buffer(4)]],
+    constant int64_t & channels        [[buffer(5)]],
+    constant int64_t & height          [[buffer(6)]],
+    constant int64_t & width           [[buffer(7)]],
+    constant int64_t & pooled_height   [[buffer(8)]],
+    constant int64_t & pooled_width    [[buffer(9)]],
+    constant int64_t & sampling_ratio  [[buffer(10)]],
+    constant int64_t & channels_out    [[buffer(11)]],
+    constant float   & spatial_scale   [[buffer(12)]],
     uint     index   [[thread_position_in_grid]]){
-  // (n, *, ph, pw) is an element in the pooled output
-  integer_t pw = index % pooled_width;
-  integer_t ph = (index / pooled_width) % pooled_height;
-  integer_t n = index / pooled_width / pooled_height / channels_out;
 
-  constant T* offset_rois = rois + n * 5;
-  integer_t roi_batch_ind = offset_rois[0];
+  // One thread per pooled-output element. Dispatched via dispatchThreads, so
+  // each element is processed exactly once; redundant passes would otherwise
+  // be silently summed by the atomic_add below (overlapping RoIs share pixels).
+  if (index >= static_cast<uint>(output_size)) {
+    return;
+  }
+  {
+    // (n, *, ph, pw) is an element in the pooled output
+    integer_t pw = index % pooled_width;
+    integer_t ph = (index / pooled_width) % pooled_height;
+    integer_t n = index / pooled_width / pooled_height / channels_out;
 
-  // Do not using rounding; this implementation detail is critical
-  T roi_start_w = offset_rois[1] * spatial_scale - static_cast<T>(0.5);
-  T roi_start_h = offset_rois[2] * spatial_scale - static_cast<T>(0.5);
-  T roi_end_w = offset_rois[3] * spatial_scale - static_cast<T>(0.5);
-  T roi_end_h = offset_rois[4] * spatial_scale - static_cast<T>(0.5);
+    constant T* offset_rois = rois + n * 5;
+    integer_t roi_batch_ind = offset_rois[0];
 
-  // Force too small ROIs to be 1x1
-  T roi_width = roi_end_w - roi_start_w;
-  T roi_height = roi_end_h - roi_start_h;
-  T bin_size_h = roi_height / static_cast<T>(pooled_height);
-  T bin_size_w = roi_width / static_cast<T>(pooled_width);
+    // Do not using rounding; this implementation detail is critical
+    T roi_start_w = offset_rois[1] * spatial_scale - static_cast<T>(0.5);
+    T roi_start_h = offset_rois[2] * spatial_scale - static_cast<T>(0.5);
+    T roi_end_w = offset_rois[3] * spatial_scale - static_cast<T>(0.5);
+    T roi_end_h = offset_rois[4] * spatial_scale - static_cast<T>(0.5);
 
-  integer_t c_in = channel_mapping[index];
+    // Force too small ROIs to be 1x1
+    T roi_width = roi_end_w - roi_start_w;
+    T roi_height = roi_end_h - roi_start_h;
+    T bin_size_h = roi_height / static_cast<T>(pooled_height);
+    T bin_size_w = roi_width / static_cast<T>(pooled_width);
 
-  // Do not using floor/ceil; this implementation detail is critical
-  T hstart = static_cast<T>(ph) * bin_size_h + roi_start_h;
-  T wstart = static_cast<T>(pw) * bin_size_w + roi_start_w;
+    integer_t c_in = channel_mapping[index];
 
-  const T grad_output_this_bin = grad_output[index];
+    // Do not using floor/ceil; this implementation detail is critical
+    T hstart = static_cast<T>(ph) * bin_size_h + roi_start_h;
+    T wstart = static_cast<T>(pw) * bin_size_w + roi_start_w;
 
-  // We use roi_bin_grid to sample the grid and mimic integral
-  integer_t roi_bin_grid_h = (sampling_ratio > 0)
-      ? sampling_ratio
-      : ceil(roi_height / pooled_height); // e.g., = 2
-  integer_t roi_bin_grid_w =
-      (sampling_ratio > 0) ? sampling_ratio : ceil(roi_width / pooled_width);
-  const T count = roi_bin_grid_h * roi_bin_grid_w;
+    const T grad_output_this_bin = grad_output[index];
 
-  const integer_t offset = (roi_batch_ind * channels + c_in) * height * width;
+    // We use roi_bin_grid to sample the grid and mimic integral
+    integer_t roi_bin_grid_h = (sampling_ratio > 0)
+        ? sampling_ratio
+        : ceil(roi_height / pooled_height); // e.g., = 2
+    integer_t roi_bin_grid_w =
+        (sampling_ratio > 0) ? sampling_ratio : ceil(roi_width / pooled_width);
+    const T count = roi_bin_grid_h * roi_bin_grid_w;
 
-  for (integer_t iy = 0; iy < roi_bin_grid_h; iy++) {
-    const T y = hstart +
-        static_cast<T>(iy + .5f) * bin_size_h /
-            static_cast<T>(roi_bin_grid_h);
-    for (integer_t ix = 0; ix < roi_bin_grid_w; ix++) {
-      const T x = wstart +
-          static_cast<T>(ix + .5f) * bin_size_w /
-              static_cast<T>(roi_bin_grid_w);
+    const integer_t offset = (roi_batch_ind * channels + c_in) * height * width;
 
-      T w1, w2, w3, w4;
-      integer_t x_low, x_high, y_low, y_high;
+    for (integer_t iy = 0; iy < roi_bin_grid_h; iy++) {
+      const T y = hstart +
+          static_cast<T>(iy + .5f) * bin_size_h /
+              static_cast<T>(roi_bin_grid_h);
+      for (integer_t ix = 0; ix < roi_bin_grid_w; ix++) {
+        const T x = wstart +
+            static_cast<T>(ix + .5f) * bin_size_w /
+                static_cast<T>(roi_bin_grid_w);
 
-      bilinear_interpolate_gradient(
-          height,
-          width,
-          y,
-          x,
-          w1,
-          w2,
-          w3,
-          w4,
-          x_low,
-          x_high,
-          y_low,
-          y_high,
-          index);
+        T w1, w2, w3, w4;
+        integer_t x_low, x_high, y_low, y_high;
 
-      T g1 = grad_output_this_bin * w1 / count;
-      T g2 = grad_output_this_bin * w2 / count;
-      T g3 = grad_output_this_bin * w3 / count;
-      T g4 = grad_output_this_bin * w4 / count;
+        bilinear_interpolate_gradient(
+            height,
+            width,
+            y,
+            x,
+            w1,
+            w2,
+            w3,
+            w4,
+            x_low,
+            x_high,
+            y_low,
+            y_high,
+            index);
 
-      if (x_low >= 0 && x_high >= 0 && y_low >= 0 && y_high >= 0) {
-        atomic_add_float(grad_input + offset + y_low * width + x_low, static_cast<T>(g1));
-        atomic_add_float(grad_input + offset + y_low * width + x_high, static_cast<T>(g2));
-        atomic_add_float(grad_input + offset + y_high * width + x_low, static_cast<T>(g3));
-        atomic_add_float(grad_input + offset + y_high * width + x_high, static_cast<T>(g4));
-      } // if
-    } // ix
-  } // iy
+        T g1 = grad_output_this_bin * w1 / count;
+        T g2 = grad_output_this_bin * w2 / count;
+        T g3 = grad_output_this_bin * w3 / count;
+        T g4 = grad_output_this_bin * w4 / count;
+
+        if (x_low >= 0 && x_high >= 0 && y_low >= 0 && y_high >= 0) {
+          atomic_add_float(grad_input + offset + y_low * width + x_low, static_cast<T>(g1));
+          atomic_add_float(grad_input + offset + y_low * width + x_high, static_cast<T>(g2));
+          atomic_add_float(grad_input + offset + y_high * width + x_low, static_cast<T>(g3));
+          atomic_add_float(grad_input + offset + y_high * width + x_high, static_cast<T>(g4));
+        } // if
+      } // ix
+    } // iy
+  }
 }
 
 #define REGISTER_PS_ROI_ALIGN_BACKWARD_OP(DTYPE, INT_DTYPE)   \
@@ -937,14 +975,15 @@ kernel void ps_roi_align_backward<DTYPE, INT_DTYPE>(          \
     constant DTYPE   * rois            [[buffer(1)]],         \
     constant int64_t * channel_mapping [[buffer(2)]],         \
     device   DTYPE   * grad_input      [[buffer(3)]],         \
-    constant int64_t & channels        [[buffer(4)]],         \
-    constant int64_t & height          [[buffer(5)]],         \
-    constant int64_t & width           [[buffer(6)]],         \
-    constant int64_t & pooled_height   [[buffer(7)]],         \
-    constant int64_t & pooled_width    [[buffer(8)]],         \
-    constant int64_t & sampling_ratio  [[buffer(9)]],         \
-    constant int64_t & channels_out    [[buffer(10)]],        \
-    constant float   & spatial_scale   [[buffer(11)]],        \
+    constant int64_t & output_size     [[buffer(4)]],         \
+    constant int64_t & channels        [[buffer(5)]],         \
+    constant int64_t & height          [[buffer(6)]],         \
+    constant int64_t & width           [[buffer(7)]],         \
+    constant int64_t & pooled_height   [[buffer(8)]],         \
+    constant int64_t & pooled_width    [[buffer(9)]],         \
+    constant int64_t & sampling_ratio  [[buffer(10)]],        \
+    constant int64_t & channels_out    [[buffer(11)]],        \
+    constant float   & spatial_scale   [[buffer(12)]],        \
     uint     index   [[thread_position_in_grid]]);
 
 template<typename T, typename integer_t>
@@ -953,62 +992,67 @@ kernel void ps_roi_pool(
     constant T       * rois            [[buffer(1)]],
     device   T       * output          [[buffer(2)]],
     device   int64_t * channel_mapping [[buffer(3)]],
-    constant int64_t & channels        [[buffer(4)]],
-    constant int64_t & height          [[buffer(5)]],
-    constant int64_t & width           [[buffer(6)]],
-    constant int64_t & pooled_height   [[buffer(7)]],
-    constant int64_t & pooled_width    [[buffer(8)]],
-    constant int64_t & channels_out    [[buffer(9)]],
-    constant float   & spatial_scale   [[buffer(10)]],
-    uint     index   [[thread_position_in_grid]]){
-  // (n, c_out, ph, pw) is an element in the pooled output
-  integer_t pw = index % pooled_width;
-  integer_t ph = (index / pooled_width) % pooled_height;
-  integer_t c_out = (index / (pooled_width * pooled_height)) % channels_out;
-  integer_t n = index / pooled_width / pooled_height / channels_out;
+    constant int64_t & output_size     [[buffer(4)]],
+    constant int64_t & channels        [[buffer(5)]],
+    constant int64_t & height          [[buffer(6)]],
+    constant int64_t & width           [[buffer(7)]],
+    constant int64_t & pooled_height   [[buffer(8)]],
+    constant int64_t & pooled_width    [[buffer(9)]],
+    constant int64_t & channels_out    [[buffer(10)]],
+    constant float   & spatial_scale   [[buffer(11)]],
+    uint2     tgid   [[threadgroup_position_in_grid]],
+    uint2     tptg   [[threads_per_threadgroup]],
+    uint2     tid2   [[thread_position_in_threadgroup]]){
+  MPS_1D_KERNEL_LOOP(index, output_size, 1) {
+    // (n, c_out, ph, pw) is an element in the pooled output
+    integer_t pw = index % pooled_width;
+    integer_t ph = (index / pooled_width) % pooled_height;
+    integer_t c_out = (index / (pooled_width * pooled_height)) % channels_out;
+    integer_t n = index / pooled_width / pooled_height / channels_out;
 
-  // (n, c_in, ph, pw) is the associated element in the input
-  integer_t c_in = (c_out * pooled_height + ph) * pooled_width + pw;
+    // (n, c_in, ph, pw) is the associated element in the input
+    integer_t c_in = (c_out * pooled_height + ph) * pooled_width + pw;
 
-  // [start, end) interval for spatial sampling
-  constant T* offset_rois = rois + n * 5;
-  integer_t roi_batch_ind = offset_rois[0];
-  integer_t roi_start_w = round(offset_rois[1] * spatial_scale);
-  integer_t roi_start_h = round(offset_rois[2] * spatial_scale);
-  integer_t roi_end_w = round(offset_rois[3] * spatial_scale);
-  integer_t roi_end_h = round(offset_rois[4] * spatial_scale);
+    // [start, end) interval for spatial sampling
+    constant T* offset_rois = rois + n * 5;
+    integer_t roi_batch_ind = offset_rois[0];
+    integer_t roi_start_w = round(offset_rois[1] * spatial_scale);
+    integer_t roi_start_h = round(offset_rois[2] * spatial_scale);
+    integer_t roi_end_w = round(offset_rois[3] * spatial_scale);
+    integer_t roi_end_h = round(offset_rois[4] * spatial_scale);
 
-  // Force too small ROIs to be 1x1
-  integer_t roi_width = max(roi_end_w - roi_start_w, static_cast<integer_t>(1));
-  integer_t roi_height = max(roi_end_h - roi_start_h, static_cast<integer_t>(1));
-  T bin_size_h = static_cast<T>(roi_height) / static_cast<T>(pooled_height);
-  T bin_size_w = static_cast<T>(roi_width) / static_cast<T>(pooled_width);
+    // Force too small ROIs to be 1x1
+    integer_t roi_width = max(roi_end_w - roi_start_w, static_cast<integer_t>(1));
+    integer_t roi_height = max(roi_end_h - roi_start_h, static_cast<integer_t>(1));
+    T bin_size_h = static_cast<T>(roi_height) / static_cast<T>(pooled_height);
+    T bin_size_w = static_cast<T>(roi_width) / static_cast<T>(pooled_width);
 
-  integer_t hstart = static_cast<integer_t>(floor(static_cast<T>(ph) * bin_size_h));
-  integer_t wstart = static_cast<integer_t>(floor(static_cast<T>(pw) * bin_size_w));
-  integer_t hend = static_cast<integer_t>(ceil(static_cast<T>(ph + 1) * bin_size_h));
-  integer_t wend = static_cast<integer_t>(ceil(static_cast<T>(pw + 1) * bin_size_w));
+    integer_t hstart = static_cast<integer_t>(floor(static_cast<T>(ph) * bin_size_h));
+    integer_t wstart = static_cast<integer_t>(floor(static_cast<T>(pw) * bin_size_w));
+    integer_t hend = static_cast<integer_t>(ceil(static_cast<T>(ph + 1) * bin_size_h));
+    integer_t wend = static_cast<integer_t>(ceil(static_cast<T>(pw + 1) * bin_size_w));
 
-  // Add roi offsets and clip to input boundaries
-  hstart = min(max(hstart + roi_start_h, static_cast<integer_t>(0)), static_cast<integer_t>(height - 1));
-  hend = min(max(hend + roi_start_h, static_cast<integer_t>(0)), static_cast<integer_t>(height - 1));
-  wstart = min(max(wstart + roi_start_w, static_cast<integer_t>(0)), static_cast<integer_t>(width - 1));
-  wend = min(max(wend + roi_start_w, static_cast<integer_t>(0)), static_cast<integer_t>(width - 1));
-  bool is_empty = (hend <= hstart) || (wend <= wstart);
+    // Add roi offsets and clip to input boundaries
+    hstart = min(max(hstart + roi_start_h, static_cast<integer_t>(0)), static_cast<integer_t>(height - 1));
+    hend = min(max(hend + roi_start_h, static_cast<integer_t>(0)), static_cast<integer_t>(height - 1));
+    wstart = min(max(wstart + roi_start_w, static_cast<integer_t>(0)), static_cast<integer_t>(width - 1));
+    wend = min(max(wend + roi_start_w, static_cast<integer_t>(0)), static_cast<integer_t>(width - 1));
+    bool is_empty = (hend <= hstart) || (wend <= wstart);
 
-  constant T* offset_input =
-      input + (roi_batch_ind * channels + c_in) * height * width;
-  T out_sum = 0;
-  for (integer_t h = hstart; h < hend; ++h) {
-    for (integer_t w = wstart; w < wend; ++w) {
-      integer_t input_index = h * width + w;
-      out_sum += offset_input[input_index];
+    constant T* offset_input =
+        input + (roi_batch_ind * channels + c_in) * height * width;
+    T out_sum = 0;
+    for (integer_t h = hstart; h < hend; ++h) {
+      for (integer_t w = wstart; w < wend; ++w) {
+        integer_t input_index = h * width + w;
+        out_sum += offset_input[input_index];
+      }
     }
-  }
 
-  T bin_area = (hend - hstart) * (wend - wstart);
-  output[index] = is_empty ? static_cast<T>(0) : out_sum / bin_area;
-  channel_mapping[index] = c_in;
+    T bin_area = (hend - hstart) * (wend - wstart);
+    output[index] = is_empty ? static_cast<T>(0) : out_sum / bin_area;
+    channel_mapping[index] = c_in;
+  }
 }
 
 #define REGISTER_PS_ROI_POOL_OP(DTYPE, INT_DTYPE)     \
@@ -1019,14 +1063,17 @@ kernel void ps_roi_pool<DTYPE, INT_DTYPE>(            \
   constant DTYPE   * rois            [[buffer(1)]],   \
   device   DTYPE   * output          [[buffer(2)]],   \
   device   int64_t * channel_mapping [[buffer(3)]],   \
-  constant int64_t & channels        [[buffer(4)]],   \
-  constant int64_t & height          [[buffer(5)]],   \
-  constant int64_t & width           [[buffer(6)]],   \
-  constant int64_t & pooled_height   [[buffer(7)]],   \
-  constant int64_t & pooled_width    [[buffer(8)]],   \
-  constant int64_t & channels_out    [[buffer(9)]],   \
-  constant float   & spatial_scale   [[buffer(10)]],  \
-  uint    index   [[thread_position_in_grid]]);
+  constant int64_t & output_size     [[buffer(4)]],   \
+  constant int64_t & channels        [[buffer(5)]],   \
+  constant int64_t & height          [[buffer(6)]],   \
+  constant int64_t & width           [[buffer(7)]],   \
+  constant int64_t & pooled_height   [[buffer(8)]],   \
+  constant int64_t & pooled_width    [[buffer(9)]],   \
+  constant int64_t & channels_out    [[buffer(10)]],  \
+  constant float   & spatial_scale   [[buffer(11)]],  \
+  uint2    tgid   [[threadgroup_position_in_grid]],   \
+  uint2    tptg   [[threads_per_threadgroup]],        \
+  uint2    tid2   [[thread_position_in_threadgroup]]);
 
 template<typename T, typename integer_t>
 kernel void ps_roi_pool_backward(
@@ -1034,56 +1081,67 @@ kernel void ps_roi_pool_backward(
     constant T       * rois            [[buffer(1)]],
     constant int64_t * channel_mapping [[buffer(2)]],
     device   T       * grad_input      [[buffer(3)]],
-    constant int64_t & channels        [[buffer(4)]],
-    constant int64_t & height          [[buffer(5)]],
-    constant int64_t & width           [[buffer(6)]],
-    constant int64_t & pooled_height   [[buffer(7)]],
-    constant int64_t & pooled_width    [[buffer(8)]],
-    constant int64_t & channels_out    [[buffer(9)]],
-    constant float   & spatial_scale   [[buffer(10)]],
+    constant int64_t & output_size     [[buffer(4)]],
+    constant int64_t & channels        [[buffer(5)]],
+    constant int64_t & height          [[buffer(6)]],
+    constant int64_t & width           [[buffer(7)]],
+    constant int64_t & pooled_height   [[buffer(8)]],
+    constant int64_t & pooled_width    [[buffer(9)]],
+    constant int64_t & channels_out    [[buffer(10)]],
+    constant float   & spatial_scale   [[buffer(11)]],
     uint     index   [[thread_position_in_grid]]){
-  // (n, *, ph, pw) is an element in the pooled output
-  integer_t pw = index % pooled_width;
-  integer_t ph = (index / pooled_width) % pooled_height;
-  integer_t n = index / pooled_width / pooled_height / channels_out;
 
-  constant T* offset_rois = rois + n * 5;
-  integer_t roi_batch_ind = offset_rois[0];
-  integer_t roi_start_w = round(offset_rois[1] * spatial_scale);
-  integer_t roi_start_h = round(offset_rois[2] * spatial_scale);
-  integer_t roi_end_w = round(offset_rois[3] * spatial_scale);
-  integer_t roi_end_h = round(offset_rois[4] * spatial_scale);
-
-  // Force too small ROIs to be 1x1
-  integer_t roi_width = max(roi_end_w - roi_start_w, static_cast<integer_t>(1));
-  integer_t roi_height = max(roi_end_h - roi_start_h, static_cast<integer_t>(1));
-  T bin_size_h = static_cast<T>(roi_height) / static_cast<T>(pooled_height);
-  T bin_size_w = static_cast<T>(roi_width) / static_cast<T>(pooled_width);
-
-  integer_t hstart = static_cast<integer_t>(floor(static_cast<T>(ph) * bin_size_h));
-  integer_t wstart = static_cast<integer_t>(floor(static_cast<T>(pw) * bin_size_w));
-  integer_t hend = static_cast<integer_t>(ceil(static_cast<T>(ph + 1) * bin_size_h));
-  integer_t wend = static_cast<integer_t>(ceil(static_cast<T>(pw + 1) * bin_size_w));
-
-  // Add roi offsets and clip to input boundaries
-  hstart = min(max(hstart + roi_start_h, static_cast<integer_t>(0)), static_cast<integer_t>(height));
-  hend = min(max(hend + roi_start_h, static_cast<integer_t>(0)), static_cast<integer_t>(height));
-  wstart = min(max(wstart + roi_start_w, static_cast<integer_t>(0)), static_cast<integer_t>(width));
-  wend = min(max(wend + roi_start_w, static_cast<integer_t>(0)), static_cast<integer_t>(width));
-  bool is_empty = (hend <= hstart) || (wend <= wstart);
-
-  integer_t c_in = channel_mapping[index];
-  T bin_area = (hend - hstart) * (wend - wstart);
-  T diff_val = is_empty ? static_cast<T>(0) : grad_output[index] / bin_area;
-
-  const integer_t offset = (roi_batch_ind * channels + c_in) * height * width;
-
-  for (integer_t h = hstart; h < hend; ++h) {
-    for (integer_t w = wstart; w < wend; ++w) {
-      integer_t grad_input_index = h * width + w;
-      atomic_add_float(grad_input + offset + grad_input_index, diff_val);
-    }
+  // One thread per pooled-output element. Dispatched via dispatchThreads, so
+  // each element is processed exactly once; redundant passes would otherwise
+  // be silently summed by the atomic_add below (overlapping RoIs share pixels).
+  if (index >= static_cast<uint>(output_size)) {
+    return;
   }
+  {
+    // (n, *, ph, pw) is an element in the pooled output
+    integer_t pw = index % pooled_width;
+    integer_t ph = (index / pooled_width) % pooled_height;
+    integer_t n = index / pooled_width / pooled_height / channels_out;
+
+    constant T* offset_rois = rois + n * 5;
+    integer_t roi_batch_ind = offset_rois[0];
+    integer_t roi_start_w = round(offset_rois[1] * spatial_scale);
+    integer_t roi_start_h = round(offset_rois[2] * spatial_scale);
+    integer_t roi_end_w = round(offset_rois[3] * spatial_scale);
+    integer_t roi_end_h = round(offset_rois[4] * spatial_scale);
+
+    // Force too small ROIs to be 1x1
+    integer_t roi_width = max(roi_end_w - roi_start_w, static_cast<integer_t>(1));
+    integer_t roi_height = max(roi_end_h - roi_start_h, static_cast<integer_t>(1));
+    T bin_size_h = static_cast<T>(roi_height) / static_cast<T>(pooled_height);
+    T bin_size_w = static_cast<T>(roi_width) / static_cast<T>(pooled_width);
+
+    integer_t hstart = static_cast<integer_t>(floor(static_cast<T>(ph) * bin_size_h));
+    integer_t wstart = static_cast<integer_t>(floor(static_cast<T>(pw) * bin_size_w));
+    integer_t hend = static_cast<integer_t>(ceil(static_cast<T>(ph + 1) * bin_size_h));
+    integer_t wend = static_cast<integer_t>(ceil(static_cast<T>(pw + 1) * bin_size_w));
+
+    // Add roi offsets and clip to input boundaries
+    hstart = min(max(hstart + roi_start_h, static_cast<integer_t>(0)), static_cast<integer_t>(height));
+    hend = min(max(hend + roi_start_h, static_cast<integer_t>(0)), static_cast<integer_t>(height));
+    wstart = min(max(wstart + roi_start_w, static_cast<integer_t>(0)), static_cast<integer_t>(width));
+    wend = min(max(wend + roi_start_w, static_cast<integer_t>(0)), static_cast<integer_t>(width));
+    bool is_empty = (hend <= hstart) || (wend <= wstart);
+
+    integer_t c_in = channel_mapping[index];
+    T bin_area = (hend - hstart) * (wend - wstart);
+    T diff_val = is_empty ? static_cast<T>(0) : grad_output[index] / bin_area;
+
+    const integer_t offset = (roi_batch_ind * channels + c_in) * height * width;
+
+    for (integer_t h = hstart; h < hend; ++h) {
+      for (integer_t w = wstart; w < wend; ++w) {
+        integer_t grad_input_index = h * width + w;
+        atomic_add_float(grad_input + offset + grad_input_index, diff_val);
+      }
+    }
+    
+  } // MPS_1D_KERNEL_LOOP
 }
 
 #define REGISTER_PS_ROI_POOL_BACKWARD_OP(DTYPE, INT_DTYPE)   \
@@ -1094,13 +1152,14 @@ kernel void ps_roi_pool_backward<DTYPE, INT_DTYPE>(          \
     constant DTYPE   * rois            [[buffer(1)]],        \
     constant int64_t * channel_mapping [[buffer(2)]],        \
     device   DTYPE   * grad_input      [[buffer(3)]],        \
-    constant int64_t & channels        [[buffer(4)]],        \
-    constant int64_t & height          [[buffer(5)]],        \
-    constant int64_t & width           [[buffer(6)]],        \
-    constant int64_t & pooled_height   [[buffer(7)]],        \
-    constant int64_t & pooled_width    [[buffer(8)]],        \
-    constant int64_t & channels_out    [[buffer(9)]],        \
-    constant float   & spatial_scale   [[buffer(10)]],       \
+    constant int64_t & output_size     [[buffer(4)]],        \
+    constant int64_t & channels        [[buffer(5)]],        \
+    constant int64_t & height          [[buffer(6)]],        \
+    constant int64_t & width           [[buffer(7)]],        \
+    constant int64_t & pooled_height   [[buffer(8)]],        \
+    constant int64_t & pooled_width    [[buffer(9)]],        \
+    constant int64_t & channels_out    [[buffer(10)]],       \
+    constant float   & spatial_scale   [[buffer(11)]],       \
     uint     index   [[thread_position_in_grid]]);
 
 REGISTER_NMS_OP(float);

--- a/torchvision/csrc/ops/mps/mps_kernels.h
+++ b/torchvision/csrc/ops/mps/mps_kernels.h
@@ -614,66 +614,61 @@ kernel void roi_pool(
     constant T       * rois          [[buffer(1)]],
     device   T       * output        [[buffer(2)]],
     device   int64_t * argmax        [[buffer(3)]],
-    constant int64_t & output_size   [[buffer(4)]],
-    constant int64_t & channels      [[buffer(5)]],
-    constant int64_t & height        [[buffer(6)]],
-    constant int64_t & width         [[buffer(7)]],
-    constant int64_t & pooled_height [[buffer(8)]],
-    constant int64_t & pooled_width  [[buffer(9)]],
-    constant float   & spatial_scale [[buffer(10)]],
-    uint2     tgid   [[threadgroup_position_in_grid]],
-    uint2     tptg   [[threads_per_threadgroup]],
-    uint2     tid2   [[thread_position_in_threadgroup]]){
-  MPS_1D_KERNEL_LOOP(index, output_size, 1) {
-    // (n, c, ph, pw) is an element in the pooled output
-    integer_t pw = index % pooled_width;
-    integer_t ph = (index / pooled_width) % pooled_height;
-    integer_t c = (index / pooled_width / pooled_height) % channels;
-    integer_t n = index / pooled_width / pooled_height / channels;
+    constant int64_t & channels      [[buffer(4)]],
+    constant int64_t & height        [[buffer(5)]],
+    constant int64_t & width         [[buffer(6)]],
+    constant int64_t & pooled_height [[buffer(7)]],
+    constant int64_t & pooled_width  [[buffer(8)]],
+    constant float   & spatial_scale [[buffer(9)]],
+    uint     index   [[thread_position_in_grid]]){
+  // (n, c, ph, pw) is an element in the pooled output
+  integer_t pw = index % pooled_width;
+  integer_t ph = (index / pooled_width) % pooled_height;
+  integer_t c = (index / pooled_width / pooled_height) % channels;
+  integer_t n = index / pooled_width / pooled_height / channels;
 
-    constant T* offset_rois = rois + n * 5;
-    integer_t roi_batch_ind = offset_rois[0];
-    integer_t roi_start_w = round(offset_rois[1] * spatial_scale);
-    integer_t roi_start_h = round(offset_rois[2] * spatial_scale);
-    integer_t roi_end_w = round(offset_rois[3] * spatial_scale);
-    integer_t roi_end_h = round(offset_rois[4] * spatial_scale);
+  constant T* offset_rois = rois + n * 5;
+  integer_t roi_batch_ind = offset_rois[0];
+  integer_t roi_start_w = round(offset_rois[1] * spatial_scale);
+  integer_t roi_start_h = round(offset_rois[2] * spatial_scale);
+  integer_t roi_end_w = round(offset_rois[3] * spatial_scale);
+  integer_t roi_end_h = round(offset_rois[4] * spatial_scale);
 
-    // Force malformed ROIs to be 1x1
-    integer_t roi_width = max(roi_end_w - roi_start_w + 1, static_cast<integer_t>(1));
-    integer_t roi_height = max(roi_end_h - roi_start_h + 1, static_cast<integer_t>(1));
-    T bin_size_h = static_cast<T>(roi_height) / static_cast<T>(pooled_height);
-    T bin_size_w = static_cast<T>(roi_width) / static_cast<T>(pooled_width);
+  // Force malformed ROIs to be 1x1
+  integer_t roi_width = max(roi_end_w - roi_start_w + 1, static_cast<integer_t>(1));
+  integer_t roi_height = max(roi_end_h - roi_start_h + 1, static_cast<integer_t>(1));
+  T bin_size_h = static_cast<T>(roi_height) / static_cast<T>(pooled_height);
+  T bin_size_w = static_cast<T>(roi_width) / static_cast<T>(pooled_width);
 
-    integer_t hstart = static_cast<integer_t>(floor(static_cast<T>(ph) * bin_size_h));
-    integer_t wstart = static_cast<integer_t>(floor(static_cast<T>(pw) * bin_size_w));
-    integer_t hend = static_cast<integer_t>(ceil(static_cast<T>(ph + 1) * bin_size_h));
-    integer_t wend = static_cast<integer_t>(ceil(static_cast<T>(pw + 1) * bin_size_w));
+  integer_t hstart = static_cast<integer_t>(floor(static_cast<T>(ph) * bin_size_h));
+  integer_t wstart = static_cast<integer_t>(floor(static_cast<T>(pw) * bin_size_w));
+  integer_t hend = static_cast<integer_t>(ceil(static_cast<T>(ph + 1) * bin_size_h));
+  integer_t wend = static_cast<integer_t>(ceil(static_cast<T>(pw + 1) * bin_size_w));
 
-    // Add roi offsets and clip to input boundaries
-    hstart = min(max(hstart + roi_start_h, static_cast<integer_t>(0)), static_cast<integer_t>(height));
-    hend = min(max(hend + roi_start_h, static_cast<integer_t>(0)), static_cast<integer_t>(height));
-    wstart = min(max(wstart + roi_start_w, static_cast<integer_t>(0)), static_cast<integer_t>(width));
-    wend = min(max(wend + roi_start_w, static_cast<integer_t>(0)), static_cast<integer_t>(width));
-    bool is_empty = (hend <= hstart) || (wend <= wstart);
+  // Add roi offsets and clip to input boundaries
+  hstart = min(max(hstart + roi_start_h, static_cast<integer_t>(0)), static_cast<integer_t>(height));
+  hend = min(max(hend + roi_start_h, static_cast<integer_t>(0)), static_cast<integer_t>(height));
+  wstart = min(max(wstart + roi_start_w, static_cast<integer_t>(0)), static_cast<integer_t>(width));
+  wend = min(max(wend + roi_start_w, static_cast<integer_t>(0)), static_cast<integer_t>(width));
+  bool is_empty = (hend <= hstart) || (wend <= wstart);
 
-    // Define an empty pooling region to be zero
-    T maxval = is_empty ? 0 : -FLT_MAX;
-    // If nothing is pooled, argmax = -1 causes nothing to be backprop'd
-    integer_t maxidx = -1;
-    constant T* offset_input =
-        input + (roi_batch_ind * channels + c) * height * width;
-    for (integer_t h = hstart; h < hend; ++h) {
-      for (integer_t w = wstart; w < wend; ++w) {
-        integer_t input_index = h * width + w;
-        if (offset_input[input_index] > maxval) {
-          maxval = offset_input[input_index];
-          maxidx = input_index;
-        }
+  // Define an empty pooling region to be zero
+  T maxval = is_empty ? 0 : -FLT_MAX;
+  // If nothing is pooled, argmax = -1 causes nothing to be backprop'd
+  integer_t maxidx = -1;
+  constant T* offset_input =
+      input + (roi_batch_ind * channels + c) * height * width;
+  for (integer_t h = hstart; h < hend; ++h) {
+    for (integer_t w = wstart; w < wend; ++w) {
+      integer_t input_index = h * width + w;
+      if (offset_input[input_index] > maxval) {
+        maxval = offset_input[input_index];
+        maxidx = input_index;
       }
     }
-    output[index] = maxval;
-    argmax[index] = maxidx;
   }
+  output[index] = maxval;
+  argmax[index] = maxidx;
 }
 
 #define REGISTER_ROI_POOL_OP(DTYPE, INT_DTYPE)          \
@@ -684,16 +679,13 @@ kernel void roi_pool<DTYPE, INT_DTYPE>(                 \
   constant DTYPE * rois            [[buffer(1)]],       \
   device   DTYPE * output          [[buffer(2)]],       \
   device   int64_t * argmax_data   [[buffer(3)]],       \
-  constant int64_t & output_size   [[buffer(4)]],       \
-  constant int64_t & channels      [[buffer(5)]],       \
-  constant int64_t & height        [[buffer(6)]],       \
-  constant int64_t & width         [[buffer(7)]],       \
-  constant int64_t & pooled_height [[buffer(8)]],       \
-  constant int64_t & pooled_width  [[buffer(9)]],       \
-  constant float   & spatial_scale [[buffer(10)]],      \
-  uint2     tgid   [[threadgroup_position_in_grid]],    \
-  uint2     tptg   [[threads_per_threadgroup]],         \
-  uint2     tid2   [[thread_position_in_threadgroup]]);
+  constant int64_t & channels      [[buffer(4)]],       \
+  constant int64_t & height        [[buffer(5)]],       \
+  constant int64_t & width         [[buffer(6)]],       \
+  constant int64_t & pooled_height [[buffer(7)]],       \
+  constant int64_t & pooled_width  [[buffer(8)]],       \
+  constant float   & spatial_scale [[buffer(9)]],       \
+  uint     index   [[thread_position_in_grid]]);
 
 template<typename T, typename integer_t>
 kernel void roi_pool_backward(
@@ -701,42 +693,35 @@ kernel void roi_pool_backward(
     constant T       * rois          [[buffer(1)]],
     constant int64_t * argmax_data   [[buffer(2)]],
     device   T       * grad_input    [[buffer(3)]],
-    constant int64_t & output_size   [[buffer(4)]],
-    constant int64_t & channels      [[buffer(5)]],
-    constant int64_t & height        [[buffer(6)]],
-    constant int64_t & width         [[buffer(7)]],
-    constant int64_t & pooled_height [[buffer(8)]],
-    constant int64_t & pooled_width  [[buffer(9)]],
-    constant float   & spatial_scale [[buffer(10)]],
-    constant int64_t & n_stride      [[buffer(11)]],
-    constant int64_t & c_stride      [[buffer(12)]],
-    constant int64_t & h_stride      [[buffer(13)]],
-    constant int64_t & w_stride      [[buffer(14)]],
-    uint2     tgid   [[threadgroup_position_in_grid]],
-    uint2     tptg   [[threads_per_threadgroup]],
-    uint2     tid2   [[thread_position_in_threadgroup]]){
+    constant int64_t & channels      [[buffer(4)]],
+    constant int64_t & height        [[buffer(5)]],
+    constant int64_t & width         [[buffer(6)]],
+    constant int64_t & pooled_height [[buffer(7)]],
+    constant int64_t & pooled_width  [[buffer(8)]],
+    constant float   & spatial_scale [[buffer(9)]],
+    constant int64_t & n_stride      [[buffer(10)]],
+    constant int64_t & c_stride      [[buffer(11)]],
+    constant int64_t & h_stride      [[buffer(12)]],
+    constant int64_t & w_stride      [[buffer(13)]],
+    uint     index   [[thread_position_in_grid]]){
+  // (n, c, ph, pw) is an element in the pooled output
+  integer_t pw = index % pooled_width;
+  integer_t ph = (index / pooled_width) % pooled_height;
+  integer_t c = (index / pooled_width / pooled_height) % channels;
+  integer_t n = index / pooled_width / pooled_height / channels;
 
-  MPS_1D_KERNEL_LOOP(index, output_size, 1) {
-    // (n, c, ph, pw) is an element in the pooled output
-    integer_t pw = index % pooled_width;
-    integer_t ph = (index / pooled_width) % pooled_height;
-    integer_t c = (index / pooled_width / pooled_height) % channels;
-    integer_t n = index / pooled_width / pooled_height / channels;
+  constant T* offset_rois = rois + n * 5;
+  integer_t roi_batch_ind = offset_rois[0];
 
-    constant T* offset_rois = rois + n * 5;
-    integer_t roi_batch_ind = offset_rois[0];
+  const integer_t output_offset = n * n_stride + c * c_stride;
+  constant integer_t * argmax_data_offset =
+      argmax_data + (n * channels + c) * pooled_height * pooled_width;
+  const integer_t argmax = argmax_data_offset[ph * pooled_width + pw];
+  const integer_t offset = (roi_batch_ind * channels + c) * height * width;
 
-    const integer_t output_offset = n * n_stride + c * c_stride;
-    constant integer_t * argmax_data_offset =
-        argmax_data + (n * channels + c) * pooled_height * pooled_width;
-    const integer_t argmax = argmax_data_offset[ph * pooled_width + pw];
-    const integer_t offset = (roi_batch_ind * channels + c) * height * width;
-
-    if (argmax != -1) {
-      atomic_add_float(grad_input + offset + argmax, static_cast<T>(grad_output[output_offset + ph * h_stride + pw * w_stride]));
-    }
-    
-  } // MPS_1D_KERNEL_LOOP
+  if (argmax != -1) {
+    atomic_add_float(grad_input + offset + argmax, static_cast<T>(grad_output[output_offset + ph * h_stride + pw * w_stride]));
+  }
 }
 
 #define REGISTER_ROI_POOL_BACKWARD_OP(DTYPE, INT_DTYPE)   \
@@ -747,20 +732,17 @@ kernel void roi_pool_backward<DTYPE, INT_DTYPE>(          \
     constant DTYPE   * rois          [[buffer(1)]],       \
     constant int64_t * argmax_data   [[buffer(2)]],       \
     device   DTYPE   * grad_input    [[buffer(3)]],       \
-    constant int64_t & output_size   [[buffer(4)]],       \
-    constant int64_t & channels      [[buffer(5)]],       \
-    constant int64_t & height        [[buffer(6)]],       \
-    constant int64_t & width         [[buffer(7)]],       \
-    constant int64_t & pooled_height [[buffer(8)]],       \
-    constant int64_t & pooled_width  [[buffer(9)]],       \
-    constant float   & spatial_scale [[buffer(10)]],      \
-    constant int64_t & n_stride      [[buffer(11)]],      \
-    constant int64_t & c_stride      [[buffer(12)]],      \
-    constant int64_t & h_stride      [[buffer(13)]],      \
-    constant int64_t & w_stride      [[buffer(14)]],      \
-    uint2     tgid   [[threadgroup_position_in_grid]],    \
-    uint2     tptg   [[threads_per_threadgroup]],         \
-    uint2     tid2   [[thread_position_in_threadgroup]]);
+    constant int64_t & channels      [[buffer(4)]],       \
+    constant int64_t & height        [[buffer(5)]],       \
+    constant int64_t & width         [[buffer(6)]],       \
+    constant int64_t & pooled_height [[buffer(7)]],       \
+    constant int64_t & pooled_width  [[buffer(8)]],       \
+    constant float   & spatial_scale [[buffer(9)]],       \
+    constant int64_t & n_stride      [[buffer(10)]],      \
+    constant int64_t & c_stride      [[buffer(11)]],      \
+    constant int64_t & h_stride      [[buffer(12)]],      \
+    constant int64_t & w_stride      [[buffer(13)]],      \
+    uint     index   [[thread_position_in_grid]]);
 
 template<typename T, typename integer_t>
 kernel void ps_roi_align(
@@ -768,75 +750,70 @@ kernel void ps_roi_align(
     constant T       * rois            [[buffer(1)]],
     device   T       * output          [[buffer(2)]],
     device   int64_t * channel_mapping [[buffer(3)]],
-    constant int64_t & output_size     [[buffer(4)]],
-    constant int64_t & channels        [[buffer(5)]],
-    constant int64_t & height          [[buffer(6)]],
-    constant int64_t & width           [[buffer(7)]],
-    constant int64_t & pooled_height   [[buffer(8)]],
-    constant int64_t & pooled_width    [[buffer(9)]],
-    constant int64_t & sampling_ratio  [[buffer(10)]],
-    constant int64_t & channels_out    [[buffer(11)]],
-    constant float   & spatial_scale   [[buffer(12)]],
-    uint2     tgid   [[threadgroup_position_in_grid]],
-    uint2     tptg   [[threads_per_threadgroup]],
-    uint2     tid2   [[thread_position_in_threadgroup]]){
-  MPS_1D_KERNEL_LOOP(index, output_size, 1) {
-    // (n, c_out, ph, pw) is an element in the pooled output
-    integer_t pw = index % pooled_width;
-    integer_t ph = (index / pooled_width) % pooled_height;
-    integer_t c_out = (index / pooled_width / pooled_height) % channels_out;
-    integer_t n = index / pooled_width / pooled_height / channels_out;
+    constant int64_t & channels        [[buffer(4)]],
+    constant int64_t & height          [[buffer(5)]],
+    constant int64_t & width           [[buffer(6)]],
+    constant int64_t & pooled_height   [[buffer(7)]],
+    constant int64_t & pooled_width    [[buffer(8)]],
+    constant int64_t & sampling_ratio  [[buffer(9)]],
+    constant int64_t & channels_out    [[buffer(10)]],
+    constant float   & spatial_scale   [[buffer(11)]],
+    uint     index   [[thread_position_in_grid]]){
+  // (n, c_out, ph, pw) is an element in the pooled output
+  integer_t pw = index % pooled_width;
+  integer_t ph = (index / pooled_width) % pooled_height;
+  integer_t c_out = (index / pooled_width / pooled_height) % channels_out;
+  integer_t n = index / pooled_width / pooled_height / channels_out;
 
-    // (n, c_in, ph, pw) is the associated element in the input
-    integer_t c_in = (c_out * pooled_height + ph) * pooled_width + pw;
+  // (n, c_in, ph, pw) is the associated element in the input
+  integer_t c_in = (c_out * pooled_height + ph) * pooled_width + pw;
 
-    // [start, end) interval for spatial sampling
-    constant T* offset_rois = rois + n * 5;
-    integer_t roi_batch_ind = offset_rois[0];
+  // [start, end) interval for spatial sampling
+  constant T* offset_rois = rois + n * 5;
+  integer_t roi_batch_ind = offset_rois[0];
 
-    // Do not using rounding; this implementation detail is critical
-    T roi_start_w = offset_rois[1] * spatial_scale - static_cast<T>(0.5);
-    T roi_start_h = offset_rois[2] * spatial_scale - static_cast<T>(0.5);
-    T roi_end_w = offset_rois[3] * spatial_scale - static_cast<T>(0.5);
-    T roi_end_h = offset_rois[4] * spatial_scale - static_cast<T>(0.5);
+  // Do not using rounding; this implementation detail is critical
+  T roi_start_w = offset_rois[1] * spatial_scale - static_cast<T>(0.5);
+  T roi_start_h = offset_rois[2] * spatial_scale - static_cast<T>(0.5);
+  T roi_end_w = offset_rois[3] * spatial_scale - static_cast<T>(0.5);
+  T roi_end_h = offset_rois[4] * spatial_scale - static_cast<T>(0.5);
 
-    T roi_width = roi_end_w - roi_start_w;
-    T roi_height = roi_end_h - roi_start_h;
-    T bin_size_h = static_cast<T>(roi_height) / static_cast<T>(pooled_height);
-    T bin_size_w = static_cast<T>(roi_width) / static_cast<T>(pooled_width);
+  T roi_width = roi_end_w - roi_start_w;
+  T roi_height = roi_end_h - roi_start_h;
+  T bin_size_h = static_cast<T>(roi_height) / static_cast<T>(pooled_height);
+  T bin_size_w = static_cast<T>(roi_width) / static_cast<T>(pooled_width);
 
-    // Do not using floor/ceil; this implementation detail is critical
-    T hstart = static_cast<T>(ph) * bin_size_h + roi_start_h;
-    T wstart = static_cast<T>(pw) * bin_size_w + roi_start_w;
+  // Do not using floor/ceil; this implementation detail is critical
+  T hstart = static_cast<T>(ph) * bin_size_h + roi_start_h;
+  T wstart = static_cast<T>(pw) * bin_size_w + roi_start_w;
 
-    // We use roi_bin_grid to sample the grid and mimic integral
-    integer_t roi_bin_grid_h = (sampling_ratio > 0)
-        ? sampling_ratio
-        : ceil(roi_height / pooled_height);
-    integer_t roi_bin_grid_w =
-        (sampling_ratio > 0) ? sampling_ratio : ceil(roi_width / pooled_width);
-    const T count = roi_bin_grid_h * roi_bin_grid_w;
+  // We use roi_bin_grid to sample the grid and mimic integral
+  integer_t roi_bin_grid_h = (sampling_ratio > 0)
+      ? sampling_ratio
+      : ceil(roi_height / pooled_height);
+  integer_t roi_bin_grid_w =
+      (sampling_ratio > 0) ? sampling_ratio : ceil(roi_width / pooled_width);
+  const T count = roi_bin_grid_h * roi_bin_grid_w;
 
-    constant T* offset_input =
-        input + (roi_batch_ind * channels + c_in) * height * width;
-    T out_sum = 0;
-    for (integer_t iy = 0; iy < roi_bin_grid_h; iy++) {
-      const T y = hstart +
-          static_cast<T>(iy + .5f) * bin_size_h /
-              static_cast<T>(roi_bin_grid_h);
-      for (integer_t ix = 0; ix < roi_bin_grid_w; ix++) {
-        const T x = wstart +
-            static_cast<T>(ix + .5f) * bin_size_w /
-                static_cast<T>(roi_bin_grid_w);
-        T val = bilinear_interpolate(offset_input, height, width, y, x, index);
-        out_sum += val;
-      }
+  constant T* offset_input =
+      input + (roi_batch_ind * channels + c_in) * height * width;
+  T out_sum = 0;
+  for (integer_t iy = 0; iy < roi_bin_grid_h; iy++) {
+    const T y = hstart +
+        static_cast<T>(iy + .5f) * bin_size_h /
+            static_cast<T>(roi_bin_grid_h);
+    for (integer_t ix = 0; ix < roi_bin_grid_w; ix++) {
+      const T x = wstart +
+          static_cast<T>(ix + .5f) * bin_size_w /
+              static_cast<T>(roi_bin_grid_w);
+      T val = bilinear_interpolate(offset_input, height, width, y, x, index);
+      out_sum += val;
     }
-
-    out_sum /= count;
-    output[index] = out_sum;
-    channel_mapping[index] = c_in;
   }
+
+  out_sum /= count;
+  output[index] = out_sum;
+  channel_mapping[index] = c_in;
 }
 
 #define REGISTER_PS_ROI_ALIGN_OP(DTYPE, INT_DTYPE)      \
@@ -847,18 +824,15 @@ kernel void ps_roi_align<DTYPE, INT_DTYPE>(             \
   constant DTYPE   * rois            [[buffer(1)]],     \
   device   DTYPE   * output          [[buffer(2)]],     \
   device   int64_t * channel_mapping [[buffer(3)]],     \
-  constant int64_t & output_size     [[buffer(4)]],     \
-  constant int64_t & channels        [[buffer(5)]],     \
-  constant int64_t & height          [[buffer(6)]],     \
-  constant int64_t & width           [[buffer(7)]],     \
-  constant int64_t & pooled_height   [[buffer(8)]],     \
-  constant int64_t & pooled_width    [[buffer(9)]],     \
-  constant int64_t & sampling_ratio  [[buffer(10)]],    \
-  constant int64_t & channels_out    [[buffer(11)]],    \
-  constant float   & spatial_scale   [[buffer(12)]],    \
-  uint2     tgid   [[threadgroup_position_in_grid]],    \
-  uint2     tptg   [[threads_per_threadgroup]],         \
-  uint2     tid2   [[thread_position_in_threadgroup]]);
+  constant int64_t & channels        [[buffer(4)]],     \
+  constant int64_t & height          [[buffer(5)]],     \
+  constant int64_t & width           [[buffer(6)]],     \
+  constant int64_t & pooled_height   [[buffer(7)]],     \
+  constant int64_t & pooled_width    [[buffer(8)]],     \
+  constant int64_t & sampling_ratio  [[buffer(9)]],     \
+  constant int64_t & channels_out    [[buffer(10)]],    \
+  constant float   & spatial_scale   [[buffer(11)]],    \
+  uint     index   [[thread_position_in_grid]]);
 
 template<typename T, typename integer_t>
 kernel void ps_roi_align_backward(
@@ -866,99 +840,93 @@ kernel void ps_roi_align_backward(
     constant T       * rois            [[buffer(1)]],
     constant int64_t * channel_mapping [[buffer(2)]],
     device   T       * grad_input      [[buffer(3)]],
-    constant int64_t & output_size     [[buffer(4)]],
-    constant int64_t & channels        [[buffer(5)]],
-    constant int64_t & height          [[buffer(6)]],
-    constant int64_t & width           [[buffer(7)]],
-    constant int64_t & pooled_height   [[buffer(8)]],
-    constant int64_t & pooled_width    [[buffer(9)]],
-    constant int64_t & sampling_ratio  [[buffer(10)]],
-    constant int64_t & channels_out    [[buffer(11)]],
-    constant float   & spatial_scale   [[buffer(12)]],
-    uint2     tgid   [[threadgroup_position_in_grid]],
-    uint2     tptg   [[threads_per_threadgroup]],
-    uint2     tid2   [[thread_position_in_threadgroup]]){
+    constant int64_t & channels        [[buffer(4)]],
+    constant int64_t & height          [[buffer(5)]],
+    constant int64_t & width           [[buffer(6)]],
+    constant int64_t & pooled_height   [[buffer(7)]],
+    constant int64_t & pooled_width    [[buffer(8)]],
+    constant int64_t & sampling_ratio  [[buffer(9)]],
+    constant int64_t & channels_out    [[buffer(10)]],
+    constant float   & spatial_scale   [[buffer(11)]],
+    uint     index   [[thread_position_in_grid]]){
+  // (n, *, ph, pw) is an element in the pooled output
+  integer_t pw = index % pooled_width;
+  integer_t ph = (index / pooled_width) % pooled_height;
+  integer_t n = index / pooled_width / pooled_height / channels_out;
 
-  MPS_1D_KERNEL_LOOP(index, output_size, 1) {
-    // (n, *, ph, pw) is an element in the pooled output
-    integer_t pw = index % pooled_width;
-    integer_t ph = (index / pooled_width) % pooled_height;
-    integer_t n = index / pooled_width / pooled_height / channels_out;
+  constant T* offset_rois = rois + n * 5;
+  integer_t roi_batch_ind = offset_rois[0];
 
-    constant T* offset_rois = rois + n * 5;
-    integer_t roi_batch_ind = offset_rois[0];
+  // Do not using rounding; this implementation detail is critical
+  T roi_start_w = offset_rois[1] * spatial_scale - static_cast<T>(0.5);
+  T roi_start_h = offset_rois[2] * spatial_scale - static_cast<T>(0.5);
+  T roi_end_w = offset_rois[3] * spatial_scale - static_cast<T>(0.5);
+  T roi_end_h = offset_rois[4] * spatial_scale - static_cast<T>(0.5);
 
-    // Do not using rounding; this implementation detail is critical
-    T roi_start_w = offset_rois[1] * spatial_scale - static_cast<T>(0.5);
-    T roi_start_h = offset_rois[2] * spatial_scale - static_cast<T>(0.5);
-    T roi_end_w = offset_rois[3] * spatial_scale - static_cast<T>(0.5);
-    T roi_end_h = offset_rois[4] * spatial_scale - static_cast<T>(0.5);
+  // Force too small ROIs to be 1x1
+  T roi_width = roi_end_w - roi_start_w;
+  T roi_height = roi_end_h - roi_start_h;
+  T bin_size_h = roi_height / static_cast<T>(pooled_height);
+  T bin_size_w = roi_width / static_cast<T>(pooled_width);
 
-    // Force too small ROIs to be 1x1
-    T roi_width = roi_end_w - roi_start_w;
-    T roi_height = roi_end_h - roi_start_h;
-    T bin_size_h = roi_height / static_cast<T>(pooled_height);
-    T bin_size_w = roi_width / static_cast<T>(pooled_width);
+  integer_t c_in = channel_mapping[index];
 
-    integer_t c_in = channel_mapping[index];
+  // Do not using floor/ceil; this implementation detail is critical
+  T hstart = static_cast<T>(ph) * bin_size_h + roi_start_h;
+  T wstart = static_cast<T>(pw) * bin_size_w + roi_start_w;
 
-    // Do not using floor/ceil; this implementation detail is critical
-    T hstart = static_cast<T>(ph) * bin_size_h + roi_start_h;
-    T wstart = static_cast<T>(pw) * bin_size_w + roi_start_w;
+  const T grad_output_this_bin = grad_output[index];
 
-    const T grad_output_this_bin = grad_output[index];
+  // We use roi_bin_grid to sample the grid and mimic integral
+  integer_t roi_bin_grid_h = (sampling_ratio > 0)
+      ? sampling_ratio
+      : ceil(roi_height / pooled_height); // e.g., = 2
+  integer_t roi_bin_grid_w =
+      (sampling_ratio > 0) ? sampling_ratio : ceil(roi_width / pooled_width);
+  const T count = roi_bin_grid_h * roi_bin_grid_w;
 
-    // We use roi_bin_grid to sample the grid and mimic integral
-    integer_t roi_bin_grid_h = (sampling_ratio > 0)
-        ? sampling_ratio
-        : ceil(roi_height / pooled_height); // e.g., = 2
-    integer_t roi_bin_grid_w =
-        (sampling_ratio > 0) ? sampling_ratio : ceil(roi_width / pooled_width);
-    const T count = roi_bin_grid_h * roi_bin_grid_w;
+  const integer_t offset = (roi_batch_ind * channels + c_in) * height * width;
 
-    const integer_t offset = (roi_batch_ind * channels + c_in) * height * width;
+  for (integer_t iy = 0; iy < roi_bin_grid_h; iy++) {
+    const T y = hstart +
+        static_cast<T>(iy + .5f) * bin_size_h /
+            static_cast<T>(roi_bin_grid_h);
+    for (integer_t ix = 0; ix < roi_bin_grid_w; ix++) {
+      const T x = wstart +
+          static_cast<T>(ix + .5f) * bin_size_w /
+              static_cast<T>(roi_bin_grid_w);
 
-    for (integer_t iy = 0; iy < roi_bin_grid_h; iy++) {
-      const T y = hstart +
-          static_cast<T>(iy + .5f) * bin_size_h /
-              static_cast<T>(roi_bin_grid_h);
-      for (integer_t ix = 0; ix < roi_bin_grid_w; ix++) {
-        const T x = wstart +
-            static_cast<T>(ix + .5f) * bin_size_w /
-                static_cast<T>(roi_bin_grid_w);
+      T w1, w2, w3, w4;
+      integer_t x_low, x_high, y_low, y_high;
 
-        T w1, w2, w3, w4;
-        integer_t x_low, x_high, y_low, y_high;
+      bilinear_interpolate_gradient(
+          height,
+          width,
+          y,
+          x,
+          w1,
+          w2,
+          w3,
+          w4,
+          x_low,
+          x_high,
+          y_low,
+          y_high,
+          index);
 
-        bilinear_interpolate_gradient(
-            height,
-            width,
-            y,
-            x,
-            w1,
-            w2,
-            w3,
-            w4,
-            x_low,
-            x_high,
-            y_low,
-            y_high,
-            index);
+      T g1 = grad_output_this_bin * w1 / count;
+      T g2 = grad_output_this_bin * w2 / count;
+      T g3 = grad_output_this_bin * w3 / count;
+      T g4 = grad_output_this_bin * w4 / count;
 
-        T g1 = grad_output_this_bin * w1 / count;
-        T g2 = grad_output_this_bin * w2 / count;
-        T g3 = grad_output_this_bin * w3 / count;
-        T g4 = grad_output_this_bin * w4 / count;
-
-        if (x_low >= 0 && x_high >= 0 && y_low >= 0 && y_high >= 0) {
-          atomic_add_float(grad_input + offset + y_low * width + x_low, static_cast<T>(g1));
-          atomic_add_float(grad_input + offset + y_low * width + x_high, static_cast<T>(g2));
-          atomic_add_float(grad_input + offset + y_high * width + x_low, static_cast<T>(g3));
-          atomic_add_float(grad_input + offset + y_high * width + x_high, static_cast<T>(g4));
-        } // if
-      } // ix
-    } // iy
-  }
+      if (x_low >= 0 && x_high >= 0 && y_low >= 0 && y_high >= 0) {
+        atomic_add_float(grad_input + offset + y_low * width + x_low, static_cast<T>(g1));
+        atomic_add_float(grad_input + offset + y_low * width + x_high, static_cast<T>(g2));
+        atomic_add_float(grad_input + offset + y_high * width + x_low, static_cast<T>(g3));
+        atomic_add_float(grad_input + offset + y_high * width + x_high, static_cast<T>(g4));
+      } // if
+    } // ix
+  } // iy
 }
 
 #define REGISTER_PS_ROI_ALIGN_BACKWARD_OP(DTYPE, INT_DTYPE)   \
@@ -969,18 +937,15 @@ kernel void ps_roi_align_backward<DTYPE, INT_DTYPE>(          \
     constant DTYPE   * rois            [[buffer(1)]],         \
     constant int64_t * channel_mapping [[buffer(2)]],         \
     device   DTYPE   * grad_input      [[buffer(3)]],         \
-    constant int64_t & output_size     [[buffer(4)]],         \
-    constant int64_t & channels        [[buffer(5)]],         \
-    constant int64_t & height          [[buffer(6)]],         \
-    constant int64_t & width           [[buffer(7)]],         \
-    constant int64_t & pooled_height   [[buffer(8)]],         \
-    constant int64_t & pooled_width    [[buffer(9)]],         \
-    constant int64_t & sampling_ratio  [[buffer(10)]],        \
-    constant int64_t & channels_out    [[buffer(11)]],        \
-    constant float   & spatial_scale   [[buffer(12)]],        \
-    uint2     tgid   [[threadgroup_position_in_grid]],        \
-    uint2     tptg   [[threads_per_threadgroup]],             \
-    uint2     tid2   [[thread_position_in_threadgroup]]);
+    constant int64_t & channels        [[buffer(4)]],         \
+    constant int64_t & height          [[buffer(5)]],         \
+    constant int64_t & width           [[buffer(6)]],         \
+    constant int64_t & pooled_height   [[buffer(7)]],         \
+    constant int64_t & pooled_width    [[buffer(8)]],         \
+    constant int64_t & sampling_ratio  [[buffer(9)]],         \
+    constant int64_t & channels_out    [[buffer(10)]],        \
+    constant float   & spatial_scale   [[buffer(11)]],        \
+    uint     index   [[thread_position_in_grid]]);
 
 template<typename T, typename integer_t>
 kernel void ps_roi_pool(
@@ -988,67 +953,62 @@ kernel void ps_roi_pool(
     constant T       * rois            [[buffer(1)]],
     device   T       * output          [[buffer(2)]],
     device   int64_t * channel_mapping [[buffer(3)]],
-    constant int64_t & output_size     [[buffer(4)]],
-    constant int64_t & channels        [[buffer(5)]],
-    constant int64_t & height          [[buffer(6)]],
-    constant int64_t & width           [[buffer(7)]],
-    constant int64_t & pooled_height   [[buffer(8)]],
-    constant int64_t & pooled_width    [[buffer(9)]],
-    constant int64_t & channels_out    [[buffer(10)]],
-    constant float   & spatial_scale   [[buffer(11)]],
-    uint2     tgid   [[threadgroup_position_in_grid]],
-    uint2     tptg   [[threads_per_threadgroup]],
-    uint2     tid2   [[thread_position_in_threadgroup]]){
-  MPS_1D_KERNEL_LOOP(index, output_size, 1) {
-    // (n, c_out, ph, pw) is an element in the pooled output
-    integer_t pw = index % pooled_width;
-    integer_t ph = (index / pooled_width) % pooled_height;
-    integer_t c_out = (index / (pooled_width * pooled_height)) % channels_out;
-    integer_t n = index / pooled_width / pooled_height / channels_out;
+    constant int64_t & channels        [[buffer(4)]],
+    constant int64_t & height          [[buffer(5)]],
+    constant int64_t & width           [[buffer(6)]],
+    constant int64_t & pooled_height   [[buffer(7)]],
+    constant int64_t & pooled_width    [[buffer(8)]],
+    constant int64_t & channels_out    [[buffer(9)]],
+    constant float   & spatial_scale   [[buffer(10)]],
+    uint     index   [[thread_position_in_grid]]){
+  // (n, c_out, ph, pw) is an element in the pooled output
+  integer_t pw = index % pooled_width;
+  integer_t ph = (index / pooled_width) % pooled_height;
+  integer_t c_out = (index / (pooled_width * pooled_height)) % channels_out;
+  integer_t n = index / pooled_width / pooled_height / channels_out;
 
-    // (n, c_in, ph, pw) is the associated element in the input
-    integer_t c_in = (c_out * pooled_height + ph) * pooled_width + pw;
+  // (n, c_in, ph, pw) is the associated element in the input
+  integer_t c_in = (c_out * pooled_height + ph) * pooled_width + pw;
 
-    // [start, end) interval for spatial sampling
-    constant T* offset_rois = rois + n * 5;
-    integer_t roi_batch_ind = offset_rois[0];
-    integer_t roi_start_w = round(offset_rois[1] * spatial_scale);
-    integer_t roi_start_h = round(offset_rois[2] * spatial_scale);
-    integer_t roi_end_w = round(offset_rois[3] * spatial_scale);
-    integer_t roi_end_h = round(offset_rois[4] * spatial_scale);
+  // [start, end) interval for spatial sampling
+  constant T* offset_rois = rois + n * 5;
+  integer_t roi_batch_ind = offset_rois[0];
+  integer_t roi_start_w = round(offset_rois[1] * spatial_scale);
+  integer_t roi_start_h = round(offset_rois[2] * spatial_scale);
+  integer_t roi_end_w = round(offset_rois[3] * spatial_scale);
+  integer_t roi_end_h = round(offset_rois[4] * spatial_scale);
 
-    // Force too small ROIs to be 1x1
-    integer_t roi_width = max(roi_end_w - roi_start_w, static_cast<integer_t>(1));
-    integer_t roi_height = max(roi_end_h - roi_start_h, static_cast<integer_t>(1));
-    T bin_size_h = static_cast<T>(roi_height) / static_cast<T>(pooled_height);
-    T bin_size_w = static_cast<T>(roi_width) / static_cast<T>(pooled_width);
+  // Force too small ROIs to be 1x1
+  integer_t roi_width = max(roi_end_w - roi_start_w, static_cast<integer_t>(1));
+  integer_t roi_height = max(roi_end_h - roi_start_h, static_cast<integer_t>(1));
+  T bin_size_h = static_cast<T>(roi_height) / static_cast<T>(pooled_height);
+  T bin_size_w = static_cast<T>(roi_width) / static_cast<T>(pooled_width);
 
-    integer_t hstart = static_cast<integer_t>(floor(static_cast<T>(ph) * bin_size_h));
-    integer_t wstart = static_cast<integer_t>(floor(static_cast<T>(pw) * bin_size_w));
-    integer_t hend = static_cast<integer_t>(ceil(static_cast<T>(ph + 1) * bin_size_h));
-    integer_t wend = static_cast<integer_t>(ceil(static_cast<T>(pw + 1) * bin_size_w));
+  integer_t hstart = static_cast<integer_t>(floor(static_cast<T>(ph) * bin_size_h));
+  integer_t wstart = static_cast<integer_t>(floor(static_cast<T>(pw) * bin_size_w));
+  integer_t hend = static_cast<integer_t>(ceil(static_cast<T>(ph + 1) * bin_size_h));
+  integer_t wend = static_cast<integer_t>(ceil(static_cast<T>(pw + 1) * bin_size_w));
 
-    // Add roi offsets and clip to input boundaries
-    hstart = min(max(hstart + roi_start_h, static_cast<integer_t>(0)), static_cast<integer_t>(height - 1));
-    hend = min(max(hend + roi_start_h, static_cast<integer_t>(0)), static_cast<integer_t>(height - 1));
-    wstart = min(max(wstart + roi_start_w, static_cast<integer_t>(0)), static_cast<integer_t>(width - 1));
-    wend = min(max(wend + roi_start_w, static_cast<integer_t>(0)), static_cast<integer_t>(width - 1));
-    bool is_empty = (hend <= hstart) || (wend <= wstart);
+  // Add roi offsets and clip to input boundaries
+  hstart = min(max(hstart + roi_start_h, static_cast<integer_t>(0)), static_cast<integer_t>(height - 1));
+  hend = min(max(hend + roi_start_h, static_cast<integer_t>(0)), static_cast<integer_t>(height - 1));
+  wstart = min(max(wstart + roi_start_w, static_cast<integer_t>(0)), static_cast<integer_t>(width - 1));
+  wend = min(max(wend + roi_start_w, static_cast<integer_t>(0)), static_cast<integer_t>(width - 1));
+  bool is_empty = (hend <= hstart) || (wend <= wstart);
 
-    constant T* offset_input =
-        input + (roi_batch_ind * channels + c_in) * height * width;
-    T out_sum = 0;
-    for (integer_t h = hstart; h < hend; ++h) {
-      for (integer_t w = wstart; w < wend; ++w) {
-        integer_t input_index = h * width + w;
-        out_sum += offset_input[input_index];
-      }
+  constant T* offset_input =
+      input + (roi_batch_ind * channels + c_in) * height * width;
+  T out_sum = 0;
+  for (integer_t h = hstart; h < hend; ++h) {
+    for (integer_t w = wstart; w < wend; ++w) {
+      integer_t input_index = h * width + w;
+      out_sum += offset_input[input_index];
     }
-
-    T bin_area = (hend - hstart) * (wend - wstart);
-    output[index] = is_empty ? static_cast<T>(0) : out_sum / bin_area;
-    channel_mapping[index] = c_in;
   }
+
+  T bin_area = (hend - hstart) * (wend - wstart);
+  output[index] = is_empty ? static_cast<T>(0) : out_sum / bin_area;
+  channel_mapping[index] = c_in;
 }
 
 #define REGISTER_PS_ROI_POOL_OP(DTYPE, INT_DTYPE)     \
@@ -1059,17 +1019,14 @@ kernel void ps_roi_pool<DTYPE, INT_DTYPE>(            \
   constant DTYPE   * rois            [[buffer(1)]],   \
   device   DTYPE   * output          [[buffer(2)]],   \
   device   int64_t * channel_mapping [[buffer(3)]],   \
-  constant int64_t & output_size     [[buffer(4)]],   \
-  constant int64_t & channels        [[buffer(5)]],   \
-  constant int64_t & height          [[buffer(6)]],   \
-  constant int64_t & width           [[buffer(7)]],   \
-  constant int64_t & pooled_height   [[buffer(8)]],   \
-  constant int64_t & pooled_width    [[buffer(9)]],   \
-  constant int64_t & channels_out    [[buffer(10)]],  \
-  constant float   & spatial_scale   [[buffer(11)]],  \
-  uint2    tgid   [[threadgroup_position_in_grid]],   \
-  uint2    tptg   [[threads_per_threadgroup]],        \
-  uint2    tid2   [[thread_position_in_threadgroup]]);
+  constant int64_t & channels        [[buffer(4)]],   \
+  constant int64_t & height          [[buffer(5)]],   \
+  constant int64_t & width           [[buffer(6)]],   \
+  constant int64_t & pooled_height   [[buffer(7)]],   \
+  constant int64_t & pooled_width    [[buffer(8)]],   \
+  constant int64_t & channels_out    [[buffer(9)]],   \
+  constant float   & spatial_scale   [[buffer(10)]],  \
+  uint    index   [[thread_position_in_grid]]);
 
 template<typename T, typename integer_t>
 kernel void ps_roi_pool_backward(
@@ -1077,63 +1034,56 @@ kernel void ps_roi_pool_backward(
     constant T       * rois            [[buffer(1)]],
     constant int64_t * channel_mapping [[buffer(2)]],
     device   T       * grad_input      [[buffer(3)]],
-    constant int64_t & output_size     [[buffer(4)]],
-    constant int64_t & channels        [[buffer(5)]],
-    constant int64_t & height          [[buffer(6)]],
-    constant int64_t & width           [[buffer(7)]],
-    constant int64_t & pooled_height   [[buffer(8)]],
-    constant int64_t & pooled_width    [[buffer(9)]],
-    constant int64_t & channels_out    [[buffer(10)]],
-    constant float   & spatial_scale   [[buffer(11)]],
-    uint2     tgid   [[threadgroup_position_in_grid]],
-    uint2     tptg   [[threads_per_threadgroup]],
-    uint2     tid2   [[thread_position_in_threadgroup]]){
+    constant int64_t & channels        [[buffer(4)]],
+    constant int64_t & height          [[buffer(5)]],
+    constant int64_t & width           [[buffer(6)]],
+    constant int64_t & pooled_height   [[buffer(7)]],
+    constant int64_t & pooled_width    [[buffer(8)]],
+    constant int64_t & channels_out    [[buffer(9)]],
+    constant float   & spatial_scale   [[buffer(10)]],
+    uint     index   [[thread_position_in_grid]]){
+  // (n, *, ph, pw) is an element in the pooled output
+  integer_t pw = index % pooled_width;
+  integer_t ph = (index / pooled_width) % pooled_height;
+  integer_t n = index / pooled_width / pooled_height / channels_out;
 
-  MPS_1D_KERNEL_LOOP(index, output_size, 1) {
-    // (n, *, ph, pw) is an element in the pooled output
-    integer_t pw = index % pooled_width;
-    integer_t ph = (index / pooled_width) % pooled_height;
-    integer_t n = index / pooled_width / pooled_height / channels_out;
+  constant T* offset_rois = rois + n * 5;
+  integer_t roi_batch_ind = offset_rois[0];
+  integer_t roi_start_w = round(offset_rois[1] * spatial_scale);
+  integer_t roi_start_h = round(offset_rois[2] * spatial_scale);
+  integer_t roi_end_w = round(offset_rois[3] * spatial_scale);
+  integer_t roi_end_h = round(offset_rois[4] * spatial_scale);
 
-    constant T* offset_rois = rois + n * 5;
-    integer_t roi_batch_ind = offset_rois[0];
-    integer_t roi_start_w = round(offset_rois[1] * spatial_scale);
-    integer_t roi_start_h = round(offset_rois[2] * spatial_scale);
-    integer_t roi_end_w = round(offset_rois[3] * spatial_scale);
-    integer_t roi_end_h = round(offset_rois[4] * spatial_scale);
+  // Force too small ROIs to be 1x1
+  integer_t roi_width = max(roi_end_w - roi_start_w, static_cast<integer_t>(1));
+  integer_t roi_height = max(roi_end_h - roi_start_h, static_cast<integer_t>(1));
+  T bin_size_h = static_cast<T>(roi_height) / static_cast<T>(pooled_height);
+  T bin_size_w = static_cast<T>(roi_width) / static_cast<T>(pooled_width);
 
-    // Force too small ROIs to be 1x1
-    integer_t roi_width = max(roi_end_w - roi_start_w, static_cast<integer_t>(1));
-    integer_t roi_height = max(roi_end_h - roi_start_h, static_cast<integer_t>(1));
-    T bin_size_h = static_cast<T>(roi_height) / static_cast<T>(pooled_height);
-    T bin_size_w = static_cast<T>(roi_width) / static_cast<T>(pooled_width);
+  integer_t hstart = static_cast<integer_t>(floor(static_cast<T>(ph) * bin_size_h));
+  integer_t wstart = static_cast<integer_t>(floor(static_cast<T>(pw) * bin_size_w));
+  integer_t hend = static_cast<integer_t>(ceil(static_cast<T>(ph + 1) * bin_size_h));
+  integer_t wend = static_cast<integer_t>(ceil(static_cast<T>(pw + 1) * bin_size_w));
 
-    integer_t hstart = static_cast<integer_t>(floor(static_cast<T>(ph) * bin_size_h));
-    integer_t wstart = static_cast<integer_t>(floor(static_cast<T>(pw) * bin_size_w));
-    integer_t hend = static_cast<integer_t>(ceil(static_cast<T>(ph + 1) * bin_size_h));
-    integer_t wend = static_cast<integer_t>(ceil(static_cast<T>(pw + 1) * bin_size_w));
+  // Add roi offsets and clip to input boundaries
+  hstart = min(max(hstart + roi_start_h, static_cast<integer_t>(0)), static_cast<integer_t>(height));
+  hend = min(max(hend + roi_start_h, static_cast<integer_t>(0)), static_cast<integer_t>(height));
+  wstart = min(max(wstart + roi_start_w, static_cast<integer_t>(0)), static_cast<integer_t>(width));
+  wend = min(max(wend + roi_start_w, static_cast<integer_t>(0)), static_cast<integer_t>(width));
+  bool is_empty = (hend <= hstart) || (wend <= wstart);
 
-    // Add roi offsets and clip to input boundaries
-    hstart = min(max(hstart + roi_start_h, static_cast<integer_t>(0)), static_cast<integer_t>(height));
-    hend = min(max(hend + roi_start_h, static_cast<integer_t>(0)), static_cast<integer_t>(height));
-    wstart = min(max(wstart + roi_start_w, static_cast<integer_t>(0)), static_cast<integer_t>(width));
-    wend = min(max(wend + roi_start_w, static_cast<integer_t>(0)), static_cast<integer_t>(width));
-    bool is_empty = (hend <= hstart) || (wend <= wstart);
+  integer_t c_in = channel_mapping[index];
+  T bin_area = (hend - hstart) * (wend - wstart);
+  T diff_val = is_empty ? static_cast<T>(0) : grad_output[index] / bin_area;
 
-    integer_t c_in = channel_mapping[index];
-    T bin_area = (hend - hstart) * (wend - wstart);
-    T diff_val = is_empty ? static_cast<T>(0) : grad_output[index] / bin_area;
+  const integer_t offset = (roi_batch_ind * channels + c_in) * height * width;
 
-    const integer_t offset = (roi_batch_ind * channels + c_in) * height * width;
-
-    for (integer_t h = hstart; h < hend; ++h) {
-      for (integer_t w = wstart; w < wend; ++w) {
-        integer_t grad_input_index = h * width + w;
-        atomic_add_float(grad_input + offset + grad_input_index, diff_val);
-      }
+  for (integer_t h = hstart; h < hend; ++h) {
+    for (integer_t w = wstart; w < wend; ++w) {
+      integer_t grad_input_index = h * width + w;
+      atomic_add_float(grad_input + offset + grad_input_index, diff_val);
     }
-    
-  } // MPS_1D_KERNEL_LOOP
+  }
 }
 
 #define REGISTER_PS_ROI_POOL_BACKWARD_OP(DTYPE, INT_DTYPE)   \
@@ -1144,17 +1094,14 @@ kernel void ps_roi_pool_backward<DTYPE, INT_DTYPE>(          \
     constant DTYPE   * rois            [[buffer(1)]],        \
     constant int64_t * channel_mapping [[buffer(2)]],        \
     device   DTYPE   * grad_input      [[buffer(3)]],        \
-    constant int64_t & output_size     [[buffer(4)]],        \
-    constant int64_t & channels        [[buffer(5)]],        \
-    constant int64_t & height          [[buffer(6)]],        \
-    constant int64_t & width           [[buffer(7)]],        \
-    constant int64_t & pooled_height   [[buffer(8)]],        \
-    constant int64_t & pooled_width    [[buffer(9)]],        \
-    constant int64_t & channels_out    [[buffer(10)]],       \
-    constant float   & spatial_scale   [[buffer(11)]],       \
-    uint2     tgid   [[threadgroup_position_in_grid]],       \
-    uint2     tptg   [[threads_per_threadgroup]],            \
-    uint2     tid2   [[thread_position_in_threadgroup]]);
+    constant int64_t & channels        [[buffer(4)]],        \
+    constant int64_t & height          [[buffer(5)]],        \
+    constant int64_t & width           [[buffer(6)]],        \
+    constant int64_t & pooled_height   [[buffer(7)]],        \
+    constant int64_t & pooled_width    [[buffer(8)]],        \
+    constant int64_t & channels_out    [[buffer(9)]],        \
+    constant float   & spatial_scale   [[buffer(10)]],       \
+    uint     index   [[thread_position_in_grid]]);
 
 REGISTER_NMS_OP(float);
 REGISTER_NMS_OP(half);

--- a/torchvision/csrc/ops/mps/ps_roi_align_kernel.mm
+++ b/torchvision/csrc/ops/mps/ps_roi_align_kernel.mm
@@ -57,6 +57,10 @@ std::tuple<at::Tensor, at::Tensor> ps_roi_align_forward_kernel(const at::Tensor&
   dispatch_sync(mpsStream->queue(), ^() {
     @autoreleasepool {
       id<MTLComputeCommandEncoder> computeEncoder = mpsStream->commandEncoder();
+      MTLSize threadgroupsPerGrid = MTLSizeMake(
+          std::min(ceil_div(static_cast<int64_t>(output_size), static_cast<int64_t>(512)), static_cast<int64_t>(4096)),
+          1,
+          1);
 
       const std::string kernel = "ps_roi_align_" + scalarToMetalTypeString(input.scalar_type());
       id<MTLComputePipelineState> visionPSO = mps::visionPipelineState(device, kernel);
@@ -73,19 +77,24 @@ std::tuple<at::Tensor, at::Tensor> ps_roi_align_forward_kernel(const at::Tensor&
                          offset:channel_mapping.storage_offset() * channel_mapping.element_size()
                         atIndex:3];
 
-      [computeEncoder setBytes:&channels length:sizeof(int64_t) atIndex:4];
-      [computeEncoder setBytes:&height length:sizeof(int64_t) atIndex:5];
-      [computeEncoder setBytes:&width length:sizeof(int64_t) atIndex:6];
-      [computeEncoder setBytes:&pooled_height length:sizeof(int64_t) atIndex:7];
-      [computeEncoder setBytes:&pooled_width length:sizeof(int64_t) atIndex:8];
-      [computeEncoder setBytes:&sampling_ratio length:sizeof(int64_t) atIndex:9];
-      [computeEncoder setBytes:&channels_out length:sizeof(int64_t) atIndex:10];
-      [computeEncoder setBytes:&spatial_scale_f length:sizeof(float) atIndex:11];
+      [computeEncoder setBytes:&output_size length:sizeof(int64_t) atIndex:4];
+      [computeEncoder setBytes:&channels length:sizeof(int64_t) atIndex:5];
+      [computeEncoder setBytes:&height length:sizeof(int64_t) atIndex:6];
+      [computeEncoder setBytes:&width length:sizeof(int64_t) atIndex:7];
+      [computeEncoder setBytes:&pooled_height length:sizeof(int64_t) atIndex:8];
+      [computeEncoder setBytes:&pooled_width length:sizeof(int64_t) atIndex:9];
+      [computeEncoder setBytes:&sampling_ratio length:sizeof(int64_t) atIndex:10];
+      [computeEncoder setBytes:&channels_out length:sizeof(int64_t) atIndex:11];
+      [computeEncoder setBytes:&spatial_scale_f length:sizeof(float) atIndex:12];
 
-      MTLSize threadsPerGrid = MTLSizeMake(output_size, 1, 1);
-      NSUInteger tgSize = std::min(static_cast<int64_t>(visionPSO.maxTotalThreadsPerThreadgroup), output_size);
-      MTLSize threadGroupSize = MTLSizeMake(std::max<NSUInteger>(tgSize, 1), 1, 1);
-      [computeEncoder dispatchThreads:threadsPerGrid threadsPerThreadgroup:threadGroupSize];
+      // A threadGroup is equivalent to a cuda's block.
+      NSUInteger tgSize = visionPSO.maxTotalThreadsPerThreadgroup;
+      if (tgSize > threadsPerBlock) {
+        tgSize = threadsPerBlock;
+      }
+
+      MTLSize threadGroupSize = MTLSizeMake(tgSize, 1, 1);
+      [computeEncoder dispatchThreadgroups:threadgroupsPerGrid threadsPerThreadgroup:threadGroupSize];
 
       getMPSProfiler().endProfileKernel(visionPSO);
     }
@@ -156,15 +165,19 @@ at::Tensor ps_roi_align_backward_kernel(const at::Tensor& grad,
                         atIndex:2];
       [computeEncoder setBuffer:outputBuffer offset:grad_input.storage_offset() * grad_input.element_size() atIndex:3];
 
-      [computeEncoder setBytes:&channels length:sizeof(int64_t) atIndex:4];
-      [computeEncoder setBytes:&height length:sizeof(int64_t) atIndex:5];
-      [computeEncoder setBytes:&width length:sizeof(int64_t) atIndex:6];
-      [computeEncoder setBytes:&pooled_height length:sizeof(int64_t) atIndex:7];
-      [computeEncoder setBytes:&pooled_width length:sizeof(int64_t) atIndex:8];
-      [computeEncoder setBytes:&sampling_ratio length:sizeof(int64_t) atIndex:9];
-      [computeEncoder setBytes:&channels_out length:sizeof(int64_t) atIndex:10];
-      [computeEncoder setBytes:&spatial_scale_f length:sizeof(float) atIndex:11];
+      [computeEncoder setBytes:&output_size length:sizeof(int64_t) atIndex:4];
+      [computeEncoder setBytes:&channels length:sizeof(int64_t) atIndex:5];
+      [computeEncoder setBytes:&height length:sizeof(int64_t) atIndex:6];
+      [computeEncoder setBytes:&width length:sizeof(int64_t) atIndex:7];
+      [computeEncoder setBytes:&pooled_height length:sizeof(int64_t) atIndex:8];
+      [computeEncoder setBytes:&pooled_width length:sizeof(int64_t) atIndex:9];
+      [computeEncoder setBytes:&sampling_ratio length:sizeof(int64_t) atIndex:10];
+      [computeEncoder setBytes:&channels_out length:sizeof(int64_t) atIndex:11];
+      [computeEncoder setBytes:&spatial_scale_f length:sizeof(float) atIndex:12];
 
+      // One thread per pooled-output element. dispatchThreads guarantees each
+      // index is handled exactly once; the kernel scatters into grad_input with
+      // atomic_add for overlapping RoIs.
       MTLSize threadsPerGrid = MTLSizeMake(output_size, 1, 1);
       NSUInteger tgSize = std::min(static_cast<int64_t>(visionPSO.maxTotalThreadsPerThreadgroup), output_size);
       MTLSize threadGroupSize = MTLSizeMake(std::max<NSUInteger>(tgSize, 1), 1, 1);

--- a/torchvision/csrc/ops/mps/ps_roi_align_kernel.mm
+++ b/torchvision/csrc/ops/mps/ps_roi_align_kernel.mm
@@ -48,6 +48,10 @@ std::tuple<at::Tensor, at::Tensor> ps_roi_align_forward_kernel(const at::Tensor&
   auto input_ = input.contiguous();
   auto rois_ = rois.contiguous();
 
+  id<MTLBuffer> inputBuffer = getMTLBufferStorage(input_);
+  id<MTLBuffer> roisBuffer = getMTLBufferStorage(rois_);
+  id<MTLBuffer> outputBuffer = getMTLBufferStorage(output);
+  id<MTLBuffer> channelMappingBuffer = getMTLBufferStorage(channel_mapping);
   id<MTLDevice> device = MPSDevice::getInstance()->device();
   MPSStream* mpsStream = getCurrentMPSStream();
   dispatch_sync(mpsStream->queue(), ^() {
@@ -62,19 +66,21 @@ std::tuple<at::Tensor, at::Tensor> ps_roi_align_forward_kernel(const at::Tensor&
 
       [computeEncoder setComputePipelineState:visionPSO];
       // [N, C, H, W]
-      mtl_setArgs(computeEncoder,
-                  input_,
-                  rois_,
-                  output,
-                  channel_mapping,
-                  channels,
-                  height,
-                  width,
-                  pooled_height,
-                  pooled_width,
-                  sampling_ratio,
-                  channels_out,
-                  spatial_scale_f);
+      [computeEncoder setBuffer:inputBuffer offset:input_.storage_offset() * input_.element_size() atIndex:0];
+      [computeEncoder setBuffer:roisBuffer offset:rois_.storage_offset() * rois_.element_size() atIndex:1];
+      [computeEncoder setBuffer:outputBuffer offset:output.storage_offset() * output.element_size() atIndex:2];
+      [computeEncoder setBuffer:channelMappingBuffer
+                         offset:channel_mapping.storage_offset() * channel_mapping.element_size()
+                        atIndex:3];
+
+      [computeEncoder setBytes:&channels length:sizeof(int64_t) atIndex:4];
+      [computeEncoder setBytes:&height length:sizeof(int64_t) atIndex:5];
+      [computeEncoder setBytes:&width length:sizeof(int64_t) atIndex:6];
+      [computeEncoder setBytes:&pooled_height length:sizeof(int64_t) atIndex:7];
+      [computeEncoder setBytes:&pooled_width length:sizeof(int64_t) atIndex:8];
+      [computeEncoder setBytes:&sampling_ratio length:sizeof(int64_t) atIndex:9];
+      [computeEncoder setBytes:&channels_out length:sizeof(int64_t) atIndex:10];
+      [computeEncoder setBytes:&spatial_scale_f length:sizeof(float) atIndex:11];
 
       MTLSize threadsPerGrid = MTLSizeMake(output_size, 1, 1);
       NSUInteger tgSize = std::min(static_cast<int64_t>(visionPSO.maxTotalThreadsPerThreadgroup), output_size);
@@ -125,6 +131,10 @@ at::Tensor ps_roi_align_backward_kernel(const at::Tensor& grad,
   at::globalContext().alertNotDeterministic("ps_roi_align_backward_kernel");
   auto grad_ = grad.contiguous(), rois_ = rois.contiguous();
 
+  id<MTLBuffer> inputBuffer = getMTLBufferStorage(grad_);
+  id<MTLBuffer> roisBuffer = getMTLBufferStorage(rois_);
+  id<MTLBuffer> channelMappingBuffer = getMTLBufferStorage(channel_mapping);
+  id<MTLBuffer> outputBuffer = getMTLBufferStorage(grad_input);
   id<MTLDevice> device = MPSDevice::getInstance()->device();
   MPSStream* mpsStream = getCurrentMPSStream();
   dispatch_sync(mpsStream->queue(), ^() {
@@ -139,19 +149,21 @@ at::Tensor ps_roi_align_backward_kernel(const at::Tensor& grad,
 
       [computeEncoder setComputePipelineState:visionPSO];
       // [N, C, H, W]
-      mtl_setArgs(computeEncoder,
-                  grad_,
-                  rois_,
-                  channel_mapping,
-                  grad_input,
-                  channels,
-                  height,
-                  width,
-                  pooled_height,
-                  pooled_width,
-                  sampling_ratio,
-                  channels_out,
-                  spatial_scale_f);
+      [computeEncoder setBuffer:inputBuffer offset:grad_.storage_offset() * grad_.element_size() atIndex:0];
+      [computeEncoder setBuffer:roisBuffer offset:rois_.storage_offset() * rois_.element_size() atIndex:1];
+      [computeEncoder setBuffer:channelMappingBuffer
+                         offset:channel_mapping.storage_offset() * channel_mapping.element_size()
+                        atIndex:2];
+      [computeEncoder setBuffer:outputBuffer offset:grad_input.storage_offset() * grad_input.element_size() atIndex:3];
+
+      [computeEncoder setBytes:&channels length:sizeof(int64_t) atIndex:4];
+      [computeEncoder setBytes:&height length:sizeof(int64_t) atIndex:5];
+      [computeEncoder setBytes:&width length:sizeof(int64_t) atIndex:6];
+      [computeEncoder setBytes:&pooled_height length:sizeof(int64_t) atIndex:7];
+      [computeEncoder setBytes:&pooled_width length:sizeof(int64_t) atIndex:8];
+      [computeEncoder setBytes:&sampling_ratio length:sizeof(int64_t) atIndex:9];
+      [computeEncoder setBytes:&channels_out length:sizeof(int64_t) atIndex:10];
+      [computeEncoder setBytes:&spatial_scale_f length:sizeof(float) atIndex:11];
 
       MTLSize threadsPerGrid = MTLSizeMake(output_size, 1, 1);
       NSUInteger tgSize = std::min(static_cast<int64_t>(visionPSO.maxTotalThreadsPerThreadgroup), output_size);

--- a/torchvision/csrc/ops/mps/ps_roi_align_kernel.mm
+++ b/torchvision/csrc/ops/mps/ps_roi_align_kernel.mm
@@ -48,19 +48,11 @@ std::tuple<at::Tensor, at::Tensor> ps_roi_align_forward_kernel(const at::Tensor&
   auto input_ = input.contiguous();
   auto rois_ = rois.contiguous();
 
-  id<MTLBuffer> inputBuffer = getMTLBufferStorage(input_);
-  id<MTLBuffer> roisBuffer = getMTLBufferStorage(rois_);
-  id<MTLBuffer> outputBuffer = getMTLBufferStorage(output);
-  id<MTLBuffer> channelMappingBuffer = getMTLBufferStorage(channel_mapping);
   id<MTLDevice> device = MPSDevice::getInstance()->device();
   MPSStream* mpsStream = getCurrentMPSStream();
   dispatch_sync(mpsStream->queue(), ^() {
     @autoreleasepool {
       id<MTLComputeCommandEncoder> computeEncoder = mpsStream->commandEncoder();
-      MTLSize threadgroupsPerGrid = MTLSizeMake(
-          std::min(ceil_div(static_cast<int64_t>(output_size), static_cast<int64_t>(512)), static_cast<int64_t>(4096)),
-          1,
-          1);
 
       const std::string kernel = "ps_roi_align_" + scalarToMetalTypeString(input.scalar_type());
       id<MTLComputePipelineState> visionPSO = mps::visionPipelineState(device, kernel);
@@ -70,31 +62,24 @@ std::tuple<at::Tensor, at::Tensor> ps_roi_align_forward_kernel(const at::Tensor&
 
       [computeEncoder setComputePipelineState:visionPSO];
       // [N, C, H, W]
-      [computeEncoder setBuffer:inputBuffer offset:input_.storage_offset() * input_.element_size() atIndex:0];
-      [computeEncoder setBuffer:roisBuffer offset:rois_.storage_offset() * rois_.element_size() atIndex:1];
-      [computeEncoder setBuffer:outputBuffer offset:output.storage_offset() * output.element_size() atIndex:2];
-      [computeEncoder setBuffer:channelMappingBuffer
-                         offset:channel_mapping.storage_offset() * channel_mapping.element_size()
-                        atIndex:3];
+      mtl_setArgs(computeEncoder,
+                  input_,
+                  rois_,
+                  output,
+                  channel_mapping,
+                  channels,
+                  height,
+                  width,
+                  pooled_height,
+                  pooled_width,
+                  sampling_ratio,
+                  channels_out,
+                  spatial_scale_f);
 
-      [computeEncoder setBytes:&output_size length:sizeof(int64_t) atIndex:4];
-      [computeEncoder setBytes:&channels length:sizeof(int64_t) atIndex:5];
-      [computeEncoder setBytes:&height length:sizeof(int64_t) atIndex:6];
-      [computeEncoder setBytes:&width length:sizeof(int64_t) atIndex:7];
-      [computeEncoder setBytes:&pooled_height length:sizeof(int64_t) atIndex:8];
-      [computeEncoder setBytes:&pooled_width length:sizeof(int64_t) atIndex:9];
-      [computeEncoder setBytes:&sampling_ratio length:sizeof(int64_t) atIndex:10];
-      [computeEncoder setBytes:&channels_out length:sizeof(int64_t) atIndex:11];
-      [computeEncoder setBytes:&spatial_scale_f length:sizeof(float) atIndex:12];
-
-      // A threadGroup is equivalent to a cuda's block.
-      NSUInteger tgSize = visionPSO.maxTotalThreadsPerThreadgroup;
-      if (tgSize > threadsPerBlock) {
-        tgSize = threadsPerBlock;
-      }
-
-      MTLSize threadGroupSize = MTLSizeMake(tgSize, 1, 1);
-      [computeEncoder dispatchThreadgroups:threadgroupsPerGrid threadsPerThreadgroup:threadGroupSize];
+      MTLSize threadsPerGrid = MTLSizeMake(output_size, 1, 1);
+      NSUInteger tgSize = std::min(static_cast<int64_t>(visionPSO.maxTotalThreadsPerThreadgroup), output_size);
+      MTLSize threadGroupSize = MTLSizeMake(std::max<NSUInteger>(tgSize, 1), 1, 1);
+      [computeEncoder dispatchThreads:threadsPerGrid threadsPerThreadgroup:threadGroupSize];
 
       getMPSProfiler().endProfileKernel(visionPSO);
     }
@@ -140,19 +125,11 @@ at::Tensor ps_roi_align_backward_kernel(const at::Tensor& grad,
   at::globalContext().alertNotDeterministic("ps_roi_align_backward_kernel");
   auto grad_ = grad.contiguous(), rois_ = rois.contiguous();
 
-  id<MTLBuffer> inputBuffer = getMTLBufferStorage(grad_);
-  id<MTLBuffer> roisBuffer = getMTLBufferStorage(rois_);
-  id<MTLBuffer> channelMappingBuffer = getMTLBufferStorage(channel_mapping);
-  id<MTLBuffer> outputBuffer = getMTLBufferStorage(grad_input);
   id<MTLDevice> device = MPSDevice::getInstance()->device();
   MPSStream* mpsStream = getCurrentMPSStream();
   dispatch_sync(mpsStream->queue(), ^() {
     @autoreleasepool {
       id<MTLComputeCommandEncoder> computeEncoder = mpsStream->commandEncoder();
-      MTLSize threadgroupsPerGrid = MTLSizeMake(
-          std::min(ceil_div(static_cast<int64_t>(grad.numel()), static_cast<int64_t>(512)), static_cast<int64_t>(4096)),
-          1,
-          1);
 
       const std::string kernel = "ps_roi_align_backward_" + scalarToMetalTypeString(grad.scalar_type());
       id<MTLComputePipelineState> visionPSO = mps::visionPipelineState(device, kernel);
@@ -162,31 +139,24 @@ at::Tensor ps_roi_align_backward_kernel(const at::Tensor& grad,
 
       [computeEncoder setComputePipelineState:visionPSO];
       // [N, C, H, W]
-      [computeEncoder setBuffer:inputBuffer offset:grad_.storage_offset() * grad_.element_size() atIndex:0];
-      [computeEncoder setBuffer:roisBuffer offset:rois_.storage_offset() * rois_.element_size() atIndex:1];
-      [computeEncoder setBuffer:channelMappingBuffer
-                         offset:channel_mapping.storage_offset() * channel_mapping.element_size()
-                        atIndex:2];
-      [computeEncoder setBuffer:outputBuffer offset:grad_input.storage_offset() * grad_input.element_size() atIndex:3];
+      mtl_setArgs(computeEncoder,
+                  grad_,
+                  rois_,
+                  channel_mapping,
+                  grad_input,
+                  channels,
+                  height,
+                  width,
+                  pooled_height,
+                  pooled_width,
+                  sampling_ratio,
+                  channels_out,
+                  spatial_scale_f);
 
-      [computeEncoder setBytes:&output_size length:sizeof(int64_t) atIndex:4];
-      [computeEncoder setBytes:&channels length:sizeof(int64_t) atIndex:5];
-      [computeEncoder setBytes:&height length:sizeof(int64_t) atIndex:6];
-      [computeEncoder setBytes:&width length:sizeof(int64_t) atIndex:7];
-      [computeEncoder setBytes:&pooled_height length:sizeof(int64_t) atIndex:8];
-      [computeEncoder setBytes:&pooled_width length:sizeof(int64_t) atIndex:9];
-      [computeEncoder setBytes:&sampling_ratio length:sizeof(int64_t) atIndex:10];
-      [computeEncoder setBytes:&channels_out length:sizeof(int64_t) atIndex:11];
-      [computeEncoder setBytes:&spatial_scale_f length:sizeof(float) atIndex:12];
-
-      // A threadGroup is equivalent to a cuda's block.
-      NSUInteger tgSize = visionPSO.maxTotalThreadsPerThreadgroup;
-      if (tgSize > threadsPerBlock) {
-        tgSize = threadsPerBlock;
-      }
-
-      MTLSize threadGroupSize = MTLSizeMake(tgSize, 1, 1);
-      [computeEncoder dispatchThreadgroups:threadgroupsPerGrid threadsPerThreadgroup:threadGroupSize];
+      MTLSize threadsPerGrid = MTLSizeMake(output_size, 1, 1);
+      NSUInteger tgSize = std::min(static_cast<int64_t>(visionPSO.maxTotalThreadsPerThreadgroup), output_size);
+      MTLSize threadGroupSize = MTLSizeMake(std::max<NSUInteger>(tgSize, 1), 1, 1);
+      [computeEncoder dispatchThreads:threadsPerGrid threadsPerThreadgroup:threadGroupSize];
 
       getMPSProfiler().endProfileKernel(visionPSO);
     }

--- a/torchvision/csrc/ops/mps/ps_roi_pool_kernel.mm
+++ b/torchvision/csrc/ops/mps/ps_roi_pool_kernel.mm
@@ -45,6 +45,10 @@ std::tuple<at::Tensor, at::Tensor> ps_roi_pool_forward_kernel(const at::Tensor& 
   auto input_ = input.contiguous();
   auto rois_ = rois.contiguous();
 
+  id<MTLBuffer> inputBuffer = getMTLBufferStorage(input_);
+  id<MTLBuffer> roisBuffer = getMTLBufferStorage(rois_);
+  id<MTLBuffer> outputBuffer = getMTLBufferStorage(output);
+  id<MTLBuffer> channelMappingBuffer = getMTLBufferStorage(channel_mapping);
   id<MTLDevice> device = MPSDevice::getInstance()->device();
   MPSStream* mpsStream = getCurrentMPSStream();
   dispatch_sync(mpsStream->queue(), ^() {
@@ -59,18 +63,20 @@ std::tuple<at::Tensor, at::Tensor> ps_roi_pool_forward_kernel(const at::Tensor& 
 
       [computeEncoder setComputePipelineState:visionPSO];
       // [N, C, H, W]
-      mtl_setArgs(computeEncoder,
-                  input_,
-                  rois_,
-                  output,
-                  channel_mapping,
-                  channels,
-                  height,
-                  width,
-                  pooled_height,
-                  pooled_width,
-                  channels_out,
-                  spatial_scale_f);
+      [computeEncoder setBuffer:inputBuffer offset:input_.storage_offset() * input_.element_size() atIndex:0];
+      [computeEncoder setBuffer:roisBuffer offset:rois_.storage_offset() * rois_.element_size() atIndex:1];
+      [computeEncoder setBuffer:outputBuffer offset:output.storage_offset() * output.element_size() atIndex:2];
+      [computeEncoder setBuffer:channelMappingBuffer
+                         offset:channel_mapping.storage_offset() * channel_mapping.element_size()
+                        atIndex:3];
+
+      [computeEncoder setBytes:&channels length:sizeof(int64_t) atIndex:4];
+      [computeEncoder setBytes:&height length:sizeof(int64_t) atIndex:5];
+      [computeEncoder setBytes:&width length:sizeof(int64_t) atIndex:6];
+      [computeEncoder setBytes:&pooled_height length:sizeof(int64_t) atIndex:7];
+      [computeEncoder setBytes:&pooled_width length:sizeof(int64_t) atIndex:8];
+      [computeEncoder setBytes:&channels_out length:sizeof(int64_t) atIndex:9];
+      [computeEncoder setBytes:&spatial_scale_f length:sizeof(float) atIndex:10];
 
       MTLSize threadsPerGrid = MTLSizeMake(output_size, 1, 1);
       NSUInteger tgSize = std::min(static_cast<int64_t>(visionPSO.maxTotalThreadsPerThreadgroup), output_size);
@@ -120,6 +126,10 @@ at::Tensor ps_roi_pool_backward_kernel(const at::Tensor& grad,
   at::globalContext().alertNotDeterministic("ps_roi_pool_backward_kernel");
   auto grad_ = grad.contiguous(), rois_ = rois.contiguous();
 
+  id<MTLBuffer> inputBuffer = getMTLBufferStorage(grad_);
+  id<MTLBuffer> roisBuffer = getMTLBufferStorage(rois_);
+  id<MTLBuffer> channelMappingBuffer = getMTLBufferStorage(channel_mapping);
+  id<MTLBuffer> outputBuffer = getMTLBufferStorage(grad_input);
   id<MTLDevice> device = MPSDevice::getInstance()->device();
   MPSStream* mpsStream = getCurrentMPSStream();
   dispatch_sync(mpsStream->queue(), ^() {
@@ -134,18 +144,20 @@ at::Tensor ps_roi_pool_backward_kernel(const at::Tensor& grad,
 
       [computeEncoder setComputePipelineState:visionPSO];
       // [N, C, H, W]
-      mtl_setArgs(computeEncoder,
-                  grad_,
-                  rois_,
-                  channel_mapping,
-                  grad_input,
-                  channels,
-                  height,
-                  width,
-                  pooled_height,
-                  pooled_width,
-                  channels_out,
-                  spatial_scale_f);
+      [computeEncoder setBuffer:inputBuffer offset:grad_.storage_offset() * grad_.element_size() atIndex:0];
+      [computeEncoder setBuffer:roisBuffer offset:rois_.storage_offset() * rois_.element_size() atIndex:1];
+      [computeEncoder setBuffer:channelMappingBuffer
+                         offset:channel_mapping.storage_offset() * channel_mapping.element_size()
+                        atIndex:2];
+      [computeEncoder setBuffer:outputBuffer offset:grad_input.storage_offset() * grad_input.element_size() atIndex:3];
+
+      [computeEncoder setBytes:&channels length:sizeof(int64_t) atIndex:4];
+      [computeEncoder setBytes:&height length:sizeof(int64_t) atIndex:5];
+      [computeEncoder setBytes:&width length:sizeof(int64_t) atIndex:6];
+      [computeEncoder setBytes:&pooled_height length:sizeof(int64_t) atIndex:7];
+      [computeEncoder setBytes:&pooled_width length:sizeof(int64_t) atIndex:8];
+      [computeEncoder setBytes:&channels_out length:sizeof(int64_t) atIndex:9];
+      [computeEncoder setBytes:&spatial_scale_f length:sizeof(float) atIndex:10];
 
       MTLSize threadsPerGrid = MTLSizeMake(output_size, 1, 1);
       NSUInteger tgSize = std::min(static_cast<int64_t>(visionPSO.maxTotalThreadsPerThreadgroup), output_size);

--- a/torchvision/csrc/ops/mps/ps_roi_pool_kernel.mm
+++ b/torchvision/csrc/ops/mps/ps_roi_pool_kernel.mm
@@ -45,19 +45,11 @@ std::tuple<at::Tensor, at::Tensor> ps_roi_pool_forward_kernel(const at::Tensor& 
   auto input_ = input.contiguous();
   auto rois_ = rois.contiguous();
 
-  id<MTLBuffer> inputBuffer = getMTLBufferStorage(input_);
-  id<MTLBuffer> roisBuffer = getMTLBufferStorage(rois_);
-  id<MTLBuffer> outputBuffer = getMTLBufferStorage(output);
-  id<MTLBuffer> channelMappingBuffer = getMTLBufferStorage(channel_mapping);
   id<MTLDevice> device = MPSDevice::getInstance()->device();
   MPSStream* mpsStream = getCurrentMPSStream();
   dispatch_sync(mpsStream->queue(), ^() {
     @autoreleasepool {
       id<MTLComputeCommandEncoder> computeEncoder = mpsStream->commandEncoder();
-      MTLSize threadgroupsPerGrid = MTLSizeMake(
-          std::min(ceil_div(static_cast<int64_t>(output_size), static_cast<int64_t>(512)), static_cast<int64_t>(4096)),
-          1,
-          1);
 
       const std::string kernel = "ps_roi_pool_" + scalarToMetalTypeString(input.scalar_type());
       id<MTLComputePipelineState> visionPSO = mps::visionPipelineState(device, kernel);
@@ -67,30 +59,23 @@ std::tuple<at::Tensor, at::Tensor> ps_roi_pool_forward_kernel(const at::Tensor& 
 
       [computeEncoder setComputePipelineState:visionPSO];
       // [N, C, H, W]
-      [computeEncoder setBuffer:inputBuffer offset:input_.storage_offset() * input_.element_size() atIndex:0];
-      [computeEncoder setBuffer:roisBuffer offset:rois_.storage_offset() * rois_.element_size() atIndex:1];
-      [computeEncoder setBuffer:outputBuffer offset:output.storage_offset() * output.element_size() atIndex:2];
-      [computeEncoder setBuffer:channelMappingBuffer
-                         offset:channel_mapping.storage_offset() * channel_mapping.element_size()
-                        atIndex:3];
+      mtl_setArgs(computeEncoder,
+                  input_,
+                  rois_,
+                  output,
+                  channel_mapping,
+                  channels,
+                  height,
+                  width,
+                  pooled_height,
+                  pooled_width,
+                  channels_out,
+                  spatial_scale_f);
 
-      [computeEncoder setBytes:&output_size length:sizeof(int64_t) atIndex:4];
-      [computeEncoder setBytes:&channels length:sizeof(int64_t) atIndex:5];
-      [computeEncoder setBytes:&height length:sizeof(int64_t) atIndex:6];
-      [computeEncoder setBytes:&width length:sizeof(int64_t) atIndex:7];
-      [computeEncoder setBytes:&pooled_height length:sizeof(int64_t) atIndex:8];
-      [computeEncoder setBytes:&pooled_width length:sizeof(int64_t) atIndex:9];
-      [computeEncoder setBytes:&channels_out length:sizeof(int64_t) atIndex:10];
-      [computeEncoder setBytes:&spatial_scale_f length:sizeof(float) atIndex:11];
-
-      // A threadGroup is equivalent to a cuda's block.
-      NSUInteger tgSize = visionPSO.maxTotalThreadsPerThreadgroup;
-      if (tgSize > threadsPerBlock) {
-        tgSize = threadsPerBlock;
-      }
-
-      MTLSize threadGroupSize = MTLSizeMake(tgSize, 1, 1);
-      [computeEncoder dispatchThreadgroups:threadgroupsPerGrid threadsPerThreadgroup:threadGroupSize];
+      MTLSize threadsPerGrid = MTLSizeMake(output_size, 1, 1);
+      NSUInteger tgSize = std::min(static_cast<int64_t>(visionPSO.maxTotalThreadsPerThreadgroup), output_size);
+      MTLSize threadGroupSize = MTLSizeMake(std::max<NSUInteger>(tgSize, 1), 1, 1);
+      [computeEncoder dispatchThreads:threadsPerGrid threadsPerThreadgroup:threadGroupSize];
 
       getMPSProfiler().endProfileKernel(visionPSO);
     }
@@ -135,19 +120,11 @@ at::Tensor ps_roi_pool_backward_kernel(const at::Tensor& grad,
   at::globalContext().alertNotDeterministic("ps_roi_pool_backward_kernel");
   auto grad_ = grad.contiguous(), rois_ = rois.contiguous();
 
-  id<MTLBuffer> inputBuffer = getMTLBufferStorage(grad_);
-  id<MTLBuffer> roisBuffer = getMTLBufferStorage(rois_);
-  id<MTLBuffer> channelMappingBuffer = getMTLBufferStorage(channel_mapping);
-  id<MTLBuffer> outputBuffer = getMTLBufferStorage(grad_input);
   id<MTLDevice> device = MPSDevice::getInstance()->device();
   MPSStream* mpsStream = getCurrentMPSStream();
   dispatch_sync(mpsStream->queue(), ^() {
     @autoreleasepool {
       id<MTLComputeCommandEncoder> computeEncoder = mpsStream->commandEncoder();
-      MTLSize threadgroupsPerGrid = MTLSizeMake(
-          std::min(ceil_div(static_cast<int64_t>(grad.numel()), static_cast<int64_t>(512)), static_cast<int64_t>(4096)),
-          1,
-          1);
 
       const std::string kernel = "ps_roi_pool_backward_" + scalarToMetalTypeString(grad.scalar_type());
       id<MTLComputePipelineState> visionPSO = mps::visionPipelineState(device, kernel);
@@ -157,30 +134,23 @@ at::Tensor ps_roi_pool_backward_kernel(const at::Tensor& grad,
 
       [computeEncoder setComputePipelineState:visionPSO];
       // [N, C, H, W]
-      [computeEncoder setBuffer:inputBuffer offset:grad_.storage_offset() * grad_.element_size() atIndex:0];
-      [computeEncoder setBuffer:roisBuffer offset:rois_.storage_offset() * rois_.element_size() atIndex:1];
-      [computeEncoder setBuffer:channelMappingBuffer
-                         offset:channel_mapping.storage_offset() * channel_mapping.element_size()
-                        atIndex:2];
-      [computeEncoder setBuffer:outputBuffer offset:grad_input.storage_offset() * grad_input.element_size() atIndex:3];
+      mtl_setArgs(computeEncoder,
+                  grad_,
+                  rois_,
+                  channel_mapping,
+                  grad_input,
+                  channels,
+                  height,
+                  width,
+                  pooled_height,
+                  pooled_width,
+                  channels_out,
+                  spatial_scale_f);
 
-      [computeEncoder setBytes:&output_size length:sizeof(int64_t) atIndex:4];
-      [computeEncoder setBytes:&channels length:sizeof(int64_t) atIndex:5];
-      [computeEncoder setBytes:&height length:sizeof(int64_t) atIndex:6];
-      [computeEncoder setBytes:&width length:sizeof(int64_t) atIndex:7];
-      [computeEncoder setBytes:&pooled_height length:sizeof(int64_t) atIndex:8];
-      [computeEncoder setBytes:&pooled_width length:sizeof(int64_t) atIndex:9];
-      [computeEncoder setBytes:&channels_out length:sizeof(int64_t) atIndex:10];
-      [computeEncoder setBytes:&spatial_scale_f length:sizeof(float) atIndex:11];
-
-      // A threadGroup is equivalent to a cuda's block.
-      NSUInteger tgSize = visionPSO.maxTotalThreadsPerThreadgroup;
-      if (tgSize > threadsPerBlock) {
-        tgSize = threadsPerBlock;
-      }
-
-      MTLSize threadGroupSize = MTLSizeMake(tgSize, 1, 1);
-      [computeEncoder dispatchThreadgroups:threadgroupsPerGrid threadsPerThreadgroup:threadGroupSize];
+      MTLSize threadsPerGrid = MTLSizeMake(output_size, 1, 1);
+      NSUInteger tgSize = std::min(static_cast<int64_t>(visionPSO.maxTotalThreadsPerThreadgroup), output_size);
+      MTLSize threadGroupSize = MTLSizeMake(std::max<NSUInteger>(tgSize, 1), 1, 1);
+      [computeEncoder dispatchThreads:threadsPerGrid threadsPerThreadgroup:threadGroupSize];
 
       getMPSProfiler().endProfileKernel(visionPSO);
     }

--- a/torchvision/csrc/ops/mps/ps_roi_pool_kernel.mm
+++ b/torchvision/csrc/ops/mps/ps_roi_pool_kernel.mm
@@ -54,6 +54,10 @@ std::tuple<at::Tensor, at::Tensor> ps_roi_pool_forward_kernel(const at::Tensor& 
   dispatch_sync(mpsStream->queue(), ^() {
     @autoreleasepool {
       id<MTLComputeCommandEncoder> computeEncoder = mpsStream->commandEncoder();
+      MTLSize threadgroupsPerGrid = MTLSizeMake(
+          std::min(ceil_div(static_cast<int64_t>(output_size), static_cast<int64_t>(512)), static_cast<int64_t>(4096)),
+          1,
+          1);
 
       const std::string kernel = "ps_roi_pool_" + scalarToMetalTypeString(input.scalar_type());
       id<MTLComputePipelineState> visionPSO = mps::visionPipelineState(device, kernel);
@@ -70,18 +74,23 @@ std::tuple<at::Tensor, at::Tensor> ps_roi_pool_forward_kernel(const at::Tensor& 
                          offset:channel_mapping.storage_offset() * channel_mapping.element_size()
                         atIndex:3];
 
-      [computeEncoder setBytes:&channels length:sizeof(int64_t) atIndex:4];
-      [computeEncoder setBytes:&height length:sizeof(int64_t) atIndex:5];
-      [computeEncoder setBytes:&width length:sizeof(int64_t) atIndex:6];
-      [computeEncoder setBytes:&pooled_height length:sizeof(int64_t) atIndex:7];
-      [computeEncoder setBytes:&pooled_width length:sizeof(int64_t) atIndex:8];
-      [computeEncoder setBytes:&channels_out length:sizeof(int64_t) atIndex:9];
-      [computeEncoder setBytes:&spatial_scale_f length:sizeof(float) atIndex:10];
+      [computeEncoder setBytes:&output_size length:sizeof(int64_t) atIndex:4];
+      [computeEncoder setBytes:&channels length:sizeof(int64_t) atIndex:5];
+      [computeEncoder setBytes:&height length:sizeof(int64_t) atIndex:6];
+      [computeEncoder setBytes:&width length:sizeof(int64_t) atIndex:7];
+      [computeEncoder setBytes:&pooled_height length:sizeof(int64_t) atIndex:8];
+      [computeEncoder setBytes:&pooled_width length:sizeof(int64_t) atIndex:9];
+      [computeEncoder setBytes:&channels_out length:sizeof(int64_t) atIndex:10];
+      [computeEncoder setBytes:&spatial_scale_f length:sizeof(float) atIndex:11];
 
-      MTLSize threadsPerGrid = MTLSizeMake(output_size, 1, 1);
-      NSUInteger tgSize = std::min(static_cast<int64_t>(visionPSO.maxTotalThreadsPerThreadgroup), output_size);
-      MTLSize threadGroupSize = MTLSizeMake(std::max<NSUInteger>(tgSize, 1), 1, 1);
-      [computeEncoder dispatchThreads:threadsPerGrid threadsPerThreadgroup:threadGroupSize];
+      // A threadGroup is equivalent to a cuda's block.
+      NSUInteger tgSize = visionPSO.maxTotalThreadsPerThreadgroup;
+      if (tgSize > threadsPerBlock) {
+        tgSize = threadsPerBlock;
+      }
+
+      MTLSize threadGroupSize = MTLSizeMake(tgSize, 1, 1);
+      [computeEncoder dispatchThreadgroups:threadgroupsPerGrid threadsPerThreadgroup:threadGroupSize];
 
       getMPSProfiler().endProfileKernel(visionPSO);
     }
@@ -151,14 +160,18 @@ at::Tensor ps_roi_pool_backward_kernel(const at::Tensor& grad,
                         atIndex:2];
       [computeEncoder setBuffer:outputBuffer offset:grad_input.storage_offset() * grad_input.element_size() atIndex:3];
 
-      [computeEncoder setBytes:&channels length:sizeof(int64_t) atIndex:4];
-      [computeEncoder setBytes:&height length:sizeof(int64_t) atIndex:5];
-      [computeEncoder setBytes:&width length:sizeof(int64_t) atIndex:6];
-      [computeEncoder setBytes:&pooled_height length:sizeof(int64_t) atIndex:7];
-      [computeEncoder setBytes:&pooled_width length:sizeof(int64_t) atIndex:8];
-      [computeEncoder setBytes:&channels_out length:sizeof(int64_t) atIndex:9];
-      [computeEncoder setBytes:&spatial_scale_f length:sizeof(float) atIndex:10];
+      [computeEncoder setBytes:&output_size length:sizeof(int64_t) atIndex:4];
+      [computeEncoder setBytes:&channels length:sizeof(int64_t) atIndex:5];
+      [computeEncoder setBytes:&height length:sizeof(int64_t) atIndex:6];
+      [computeEncoder setBytes:&width length:sizeof(int64_t) atIndex:7];
+      [computeEncoder setBytes:&pooled_height length:sizeof(int64_t) atIndex:8];
+      [computeEncoder setBytes:&pooled_width length:sizeof(int64_t) atIndex:9];
+      [computeEncoder setBytes:&channels_out length:sizeof(int64_t) atIndex:10];
+      [computeEncoder setBytes:&spatial_scale_f length:sizeof(float) atIndex:11];
 
+      // One thread per pooled-output element. dispatchThreads guarantees each
+      // index is handled exactly once; the kernel scatters into grad_input with
+      // atomic_add for overlapping RoIs.
       MTLSize threadsPerGrid = MTLSizeMake(output_size, 1, 1);
       NSUInteger tgSize = std::min(static_cast<int64_t>(visionPSO.maxTotalThreadsPerThreadgroup), output_size);
       MTLSize threadGroupSize = MTLSizeMake(std::max<NSUInteger>(tgSize, 1), 1, 1);

--- a/torchvision/csrc/ops/mps/roi_pool_kernel.mm
+++ b/torchvision/csrc/ops/mps/roi_pool_kernel.mm
@@ -42,19 +42,11 @@ std::tuple<at::Tensor, at::Tensor> roi_pool_forward_kernel(const at::Tensor& inp
   auto input_ = input.contiguous();
   auto rois_ = rois.contiguous();
 
-  id<MTLBuffer> inputBuffer = getMTLBufferStorage(input_);
-  id<MTLBuffer> roisBuffer = getMTLBufferStorage(rois_);
-  id<MTLBuffer> outputBuffer = getMTLBufferStorage(output);
-  id<MTLBuffer> argmaxBuffer = getMTLBufferStorage(argmax);
   id<MTLDevice> device = MPSDevice::getInstance()->device();
   MPSStream* mpsStream = getCurrentMPSStream();
   dispatch_sync(mpsStream->queue(), ^() {
     @autoreleasepool {
       id<MTLComputeCommandEncoder> computeEncoder = mpsStream->commandEncoder();
-      MTLSize threadgroupsPerGrid = MTLSizeMake(
-          std::min(ceil_div(static_cast<int64_t>(output_size), static_cast<int64_t>(512)), static_cast<int64_t>(4096)),
-          1,
-          1);
 
       const std::string kernel = "roi_pool_" + scalarToMetalTypeString(input.scalar_type());
       id<MTLComputePipelineState> visionPSO = mps::visionPipelineState(device, kernel);
@@ -64,27 +56,22 @@ std::tuple<at::Tensor, at::Tensor> roi_pool_forward_kernel(const at::Tensor& inp
 
       [computeEncoder setComputePipelineState:visionPSO];
       // [N, C, H, W]
-      [computeEncoder setBuffer:inputBuffer offset:input_.storage_offset() * input_.element_size() atIndex:0];
-      [computeEncoder setBuffer:roisBuffer offset:rois_.storage_offset() * rois_.element_size() atIndex:1];
-      [computeEncoder setBuffer:outputBuffer offset:output.storage_offset() * output.element_size() atIndex:2];
-      [computeEncoder setBuffer:argmaxBuffer offset:argmax.storage_offset() * argmax.element_size() atIndex:3];
+      mtl_setArgs(computeEncoder,
+                  input_,
+                  rois_,
+                  output,
+                  argmax,
+                  channels,
+                  height,
+                  width,
+                  pooled_height,
+                  pooled_width,
+                  spatial_scale_f);
 
-      [computeEncoder setBytes:&output_size length:sizeof(int64_t) atIndex:4];
-      [computeEncoder setBytes:&channels length:sizeof(int64_t) atIndex:5];
-      [computeEncoder setBytes:&height length:sizeof(int64_t) atIndex:6];
-      [computeEncoder setBytes:&width length:sizeof(int64_t) atIndex:7];
-      [computeEncoder setBytes:&pooled_height length:sizeof(int64_t) atIndex:8];
-      [computeEncoder setBytes:&pooled_width length:sizeof(int64_t) atIndex:9];
-      [computeEncoder setBytes:&spatial_scale_f length:sizeof(float) atIndex:10];
-
-      // A threadGroup is equivalent to a cuda's block.
-      NSUInteger tgSize = visionPSO.maxTotalThreadsPerThreadgroup;
-      if (tgSize > threadsPerBlock) {
-        tgSize = threadsPerBlock;
-      }
-
-      MTLSize threadGroupSize = MTLSizeMake(tgSize, 1, 1);
-      [computeEncoder dispatchThreadgroups:threadgroupsPerGrid threadsPerThreadgroup:threadGroupSize];
+      MTLSize threadsPerGrid = MTLSizeMake(output_size, 1, 1);
+      NSUInteger tgSize = std::min(static_cast<int64_t>(visionPSO.maxTotalThreadsPerThreadgroup), output_size);
+      MTLSize threadGroupSize = MTLSizeMake(std::max<NSUInteger>(tgSize, 1), 1, 1);
+      [computeEncoder dispatchThreads:threadsPerGrid threadsPerThreadgroup:threadGroupSize];
 
       getMPSProfiler().endProfileKernel(visionPSO);
     }
@@ -131,19 +118,11 @@ at::Tensor roi_pool_backward_kernel(const at::Tensor& grad,
   at::globalContext().alertNotDeterministic("roi_pool_backward_kernel");
   auto argmax_ = argmax.contiguous(), rois_ = rois.contiguous();
 
-  id<MTLBuffer> inputBuffer = getMTLBufferStorage(grad);
-  id<MTLBuffer> roisBuffer = getMTLBufferStorage(rois_);
-  id<MTLBuffer> argmaxBuffer = getMTLBufferStorage(argmax_);
-  id<MTLBuffer> outputBuffer = getMTLBufferStorage(grad_input);
   id<MTLDevice> device = MPSDevice::getInstance()->device();
   MPSStream* mpsStream = getCurrentMPSStream();
   dispatch_sync(mpsStream->queue(), ^() {
     @autoreleasepool {
       id<MTLComputeCommandEncoder> computeEncoder = mpsStream->commandEncoder();
-      MTLSize threadgroupsPerGrid = MTLSizeMake(
-          std::min(ceil_div(static_cast<int64_t>(grad.numel()), static_cast<int64_t>(512)), static_cast<int64_t>(4096)),
-          1,
-          1);
 
       const std::string kernel = "roi_pool_backward_" + scalarToMetalTypeString(grad.scalar_type());
       id<MTLComputePipelineState> visionPSO = mps::visionPipelineState(device, kernel);
@@ -153,31 +132,26 @@ at::Tensor roi_pool_backward_kernel(const at::Tensor& grad,
 
       [computeEncoder setComputePipelineState:visionPSO];
       // [N, C, H, W]
-      [computeEncoder setBuffer:inputBuffer offset:grad.storage_offset() * grad.element_size() atIndex:0];
-      [computeEncoder setBuffer:roisBuffer offset:rois_.storage_offset() * rois_.element_size() atIndex:1];
-      [computeEncoder setBuffer:argmaxBuffer offset:argmax_.storage_offset() * argmax_.element_size() atIndex:2];
-      [computeEncoder setBuffer:outputBuffer offset:grad_input.storage_offset() * grad_input.element_size() atIndex:3];
+      mtl_setArgs(computeEncoder,
+                  grad,
+                  rois_,
+                  argmax_,
+                  grad_input,
+                  channels,
+                  height,
+                  width,
+                  pooled_height,
+                  pooled_width,
+                  spatial_scale_f,
+                  n_stride,
+                  c_stride,
+                  h_stride,
+                  w_stride);
 
-      [computeEncoder setBytes:&output_size length:sizeof(int64_t) atIndex:4];
-      [computeEncoder setBytes:&channels length:sizeof(int64_t) atIndex:5];
-      [computeEncoder setBytes:&height length:sizeof(int64_t) atIndex:6];
-      [computeEncoder setBytes:&width length:sizeof(int64_t) atIndex:7];
-      [computeEncoder setBytes:&pooled_height length:sizeof(int64_t) atIndex:8];
-      [computeEncoder setBytes:&pooled_width length:sizeof(int64_t) atIndex:9];
-      [computeEncoder setBytes:&spatial_scale_f length:sizeof(float) atIndex:10];
-      [computeEncoder setBytes:&n_stride length:sizeof(int64_t) atIndex:11];
-      [computeEncoder setBytes:&c_stride length:sizeof(int64_t) atIndex:12];
-      [computeEncoder setBytes:&h_stride length:sizeof(int64_t) atIndex:13];
-      [computeEncoder setBytes:&w_stride length:sizeof(int64_t) atIndex:14];
-
-      // A threadGroup is equivalent to a cuda's block.
-      NSUInteger tgSize = visionPSO.maxTotalThreadsPerThreadgroup;
-      if (tgSize > threadsPerBlock) {
-        tgSize = threadsPerBlock;
-      }
-
-      MTLSize threadGroupSize = MTLSizeMake(tgSize, 1, 1);
-      [computeEncoder dispatchThreadgroups:threadgroupsPerGrid threadsPerThreadgroup:threadGroupSize];
+      MTLSize threadsPerGrid = MTLSizeMake(output_size, 1, 1);
+      NSUInteger tgSize = std::min(static_cast<int64_t>(visionPSO.maxTotalThreadsPerThreadgroup), output_size);
+      MTLSize threadGroupSize = MTLSizeMake(std::max<NSUInteger>(tgSize, 1), 1, 1);
+      [computeEncoder dispatchThreads:threadsPerGrid threadsPerThreadgroup:threadGroupSize];
 
       getMPSProfiler().endProfileKernel(visionPSO);
     }

--- a/torchvision/csrc/ops/mps/roi_pool_kernel.mm
+++ b/torchvision/csrc/ops/mps/roi_pool_kernel.mm
@@ -51,6 +51,10 @@ std::tuple<at::Tensor, at::Tensor> roi_pool_forward_kernel(const at::Tensor& inp
   dispatch_sync(mpsStream->queue(), ^() {
     @autoreleasepool {
       id<MTLComputeCommandEncoder> computeEncoder = mpsStream->commandEncoder();
+      MTLSize threadgroupsPerGrid = MTLSizeMake(
+          std::min(ceil_div(static_cast<int64_t>(output_size), static_cast<int64_t>(512)), static_cast<int64_t>(4096)),
+          1,
+          1);
 
       const std::string kernel = "roi_pool_" + scalarToMetalTypeString(input.scalar_type());
       id<MTLComputePipelineState> visionPSO = mps::visionPipelineState(device, kernel);
@@ -65,17 +69,22 @@ std::tuple<at::Tensor, at::Tensor> roi_pool_forward_kernel(const at::Tensor& inp
       [computeEncoder setBuffer:outputBuffer offset:output.storage_offset() * output.element_size() atIndex:2];
       [computeEncoder setBuffer:argmaxBuffer offset:argmax.storage_offset() * argmax.element_size() atIndex:3];
 
-      [computeEncoder setBytes:&channels length:sizeof(int64_t) atIndex:4];
-      [computeEncoder setBytes:&height length:sizeof(int64_t) atIndex:5];
-      [computeEncoder setBytes:&width length:sizeof(int64_t) atIndex:6];
-      [computeEncoder setBytes:&pooled_height length:sizeof(int64_t) atIndex:7];
-      [computeEncoder setBytes:&pooled_width length:sizeof(int64_t) atIndex:8];
-      [computeEncoder setBytes:&spatial_scale_f length:sizeof(float) atIndex:9];
+      [computeEncoder setBytes:&output_size length:sizeof(int64_t) atIndex:4];
+      [computeEncoder setBytes:&channels length:sizeof(int64_t) atIndex:5];
+      [computeEncoder setBytes:&height length:sizeof(int64_t) atIndex:6];
+      [computeEncoder setBytes:&width length:sizeof(int64_t) atIndex:7];
+      [computeEncoder setBytes:&pooled_height length:sizeof(int64_t) atIndex:8];
+      [computeEncoder setBytes:&pooled_width length:sizeof(int64_t) atIndex:9];
+      [computeEncoder setBytes:&spatial_scale_f length:sizeof(float) atIndex:10];
 
-      MTLSize threadsPerGrid = MTLSizeMake(output_size, 1, 1);
-      NSUInteger tgSize = std::min(static_cast<int64_t>(visionPSO.maxTotalThreadsPerThreadgroup), output_size);
-      MTLSize threadGroupSize = MTLSizeMake(std::max<NSUInteger>(tgSize, 1), 1, 1);
-      [computeEncoder dispatchThreads:threadsPerGrid threadsPerThreadgroup:threadGroupSize];
+      // A threadGroup is equivalent to a cuda's block.
+      NSUInteger tgSize = visionPSO.maxTotalThreadsPerThreadgroup;
+      if (tgSize > threadsPerBlock) {
+        tgSize = threadsPerBlock;
+      }
+
+      MTLSize threadGroupSize = MTLSizeMake(tgSize, 1, 1);
+      [computeEncoder dispatchThreadgroups:threadgroupsPerGrid threadsPerThreadgroup:threadGroupSize];
 
       getMPSProfiler().endProfileKernel(visionPSO);
     }
@@ -145,17 +154,21 @@ at::Tensor roi_pool_backward_kernel(const at::Tensor& grad,
       [computeEncoder setBuffer:argmaxBuffer offset:argmax_.storage_offset() * argmax_.element_size() atIndex:2];
       [computeEncoder setBuffer:outputBuffer offset:grad_input.storage_offset() * grad_input.element_size() atIndex:3];
 
-      [computeEncoder setBytes:&channels length:sizeof(int64_t) atIndex:4];
-      [computeEncoder setBytes:&height length:sizeof(int64_t) atIndex:5];
-      [computeEncoder setBytes:&width length:sizeof(int64_t) atIndex:6];
-      [computeEncoder setBytes:&pooled_height length:sizeof(int64_t) atIndex:7];
-      [computeEncoder setBytes:&pooled_width length:sizeof(int64_t) atIndex:8];
-      [computeEncoder setBytes:&spatial_scale_f length:sizeof(float) atIndex:9];
-      [computeEncoder setBytes:&n_stride length:sizeof(int64_t) atIndex:10];
-      [computeEncoder setBytes:&c_stride length:sizeof(int64_t) atIndex:11];
-      [computeEncoder setBytes:&h_stride length:sizeof(int64_t) atIndex:12];
-      [computeEncoder setBytes:&w_stride length:sizeof(int64_t) atIndex:13];
+      [computeEncoder setBytes:&output_size length:sizeof(int64_t) atIndex:4];
+      [computeEncoder setBytes:&channels length:sizeof(int64_t) atIndex:5];
+      [computeEncoder setBytes:&height length:sizeof(int64_t) atIndex:6];
+      [computeEncoder setBytes:&width length:sizeof(int64_t) atIndex:7];
+      [computeEncoder setBytes:&pooled_height length:sizeof(int64_t) atIndex:8];
+      [computeEncoder setBytes:&pooled_width length:sizeof(int64_t) atIndex:9];
+      [computeEncoder setBytes:&spatial_scale_f length:sizeof(float) atIndex:10];
+      [computeEncoder setBytes:&n_stride length:sizeof(int64_t) atIndex:11];
+      [computeEncoder setBytes:&c_stride length:sizeof(int64_t) atIndex:12];
+      [computeEncoder setBytes:&h_stride length:sizeof(int64_t) atIndex:13];
+      [computeEncoder setBytes:&w_stride length:sizeof(int64_t) atIndex:14];
 
+      // One thread per pooled-output element. dispatchThreads guarantees each
+      // index is handled exactly once; the kernel scatters into grad_input with
+      // atomic_add for overlapping RoIs.
       MTLSize threadsPerGrid = MTLSizeMake(output_size, 1, 1);
       NSUInteger tgSize = std::min(static_cast<int64_t>(visionPSO.maxTotalThreadsPerThreadgroup), output_size);
       MTLSize threadGroupSize = MTLSizeMake(std::max<NSUInteger>(tgSize, 1), 1, 1);

--- a/torchvision/csrc/ops/mps/roi_pool_kernel.mm
+++ b/torchvision/csrc/ops/mps/roi_pool_kernel.mm
@@ -42,6 +42,10 @@ std::tuple<at::Tensor, at::Tensor> roi_pool_forward_kernel(const at::Tensor& inp
   auto input_ = input.contiguous();
   auto rois_ = rois.contiguous();
 
+  id<MTLBuffer> inputBuffer = getMTLBufferStorage(input_);
+  id<MTLBuffer> roisBuffer = getMTLBufferStorage(rois_);
+  id<MTLBuffer> outputBuffer = getMTLBufferStorage(output);
+  id<MTLBuffer> argmaxBuffer = getMTLBufferStorage(argmax);
   id<MTLDevice> device = MPSDevice::getInstance()->device();
   MPSStream* mpsStream = getCurrentMPSStream();
   dispatch_sync(mpsStream->queue(), ^() {
@@ -56,17 +60,17 @@ std::tuple<at::Tensor, at::Tensor> roi_pool_forward_kernel(const at::Tensor& inp
 
       [computeEncoder setComputePipelineState:visionPSO];
       // [N, C, H, W]
-      mtl_setArgs(computeEncoder,
-                  input_,
-                  rois_,
-                  output,
-                  argmax,
-                  channels,
-                  height,
-                  width,
-                  pooled_height,
-                  pooled_width,
-                  spatial_scale_f);
+      [computeEncoder setBuffer:inputBuffer offset:input_.storage_offset() * input_.element_size() atIndex:0];
+      [computeEncoder setBuffer:roisBuffer offset:rois_.storage_offset() * rois_.element_size() atIndex:1];
+      [computeEncoder setBuffer:outputBuffer offset:output.storage_offset() * output.element_size() atIndex:2];
+      [computeEncoder setBuffer:argmaxBuffer offset:argmax.storage_offset() * argmax.element_size() atIndex:3];
+
+      [computeEncoder setBytes:&channels length:sizeof(int64_t) atIndex:4];
+      [computeEncoder setBytes:&height length:sizeof(int64_t) atIndex:5];
+      [computeEncoder setBytes:&width length:sizeof(int64_t) atIndex:6];
+      [computeEncoder setBytes:&pooled_height length:sizeof(int64_t) atIndex:7];
+      [computeEncoder setBytes:&pooled_width length:sizeof(int64_t) atIndex:8];
+      [computeEncoder setBytes:&spatial_scale_f length:sizeof(float) atIndex:9];
 
       MTLSize threadsPerGrid = MTLSizeMake(output_size, 1, 1);
       NSUInteger tgSize = std::min(static_cast<int64_t>(visionPSO.maxTotalThreadsPerThreadgroup), output_size);
@@ -118,6 +122,10 @@ at::Tensor roi_pool_backward_kernel(const at::Tensor& grad,
   at::globalContext().alertNotDeterministic("roi_pool_backward_kernel");
   auto argmax_ = argmax.contiguous(), rois_ = rois.contiguous();
 
+  id<MTLBuffer> inputBuffer = getMTLBufferStorage(grad);
+  id<MTLBuffer> roisBuffer = getMTLBufferStorage(rois_);
+  id<MTLBuffer> argmaxBuffer = getMTLBufferStorage(argmax_);
+  id<MTLBuffer> outputBuffer = getMTLBufferStorage(grad_input);
   id<MTLDevice> device = MPSDevice::getInstance()->device();
   MPSStream* mpsStream = getCurrentMPSStream();
   dispatch_sync(mpsStream->queue(), ^() {
@@ -132,21 +140,21 @@ at::Tensor roi_pool_backward_kernel(const at::Tensor& grad,
 
       [computeEncoder setComputePipelineState:visionPSO];
       // [N, C, H, W]
-      mtl_setArgs(computeEncoder,
-                  grad,
-                  rois_,
-                  argmax_,
-                  grad_input,
-                  channels,
-                  height,
-                  width,
-                  pooled_height,
-                  pooled_width,
-                  spatial_scale_f,
-                  n_stride,
-                  c_stride,
-                  h_stride,
-                  w_stride);
+      [computeEncoder setBuffer:inputBuffer offset:grad.storage_offset() * grad.element_size() atIndex:0];
+      [computeEncoder setBuffer:roisBuffer offset:rois_.storage_offset() * rois_.element_size() atIndex:1];
+      [computeEncoder setBuffer:argmaxBuffer offset:argmax_.storage_offset() * argmax_.element_size() atIndex:2];
+      [computeEncoder setBuffer:outputBuffer offset:grad_input.storage_offset() * grad_input.element_size() atIndex:3];
+
+      [computeEncoder setBytes:&channels length:sizeof(int64_t) atIndex:4];
+      [computeEncoder setBytes:&height length:sizeof(int64_t) atIndex:5];
+      [computeEncoder setBytes:&width length:sizeof(int64_t) atIndex:6];
+      [computeEncoder setBytes:&pooled_height length:sizeof(int64_t) atIndex:7];
+      [computeEncoder setBytes:&pooled_width length:sizeof(int64_t) atIndex:8];
+      [computeEncoder setBytes:&spatial_scale_f length:sizeof(float) atIndex:9];
+      [computeEncoder setBytes:&n_stride length:sizeof(int64_t) atIndex:10];
+      [computeEncoder setBytes:&c_stride length:sizeof(int64_t) atIndex:11];
+      [computeEncoder setBytes:&h_stride length:sizeof(int64_t) atIndex:12];
+      [computeEncoder setBytes:&w_stride length:sizeof(int64_t) atIndex:13];
 
       MTLSize threadsPerGrid = MTLSizeMake(output_size, 1, 1);
       NSUInteger tgSize = std::min(static_cast<int64_t>(visionPSO.maxTotalThreadsPerThreadgroup), output_size);


### PR DESCRIPTION
MPS ROI kernels combined excess threadgroups with grid-stride loops, repeating outputs and gradients. Dispatch one thread per output for ROI Pool, PS ROI Pool and PS ROI.

Thanks to @jveitchmichaelis for comment on the below PR with the bug:
https://github.com/pytorch/vision/pull/9510

Main change is in the kernel and everything else is just shifting the sizes we input to the kernel (thus the huge diff):
MPS 1D loop used `n_tgs=1`, which caused multiple threadgroups to traverse overlapping indices. In backward ROI kernels, repeated `atomic_add` calls over-accumulated gradients. 
This switches to `dispatchThreads` with one thread per pooled output element, ensuring each gradient contribution is processed exactly once.