### PR TITLE
Port roi_pool (CPU) to stable ABI.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,8 @@ set(TORCHVISION_STABLE_SOURCES
   ${TVCPP}/ops/cuda/box_iou_rotated_kernel.cu
   ${TVCPP}/ops/roi_align.cpp
   ${TVCPP}/ops/cpu/roi_align_kernel.cpp
+  ${TVCPP}/ops/roi_pool.cpp
+  ${TVCPP}/ops/cpu/roi_pool_kernel.cpp
   ${TVCPP}/io/image/cuda/decode_jpegs_cuda.cpp
   ${TVCPP}/io/image/cuda/encode_jpegs_cuda.cpp
   ${TVCPP}/io/image/cpu/encode_png.cpp

--- a/setup.py
+++ b/setup.py
@@ -169,6 +169,8 @@ STABLE_SOURCES = {
     CSRS_DIR / "ops/roi_align.cpp",
     CSRS_DIR / "ops/cpu/roi_align_kernel.cpp",
     CSRS_DIR / "ops/quantized/cpu/qroi_align_kernel.cpp",
+    CSRS_DIR / "ops/roi_pool.cpp",
+    CSRS_DIR / "ops/cpu/roi_pool_kernel.cpp",
 }
 STABLE_SOURCES.add(CSRS_DIR / ("ops/hip/nms_kernel.hip" if IS_ROCM else "ops/cuda/nms_kernel.cu"))
 STABLE_SOURCES.add(

--- a/torchvision/csrc/ops/cpu/roi_pool_kernel.cpp
+++ b/torchvision/csrc/ops/cpu/roi_pool_kernel.cpp
@@ -1,12 +1,20 @@
 #include <float.h>
 
-#include <ATen/ATen.h>
-#include <torch/library.h>
+#include <torch/csrc/stable/library.h>
+#include <torch/csrc/stable/ops.h>
+#include <torch/csrc/stable/tensor.h>
+#include <torch/headeronly/core/Dispatch_v2.h>
+
+#include <algorithm>
+#include <cmath>
+#include <tuple>
 
 namespace vision {
 namespace ops {
 
 namespace {
+
+using torch::stable::Tensor;
 
 template <class T>
 inline void add(T* address, const T& val) {
@@ -125,58 +133,62 @@ void roi_pool_backward_kernel_impl(
   } // num_rois
 }
 
-std::tuple<at::Tensor, at::Tensor> roi_pool_forward_kernel(
-    const at::Tensor& input,
-    const at::Tensor& rois,
+std::tuple<Tensor, Tensor> roi_pool_forward_kernel(
+    const Tensor& input,
+    const Tensor& rois,
     double spatial_scale,
     int64_t pooled_height,
     int64_t pooled_width) {
-  TORCH_CHECK(input.device().is_cpu(), "input must be a CPU tensor");
-  TORCH_CHECK(rois.device().is_cpu(), "rois must be a CPU tensor");
-
-  at::TensorArg input_t{input, "input", 1}, rois_t{rois, "rois", 2};
-
-  at::CheckedFrom c = "roi_pool_forward_kernel";
-  at::checkAllSameType(c, {input_t, rois_t});
+  STD_TORCH_CHECK(input.is_cpu(), "input must be a CPU tensor");
+  STD_TORCH_CHECK(rois.is_cpu(), "rois must be a CPU tensor");
+  STD_TORCH_CHECK(
+      input.scalar_type() == rois.scalar_type(),
+      "input should have the same type as rois");
 
   int num_rois = rois.size(0);
   int channels = input.size(1);
   int height = input.size(2);
   int width = input.size(3);
 
-  at::Tensor output = at::zeros(
-      {num_rois, channels, pooled_height, pooled_width}, input.options());
-  at::Tensor argmax = at::zeros(
+  Tensor output = torch::stable::new_zeros(
+      input, {num_rois, channels, pooled_height, pooled_width});
+  Tensor argmax = torch::stable::new_zeros(
+      input,
       {num_rois, channels, pooled_height, pooled_width},
-      input.options().dtype(at::kInt));
+      torch::headeronly::ScalarType::Int);
 
   if (output.numel() == 0) {
     return std::make_tuple(output, argmax);
   }
 
-  auto input_ = input.contiguous(), rois_ = rois.contiguous();
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-      input.scalar_type(), "roi_pool_forward_kernel", [&] {
+  auto input_ = torch::stable::contiguous(input);
+  auto rois_ = torch::stable::contiguous(rois);
+  THO_DISPATCH_V2(
+      input.scalar_type(),
+      "roi_pool_forward_kernel",
+      AT_WRAP([&]() {
         roi_pool_forward_kernel_impl<scalar_t>(
-            input_.data_ptr<scalar_t>(),
+            input_.const_data_ptr<scalar_t>(),
             spatial_scale,
             channels,
             height,
             width,
             pooled_height,
             pooled_width,
-            rois_.data_ptr<scalar_t>(),
+            rois_.const_data_ptr<scalar_t>(),
             num_rois,
-            output.data_ptr<scalar_t>(),
-            argmax.data_ptr<int>());
-      });
+            output.mutable_data_ptr<scalar_t>(),
+            argmax.mutable_data_ptr<int>());
+      }),
+      AT_EXPAND(AT_FLOATING_TYPES),
+      torch::headeronly::ScalarType::Half);
   return std::make_tuple(output, argmax);
 }
 
-at::Tensor roi_pool_backward_kernel(
-    const at::Tensor& grad,
-    const at::Tensor& rois,
-    const at::Tensor& argmax,
+Tensor roi_pool_backward_kernel(
+    const Tensor& grad,
+    const Tensor& rois,
+    const Tensor& argmax,
     double spatial_scale,
     int64_t pooled_height,
     int64_t pooled_width,
@@ -185,21 +197,19 @@ at::Tensor roi_pool_backward_kernel(
     int64_t height,
     int64_t width) {
   // Check if input tensors are CPU tensors
-  TORCH_CHECK(grad.device().is_cpu(), "grad must be a CPU tensor");
-  TORCH_CHECK(rois.device().is_cpu(), "rois must be a CPU tensor");
-  TORCH_CHECK(argmax.device().is_cpu(), "argmax must be a CPU tensor");
-  TORCH_CHECK(
+  STD_TORCH_CHECK(grad.is_cpu(), "grad must be a CPU tensor");
+  STD_TORCH_CHECK(rois.is_cpu(), "rois must be a CPU tensor");
+  STD_TORCH_CHECK(argmax.is_cpu(), "argmax must be a CPU tensor");
+  STD_TORCH_CHECK(
       rois.size(1) == 5, "Tensor rois should have shape as Tensor[K, 5]");
-
-  at::TensorArg grad_t{grad, "grad", 1}, rois_t{rois, "rois", 2};
-
-  at::CheckedFrom c = "roi_pool_backward_kernel";
-  at::checkAllSameType(c, {grad_t, rois_t});
+  STD_TORCH_CHECK(
+      grad.scalar_type() == rois.scalar_type(),
+      "grad should have the same type as rois");
 
   auto num_rois = rois.size(0);
 
-  at::Tensor grad_input =
-      at::zeros({batch_size, channels, height, width}, grad.options());
+  Tensor grad_input =
+      torch::stable::new_zeros(grad, {batch_size, channels, height, width});
 
   // handle possibly empty gradients
   if (grad.numel() == 0) {
@@ -212,37 +222,37 @@ at::Tensor roi_pool_backward_kernel(
   int h_stride = grad.stride(2);
   int w_stride = grad.stride(3);
 
-  auto rois_ = rois.contiguous();
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-      grad.scalar_type(), "roi_pool_backward_kernel", [&] {
+  auto rois_ = torch::stable::contiguous(rois);
+  THO_DISPATCH_V2(
+      grad.scalar_type(),
+      "roi_pool_backward_kernel",
+      AT_WRAP([&]() {
         roi_pool_backward_kernel_impl<scalar_t>(
-            grad.data_ptr<scalar_t>(),
-            argmax.data_ptr<int>(),
+            grad.const_data_ptr<scalar_t>(),
+            argmax.const_data_ptr<int>(),
             num_rois,
             channels,
             height,
             width,
             pooled_height,
             pooled_width,
-            grad_input.data_ptr<scalar_t>(),
-            rois_.data_ptr<scalar_t>(),
+            grad_input.mutable_data_ptr<scalar_t>(),
+            rois_.const_data_ptr<scalar_t>(),
             n_stride,
             c_stride,
             h_stride,
             w_stride);
-      });
+      }),
+      AT_EXPAND(AT_FLOATING_TYPES),
+      torch::headeronly::ScalarType::Half);
   return grad_input;
 }
 
 } // namespace
 
-TORCH_LIBRARY_IMPL(torchvision, CPU, m) {
-  m.impl(
-      TORCH_SELECTIVE_NAME("torchvision::roi_pool"),
-      TORCH_FN(roi_pool_forward_kernel));
-  m.impl(
-      TORCH_SELECTIVE_NAME("torchvision::_roi_pool_backward"),
-      TORCH_FN(roi_pool_backward_kernel));
+STABLE_TORCH_LIBRARY_IMPL(torchvision, CPU, m) {
+  m.impl("roi_pool", TORCH_BOX(&roi_pool_forward_kernel));
+  m.impl("_roi_pool_backward", TORCH_BOX(&roi_pool_backward_kernel));
 }
 
 } // namespace ops

--- a/torchvision/csrc/ops/roi_pool.cpp
+++ b/torchvision/csrc/ops/roi_pool.cpp
@@ -1,44 +1,43 @@
 #include "roi_pool.h"
 
-#include <ATen/core/dispatch/Dispatcher.h>
-#include <torch/library.h>
-#include <torch/types.h>
+#include <torch/csrc/stable/c/shim.h>
+#include <torch/csrc/stable/library.h>
+#include <torch/csrc/stable/stableivalue_conversions.h>
+#include <torch/headeronly/util/shim_utils.h>
+#include <torch/headeronly/version.h>
+
+#include <array>
 
 namespace vision {
 namespace ops {
 
-std::tuple<at::Tensor, at::Tensor> roi_pool(
-    const at::Tensor& input,
-    const at::Tensor& rois,
+using torch::stable::Tensor;
+
+std::tuple<Tensor, Tensor> roi_pool(
+    const Tensor& input,
+    const Tensor& rois,
     double spatial_scale,
     int64_t pooled_height,
     int64_t pooled_width) {
-  C10_LOG_API_USAGE_ONCE("torchvision.csrc.ops.roi_pool.roi_pool");
-  static auto op = c10::Dispatcher::singleton()
-                       .findSchemaOrThrow("torchvision::roi_pool", "")
-                       .typed<decltype(roi_pool)>();
-  return op.call(input, rois, spatial_scale, pooled_height, pooled_width);
-}
-
-std::tuple<at::Tensor, at::Tensor> roi_pool_symint(
-    const at::Tensor& input,
-    const at::Tensor& rois,
-    double spatial_scale,
-    c10::SymInt pooled_height,
-    c10::SymInt pooled_width) {
-  C10_LOG_API_USAGE_ONCE("torchvision.csrc.ops.roi_pool.roi_pool");
-  static auto op = c10::Dispatcher::singleton()
-                       .findSchemaOrThrow("torchvision::roi_pool", "")
-                       .typed<decltype(roi_pool_symint)>();
-  return op.call(input, rois, spatial_scale, pooled_height, pooled_width);
+  std::array<StableIValue, 5> stack{
+      torch::stable::detail::from(input),
+      torch::stable::detail::from(rois),
+      torch::stable::detail::from(spatial_scale),
+      torch::stable::detail::from(pooled_height),
+      torch::stable::detail::from(pooled_width)};
+  TORCH_ERROR_CODE_CHECK(torch_call_dispatcher(
+      "torchvision::roi_pool", "", stack.data(), TORCH_ABI_VERSION));
+  return std::make_tuple(
+      torch::stable::detail::to<Tensor>(stack[0]),
+      torch::stable::detail::to<Tensor>(stack[1]));
 }
 
 namespace detail {
 
-at::Tensor _roi_pool_backward(
-    const at::Tensor& grad,
-    const at::Tensor& rois,
-    const at::Tensor& argmax,
+Tensor _roi_pool_backward(
+    const Tensor& grad,
+    const Tensor& rois,
+    const Tensor& argmax,
     double spatial_scale,
     int64_t pooled_height,
     int64_t pooled_width,
@@ -46,56 +45,29 @@ at::Tensor _roi_pool_backward(
     int64_t channels,
     int64_t height,
     int64_t width) {
-  static auto op = c10::Dispatcher::singleton()
-                       .findSchemaOrThrow("torchvision::_roi_pool_backward", "")
-                       .typed<decltype(_roi_pool_backward)>();
-  return op.call(
-      grad,
-      rois,
-      argmax,
-      spatial_scale,
-      pooled_height,
-      pooled_width,
-      batch_size,
-      channels,
-      height,
-      width);
-}
-
-at::Tensor _roi_pool_backward_symint(
-    const at::Tensor& grad,
-    const at::Tensor& rois,
-    const at::Tensor& argmax,
-    double spatial_scale,
-    c10::SymInt pooled_height,
-    c10::SymInt pooled_width,
-    c10::SymInt batch_size,
-    c10::SymInt channels,
-    c10::SymInt height,
-    c10::SymInt width) {
-  static auto op = c10::Dispatcher::singleton()
-                       .findSchemaOrThrow("torchvision::_roi_pool_backward", "")
-                       .typed<decltype(_roi_pool_backward_symint)>();
-  return op.call(
-      grad,
-      rois,
-      argmax,
-      spatial_scale,
-      pooled_height,
-      pooled_width,
-      batch_size,
-      channels,
-      height,
-      width);
+  std::array<StableIValue, 10> stack{
+      torch::stable::detail::from(grad),
+      torch::stable::detail::from(rois),
+      torch::stable::detail::from(argmax),
+      torch::stable::detail::from(spatial_scale),
+      torch::stable::detail::from(pooled_height),
+      torch::stable::detail::from(pooled_width),
+      torch::stable::detail::from(batch_size),
+      torch::stable::detail::from(channels),
+      torch::stable::detail::from(height),
+      torch::stable::detail::from(width)};
+  TORCH_ERROR_CODE_CHECK(torch_call_dispatcher(
+      "torchvision::_roi_pool_backward", "", stack.data(), TORCH_ABI_VERSION));
+  return torch::stable::detail::to<Tensor>(stack[0]);
 }
 
 } // namespace detail
 
-TORCH_LIBRARY_FRAGMENT(torchvision, m) {
-  m.def(TORCH_SELECTIVE_SCHEMA(
-      "torchvision::roi_pool(Tensor input, Tensor rois, float spatial_scale, SymInt pooled_height, SymInt pooled_width) -> (Tensor, Tensor)"));
-  m.def(TORCH_SELECTIVE_SCHEMA(
-      "torchvision::_roi_pool_backward(Tensor grad, Tensor rois, Tensor argmax, float spatial_scale, SymInt pooled_height, SymInt pooled_width, SymInt batch_size, SymInt channels, SymInt height, SymInt width) -> Tensor"));
+STABLE_TORCH_LIBRARY_FRAGMENT(torchvision, m) {
+  m.def(
+      "roi_pool(Tensor input, Tensor rois, float spatial_scale, SymInt pooled_height, SymInt pooled_width) -> (Tensor, Tensor)");
+  m.def(
+      "_roi_pool_backward(Tensor grad, Tensor rois, Tensor argmax, float spatial_scale, SymInt pooled_height, SymInt pooled_width, SymInt batch_size, SymInt channels, SymInt height, SymInt width) -> Tensor");
 }
 
 } // namespace ops

--- a/torchvision/csrc/ops/roi_pool.h
+++ b/torchvision/csrc/ops/roi_pool.h
@@ -1,31 +1,26 @@
 #pragma once
 
-#include <ATen/ATen.h>
+#include <torch/csrc/stable/tensor.h>
 #include "../macros.h"
+
+#include <tuple>
 
 namespace vision {
 namespace ops {
 
-VISION_API std::tuple<at::Tensor, at::Tensor> roi_pool(
-    const at::Tensor& input,
-    const at::Tensor& rois,
+VISION_API std::tuple<torch::stable::Tensor, torch::stable::Tensor> roi_pool(
+    const torch::stable::Tensor& input,
+    const torch::stable::Tensor& rois,
     double spatial_scale,
     int64_t pooled_height,
     int64_t pooled_width);
 
-VISION_API std::tuple<at::Tensor, at::Tensor> roi_pool_symint(
-    const at::Tensor& input,
-    const at::Tensor& rois,
-    double spatial_scale,
-    c10::SymInt pooled_height,
-    c10::SymInt pooled_width);
-
 namespace detail {
 
-at::Tensor _roi_pool_backward(
-    const at::Tensor& grad,
-    const at::Tensor& rois,
-    const at::Tensor& argmax,
+torch::stable::Tensor _roi_pool_backward(
+    const torch::stable::Tensor& grad,
+    const torch::stable::Tensor& rois,
+    const torch::stable::Tensor& argmax,
     double spatial_scale,
     int64_t pooled_height,
     int64_t pooled_width,
@@ -33,18 +28,6 @@ at::Tensor _roi_pool_backward(
     int64_t channels,
     int64_t height,
     int64_t width);
-
-at::Tensor _roi_pool_backward_symint(
-    const at::Tensor& grad,
-    const at::Tensor& rois,
-    const at::Tensor& argmax,
-    double spatial_scale,
-    c10::SymInt pooled_height,
-    c10::SymInt pooled_width,
-    c10::SymInt batch_size,
-    c10::SymInt channels,
-    c10::SymInt height,
-    c10::SymInt width);
 
 } // namespace detail
 


### PR DESCRIPTION
Ports `roi_pool` (CPU) to stable ABI.

## Notes
- **Dropped the `*_symint` C++ wrappers.**. Follows  `roi_align` port #9572).

## Stable-ABI audit (`torch-abi-audit`)
Ran [`torch-abi-audit`](https://github.com/Quansight/torch-abi-audit). `roi_pool`'s CPU op moves into the fully-STABLE `_C_stable.so` (`unstable=0`) and pulls in no new shim symbols. The unstable `_C.so` count is unchanged at 104. `roi_pool`'s CPU sources shared their unstable-API surface with the still-legacy kernels (its own CUDA/MPS plus the other unported ops), so no symbol is uniquely removed until those migrate.
  ```text
  Package: torchvision
    Torch ABI:   UNSTABLE
    CPython ABI: n/a
    Bundled libs: 3
    -- bundled libs --
      [UNSTABLE] [not-abi3] _C.so            (stable_shim=0,  unstable=104)
      [STABLE  ] [not-abi3] _C_stable.so     (stable_shim=70, unstable=0)
      [STABLE  ] [not-abi3] image_stable.so  (stable_shim=76, unstable=0)
  ```
