### PR TITLE
Skip torchvision-extra-decoders install on Python 3.15 / 3.15t

### DIFF
--- a/packaging/post_build_script.sh
+++ b/packaging/post_build_script.sh
@@ -13,4 +13,11 @@ else
     extra_decoders_channel=""
 fi
 
-pip install torchvision-extra-decoders $extra_decoders_channel
+# torchvision-extra-decoders is not yet published for Python 3.15 / 3.15t
+# (both the standard and free-threaded builds report version 3.15), so skip
+# installing it there until wheels are available.
+if python -c "import sys; sys.exit(0 if sys.version_info[:2] == (3, 15) else 1)"; then
+    echo "Skipping torchvision-extra-decoders: no Python 3.15 wheel published yet"
+else
+    pip install torchvision-extra-decoders $extra_decoders_channel
+fi


### PR DESCRIPTION
torchvision-extra-decoders has no cp315 / cp315t wheel published yet (the nightly cpu index only ships cp310-cp314t), so the unconditional `pip install torchvision-extra-decoders` in packaging/post_build_script.sh fails the build on Python 3.15 with no matching wheel and no source fallback.

This guards the install so it is skipped on Python 3.15 (both the standard and free-threaded builds report version 3.15). The wheel itself builds fine; only the optional extra-decoders companion is unavailable. The guard should be removed once cp315 wheels are published.

Surfaced while enabling Python 3.15 / 3.15t Linux wheel builds in pytorch/test-infra#8148.

Authored with assistance from Claude Code (AI assistant).