### PR TITLE
Faster ElasticTransform using separable Gaussian filters

### DIFF
--- a/test/test_transforms_v2.py
+++ b/test/test_transforms_v2.py
@@ -3413,16 +3413,17 @@ class TestElastic:
         ],
     )
     # ElasticTransform needs larger images to avoid the needed internal padding being larger than the actual image
-    @pytest.mark.parametrize("size", [(163, 163), (72, 333), (313, 95)])
+    @pytest.mark.parametrize("size", [(163, 163), (72, 333), (313, 95), (423, 617), (1008, 1008)])
+    @pytest.mark.parametrize("sigma", [0.5, 5.0, 15.0])
     @pytest.mark.parametrize("device", cpu_and_cuda())
-    def test_transform(self, make_input, size, device):
+    def test_transform(self, make_input, size, sigma, device):
         # We have to skip that test on M1 because it's flaky: Mismatched elements: 35 / 89205 (0.0%)
         # See https://github.com/pytorch/vision/issues/8154
         # All other platforms are fine, so the differences do not come from something we own in torchvision
         check_v1_compatibility = False if sys.platform == "darwin" else dict(rtol=0, atol=1)
 
         check_transform(
-            transforms.ElasticTransform(),
+            transforms.ElasticTransform(sigma=sigma),
             make_input(size, device=device),
             check_v1_compatibility=check_v1_compatibility,
         )

--- a/torchvision/transforms/v2/_geometry.py
+++ b/torchvision/transforms/v2/_geometry.py
@@ -1051,9 +1051,11 @@ class ElasticTransform(Transform):
 
     Args:
         alpha (float or sequence of floats, optional): Magnitude of displacements.
-            Default is 50.0. A single value is ``[alpha, alpha]``.
+            Default is 50.0. A single value is ``[alpha, alpha]``, specifying the strength of the
+            displacement along the x and y axes, respectively.
         sigma (float or sequence of floats, optional): Smoothness of displacements.
-            Default is 5.0. A single value is ``[sigma, sigma]``.
+            Default is 5.0. A single value is ``[sigma, sigma]``, specifying the smoothness of the
+            displacement along the x and y axes, respectively.
         interpolation (str or InterpolationMode, optional): Desired interpolation enum defined by
             :class:`torchvision.transforms.v2.InterpolationMode`.
             Accepted string values are ``"nearest"``, ``"nearest-exact"``, ``"bilinear"``, ``"bicubic"``,
@@ -1087,27 +1089,28 @@ class ElasticTransform(Transform):
         self._fill = _setup_fill_arg(fill)
 
     def make_params(self, flat_inputs: list[Any]) -> dict[str, Any]:
-        height, width = query_size(flat_inputs)
-
-        dx = torch.rand(1, 1, height, width) * 2 - 1
-        if self.sigma[0] > 0.0:
-            kx = int(8 * self.sigma[0] + 1)
-            # if kernel size is even we have to make it odd
-            if kx % 2 == 0:
-                kx += 1
-            dx = self._call_kernel(F.gaussian_blur, dx, [kx, kx], list(self.sigma))
-        dx = dx * self.alpha[0] / width
-
-        dy = torch.rand(1, 1, height, width) * 2 - 1
-        if self.sigma[1] > 0.0:
-            ky = int(8 * self.sigma[1] + 1)
-            # if kernel size is even we have to make it odd
-            if ky % 2 == 0:
-                ky += 1
-            dy = self._call_kernel(F.gaussian_blur, dy, [ky, ky], list(self.sigma))
-        dy = dy * self.alpha[1] / height
+        height, width = list(query_size(flat_inputs))
+        dx = self._make_displacement_field(0, [height, width]) * self.alpha[0] / width
+        dy = self._make_displacement_field(1, [height, width]) * self.alpha[1] / height
         displacement = torch.concat([dx, dy], 1).permute([0, 2, 3, 1])  # 1 x H x W x 2
         return dict(displacement=displacement)
+
+    def _make_displacement_field(self, axis: Literal[0, 1], size: list[int]) -> torch.Tensor:
+        # Sample random displacement field
+        d = torch.rand([1, 1] + size) * 2 - 1
+
+        # Apply Gaussian smoothing to the random field
+        sigma = self.sigma[axis]
+        if sigma > 0.0:
+            ks = int(8 * sigma + 1)
+            # if kernel size is even we have to make it odd
+            if ks % 2 == 0:
+                ks += 1
+            sigma_x, sigma_y = self.sigma
+            d = self._call_kernel(F.gaussian_blur, d, [ks, 1], [sigma_x, 1.0])
+            d = self._call_kernel(F.gaussian_blur, d, [1, ks], [1.0, sigma_y])
+
+        return d
 
     def transform(self, inpt: Any, params: dict[str, Any]) -> Any:
         fill = _get_fill(self._fill, type(inpt))


### PR DESCRIPTION
# Fix

Fixes #9577 by using separable Gaussian filters for smoothing the displacement field in `torchvision.transforms.v2.ElasticTransform`.

## Runtime Comparison of `ElasticTransform.make_params`

### Image Size `1008 x 1008`

| Sigma | Old Implementation | New Implementation |
|---:|---:|---:|
| 1.0 | 19 ms | 35 ms |
| 3.0 | 28 ms | 35 ms |
| 5.0 | 49 ms | 35 ms |
| 8.0 | 96 ms | 35 ms |
| 10.0 | 142 ms | 36 ms |
| 20.0 | 575 ms | 37 ms |
| 30.0 | 1,210 ms | 43 ms |
| 50.0 | 3,310 ms | 47 ms |
| 100.0 | 31,900 ms | 77 ms |

### Image Size `256 x 256`

| Sigma | Old Implementation | New Implementation |
|---:|---:|---:|
| 1.0 | 0.6 ms | 0.7 ms |
| 3.0 | 1.4 ms | 0.7 ms |
| 5.0 | 2.7 ms | 0.7 ms |
| 10.0 | 9 ms | 1 ms |
| 20.0 | 34 ms | 1 ms |
| 30.0 | 82 ms | 1 ms |
| 50.0 | 276 ms | 2 ms |

## Tests

Larger image sizes and different variants for `sigma` have been added to the test `test_transforms_v2.py::TestElastic::test_transform`. Run with:

```bash
pytest test/test_transforms_v2.py::TestElastic::test_transform
```