### PR TITLE
Port roi_align (CPU/quantized) to stable ABI.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,8 @@ set(TORCHVISION_STABLE_SOURCES
   ${TVCPP}/ops/box_iou_rotated.cpp
   ${TVCPP}/ops/cpu/box_iou_rotated_kernel.cpp
   ${TVCPP}/ops/cuda/box_iou_rotated_kernel.cu
+  ${TVCPP}/ops/roi_align.cpp
+  ${TVCPP}/ops/cpu/roi_align_kernel.cpp
   ${TVCPP}/io/image/cuda/decode_jpegs_cuda.cpp
   ${TVCPP}/io/image/cuda/encode_jpegs_cuda.cpp
   ${TVCPP}/io/image/cpu/encode_png.cpp

--- a/setup.py
+++ b/setup.py
@@ -166,6 +166,9 @@ STABLE_SOURCES = {
     CSRS_DIR / "ops/quantized/cpu/qnms_kernel.cpp",
     CSRS_DIR / "ops/box_iou_rotated.cpp",
     CSRS_DIR / "ops/cpu/box_iou_rotated_kernel.cpp",
+    CSRS_DIR / "ops/roi_align.cpp",
+    CSRS_DIR / "ops/cpu/roi_align_kernel.cpp",
+    CSRS_DIR / "ops/quantized/cpu/qroi_align_kernel.cpp",
 }
 STABLE_SOURCES.add(CSRS_DIR / ("ops/hip/nms_kernel.hip" if IS_ROCM else "ops/cuda/nms_kernel.cu"))
 STABLE_SOURCES.add(

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -23,6 +23,8 @@ from torchvision import models, ops
 from torchvision.models.feature_extraction import get_graph_node_names
 
 
+IS_WINDOWS = sys.platform in ("win32", "cygwin")
+
 OPTESTS = [
     "test_schema",
     "test_autograd_registration",
@@ -809,6 +811,7 @@ def _check_symint(f, inputs):
                 torch.testing.assert_close(cf(inp), f(inp))
 
 
+@pytest.mark.skipif(IS_WINDOWS, reason="torch.compile is flaky on Windows")
 @pytest.mark.skipif(not is_compile_supported("cpu"), reason="torch.compile not supported")
 @pytest.mark.parametrize("op", (ops.roi_align, ops.roi_pool, ops.ps_roi_align, ops.ps_roi_pool))
 def test_roi_pooled_size_symint(op):
@@ -824,6 +827,7 @@ def test_roi_pooled_size_symint(op):
     _check_symint(f, [torch.empty(h, w) for h, w in ((2, 2), (2, 3), (3, 2), (3, 4))])
 
 
+@pytest.mark.skipif(IS_WINDOWS, reason="torch.compile is flaky on Windows")
 @pytest.mark.skipif(not is_compile_supported("cpu"), reason="torch.compile not supported")
 def test_deform_conv2d_padding_symint():
     x, weight = torch.rand(1, 2, 8, 8), torch.rand(3, 2, 3, 3)

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -793,6 +793,49 @@ def test_roi_opcheck(op, dtype, device, requires_grad):
     optests.opcheck(op, args=(x,), kwargs=kwargs)
 
 
+def _check_symint(f, inputs):
+    torch._dynamo.reset()
+    # Duck shapes would guard on incidental equalities between the size args and
+    # unrelated tensor dims, causing recompiles that have nothing to do with SymInt.
+    with torch.fx.experimental._config.patch(use_duck_shape=False):
+        cf = torch.compile(f, dynamic=True, fullgraph=True)
+        # Dynamo's 0/1/many specialization: the size args only become symbolic on
+        # the second call. From then on the graph must be reused, which is what
+        # tells us they really are SymInts and not baked-in ints.
+        for inp in inputs[:2]:
+            cf(inp)
+        with torch._dynamo.config.patch(error_on_recompile=True):
+            for inp in inputs[2:]:
+                torch.testing.assert_close(cf(inp), f(inp))
+
+
+@pytest.mark.skipif(not is_compile_supported("cpu"), reason="torch.compile not supported")
+@pytest.mark.parametrize("op", (ops.roi_align, ops.roi_pool, ops.ps_roi_align, ops.ps_roi_pool))
+def test_roi_pooled_size_symint(op):
+    # The ps_roi_* ops need the channels to be divisible by pooled_height *
+    # pooled_width, and 24 // (h * w) stays > 1 for every size below, which keeps
+    # dynamo from specializing on a single-channel output being contiguous.
+    x = torch.rand(2, 24, 10, 10)
+    rois = torch.tensor([[0.0, 0.0, 0.0, 9.0, 9.0], [1.0, 0.0, 0.0, 9.0, 9.0]])
+
+    def f(sizer):
+        return op(x, rois, (sizer.shape[0], sizer.shape[1]))
+
+    _check_symint(f, [torch.empty(h, w) for h, w in ((2, 2), (2, 3), (3, 2), (3, 4))])
+
+
+@pytest.mark.skipif(not is_compile_supported("cpu"), reason="torch.compile not supported")
+def test_deform_conv2d_padding_symint():
+    x, weight = torch.rand(1, 2, 8, 8), torch.rand(3, 2, 3, 3)
+
+    def f(sizer):
+        pad = sizer.shape[0]
+        out_size = 8 + 2 * pad - 2  # 3x3 kernel, unit stride and dilation
+        return ops.deform_conv2d(x, torch.zeros(1, 18, out_size, out_size), weight, padding=(pad, pad))
+
+    _check_symint(f, [torch.empty(pad) for pad in (2, 3, 4, 5)])
+
+
 class TestMultiScaleRoIAlign:
     def make_obj(self, fmap_names=None, output_size=(7, 7), sampling_ratio=2, wrap=False):
         if fmap_names is None:

--- a/torchvision/csrc/ops/cpu/roi_align_common.h
+++ b/torchvision/csrc/ops/cpu/roi_align_common.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <ATen/ATen.h>
+#include <vector>
 
 namespace vision {
 namespace ops {

--- a/torchvision/csrc/ops/cpu/roi_align_kernel.cpp
+++ b/torchvision/csrc/ops/cpu/roi_align_kernel.cpp
@@ -1,5 +1,10 @@
-#include <ATen/ATen.h>
-#include <torch/library.h>
+#include <torch/csrc/stable/library.h>
+#include <torch/csrc/stable/ops.h>
+#include <torch/csrc/stable/tensor.h>
+#include <torch/headeronly/core/Dispatch_v2.h>
+
+#include <algorithm>
+#include <cmath>
 
 #include "./roi_align_common.h"
 
@@ -7,6 +12,8 @@ namespace vision {
 namespace ops {
 
 namespace {
+
+using torch::stable::Tensor;
 
 template <typename T>
 void roi_align_forward_kernel_impl(
@@ -281,41 +288,42 @@ void roi_align_backward_kernel_impl(
   } // for
 }
 
-at::Tensor roi_align_forward_kernel(
-    const at::Tensor& input,
-    const at::Tensor& rois,
+Tensor roi_align_forward_kernel(
+    const Tensor& input,
+    const Tensor& rois,
     double spatial_scale,
     int64_t pooled_height,
     int64_t pooled_width,
     int64_t sampling_ratio,
     bool aligned) {
-  TORCH_CHECK(input.device().is_cpu(), "input must be a CPU tensor");
-  TORCH_CHECK(rois.device().is_cpu(), "rois must be a CPU tensor");
-  TORCH_CHECK(rois.size(1) == 5, "rois must have shape as Tensor[K, 5]");
-
-  at::TensorArg input_t{input, "input", 1}, rois_t{rois, "rois", 2};
-
-  at::CheckedFrom c = "roi_align_forward_kernel";
-  at::checkAllSameType(c, {input_t, rois_t});
+  STD_TORCH_CHECK(input.is_cpu(), "input must be a CPU tensor");
+  STD_TORCH_CHECK(rois.is_cpu(), "rois must be a CPU tensor");
+  STD_TORCH_CHECK(rois.size(1) == 5, "rois must have shape as Tensor[K, 5]");
+  STD_TORCH_CHECK(
+      input.scalar_type() == rois.scalar_type(),
+      "input should have the same type as rois");
 
   auto num_rois = rois.size(0);
   auto channels = input.size(1);
   auto height = input.size(2);
   auto width = input.size(3);
 
-  at::Tensor output = at::zeros(
-      {num_rois, channels, pooled_height, pooled_width}, input.options());
+  Tensor output = torch::stable::new_zeros(
+      input, {num_rois, channels, pooled_height, pooled_width});
 
   if (output.numel() == 0) {
     return output;
   }
 
-  auto input_ = input.contiguous(), rois_ = rois.contiguous();
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-      input.scalar_type(), "roi_align_forward_kernel", [&] {
+  auto input_ = torch::stable::contiguous(input);
+  auto rois_ = torch::stable::contiguous(rois);
+  THO_DISPATCH_V2(
+      input.scalar_type(),
+      "roi_align_forward_kernel",
+      AT_WRAP([&]() {
         roi_align_forward_kernel_impl<scalar_t>(
             num_rois,
-            input_.data_ptr<scalar_t>(),
+            input_.const_data_ptr<scalar_t>(),
             spatial_scale,
             channels,
             height,
@@ -324,15 +332,17 @@ at::Tensor roi_align_forward_kernel(
             pooled_width,
             sampling_ratio,
             aligned,
-            rois_.data_ptr<scalar_t>(),
-            output.data_ptr<scalar_t>());
-      });
+            rois_.const_data_ptr<scalar_t>(),
+            output.mutable_data_ptr<scalar_t>());
+      }),
+      AT_EXPAND(AT_FLOATING_TYPES),
+      torch::headeronly::ScalarType::Half);
   return output;
 }
 
-at::Tensor roi_align_backward_kernel(
-    const at::Tensor& grad,
-    const at::Tensor& rois,
+Tensor roi_align_backward_kernel(
+    const Tensor& grad,
+    const Tensor& rois,
     double spatial_scale,
     int64_t pooled_height,
     int64_t pooled_width,
@@ -342,16 +352,14 @@ at::Tensor roi_align_backward_kernel(
     int64_t width,
     int64_t sampling_ratio,
     bool aligned) {
-  TORCH_CHECK(grad.device().is_cpu(), "grad must be a CPU tensor");
-  TORCH_CHECK(rois.device().is_cpu(), "rois must be a CPU tensor");
+  STD_TORCH_CHECK(grad.is_cpu(), "grad must be a CPU tensor");
+  STD_TORCH_CHECK(rois.is_cpu(), "rois must be a CPU tensor");
+  STD_TORCH_CHECK(
+      grad.scalar_type() == rois.scalar_type(),
+      "grad should have the same type as rois");
 
-  at::TensorArg grad_t{grad, "grad", 1}, rois_t{rois, "rois", 2};
-
-  at::CheckedFrom c = "roi_align_backward_kernel";
-  at::checkAllSameType(c, {grad_t, rois_t});
-
-  at::Tensor grad_input =
-      at::zeros({batch_size, channels, height, width}, grad.options());
+  Tensor grad_input =
+      torch::stable::new_zeros(grad, {batch_size, channels, height, width});
 
   // handle possibly empty gradients
   if (grad.numel() == 0) {
@@ -364,12 +372,14 @@ at::Tensor roi_align_backward_kernel(
   int h_stride = grad.stride(2);
   int w_stride = grad.stride(3);
 
-  auto rois_ = rois.contiguous();
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-      grad.scalar_type(), "roi_align_backward_kernel", [&] {
+  auto rois_ = torch::stable::contiguous(rois);
+  THO_DISPATCH_V2(
+      grad.scalar_type(),
+      "roi_align_backward_kernel",
+      AT_WRAP([&]() {
         roi_align_backward_kernel_impl<scalar_t>(
             grad.numel(),
-            grad.data_ptr<scalar_t>(),
+            grad.const_data_ptr<scalar_t>(),
             spatial_scale,
             channels,
             height,
@@ -378,25 +388,23 @@ at::Tensor roi_align_backward_kernel(
             pooled_width,
             sampling_ratio,
             aligned,
-            grad_input.data_ptr<scalar_t>(),
-            rois_.data_ptr<scalar_t>(),
+            grad_input.mutable_data_ptr<scalar_t>(),
+            rois_.const_data_ptr<scalar_t>(),
             n_stride,
             c_stride,
             h_stride,
             w_stride);
-      });
+      }),
+      AT_EXPAND(AT_FLOATING_TYPES),
+      torch::headeronly::ScalarType::Half);
   return grad_input;
 }
 
 } // namespace
 
-TORCH_LIBRARY_IMPL(torchvision, CPU, m) {
-  m.impl(
-      TORCH_SELECTIVE_NAME("torchvision::roi_align"),
-      TORCH_FN(roi_align_forward_kernel));
-  m.impl(
-      TORCH_SELECTIVE_NAME("torchvision::_roi_align_backward"),
-      TORCH_FN(roi_align_backward_kernel));
+STABLE_TORCH_LIBRARY_IMPL(torchvision, CPU, m) {
+  m.impl("roi_align", TORCH_BOX(&roi_align_forward_kernel));
+  m.impl("_roi_align_backward", TORCH_BOX(&roi_align_backward_kernel));
 }
 
 } // namespace ops

--- a/torchvision/csrc/ops/quantized/cpu/qroi_align_kernel.cpp
+++ b/torchvision/csrc/ops/quantized/cpu/qroi_align_kernel.cpp
@@ -1,5 +1,11 @@
-#include <ATen/ATen.h>
-#include <torch/library.h>
+#include <torch/csrc/stable/library.h>
+#include <torch/csrc/stable/ops.h>
+#include <torch/csrc/stable/tensor.h>
+#include <torch/headeronly/core/Dispatch_v2.h>
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
 
 #include "../../cpu/roi_align_common.h"
 
@@ -7,6 +13,8 @@ namespace vision {
 namespace ops {
 
 namespace {
+
+using torch::stable::Tensor;
 
 template <typename T>
 inline float dequantize_val(float scale, int64_t zero_point, T value) {
@@ -16,7 +24,7 @@ inline float dequantize_val(float scale, int64_t zero_point, T value) {
 template <typename T, typename R>
 void qroi_align_forward_kernel_impl(
     int n_rois,
-    const at::Tensor& t_input,
+    const Tensor& t_input,
     double input_scale,
     int64_t input_zero_point,
     const float& spatial_scale,
@@ -27,16 +35,16 @@ void qroi_align_forward_kernel_impl(
     int pooled_width,
     int sampling_ratio,
     bool aligned,
-    const at::Tensor& t_rois,
+    const Tensor& t_rois,
     double rois_scale,
     int64_t rois_zero_point,
     T* output) {
   // Don't delete these otherwise the .data_ptr() data might be undefined
-  auto t_input_cont = t_input.contiguous();
-  auto t_rois_cont = t_rois.contiguous();
+  auto t_input_cont = torch::stable::contiguous(t_input);
+  auto t_rois_cont = torch::stable::contiguous(t_rois);
 
-  const T* input = t_input_cont.data_ptr<T>();
-  const R* rois = t_rois_cont.data_ptr<R>();
+  const T* input = t_input_cont.const_data_ptr<T>();
+  const R* rois = t_rois_cont.const_data_ptr<R>();
 
   float input_scale_f = static_cast<float>(input_scale);
   float rois_scale_f = static_cast<float>(rois_scale);
@@ -158,9 +166,9 @@ void qroi_align_forward_kernel_impl(
   } // for n
 }
 
-at::Tensor qroi_align_forward_kernel(
-    const at::Tensor& input,
-    const at::Tensor& rois,
+Tensor qroi_align_forward_kernel(
+    const Tensor& input,
+    const Tensor& rois,
     double input_scale,
     int64_t input_zero_point,
     double rois_scale,
@@ -170,35 +178,36 @@ at::Tensor qroi_align_forward_kernel(
     int64_t pooled_width,
     int64_t sampling_ratio,
     bool aligned) {
-  TORCH_CHECK(input.device().is_cpu(), "input must be a CPU tensor");
-  TORCH_CHECK(rois.device().is_cpu(), "rois must be a CPU tensor");
-  TORCH_CHECK(rois.size(1) == 5, "rois must have shape as Tensor[K, 5]");
+  STD_TORCH_CHECK(input.is_cpu(), "input must be a CPU tensor");
+  STD_TORCH_CHECK(rois.is_cpu(), "rois must be a CPU tensor");
+  STD_TORCH_CHECK(rois.size(1) == 5, "rois must have shape as Tensor[K, 5]");
   // The kernel hardcodes roi_batch_ind to 0, so only batch size 1 is supported.
   // This restriction originates from quantized inputs where not all batch
   // indices are representable depending on the quantization parameters
   // (e.g. 1, 3, 5... can't be represented when qscale is 2).
-  TORCH_CHECK(
+  STD_TORCH_CHECK(
       input.size(0) == 1, "Only one image per batch is allowed in qroi_align.");
-
-  at::TensorArg input_t{input, "input", 1}, rois_t{rois, "rois", 2};
-  at::CheckedFrom c = "qroi_align_forward_kernel";
-  at::checkAllSameType(c, {input_t, rois_t});
+  STD_TORCH_CHECK(
+      input.scalar_type() == rois.scalar_type(),
+      "input should have the same type as rois");
 
   auto num_rois = rois.size(0);
   auto channels = input.size(1);
   auto height = input.size(2);
   auto width = input.size(3);
 
-  at::Tensor output = at::empty(
-      {num_rois, channels, pooled_height, pooled_width}, input.options());
+  Tensor output = torch::stable::new_empty(
+      input, {num_rois, channels, pooled_height, pooled_width});
 
   if (output.numel() == 0) {
     return output;
   }
 
-  AT_DISPATCH_INTEGRAL_TYPES(
-      input.scalar_type(), "qroi_align_forward_kernel", [&] {
-        qroi_align_forward_kernel_impl<scalar_t, scalar_t>(
+  THO_DISPATCH_V2(
+      input.scalar_type(),
+      "qroi_align_forward_kernel",
+      AT_WRAP([&]() {
+        (qroi_align_forward_kernel_impl<scalar_t, scalar_t>(
             num_rois,
             input,
             input_scale,
@@ -214,22 +223,21 @@ at::Tensor qroi_align_forward_kernel(
             rois,
             rois_scale,
             rois_zero_point,
-            output.data_ptr<scalar_t>());
-      });
+            output.mutable_data_ptr<scalar_t>()));
+      }),
+      AT_EXPAND(AT_INTEGRAL_TYPES));
   return output;
 }
 
 } // namespace
 
-TORCH_LIBRARY_FRAGMENT(torchvision, m) {
-  m.def(TORCH_SELECTIVE_SCHEMA(
-      "torchvision::qroi_align(Tensor input, Tensor rois, float input_scale, int input_zero_point, float rois_scale, int rois_zero_point, float spatial_scale, SymInt pooled_height, SymInt pooled_width, int sampling_ratio, bool aligned) -> Tensor"));
+STABLE_TORCH_LIBRARY_FRAGMENT(torchvision, m) {
+  m.def(
+      "qroi_align(Tensor input, Tensor rois, float input_scale, int input_zero_point, float rois_scale, int rois_zero_point, float spatial_scale, SymInt pooled_height, SymInt pooled_width, int sampling_ratio, bool aligned) -> Tensor");
 }
 
-TORCH_LIBRARY_IMPL(torchvision, CPU, m) {
-  m.impl(
-      TORCH_SELECTIVE_NAME("torchvision::qroi_align"),
-      TORCH_FN(qroi_align_forward_kernel));
+STABLE_TORCH_LIBRARY_IMPL(torchvision, CPU, m) {
+  m.impl("qroi_align", TORCH_BOX(&qroi_align_forward_kernel));
 }
 
 } // namespace ops

--- a/torchvision/csrc/ops/roi_align.cpp
+++ b/torchvision/csrc/ops/roi_align.cpp
@@ -1,15 +1,21 @@
 #include "roi_align.h"
 
-#include <ATen/core/dispatch/Dispatcher.h>
-#include <torch/library.h>
-#include <torch/types.h>
+#include <torch/csrc/stable/c/shim.h>
+#include <torch/csrc/stable/library.h>
+#include <torch/csrc/stable/stableivalue_conversions.h>
+#include <torch/headeronly/util/shim_utils.h>
+#include <torch/headeronly/version.h>
+
+#include <array>
 
 namespace vision {
 namespace ops {
 
-at::Tensor roi_align(
-    const at::Tensor& input, // Input feature map.
-    const at::Tensor& rois, // List of ROIs to pool over.
+using torch::stable::Tensor;
+
+Tensor roi_align(
+    const Tensor& input, // Input feature map.
+    const Tensor& rois, // List of ROIs to pool over.
     double spatial_scale, // The scale of the image features. ROIs will be
     // scaled to this.
     int64_t pooled_height, // The height of the pooled feature map.
@@ -18,50 +24,24 @@ at::Tensor roi_align(
     bool aligned) // The flag for pixel shift
 // along each axis.
 {
-  C10_LOG_API_USAGE_ONCE("torchvision.csrc.ops.roi_align.roi_align");
-  static auto op = c10::Dispatcher::singleton()
-                       .findSchemaOrThrow("torchvision::roi_align", "")
-                       .typed<decltype(roi_align)>();
-  return op.call(
-      input,
-      rois,
-      spatial_scale,
-      pooled_height,
-      pooled_width,
-      sampling_ratio,
-      aligned);
-}
-
-at::Tensor roi_align_symint(
-    const at::Tensor& input, // Input feature map.
-    const at::Tensor& rois, // List of ROIs to pool over.
-    double spatial_scale, // The scale of the image features. ROIs will be
-    // scaled to this.
-    c10::SymInt pooled_height, // The height of the pooled feature map.
-    c10::SymInt pooled_width, // The width of the pooled feature
-    int64_t sampling_ratio, // The number of points to sample in each bin
-    bool aligned) // The flag for pixel shift
-// along each axis.
-{
-  C10_LOG_API_USAGE_ONCE("torchvision.csrc.ops.roi_align.roi_align");
-  static auto op = c10::Dispatcher::singleton()
-                       .findSchemaOrThrow("torchvision::roi_align", "")
-                       .typed<decltype(roi_align_symint)>();
-  return op.call(
-      input,
-      rois,
-      spatial_scale,
-      pooled_height,
-      pooled_width,
-      sampling_ratio,
-      aligned);
+  std::array<StableIValue, 7> stack{
+      torch::stable::detail::from(input),
+      torch::stable::detail::from(rois),
+      torch::stable::detail::from(spatial_scale),
+      torch::stable::detail::from(pooled_height),
+      torch::stable::detail::from(pooled_width),
+      torch::stable::detail::from(sampling_ratio),
+      torch::stable::detail::from(aligned)};
+  TORCH_ERROR_CODE_CHECK(torch_call_dispatcher(
+      "torchvision::roi_align", "", stack.data(), TORCH_ABI_VERSION));
+  return torch::stable::detail::to<Tensor>(stack[0]);
 }
 
 namespace detail {
 
-at::Tensor _roi_align_backward(
-    const at::Tensor& grad,
-    const at::Tensor& rois,
+Tensor _roi_align_backward(
+    const Tensor& grad,
+    const Tensor& rois,
     double spatial_scale,
     int64_t pooled_height,
     int64_t pooled_width,
@@ -71,61 +51,30 @@ at::Tensor _roi_align_backward(
     int64_t width,
     int64_t sampling_ratio,
     bool aligned) {
-  static auto op =
-      c10::Dispatcher::singleton()
-          .findSchemaOrThrow("torchvision::_roi_align_backward", "")
-          .typed<decltype(_roi_align_backward)>();
-  return op.call(
-      grad,
-      rois,
-      spatial_scale,
-      pooled_height,
-      pooled_width,
-      batch_size,
-      channels,
-      height,
-      width,
-      sampling_ratio,
-      aligned);
-}
-
-at::Tensor _roi_align_backward_symint(
-    const at::Tensor& grad,
-    const at::Tensor& rois,
-    double spatial_scale,
-    c10::SymInt pooled_height,
-    c10::SymInt pooled_width,
-    c10::SymInt batch_size,
-    c10::SymInt channels,
-    c10::SymInt height,
-    c10::SymInt width,
-    int64_t sampling_ratio,
-    bool aligned) {
-  static auto op =
-      c10::Dispatcher::singleton()
-          .findSchemaOrThrow("torchvision::_roi_align_backward", "")
-          .typed<decltype(_roi_align_backward_symint)>();
-  return op.call(
-      grad,
-      rois,
-      spatial_scale,
-      pooled_height,
-      pooled_width,
-      batch_size,
-      channels,
-      height,
-      width,
-      sampling_ratio,
-      aligned);
+  std::array<StableIValue, 11> stack{
+      torch::stable::detail::from(grad),
+      torch::stable::detail::from(rois),
+      torch::stable::detail::from(spatial_scale),
+      torch::stable::detail::from(pooled_height),
+      torch::stable::detail::from(pooled_width),
+      torch::stable::detail::from(batch_size),
+      torch::stable::detail::from(channels),
+      torch::stable::detail::from(height),
+      torch::stable::detail::from(width),
+      torch::stable::detail::from(sampling_ratio),
+      torch::stable::detail::from(aligned)};
+  TORCH_ERROR_CODE_CHECK(torch_call_dispatcher(
+      "torchvision::_roi_align_backward", "", stack.data(), TORCH_ABI_VERSION));
+  return torch::stable::detail::to<Tensor>(stack[0]);
 }
 
 } // namespace detail
 
-TORCH_LIBRARY_FRAGMENT(torchvision, m) {
-  m.def(TORCH_SELECTIVE_SCHEMA(
-      "torchvision::roi_align(Tensor input, Tensor rois, float spatial_scale, SymInt pooled_height, SymInt pooled_width, int sampling_ratio, bool aligned) -> Tensor"));
-  m.def(TORCH_SELECTIVE_SCHEMA(
-      "torchvision::_roi_align_backward(Tensor grad, Tensor rois, float spatial_scale, SymInt pooled_height, SymInt pooled_width, SymInt batch_size, SymInt channels, SymInt height, SymInt width, int sampling_ratio, bool aligned) -> Tensor"));
+STABLE_TORCH_LIBRARY_FRAGMENT(torchvision, m) {
+  m.def(
+      "roi_align(Tensor input, Tensor rois, float spatial_scale, SymInt pooled_height, SymInt pooled_width, int sampling_ratio, bool aligned) -> Tensor");
+  m.def(
+      "_roi_align_backward(Tensor grad, Tensor rois, float spatial_scale, SymInt pooled_height, SymInt pooled_width, SymInt batch_size, SymInt channels, SymInt height, SymInt width, int sampling_ratio, bool aligned) -> Tensor");
 }
 
 } // namespace ops

--- a/torchvision/csrc/ops/roi_align.h
+++ b/torchvision/csrc/ops/roi_align.h
@@ -1,34 +1,25 @@
 #pragma once
 
-#include <ATen/ATen.h>
+#include <torch/csrc/stable/tensor.h>
 #include "../macros.h"
 
 namespace vision {
 namespace ops {
 
-VISION_API at::Tensor roi_align(
-    const at::Tensor& input,
-    const at::Tensor& rois,
+VISION_API torch::stable::Tensor roi_align(
+    const torch::stable::Tensor& input,
+    const torch::stable::Tensor& rois,
     double spatial_scale,
     int64_t pooled_height,
     int64_t pooled_width,
     int64_t sampling_ratio,
     bool aligned);
 
-VISION_API at::Tensor roi_align_symint(
-    const at::Tensor& input,
-    const at::Tensor& rois,
-    double spatial_scale,
-    c10::SymInt pooled_height,
-    c10::SymInt pooled_width,
-    int64_t sampling_ratio,
-    bool aligned);
-
 namespace detail {
 
-at::Tensor _roi_align_backward(
-    const at::Tensor& grad,
-    const at::Tensor& rois,
+torch::stable::Tensor _roi_align_backward(
+    const torch::stable::Tensor& grad,
+    const torch::stable::Tensor& rois,
     double spatial_scale,
     int64_t pooled_height,
     int64_t pooled_width,
@@ -36,19 +27,6 @@ at::Tensor _roi_align_backward(
     int64_t channels,
     int64_t height,
     int64_t width,
-    int64_t sampling_ratio,
-    bool aligned);
-
-at::Tensor _roi_align_backward_symint(
-    const at::Tensor& grad,
-    const at::Tensor& rois,
-    double spatial_scale,
-    c10::SymInt pooled_height,
-    c10::SymInt pooled_width,
-    c10::SymInt batch_size,
-    c10::SymInt channels,
-    c10::SymInt height,
-    c10::SymInt width,
     int64_t sampling_ratio,
     bool aligned);
 


### PR DESCRIPTION
Ports `roi_align` (CPU + quantized-CPU, forward and backward) to stable ABI. The CUDA/ROCm and MPS kernels are unchanged and continue to register from the legacy `_C` extension.

## Notes
- **Dropped the `*_symint` C++ wrappers.** `c10::SymInt` isn't part of the stable ABI, so the overloads can't be expressed. The schemas keep `SymInt`, so dispatcher and tracing behavior are unchanged.

## Stable-ABI audit (`torch-abi-audit`)
Ran [`torch-abi-audit`](https://github.com/Quansight/torch-abi-audit). The legacy `_C.so` drops 107 → 103.
 ```text
    Package: torchvision
      Torch ABI:   UNSTABLE
      CPython ABI: n/a
      Bundled libs: 3
      -- bundled libs --
        [UNSTABLE] [not-abi3] _C.so            (stable_shim=0,  unstable=103)
        [STABLE  ] [not-abi3] _C_stable.so     (stable_shim=70, unstable=0)
        [STABLE  ] [not-abi3] image_stable.so  (stable_shim=76, unstable=0)
 ```