### PR TITLE
[ROCm][CI] Route unittests to MI350 ecosystem runners

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,7 +54,7 @@ jobs:
       matrix:
         python-version:
           - "3.10"
-        runner: ["linux.rocm.gpu.gfx942.1"]
+        runner: ["linux.rocm.gpu.ecosystem.gfx950.1"]
         gpu-arch-type: ["rocm"]
         gpu-arch-version: ["7.1"]
       fail-fast: false


### PR DESCRIPTION
## Summary

Switch the ROCm `unittests-rocm` job in `.github/workflows/tests.yml` to the
shared **MI350 (gfx950) ecosystem** runner scale set used by downstream PyTorch
ecosystem projects (e.g. `pytorch/helion`, `pytorch/torchtitan`):

- runner label -> `linux.rocm.gpu.ecosystem.gfx950.1`

## Test plan

- ROCm `unittests-rocm` job should schedule and run on a
  `linux.rocm.gpu.ecosystem.gfx950.1` runner (same-repo PR / push /
  workflow_dispatch; the job is skipped for fork PRs by design because fork PRs
  don't receive a GitHub OIDC id-token for ECR/AWS auth).

Made with Cursor

cc @jeffdaily @jithunnair-amd