### PR TITLE
[ROCm][CI] Switch ROCm CI runner label from gfx942 to ecosystem.mi350

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,7 +54,7 @@ jobs:
       matrix:
         python-version:
           - "3.10"
-        runner: ["linux.rocm.gpu.gfx942.1"]
+        runner: ["linux.rocm.gpu.ecosystem.mi350.1"]
         gpu-arch-type: ["rocm"]
         gpu-arch-version: ["7.1"]
       fail-fast: false


### PR DESCRIPTION
This PR replaces gfx942 label with ecosystem.mi350 label.

cc @jeffdaily @jithunnair-amd