### PR TITLE
Port roi_pool (MPS) to stable ABI.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,12 +123,12 @@ set(TORCHVISION_STABLE_SOURCES
   ${TVCPP}/io/image/cpu/decode_webp.cpp
   ${TVCPP}/io/image/common_stable.cpp
   ${TVCPP}/vision_stable.cpp)
-# Pin them to torch 2.11. Per source, not library-wide: the pin makes ATen headers
+# Pin them to torch 2.14. Per source, not library-wide: the pin makes ATen headers
 # error, and the legacy ops sharing this library still include them.
 # TODO(stable-abi): once every op is ported, drop this list and pin the whole
 # library target instead.
 set_source_files_properties(${TORCHVISION_STABLE_SOURCES} PROPERTIES
-  COMPILE_DEFINITIONS TORCH_TARGET_VERSION=0x020b000000000000)
+  COMPILE_DEFINITIONS TORCH_TARGET_VERSION=0x020e000000000000)
 
 add_library(${PROJECT_NAME} SHARED ${ALL_SOURCES})
 target_link_libraries(${PROJECT_NAME} PRIVATE ${TORCH_LIBRARIES})

--- a/setup.py
+++ b/setup.py
@@ -153,7 +153,7 @@ def get_macros_and_flags():
     return define_macros, extra_compile_args
 
 
-TORCH_TARGET_VERSION = "0x020b000000000000"
+TORCH_TARGET_VERSION = "0x020e000000000000"
 
 # Files migrated to the stable ABI: subtracted from make_C_extension()'s globs and
 # built into _C_stable instead. Add an op's files here as it migrates.
@@ -171,6 +171,7 @@ STABLE_SOURCES = {
     CSRS_DIR / "ops/quantized/cpu/qroi_align_kernel.cpp",
     CSRS_DIR / "ops/roi_pool.cpp",
     CSRS_DIR / "ops/cpu/roi_pool_kernel.cpp",
+    CSRS_DIR / "ops/mps/roi_pool_kernel.mm",
 }
 STABLE_SOURCES.add(CSRS_DIR / ("ops/hip/nms_kernel.hip" if IS_ROCM else "ops/cuda/nms_kernel.cu"))
 STABLE_SOURCES.add(
@@ -261,6 +262,8 @@ def get_stable_macros_and_flags():
             # The jpeg decode .cpp also calls these shims (incl.
             # torch_get_cuda_stream_from_pool), so cxx needs USE_CUDA too.
             extra_compile_args["cxx"].append("-DUSE_CUDA")
+    if torch.backends.mps.is_available() or FORCE_MPS:
+        extra_compile_args["cxx"].append("-DUSE_MPS")
     return define_macros, extra_compile_args
 
 

--- a/setup.py
+++ b/setup.py
@@ -170,6 +170,7 @@ STABLE_SOURCES = {
     CSRS_DIR / "ops/quantized/cpu/qroi_align_kernel.cpp",
     CSRS_DIR / "ops/roi_pool.cpp",
     CSRS_DIR / "ops/cpu/roi_pool_kernel.cpp",
+    CSRS_DIR / "ops/mps/roi_pool_kernel.mm",
     CSRS_DIR / "ops/ps_roi_pool.cpp",
     CSRS_DIR / "ops/cpu/ps_roi_pool_kernel.cpp",
     CSRS_DIR / "ops/ps_roi_align.cpp",

--- a/torchvision/_autograd_registrations.py
+++ b/torchvision/_autograd_registrations.py
@@ -53,11 +53,10 @@ def _roi_pool_setup_context(ctx, inputs, output):
 
 
 def _roi_pool_backward(ctx, grad_output, _grad_argmax):
-    # The CUDA backward accumulates with atomicAdd. Stable kernels can't call
-    # alertNotDeterministic, so the alert lives here in Python. The CPU
-    # backward is deterministic and must not alert. The MPS backward still
-    # alerts from C++ until it is ported.
-    if grad_output.device.type == "cuda":
+    # The CUDA and MPS backwards accumulate with atomicAdd. Stable kernels
+    # can't call alertNotDeterministic, so the alert lives here in Python.
+    # The CPU backward is deterministic and must not alert.
+    if grad_output.device.type in ("cuda", "mps"):
         torch._prims_common.alert_not_deterministic("roi_pool_backward_kernel")
     rois, argmax = ctx.saved_tensors
     batch_size, channels, height, width = ctx.input_shape

--- a/torchvision/_autograd_registrations.py
+++ b/torchvision/_autograd_registrations.py
@@ -55,6 +55,8 @@ def _roi_pool_setup_context(ctx, inputs, output):
 
 
 def _roi_pool_backward(ctx, grad_output, _grad_argmax):
+    if grad_output.device.type == "mps":
+        torch._prims_common.alert_not_deterministic("roi_pool_backward_kernel")
     rois, argmax = ctx.saved_tensors
     batch_size, channels, height, width = ctx.input_shape
     grad_input = torch.ops.torchvision._roi_pool_backward(

--- a/torchvision/csrc/ops/mps/roi_pool_kernel.mm
+++ b/torchvision/csrc/ops/mps/roi_pool_kernel.mm
@@ -1,37 +1,190 @@
-#include <ATen/mps/MPSProfiler.h>
-#include <ATen/native/mps/OperationUtils.h>
-#include "mps_helpers.h"
-#include "mps_kernels.h"
+#include <torch/csrc/inductor/aoti_torch/c/shim_mps.h>
+#include <torch/csrc/stable/device.h>
+#include <torch/csrc/stable/library.h>
+#include <torch/csrc/stable/ops.h>
+#include <torch/csrc/stable/tensor.h>
+#include <torch/headeronly/core/DeviceType.h>
+#include <torch/headeronly/core/ScalarType.h>
+#include <torch/headeronly/util/Exception.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <string>
+#include <tuple>
+
+#include "roi_pool_metal_shader.h"
 
 namespace vision {
 namespace ops {
 
 namespace {
 
-std::tuple<at::Tensor, at::Tensor> roi_pool_forward_kernel(const at::Tensor& input,
-                                                           const at::Tensor& rois,
-                                                           double spatial_scale,
-                                                           int64_t pooled_height,
-                                                           int64_t pooled_width) {
-  using namespace at::native::mps;
-  TORCH_CHECK(input.is_mps(), "input must be a MPS tensor");
-  TORCH_CHECK(rois.is_mps(), "rois must be a MPS tensor");
-  TORCH_CHECK(rois.size(1) == 5, "rois must have shape as Tensor[K, 5]");
+using torch::stable::Tensor;
 
-  at::TensorArg input_t{input, "input", 1}, rois_t{rois, "rois", 2};
+constexpr int64_t threadsPerBlock = 512;
 
-  at::CheckedFrom c = "roi_pool_forward_kernel";
-  at::checkAllSameGPU(c, {input_t, rois_t});
-  at::checkAllSameType(c, {input_t, rois_t});
+AOTIMetalShaderLibraryHandle roi_pool_shader_library() {
+  static AOTIMetalShaderLibraryHandle library = []() {
+    AOTIMetalShaderLibraryHandle handle = nullptr;
+    TORCH_ERROR_CODE_CHECK(
+        aoti_torch_mps_create_shader_library(roi_pool_metal_shader, &handle));
+    return handle;
+  }();
+  return library;
+}
+
+const char* metal_type_string(torch::headeronly::ScalarType scalar_type) {
+  if (scalar_type == torch::headeronly::ScalarType::Float) {
+    return "float";
+  }
+  if (scalar_type == torch::headeronly::ScalarType::Half) {
+    return "half";
+  }
+  return "";
+}
+
+struct RoiPoolForwardLaunchArgs {
+  AtenTensorHandle input;
+  AtenTensorHandle rois;
+  AtenTensorHandle output;
+  AtenTensorHandle argmax;
+  int64_t output_size;
+  int64_t channels;
+  int64_t height;
+  int64_t width;
+  int64_t pooled_height;
+  int64_t pooled_width;
+  float spatial_scale;
+  uint64_t grid;
+  uint64_t threadgroup;
+};
+
+void roi_pool_forward_encode(
+    AOTIMetalKernelFunctionHandle func,
+    void* user_data) {
+  const auto* launch_args =
+      static_cast<const RoiPoolForwardLaunchArgs*>(user_data);
+  TORCH_ERROR_CODE_CHECK(aoti_torch_mps_start_encoding(func));
+  // [N, C, H, W]
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_tensor(func, 0, launch_args->input));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_tensor(func, 1, launch_args->rois));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_tensor(func, 2, launch_args->output));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_tensor(func, 3, launch_args->argmax));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_int(func, 4, launch_args->output_size));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_int(func, 5, launch_args->channels));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_int(func, 6, launch_args->height));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_int(func, 7, launch_args->width));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_int(func, 8, launch_args->pooled_height));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_int(func, 9, launch_args->pooled_width));
+  TORCH_ERROR_CODE_CHECK(torch_mps_set_arg_bytes(
+      func, 10, &launch_args->spatial_scale, sizeof(float)));
+  TORCH_ERROR_CODE_CHECK(aoti_torch_mps_dispatch_single_with_group_size(
+      func, launch_args->grid, launch_args->threadgroup));
+}
+
+struct RoiPoolBackwardLaunchArgs {
+  AtenTensorHandle grad_output;
+  AtenTensorHandle rois;
+  AtenTensorHandle argmax;
+  AtenTensorHandle grad_input;
+  int64_t output_size;
+  int64_t channels;
+  int64_t height;
+  int64_t width;
+  int64_t pooled_height;
+  int64_t pooled_width;
+  float spatial_scale;
+  int64_t n_stride;
+  int64_t c_stride;
+  int64_t h_stride;
+  int64_t w_stride;
+};
+
+void roi_pool_backward_encode(
+    AOTIMetalKernelFunctionHandle func,
+    void* user_data) {
+  const auto* launch_args =
+      static_cast<const RoiPoolBackwardLaunchArgs*>(user_data);
+  TORCH_ERROR_CODE_CHECK(aoti_torch_mps_start_encoding(func));
+  // [N, C, H, W]
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_tensor(func, 0, launch_args->grad_output));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_tensor(func, 1, launch_args->rois));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_tensor(func, 2, launch_args->argmax));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_tensor(func, 3, launch_args->grad_input));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_int(func, 4, launch_args->output_size));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_int(func, 5, launch_args->channels));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_int(func, 6, launch_args->height));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_int(func, 7, launch_args->width));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_int(func, 8, launch_args->pooled_height));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_int(func, 9, launch_args->pooled_width));
+  TORCH_ERROR_CODE_CHECK(torch_mps_set_arg_bytes(
+      func, 10, &launch_args->spatial_scale, sizeof(float)));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_int(func, 11, launch_args->n_stride));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_int(func, 12, launch_args->c_stride));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_int(func, 13, launch_args->h_stride));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_int(func, 14, launch_args->w_stride));
+  // One thread per pooled-output element. dispatchThreads guarantees each
+  // index is handled exactly once; the kernel scatters into grad_input with
+  // atomic_add for overlapping RoIs.
+  TORCH_ERROR_CODE_CHECK(aoti_torch_mps_dispatch_single(
+      func, static_cast<uint64_t>(launch_args->output_size)));
+}
+
+std::tuple<Tensor, Tensor> roi_pool_forward_kernel(
+    const Tensor& input,
+    const Tensor& rois,
+    double spatial_scale,
+    int64_t pooled_height,
+    int64_t pooled_width) {
+  STD_TORCH_CHECK(
+      input.device().type() == torch::headeronly::DeviceType::MPS,
+      "input must be a MPS tensor");
+  STD_TORCH_CHECK(
+      rois.device().type() == torch::headeronly::DeviceType::MPS,
+      "rois must be a MPS tensor");
+  STD_TORCH_CHECK(rois.size(1) == 5, "rois must have shape as Tensor[K, 5]");
+  STD_TORCH_CHECK(
+      input.get_device_index() == rois.get_device_index(),
+      "input should be on the same device as rois");
+  STD_TORCH_CHECK(
+      input.scalar_type() == rois.scalar_type(),
+      "input should have the same type as rois");
 
   int64_t num_rois = rois.size(0);
   int64_t channels = input.size(1);
   int64_t height = input.size(2);
   int64_t width = input.size(3);
-  float spatial_scale_f = static_cast<float>(spatial_scale);
 
-  at::Tensor output = at::zeros({num_rois, channels, pooled_height, pooled_width}, input.options());
-  at::Tensor argmax = at::zeros({num_rois, channels, pooled_height, pooled_width}, input.options().dtype(at::kLong));
+  Tensor output = torch::stable::new_zeros(
+      input, {num_rois, channels, pooled_height, pooled_width});
+  Tensor argmax = torch::stable::new_zeros(
+      input,
+      {num_rois, channels, pooled_height, pooled_width},
+      torch::headeronly::ScalarType::Long);
 
   int64_t output_size = num_rois * pooled_height * pooled_width * channels;
 
@@ -39,84 +192,75 @@ std::tuple<at::Tensor, at::Tensor> roi_pool_forward_kernel(const at::Tensor& inp
     return std::make_tuple(output, argmax);
   }
 
-  auto input_ = input.contiguous();
-  auto rois_ = rois.contiguous();
-
-  id<MTLBuffer> inputBuffer = getMTLBufferStorage(input_);
-  id<MTLBuffer> roisBuffer = getMTLBufferStorage(rois_);
-  id<MTLBuffer> outputBuffer = getMTLBufferStorage(output);
-  id<MTLBuffer> argmaxBuffer = getMTLBufferStorage(argmax);
-  id<MTLDevice> device = MPSDevice::getInstance()->device();
-  MPSStream* mpsStream = getCurrentMPSStream();
-  dispatch_sync(mpsStream->queue(), ^() {
-    @autoreleasepool {
-      id<MTLComputeCommandEncoder> computeEncoder = mpsStream->commandEncoder();
-      MTLSize threadgroupsPerGrid = MTLSizeMake(
-          std::min(ceil_div(static_cast<int64_t>(output_size), static_cast<int64_t>(512)), static_cast<int64_t>(4096)),
-          1,
-          1);
-
-      const std::string kernel = "roi_pool_" + scalarToMetalTypeString(input.scalar_type());
-      id<MTLComputePipelineState> visionPSO = mps::visionPipelineState(device, kernel);
-
-      // this function call is a no-op if MPS Profiler is not enabled
-      getMPSProfiler().beginProfileKernel(visionPSO, kernel, {input_, rois_});
-
-      [computeEncoder setComputePipelineState:visionPSO];
-      // [N, C, H, W]
-      [computeEncoder setBuffer:inputBuffer offset:input_.storage_offset() * input_.element_size() atIndex:0];
-      [computeEncoder setBuffer:roisBuffer offset:rois_.storage_offset() * rois_.element_size() atIndex:1];
-      [computeEncoder setBuffer:outputBuffer offset:output.storage_offset() * output.element_size() atIndex:2];
-      [computeEncoder setBuffer:argmaxBuffer offset:argmax.storage_offset() * argmax.element_size() atIndex:3];
-
-      [computeEncoder setBytes:&output_size length:sizeof(int64_t) atIndex:4];
-      [computeEncoder setBytes:&channels length:sizeof(int64_t) atIndex:5];
-      [computeEncoder setBytes:&height length:sizeof(int64_t) atIndex:6];
-      [computeEncoder setBytes:&width length:sizeof(int64_t) atIndex:7];
-      [computeEncoder setBytes:&pooled_height length:sizeof(int64_t) atIndex:8];
-      [computeEncoder setBytes:&pooled_width length:sizeof(int64_t) atIndex:9];
-      [computeEncoder setBytes:&spatial_scale_f length:sizeof(float) atIndex:10];
-
-      // A threadGroup is equivalent to a cuda's block.
-      NSUInteger tgSize = visionPSO.maxTotalThreadsPerThreadgroup;
-      if (tgSize > threadsPerBlock) {
-        tgSize = threadsPerBlock;
-      }
-
-      MTLSize threadGroupSize = MTLSizeMake(tgSize, 1, 1);
-      [computeEncoder dispatchThreadgroups:threadgroupsPerGrid threadsPerThreadgroup:threadGroupSize];
-
-      getMPSProfiler().endProfileKernel(visionPSO);
-    }
-  });
-  return std::make_tuple(output, argmax);
-}
-
-at::Tensor roi_pool_backward_kernel(const at::Tensor& grad,
-                                    const at::Tensor& rois,
-                                    const at::Tensor& argmax,
-                                    double spatial_scale,
-                                    int64_t pooled_height,
-                                    int64_t pooled_width,
-                                    int64_t batch_size,
-                                    int64_t channels,
-                                    int64_t height,
-                                    int64_t width) {
-  using namespace at::native::mps;
-  TORCH_CHECK(grad.is_mps(), "grad must be a MPS tensor");
-  TORCH_CHECK(rois.is_mps(), "rois must be a MPS tensor");
-  TORCH_CHECK(grad.scalar_type() != at::kHalf, "MPS does not support roi_pool backward with float16 inputs.");
-  TORCH_CHECK(argmax.is_mps(), "argmax must be a MPS tensor");
-
-  at::TensorArg grad_t{grad, "input", 1}, rois_t{rois, "rois", 2}, argmax_t{argmax, "argmax", 3};
-
-  at::CheckedFrom c = "roi_pool_backward_kernel";
-  at::checkAllSameGPU(c, {grad_t, rois_t, argmax_t});
-  at::checkAllSameType(c, {grad_t, rois_t});
+  auto input_ = torch::stable::contiguous(input);
+  auto rois_ = torch::stable::contiguous(rois);
 
   float spatial_scale_f = static_cast<float>(spatial_scale);
 
-  at::Tensor grad_input = at::zeros({batch_size, channels, height, width}, grad.options());
+  const std::string kernel =
+      "roi_pool_" + std::string(metal_type_string(input.scalar_type()));
+  AOTIMetalKernelFunctionHandle func = nullptr;
+  TORCH_ERROR_CODE_CHECK(aoti_torch_mps_get_kernel_function(
+      roi_pool_shader_library(), kernel.c_str(), &func));
+
+  const int64_t threadgroups = std::min(
+      (output_size + threadsPerBlock - 1) / threadsPerBlock,
+      static_cast<int64_t>(4096));
+
+  RoiPoolForwardLaunchArgs launch_args{
+      input_.get(),
+      rois_.get(),
+      output.get(),
+      argmax.get(),
+      output_size,
+      channels,
+      height,
+      width,
+      pooled_height,
+      pooled_width,
+      spatial_scale_f,
+      static_cast<uint64_t>(threadgroups * threadsPerBlock),
+      static_cast<uint64_t>(threadsPerBlock)};
+  TORCH_ERROR_CODE_CHECK(aoti_torch_mps_run_command_block(
+      func, &roi_pool_forward_encode, &launch_args));
+  return std::make_tuple(output, argmax);
+}
+
+Tensor roi_pool_backward_kernel(
+    const Tensor& grad,
+    const Tensor& rois,
+    const Tensor& argmax,
+    double spatial_scale,
+    int64_t pooled_height,
+    int64_t pooled_width,
+    int64_t batch_size,
+    int64_t channels,
+    int64_t height,
+    int64_t width) {
+  STD_TORCH_CHECK(
+      grad.device().type() == torch::headeronly::DeviceType::MPS,
+      "grad must be a MPS tensor");
+  STD_TORCH_CHECK(
+      rois.device().type() == torch::headeronly::DeviceType::MPS,
+      "rois must be a MPS tensor");
+  STD_TORCH_CHECK(
+      grad.scalar_type() != torch::headeronly::ScalarType::Half,
+      "MPS does not support roi_pool backward with float16 inputs.");
+  STD_TORCH_CHECK(
+      argmax.device().type() == torch::headeronly::DeviceType::MPS,
+      "argmax must be a MPS tensor");
+  STD_TORCH_CHECK(
+      grad.get_device_index() == rois.get_device_index(),
+      "grad should be on the same device as rois");
+  STD_TORCH_CHECK(
+      grad.get_device_index() == argmax.get_device_index(),
+      "grad should be on the same device as argmax");
+  STD_TORCH_CHECK(
+      grad.scalar_type() == rois.scalar_type(),
+      "grad should have the same type as rois");
+
+  Tensor grad_input =
+      torch::stable::new_zeros(grad, {batch_size, channels, height, width});
 
   if (grad.numel() == 0) {
     return grad_input;
@@ -128,63 +272,43 @@ at::Tensor roi_pool_backward_kernel(const at::Tensor& grad,
   int64_t w_stride = grad.stride(3);
   int64_t output_size = grad.numel();
 
-  at::globalContext().alertNotDeterministic("roi_pool_backward_kernel");
-  auto argmax_ = argmax.contiguous(), rois_ = rois.contiguous();
+  auto argmax_ = torch::stable::contiguous(argmax);
+  auto rois_ = torch::stable::contiguous(rois);
 
-  id<MTLBuffer> inputBuffer = getMTLBufferStorage(grad);
-  id<MTLBuffer> roisBuffer = getMTLBufferStorage(rois_);
-  id<MTLBuffer> argmaxBuffer = getMTLBufferStorage(argmax_);
-  id<MTLBuffer> outputBuffer = getMTLBufferStorage(grad_input);
-  id<MTLDevice> device = MPSDevice::getInstance()->device();
-  MPSStream* mpsStream = getCurrentMPSStream();
-  dispatch_sync(mpsStream->queue(), ^() {
-    @autoreleasepool {
-      id<MTLComputeCommandEncoder> computeEncoder = mpsStream->commandEncoder();
+  float spatial_scale_f = static_cast<float>(spatial_scale);
 
-      const std::string kernel = "roi_pool_backward_" + scalarToMetalTypeString(grad.scalar_type());
-      id<MTLComputePipelineState> visionPSO = mps::visionPipelineState(device, kernel);
+  const std::string kernel =
+      "roi_pool_backward_" + std::string(metal_type_string(grad.scalar_type()));
+  AOTIMetalKernelFunctionHandle func = nullptr;
+  TORCH_ERROR_CODE_CHECK(aoti_torch_mps_get_kernel_function(
+      roi_pool_shader_library(), kernel.c_str(), &func));
 
-      // this function call is a no-op if MPS Profiler is not enabled
-      getMPSProfiler().beginProfileKernel(visionPSO, kernel, {grad, rois_, argmax_});
-
-      [computeEncoder setComputePipelineState:visionPSO];
-      // [N, C, H, W]
-      [computeEncoder setBuffer:inputBuffer offset:grad.storage_offset() * grad.element_size() atIndex:0];
-      [computeEncoder setBuffer:roisBuffer offset:rois_.storage_offset() * rois_.element_size() atIndex:1];
-      [computeEncoder setBuffer:argmaxBuffer offset:argmax_.storage_offset() * argmax_.element_size() atIndex:2];
-      [computeEncoder setBuffer:outputBuffer offset:grad_input.storage_offset() * grad_input.element_size() atIndex:3];
-
-      [computeEncoder setBytes:&output_size length:sizeof(int64_t) atIndex:4];
-      [computeEncoder setBytes:&channels length:sizeof(int64_t) atIndex:5];
-      [computeEncoder setBytes:&height length:sizeof(int64_t) atIndex:6];
-      [computeEncoder setBytes:&width length:sizeof(int64_t) atIndex:7];
-      [computeEncoder setBytes:&pooled_height length:sizeof(int64_t) atIndex:8];
-      [computeEncoder setBytes:&pooled_width length:sizeof(int64_t) atIndex:9];
-      [computeEncoder setBytes:&spatial_scale_f length:sizeof(float) atIndex:10];
-      [computeEncoder setBytes:&n_stride length:sizeof(int64_t) atIndex:11];
-      [computeEncoder setBytes:&c_stride length:sizeof(int64_t) atIndex:12];
-      [computeEncoder setBytes:&h_stride length:sizeof(int64_t) atIndex:13];
-      [computeEncoder setBytes:&w_stride length:sizeof(int64_t) atIndex:14];
-
-      // One thread per pooled-output element. dispatchThreads guarantees each
-      // index is handled exactly once; the kernel scatters into grad_input with
-      // atomic_add for overlapping RoIs.
-      MTLSize threadsPerGrid = MTLSizeMake(output_size, 1, 1);
-      NSUInteger tgSize = std::min(static_cast<int64_t>(visionPSO.maxTotalThreadsPerThreadgroup), output_size);
-      MTLSize threadGroupSize = MTLSizeMake(std::max<NSUInteger>(tgSize, 1), 1, 1);
-      [computeEncoder dispatchThreads:threadsPerGrid threadsPerThreadgroup:threadGroupSize];
-
-      getMPSProfiler().endProfileKernel(visionPSO);
-    }
-  });
+  RoiPoolBackwardLaunchArgs launch_args{
+      grad.get(),
+      rois_.get(),
+      argmax_.get(),
+      grad_input.get(),
+      output_size,
+      channels,
+      height,
+      width,
+      pooled_height,
+      pooled_width,
+      spatial_scale_f,
+      n_stride,
+      c_stride,
+      h_stride,
+      w_stride};
+  TORCH_ERROR_CODE_CHECK(aoti_torch_mps_run_command_block(
+      func, &roi_pool_backward_encode, &launch_args));
   return grad_input;
 }
 
 } // namespace
 
-TORCH_LIBRARY_IMPL(torchvision, MPS, m) {
-  m.impl(TORCH_SELECTIVE_NAME("torchvision::roi_pool"), TORCH_FN(roi_pool_forward_kernel));
-  m.impl(TORCH_SELECTIVE_NAME("torchvision::_roi_pool_backward"), TORCH_FN(roi_pool_backward_kernel));
+STABLE_TORCH_LIBRARY_IMPL(torchvision, MPS, m) {
+  m.impl("roi_pool", TORCH_BOX(&roi_pool_forward_kernel));
+  m.impl("_roi_pool_backward", TORCH_BOX(&roi_pool_backward_kernel));
 }
 
 } // namespace ops

--- a/torchvision/csrc/ops/mps/roi_pool_kernel.mm
+++ b/torchvision/csrc/ops/mps/roi_pool_kernel.mm
@@ -1,37 +1,190 @@
-#include <ATen/mps/MPSProfiler.h>
-#include <ATen/native/mps/OperationUtils.h>
-#include "mps_helpers.h"
-#include "mps_kernels.h"
+#include <torch/csrc/inductor/aoti_torch/c/shim_mps.h>
+#include <torch/csrc/stable/device.h>
+#include <torch/csrc/stable/library.h>
+#include <torch/csrc/stable/ops.h>
+#include <torch/csrc/stable/tensor.h>
+#include <torch/headeronly/core/DeviceType.h>
+#include <torch/headeronly/core/ScalarType.h>
+#include <torch/headeronly/util/Exception.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <string>
+#include <tuple>
+
+#include "roi_pool_metal_shader.h"
 
 namespace vision {
 namespace ops {
 
 namespace {
 
-std::tuple<at::Tensor, at::Tensor> roi_pool_forward_kernel(const at::Tensor& input,
-                                                           const at::Tensor& rois,
-                                                           double spatial_scale,
-                                                           int64_t pooled_height,
-                                                           int64_t pooled_width) {
-  using namespace at::native::mps;
-  TORCH_CHECK(input.is_mps(), "input must be a MPS tensor");
-  TORCH_CHECK(rois.is_mps(), "rois must be a MPS tensor");
-  TORCH_CHECK(rois.size(1) == 5, "rois must have shape as Tensor[K, 5]");
+using torch::stable::Tensor;
 
-  at::TensorArg input_t{input, "input", 1}, rois_t{rois, "rois", 2};
+constexpr int64_t threadsPerBlock = 512;
 
-  at::CheckedFrom c = "roi_pool_forward_kernel";
-  at::checkAllSameGPU(c, {input_t, rois_t});
-  at::checkAllSameType(c, {input_t, rois_t});
+AOTIMetalShaderLibraryHandle roi_pool_shader_library() {
+  static AOTIMetalShaderLibraryHandle library = []() {
+    AOTIMetalShaderLibraryHandle handle = nullptr;
+    TORCH_ERROR_CODE_CHECK(
+        aoti_torch_mps_create_shader_library(roi_pool_metal_shader, &handle));
+    return handle;
+  }();
+  return library;
+}
+
+const char* metal_type_string(torch::headeronly::ScalarType scalar_type) {
+  if (scalar_type == torch::headeronly::ScalarType::Float) {
+    return "float";
+  }
+  if (scalar_type == torch::headeronly::ScalarType::Half) {
+    return "half";
+  }
+  return "";
+}
+
+struct RoiPoolForwardLaunchArgs {
+  AtenTensorHandle input;
+  AtenTensorHandle rois;
+  AtenTensorHandle output;
+  AtenTensorHandle argmax;
+  int64_t output_size;
+  int64_t channels;
+  int64_t height;
+  int64_t width;
+  int64_t pooled_height;
+  int64_t pooled_width;
+  float spatial_scale;
+  uint64_t grid;
+  uint64_t threadgroup;
+};
+
+void roi_pool_forward_encode(
+    AOTIMetalKernelFunctionHandle func,
+    void* user_data) {
+  const auto* launch_args =
+      static_cast<const RoiPoolForwardLaunchArgs*>(user_data);
+  TORCH_ERROR_CODE_CHECK(aoti_torch_mps_start_encoding(func));
+  // [N, C, H, W]
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_tensor(func, 0, launch_args->input));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_tensor(func, 1, launch_args->rois));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_tensor(func, 2, launch_args->output));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_tensor(func, 3, launch_args->argmax));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_int(func, 4, launch_args->output_size));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_int(func, 5, launch_args->channels));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_int(func, 6, launch_args->height));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_int(func, 7, launch_args->width));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_int(func, 8, launch_args->pooled_height));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_int(func, 9, launch_args->pooled_width));
+  TORCH_ERROR_CODE_CHECK(torch_mps_set_arg_bytes(
+      func, 10, &launch_args->spatial_scale, sizeof(float)));
+  TORCH_ERROR_CODE_CHECK(aoti_torch_mps_dispatch_single_with_group_size(
+      func, launch_args->grid, launch_args->threadgroup));
+}
+
+struct RoiPoolBackwardLaunchArgs {
+  AtenTensorHandle grad_output;
+  AtenTensorHandle rois;
+  AtenTensorHandle argmax;
+  AtenTensorHandle grad_input;
+  int64_t output_size;
+  int64_t channels;
+  int64_t height;
+  int64_t width;
+  int64_t pooled_height;
+  int64_t pooled_width;
+  float spatial_scale;
+  int64_t n_stride;
+  int64_t c_stride;
+  int64_t h_stride;
+  int64_t w_stride;
+};
+
+void roi_pool_backward_encode(
+    AOTIMetalKernelFunctionHandle func,
+    void* user_data) {
+  const auto* launch_args =
+      static_cast<const RoiPoolBackwardLaunchArgs*>(user_data);
+  TORCH_ERROR_CODE_CHECK(aoti_torch_mps_start_encoding(func));
+  // [N, C, H, W]
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_tensor(func, 0, launch_args->grad_output));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_tensor(func, 1, launch_args->rois));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_tensor(func, 2, launch_args->argmax));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_tensor(func, 3, launch_args->grad_input));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_int(func, 4, launch_args->output_size));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_int(func, 5, launch_args->channels));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_int(func, 6, launch_args->height));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_int(func, 7, launch_args->width));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_int(func, 8, launch_args->pooled_height));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_int(func, 9, launch_args->pooled_width));
+  TORCH_ERROR_CODE_CHECK(torch_mps_set_arg_bytes(
+      func, 10, &launch_args->spatial_scale, sizeof(float)));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_int(func, 11, launch_args->n_stride));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_int(func, 12, launch_args->c_stride));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_int(func, 13, launch_args->h_stride));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_int(func, 14, launch_args->w_stride));
+  // One thread per pooled-output element. dispatchThreads guarantees each
+  // index is handled exactly once; the kernel scatters into grad_input with
+  // atomic_add for overlapping RoIs.
+  TORCH_ERROR_CODE_CHECK(aoti_torch_mps_dispatch_single(
+      func, static_cast<uint64_t>(launch_args->output_size)));
+}
+
+std::tuple<Tensor, Tensor> roi_pool_forward_kernel(
+    const Tensor& input,
+    const Tensor& rois,
+    double spatial_scale,
+    int64_t pooled_height,
+    int64_t pooled_width) {
+  STD_TORCH_CHECK(
+      input.device().type() == torch::headeronly::DeviceType::MPS,
+      "input must be a MPS tensor");
+  STD_TORCH_CHECK(
+      rois.device().type() == torch::headeronly::DeviceType::MPS,
+      "rois must be a MPS tensor");
+  STD_TORCH_CHECK(rois.size(1) == 5, "rois must have shape as Tensor[K, 5]");
+  STD_TORCH_CHECK(
+      input.get_device_index() == rois.get_device_index(),
+      "input should be on the same device as rois");
+  STD_TORCH_CHECK(
+      input.scalar_type() == rois.scalar_type(),
+      "input should have the same type as rois");
 
   int64_t num_rois = rois.size(0);
   int64_t channels = input.size(1);
   int64_t height = input.size(2);
   int64_t width = input.size(3);
-  float spatial_scale_f = static_cast<float>(spatial_scale);
 
-  at::Tensor output = at::zeros({num_rois, channels, pooled_height, pooled_width}, input.options());
-  at::Tensor argmax = at::zeros({num_rois, channels, pooled_height, pooled_width}, input.options().dtype(at::kLong));
+  Tensor output = torch::stable::new_zeros(
+      input, {num_rois, channels, pooled_height, pooled_width});
+  Tensor argmax = torch::stable::new_zeros(
+      input,
+      {num_rois, channels, pooled_height, pooled_width},
+      torch::headeronly::ScalarType::Long);
 
   int64_t output_size = num_rois * pooled_height * pooled_width * channels;
 
@@ -39,84 +192,75 @@ std::tuple<at::Tensor, at::Tensor> roi_pool_forward_kernel(const at::Tensor& inp
     return std::make_tuple(output, argmax);
   }
 
-  auto input_ = input.contiguous();
-  auto rois_ = rois.contiguous();
-
-  id<MTLBuffer> inputBuffer = getMTLBufferStorage(input_);
-  id<MTLBuffer> roisBuffer = getMTLBufferStorage(rois_);
-  id<MTLBuffer> outputBuffer = getMTLBufferStorage(output);
-  id<MTLBuffer> argmaxBuffer = getMTLBufferStorage(argmax);
-  id<MTLDevice> device = MPSDevice::getInstance()->device();
-  MPSStream* mpsStream = getCurrentMPSStream();
-  dispatch_sync(mpsStream->queue(), ^() {
-    @autoreleasepool {
-      id<MTLComputeCommandEncoder> computeEncoder = mpsStream->commandEncoder();
-      MTLSize threadgroupsPerGrid = MTLSizeMake(
-          std::min(ceil_div(static_cast<int64_t>(output_size), static_cast<int64_t>(512)), static_cast<int64_t>(4096)),
-          1,
-          1);
-
-      const std::string kernel = "roi_pool_" + scalarToMetalTypeString(input.scalar_type());
-      id<MTLComputePipelineState> visionPSO = mps::visionPipelineState(device, kernel);
-
-      // this function call is a no-op if MPS Profiler is not enabled
-      getMPSProfiler().beginProfileKernel(visionPSO, kernel, {input_, rois_}, mpsStream);
-
-      [computeEncoder setComputePipelineState:visionPSO];
-      // [N, C, H, W]
-      [computeEncoder setBuffer:inputBuffer offset:input_.storage_offset() * input_.element_size() atIndex:0];
-      [computeEncoder setBuffer:roisBuffer offset:rois_.storage_offset() * rois_.element_size() atIndex:1];
-      [computeEncoder setBuffer:outputBuffer offset:output.storage_offset() * output.element_size() atIndex:2];
-      [computeEncoder setBuffer:argmaxBuffer offset:argmax.storage_offset() * argmax.element_size() atIndex:3];
-
-      [computeEncoder setBytes:&output_size length:sizeof(int64_t) atIndex:4];
-      [computeEncoder setBytes:&channels length:sizeof(int64_t) atIndex:5];
-      [computeEncoder setBytes:&height length:sizeof(int64_t) atIndex:6];
-      [computeEncoder setBytes:&width length:sizeof(int64_t) atIndex:7];
-      [computeEncoder setBytes:&pooled_height length:sizeof(int64_t) atIndex:8];
-      [computeEncoder setBytes:&pooled_width length:sizeof(int64_t) atIndex:9];
-      [computeEncoder setBytes:&spatial_scale_f length:sizeof(float) atIndex:10];
-
-      // A threadGroup is equivalent to a cuda's block.
-      NSUInteger tgSize = visionPSO.maxTotalThreadsPerThreadgroup;
-      if (tgSize > threadsPerBlock) {
-        tgSize = threadsPerBlock;
-      }
-
-      MTLSize threadGroupSize = MTLSizeMake(tgSize, 1, 1);
-      [computeEncoder dispatchThreadgroups:threadgroupsPerGrid threadsPerThreadgroup:threadGroupSize];
-
-      getMPSProfiler().endProfileKernel(visionPSO, mpsStream);
-    }
-  });
-  return std::make_tuple(output, argmax);
-}
-
-at::Tensor roi_pool_backward_kernel(const at::Tensor& grad,
-                                    const at::Tensor& rois,
-                                    const at::Tensor& argmax,
-                                    double spatial_scale,
-                                    int64_t pooled_height,
-                                    int64_t pooled_width,
-                                    int64_t batch_size,
-                                    int64_t channels,
-                                    int64_t height,
-                                    int64_t width) {
-  using namespace at::native::mps;
-  TORCH_CHECK(grad.is_mps(), "grad must be a MPS tensor");
-  TORCH_CHECK(rois.is_mps(), "rois must be a MPS tensor");
-  TORCH_CHECK(grad.scalar_type() != at::kHalf, "MPS does not support roi_pool backward with float16 inputs.");
-  TORCH_CHECK(argmax.is_mps(), "argmax must be a MPS tensor");
-
-  at::TensorArg grad_t{grad, "input", 1}, rois_t{rois, "rois", 2}, argmax_t{argmax, "argmax", 3};
-
-  at::CheckedFrom c = "roi_pool_backward_kernel";
-  at::checkAllSameGPU(c, {grad_t, rois_t, argmax_t});
-  at::checkAllSameType(c, {grad_t, rois_t});
+  auto input_ = torch::stable::contiguous(input);
+  auto rois_ = torch::stable::contiguous(rois);
 
   float spatial_scale_f = static_cast<float>(spatial_scale);
 
-  at::Tensor grad_input = at::zeros({batch_size, channels, height, width}, grad.options());
+  const std::string kernel =
+      "roi_pool_" + std::string(metal_type_string(input.scalar_type()));
+  AOTIMetalKernelFunctionHandle func = nullptr;
+  TORCH_ERROR_CODE_CHECK(aoti_torch_mps_get_kernel_function(
+      roi_pool_shader_library(), kernel.c_str(), &func));
+
+  const int64_t threadgroups = std::min(
+      (output_size + threadsPerBlock - 1) / threadsPerBlock,
+      static_cast<int64_t>(4096));
+
+  RoiPoolForwardLaunchArgs launch_args{
+      input_.get(),
+      rois_.get(),
+      output.get(),
+      argmax.get(),
+      output_size,
+      channels,
+      height,
+      width,
+      pooled_height,
+      pooled_width,
+      spatial_scale_f,
+      static_cast<uint64_t>(threadgroups * threadsPerBlock),
+      static_cast<uint64_t>(threadsPerBlock)};
+  TORCH_ERROR_CODE_CHECK(aoti_torch_mps_run_command_block(
+      func, &roi_pool_forward_encode, &launch_args));
+  return std::make_tuple(output, argmax);
+}
+
+Tensor roi_pool_backward_kernel(
+    const Tensor& grad,
+    const Tensor& rois,
+    const Tensor& argmax,
+    double spatial_scale,
+    int64_t pooled_height,
+    int64_t pooled_width,
+    int64_t batch_size,
+    int64_t channels,
+    int64_t height,
+    int64_t width) {
+  STD_TORCH_CHECK(
+      grad.device().type() == torch::headeronly::DeviceType::MPS,
+      "grad must be a MPS tensor");
+  STD_TORCH_CHECK(
+      rois.device().type() == torch::headeronly::DeviceType::MPS,
+      "rois must be a MPS tensor");
+  STD_TORCH_CHECK(
+      grad.scalar_type() != torch::headeronly::ScalarType::Half,
+      "MPS does not support roi_pool backward with float16 inputs.");
+  STD_TORCH_CHECK(
+      argmax.device().type() == torch::headeronly::DeviceType::MPS,
+      "argmax must be a MPS tensor");
+  STD_TORCH_CHECK(
+      grad.get_device_index() == rois.get_device_index(),
+      "grad should be on the same device as rois");
+  STD_TORCH_CHECK(
+      grad.get_device_index() == argmax.get_device_index(),
+      "grad should be on the same device as argmax");
+  STD_TORCH_CHECK(
+      grad.scalar_type() == rois.scalar_type(),
+      "grad should have the same type as rois");
+
+  Tensor grad_input =
+      torch::stable::new_zeros(grad, {batch_size, channels, height, width});
 
   if (grad.numel() == 0) {
     return grad_input;
@@ -128,63 +272,43 @@ at::Tensor roi_pool_backward_kernel(const at::Tensor& grad,
   int64_t w_stride = grad.stride(3);
   int64_t output_size = grad.numel();
 
-  at::globalContext().alertNotDeterministic("roi_pool_backward_kernel");
-  auto argmax_ = argmax.contiguous(), rois_ = rois.contiguous();
+  auto argmax_ = torch::stable::contiguous(argmax);
+  auto rois_ = torch::stable::contiguous(rois);
 
-  id<MTLBuffer> inputBuffer = getMTLBufferStorage(grad);
-  id<MTLBuffer> roisBuffer = getMTLBufferStorage(rois_);
-  id<MTLBuffer> argmaxBuffer = getMTLBufferStorage(argmax_);
-  id<MTLBuffer> outputBuffer = getMTLBufferStorage(grad_input);
-  id<MTLDevice> device = MPSDevice::getInstance()->device();
-  MPSStream* mpsStream = getCurrentMPSStream();
-  dispatch_sync(mpsStream->queue(), ^() {
-    @autoreleasepool {
-      id<MTLComputeCommandEncoder> computeEncoder = mpsStream->commandEncoder();
+  float spatial_scale_f = static_cast<float>(spatial_scale);
 
-      const std::string kernel = "roi_pool_backward_" + scalarToMetalTypeString(grad.scalar_type());
-      id<MTLComputePipelineState> visionPSO = mps::visionPipelineState(device, kernel);
+  const std::string kernel =
+      "roi_pool_backward_" + std::string(metal_type_string(grad.scalar_type()));
+  AOTIMetalKernelFunctionHandle func = nullptr;
+  TORCH_ERROR_CODE_CHECK(aoti_torch_mps_get_kernel_function(
+      roi_pool_shader_library(), kernel.c_str(), &func));
 
-      // this function call is a no-op if MPS Profiler is not enabled
-      getMPSProfiler().beginProfileKernel(visionPSO, kernel, {grad, rois_, argmax_}, mpsStream);
-
-      [computeEncoder setComputePipelineState:visionPSO];
-      // [N, C, H, W]
-      [computeEncoder setBuffer:inputBuffer offset:grad.storage_offset() * grad.element_size() atIndex:0];
-      [computeEncoder setBuffer:roisBuffer offset:rois_.storage_offset() * rois_.element_size() atIndex:1];
-      [computeEncoder setBuffer:argmaxBuffer offset:argmax_.storage_offset() * argmax_.element_size() atIndex:2];
-      [computeEncoder setBuffer:outputBuffer offset:grad_input.storage_offset() * grad_input.element_size() atIndex:3];
-
-      [computeEncoder setBytes:&output_size length:sizeof(int64_t) atIndex:4];
-      [computeEncoder setBytes:&channels length:sizeof(int64_t) atIndex:5];
-      [computeEncoder setBytes:&height length:sizeof(int64_t) atIndex:6];
-      [computeEncoder setBytes:&width length:sizeof(int64_t) atIndex:7];
-      [computeEncoder setBytes:&pooled_height length:sizeof(int64_t) atIndex:8];
-      [computeEncoder setBytes:&pooled_width length:sizeof(int64_t) atIndex:9];
-      [computeEncoder setBytes:&spatial_scale_f length:sizeof(float) atIndex:10];
-      [computeEncoder setBytes:&n_stride length:sizeof(int64_t) atIndex:11];
-      [computeEncoder setBytes:&c_stride length:sizeof(int64_t) atIndex:12];
-      [computeEncoder setBytes:&h_stride length:sizeof(int64_t) atIndex:13];
-      [computeEncoder setBytes:&w_stride length:sizeof(int64_t) atIndex:14];
-
-      // One thread per pooled-output element. dispatchThreads guarantees each
-      // index is handled exactly once; the kernel scatters into grad_input with
-      // atomic_add for overlapping RoIs.
-      MTLSize threadsPerGrid = MTLSizeMake(output_size, 1, 1);
-      NSUInteger tgSize = std::min(static_cast<int64_t>(visionPSO.maxTotalThreadsPerThreadgroup), output_size);
-      MTLSize threadGroupSize = MTLSizeMake(std::max<NSUInteger>(tgSize, 1), 1, 1);
-      [computeEncoder dispatchThreads:threadsPerGrid threadsPerThreadgroup:threadGroupSize];
-
-      getMPSProfiler().endProfileKernel(visionPSO, mpsStream);
-    }
-  });
+  RoiPoolBackwardLaunchArgs launch_args{
+      grad.get(),
+      rois_.get(),
+      argmax_.get(),
+      grad_input.get(),
+      output_size,
+      channels,
+      height,
+      width,
+      pooled_height,
+      pooled_width,
+      spatial_scale_f,
+      n_stride,
+      c_stride,
+      h_stride,
+      w_stride};
+  TORCH_ERROR_CODE_CHECK(aoti_torch_mps_run_command_block(
+      func, &roi_pool_backward_encode, &launch_args));
   return grad_input;
 }
 
 } // namespace
 
-TORCH_LIBRARY_IMPL(torchvision, MPS, m) {
-  m.impl(TORCH_SELECTIVE_NAME("torchvision::roi_pool"), TORCH_FN(roi_pool_forward_kernel));
-  m.impl(TORCH_SELECTIVE_NAME("torchvision::_roi_pool_backward"), TORCH_FN(roi_pool_backward_kernel));
+STABLE_TORCH_LIBRARY_IMPL(torchvision, MPS, m) {
+  m.impl("roi_pool", TORCH_BOX(&roi_pool_forward_kernel));
+  m.impl("_roi_pool_backward", TORCH_BOX(&roi_pool_backward_kernel));
 }
 
 } // namespace ops

--- a/torchvision/csrc/ops/mps/roi_pool_metal_shader.h
+++ b/torchvision/csrc/ops/mps/roi_pool_metal_shader.h
@@ -1,0 +1,210 @@
+#pragma once
+
+// Metal shader source for the roi_pool MPS kernels.
+//
+// Carved out of the shared ops/mps/mps_kernels.h (which is still used by the
+// legacy _C ops) so it can be compiled into the stable-ABI _C_stable extension.
+// mps_kernels.h opens with #include <ATen/native/mps/OperationUtils.h> and
+// instantiates at::native::mps::MetalShaderLibrary, both unavailable under
+// -DTORCH_TARGET_VERSION. This header carries only the roi_pool Metal source
+// as a plain string, handed to aoti_torch_mps_create_shader_library at
+// runtime, the same shape PyTorch's AOTInductor MPS backend emits.
+
+namespace vision {
+namespace ops {
+
+static const char* roi_pool_metal_shader = R"VISION_METAL(
+#include <metal_atomic>
+#include <metal_stdlib>
+using namespace metal;
+
+/*----------Macros----------*/
+
+#define MPS_1D_KERNEL_LOOP_T(i, n, n_tgs, index_t)      \
+  for (index_t i = (tgid.x * tptg.x) + tid2.x; i < (n); \
+       i += (tptg.x * n_tgs))
+
+#define MPS_1D_KERNEL_LOOP(i, n, n_tgs) MPS_1D_KERNEL_LOOP_T(i, n, n_tgs, uint)
+/*----------Helpers--------*/
+
+template <typename T>
+inline T ceil_div(T n, T m) {
+  return (n + m - 1) / m;
+}
+
+inline void atomic_add_float(device float* data_ptr, const float val)
+{
+  atomic_fetch_add_explicit((device atomic_float*) data_ptr, val, memory_order_relaxed);
+}
+
+
+inline void atomic_add_float(device half* data_ptr, const half val)
+{
+  atomic_fetch_add_explicit((device atomic_float*) data_ptr, static_cast<float>(val), memory_order_relaxed);
+}
+
+/*----------Kernels----------*/
+
+template<typename T, typename integer_t>
+kernel void roi_pool(
+    constant T       * input         [[buffer(0)]],
+    constant T       * rois          [[buffer(1)]],
+    device   T       * output        [[buffer(2)]],
+    device   int64_t * argmax        [[buffer(3)]],
+    constant int64_t & output_size   [[buffer(4)]],
+    constant int64_t & channels      [[buffer(5)]],
+    constant int64_t & height        [[buffer(6)]],
+    constant int64_t & width         [[buffer(7)]],
+    constant int64_t & pooled_height [[buffer(8)]],
+    constant int64_t & pooled_width  [[buffer(9)]],
+    constant float   & spatial_scale [[buffer(10)]],
+    uint2     tgid   [[threadgroup_position_in_grid]],
+    uint2     tptg   [[threads_per_threadgroup]],
+    uint2     tid2   [[thread_position_in_threadgroup]]){
+  MPS_1D_KERNEL_LOOP(index, output_size, 1) {
+    // (n, c, ph, pw) is an element in the pooled output
+    integer_t pw = index % pooled_width;
+    integer_t ph = (index / pooled_width) % pooled_height;
+    integer_t c = (index / pooled_width / pooled_height) % channels;
+    integer_t n = index / pooled_width / pooled_height / channels;
+
+    constant T* offset_rois = rois + n * 5;
+    integer_t roi_batch_ind = offset_rois[0];
+    integer_t roi_start_w = round(offset_rois[1] * spatial_scale);
+    integer_t roi_start_h = round(offset_rois[2] * spatial_scale);
+    integer_t roi_end_w = round(offset_rois[3] * spatial_scale);
+    integer_t roi_end_h = round(offset_rois[4] * spatial_scale);
+
+    // Force malformed ROIs to be 1x1
+    integer_t roi_width = max(roi_end_w - roi_start_w + 1, static_cast<integer_t>(1));
+    integer_t roi_height = max(roi_end_h - roi_start_h + 1, static_cast<integer_t>(1));
+    T bin_size_h = static_cast<T>(roi_height) / static_cast<T>(pooled_height);
+    T bin_size_w = static_cast<T>(roi_width) / static_cast<T>(pooled_width);
+
+    integer_t hstart = static_cast<integer_t>(floor(static_cast<T>(ph) * bin_size_h));
+    integer_t wstart = static_cast<integer_t>(floor(static_cast<T>(pw) * bin_size_w));
+    integer_t hend = static_cast<integer_t>(ceil(static_cast<T>(ph + 1) * bin_size_h));
+    integer_t wend = static_cast<integer_t>(ceil(static_cast<T>(pw + 1) * bin_size_w));
+
+    // Add roi offsets and clip to input boundaries
+    hstart = min(max(hstart + roi_start_h, static_cast<integer_t>(0)), static_cast<integer_t>(height));
+    hend = min(max(hend + roi_start_h, static_cast<integer_t>(0)), static_cast<integer_t>(height));
+    wstart = min(max(wstart + roi_start_w, static_cast<integer_t>(0)), static_cast<integer_t>(width));
+    wend = min(max(wend + roi_start_w, static_cast<integer_t>(0)), static_cast<integer_t>(width));
+    bool is_empty = (hend <= hstart) || (wend <= wstart);
+
+    // Define an empty pooling region to be zero
+    T maxval = is_empty ? 0 : -FLT_MAX;
+    // If nothing is pooled, argmax = -1 causes nothing to be backprop'd
+    integer_t maxidx = -1;
+    constant T* offset_input =
+        input + (roi_batch_ind * channels + c) * height * width;
+    for (integer_t h = hstart; h < hend; ++h) {
+      for (integer_t w = wstart; w < wend; ++w) {
+        integer_t input_index = h * width + w;
+        if (offset_input[input_index] > maxval) {
+          maxval = offset_input[input_index];
+          maxidx = input_index;
+        }
+      }
+    }
+    output[index] = maxval;
+    argmax[index] = maxidx;
+  }
+}
+
+#define REGISTER_ROI_POOL_OP(DTYPE, INT_DTYPE)          \
+template                                                \
+[[host_name("roi_pool_" #DTYPE)]]                       \
+kernel void roi_pool<DTYPE, INT_DTYPE>(                 \
+  constant DTYPE * input           [[buffer(0)]],       \
+  constant DTYPE * rois            [[buffer(1)]],       \
+  device   DTYPE * output          [[buffer(2)]],       \
+  device   int64_t * argmax_data   [[buffer(3)]],       \
+  constant int64_t & output_size   [[buffer(4)]],       \
+  constant int64_t & channels      [[buffer(5)]],       \
+  constant int64_t & height        [[buffer(6)]],       \
+  constant int64_t & width         [[buffer(7)]],       \
+  constant int64_t & pooled_height [[buffer(8)]],       \
+  constant int64_t & pooled_width  [[buffer(9)]],       \
+  constant float   & spatial_scale [[buffer(10)]],      \
+  uint2     tgid   [[threadgroup_position_in_grid]],    \
+  uint2     tptg   [[threads_per_threadgroup]],         \
+  uint2     tid2   [[thread_position_in_threadgroup]]);
+template<typename T, typename integer_t>
+kernel void roi_pool_backward(
+    constant T       * grad_output   [[buffer(0)]],
+    constant T       * rois          [[buffer(1)]],
+    constant int64_t * argmax_data   [[buffer(2)]],
+    device   T       * grad_input    [[buffer(3)]],
+    constant int64_t & output_size   [[buffer(4)]],
+    constant int64_t & channels      [[buffer(5)]],
+    constant int64_t & height        [[buffer(6)]],
+    constant int64_t & width         [[buffer(7)]],
+    constant int64_t & pooled_height [[buffer(8)]],
+    constant int64_t & pooled_width  [[buffer(9)]],
+    constant float   & spatial_scale [[buffer(10)]],
+    constant int64_t & n_stride      [[buffer(11)]],
+    constant int64_t & c_stride      [[buffer(12)]],
+    constant int64_t & h_stride      [[buffer(13)]],
+    constant int64_t & w_stride      [[buffer(14)]],
+    uint     index   [[thread_position_in_grid]]){
+
+  // One thread per pooled-output element. Dispatched via dispatchThreads, so
+  // each element is processed exactly once; redundant passes would otherwise
+  // be silently summed by the atomic_add below (overlapping RoIs share pixels).
+  if (index >= static_cast<uint>(output_size)) {
+    return;
+  }
+  {
+    // (n, c, ph, pw) is an element in the pooled output
+    integer_t pw = index % pooled_width;
+    integer_t ph = (index / pooled_width) % pooled_height;
+    integer_t c = (index / pooled_width / pooled_height) % channels;
+    integer_t n = index / pooled_width / pooled_height / channels;
+
+    constant T* offset_rois = rois + n * 5;
+    integer_t roi_batch_ind = offset_rois[0];
+
+    const integer_t output_offset = n * n_stride + c * c_stride;
+    constant integer_t * argmax_data_offset =
+        argmax_data + (n * channels + c) * pooled_height * pooled_width;
+    const integer_t argmax = argmax_data_offset[ph * pooled_width + pw];
+    const integer_t offset = (roi_batch_ind * channels + c) * height * width;
+
+    if (argmax != -1) {
+      atomic_add_float(grad_input + offset + argmax, static_cast<T>(grad_output[output_offset + ph * h_stride + pw * w_stride]));
+    }
+    
+  } // MPS_1D_KERNEL_LOOP
+}
+
+#define REGISTER_ROI_POOL_BACKWARD_OP(DTYPE, INT_DTYPE)   \
+template                                                  \
+[[host_name("roi_pool_backward_" #DTYPE)]]                \
+kernel void roi_pool_backward<DTYPE, INT_DTYPE>(          \
+    constant DTYPE   * grad_output   [[buffer(0)]],       \
+    constant DTYPE   * rois          [[buffer(1)]],       \
+    constant int64_t * argmax_data   [[buffer(2)]],       \
+    device   DTYPE   * grad_input    [[buffer(3)]],       \
+    constant int64_t & output_size   [[buffer(4)]],       \
+    constant int64_t & channels      [[buffer(5)]],       \
+    constant int64_t & height        [[buffer(6)]],       \
+    constant int64_t & width         [[buffer(7)]],       \
+    constant int64_t & pooled_height [[buffer(8)]],       \
+    constant int64_t & pooled_width  [[buffer(9)]],       \
+    constant float   & spatial_scale [[buffer(10)]],      \
+    constant int64_t & n_stride      [[buffer(11)]],      \
+    constant int64_t & c_stride      [[buffer(12)]],      \
+    constant int64_t & h_stride      [[buffer(13)]],      \
+    constant int64_t & w_stride      [[buffer(14)]],      \
+    uint     index   [[thread_position_in_grid]]);
+REGISTER_ROI_POOL_OP(float, int64_t);
+REGISTER_ROI_POOL_OP(half, int64_t);
+REGISTER_ROI_POOL_BACKWARD_OP(float, int64_t);
+REGISTER_ROI_POOL_BACKWARD_OP(half, int64_t);
+
+)VISION_METAL";
+
+} // namespace ops
+} // namespace vision


### PR DESCRIPTION
Ports `roi_pool`'s MPS kernels to the stable ABI.

## Notes
- **Requires pytorch/pytorch#190932**, which lands `torch_mps_set_arg_bytes`.
 - **Shader source moves to `roi_pool_metal_shader.h`.** Once every MPS op migrates, the per-op headers can consolidate to a mps_stable_kernels.h and mps_kernels.h gets dropped.
