### PR TITLE
Fix headless ROCm extension builds

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ TORCHVISION_LIBRARY = TORCHVISION_LIBRARY.split(os.pathsep) if TORCHVISION_LIBRA
 ROOT_DIR = Path(__file__).absolute().parent
 CSRS_DIR = ROOT_DIR / "torchvision/csrc"
 IS_ROCM = (torch.version.hip is not None) and (ROCM_HOME is not None)
-BUILD_CUDA_SOURCES = (torch.cuda.is_available() and ((CUDA_HOME is not None) or IS_ROCM)) or FORCE_CUDA
+BUILD_CUDA_SOURCES = IS_ROCM or (torch.cuda.is_available() and CUDA_HOME is not None) or FORCE_CUDA
 
 package_name = os.getenv("TORCHVISION_PACKAGE_NAME", "torchvision")
 


### PR DESCRIPTION
Fixes https://github.com/pytorch/vision/issues/9298

## Summary

- Select `CUDAExtension` whenever torchvision is built against a ROCm-enabled PyTorch installation.
- Stop using runtime GPU visibility to decide whether ROCm sources can be compiled.
- Prevent headless PEP 517 builds from linking both `vision.cpp` and generated `vision_hip.cpp`.

## Root cause

Headless build workers do not expose `/dev/kfd`, so `torch.cuda.is_available()` is false even though PyTorch and the ROCm toolchain are installed. `IS_ROCM` still triggers hipification, but the old condition selects `CppExtension`. Generated `_hip.cpp` files then enter the C++ source glob and produce duplicate definitions such as `vision::cuda_version()`.

PyTorch's ROCm `CUDAExtension` maps original sources to their hipified paths and deduplicates them, so ROCm toolchain detection is sufficient to select that path.

## Testing

Built a wheel from current `main` in a container with no GPU devices exposed:

```text
FORCE_CUDA=False
IS_ROCM=True
BUILD_CUDA_SOURCES=True
PYTORCH_ROCM_ARCH=gfx950;gfx1033
Successfully built torchvision
```

Command:

```bash
python -m pip wheel . --no-build-isolation --no-deps
```

The same one-line change was also validated against torchvision commit `f23f832d090c868691855cc1261ed907e400c2a2`, which failed in the headless ROCm vLLM workflow before this fix.


cc @jeffdaily @jithunnair-amd