### PR TITLE
Fix CPU segfault in roi_align when a ROI is non-finite (NaN or ±inf)

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -476,6 +476,38 @@ class TestRoIAlign(RoIOpTester):
     def test_boxes_shape(self):
         self._helper_boxes_shape(ops.roi_align)
 
+    @pytest.mark.parametrize("aligned", (True, False))
+    @pytest.mark.parametrize("sampling_ratio", (1, -1))
+    @pytest.mark.parametrize("dtype", (torch.float32, torch.float64, torch.float16))
+    # A non-finite value in any column is malformed: NaN slips past the bounds
+    # check directly, and +/-inf coordinates produce a NaN width (inf - inf)
+    # that does the same. Cover both hazards.
+    @pytest.mark.parametrize("bad_value", (float("nan"), float("inf"), float("-inf")))
+    # bad_col indexes a rois row [batch_idx, x1, y1, x2, y2]; a bad value in any
+    # column (batch index included) must not crash the kernel.
+    @pytest.mark.parametrize("bad_col", (0, 1, 2, 3, 4))
+    def test_nonfinite_rois_no_segfault(self, aligned, sampling_ratio, dtype, bad_value, bad_col):
+        # Regression test for https://github.com/pytorch/vision/issues/9273:
+        # a ROI with a non-finite batch index or coordinate (NaN or +/-inf) used
+        # to slip past the CPU kernel's bounds check (every comparison against
+        # NaN is false; inf coords yield NaN widths), get cast to int and read
+        # out of bounds, segfaulting the whole process. A malformed ROI must
+        # instead be treated as empty (zero output / zero gradient).
+        x = torch.zeros(2, 3, 15, 19, dtype=dtype, requires_grad=True)
+        row = [1.0, 0.0, 0.0, 1.0, 1.0]
+        row[bad_col] = bad_value
+        rois = torch.tensor([row], dtype=dtype)
+
+        y = ops.roi_align(x, rois, (7, 7), spatial_scale=0.1, sampling_ratio=sampling_ratio, aligned=aligned)
+        assert y.shape == (1, 3, 7, 7)
+        assert torch.isfinite(y).all()
+        assert (y == 0).all()
+
+        # Backward must be crash-free too (the same hazard lives in the gradient
+        # kernel) and must not propagate non-finite values into the input grad.
+        y.sum().backward()
+        assert torch.isfinite(x.grad).all()
+
     @needs_mps
     @pytest.mark.parametrize("seed", range(3))
     def test_backward_mps_consistency(self, seed):

--- a/torchvision/csrc/ops/cpu/roi_align_kernel.cpp
+++ b/torchvision/csrc/ops/cpu/roi_align_kernel.cpp
@@ -36,6 +36,24 @@ void roi_align_forward_kernel_impl(
     int index_n = n * channels * pooled_width * pooled_height;
 
     const T* offset_rois = rois + n * 5;
+
+    // A ROI with a non-finite batch index or coordinate (NaN or +/-inf) is
+    // malformed. Every comparison against NaN is false, and inf coordinates
+    // produce a NaN width (inf - inf), so such a ROI slips past the bilinear
+    // bounds check below; casting a non-finite value to int then yields a
+    // garbage index that reads out of bounds and segfaults (and ceil() of a
+    // non-finite value is UB when sampling_ratio <= 0). Guard on the raw ROI
+    // before the batch-index cast just below, which is itself UB on a
+    // non-finite value. Treat the ROI as empty: leave zeros for it.
+    // https://github.com/pytorch/vision/issues/9273
+    if (!std::isfinite(static_cast<double>(offset_rois[0])) ||
+        !std::isfinite(static_cast<double>(offset_rois[1])) ||
+        !std::isfinite(static_cast<double>(offset_rois[2])) ||
+        !std::isfinite(static_cast<double>(offset_rois[3])) ||
+        !std::isfinite(static_cast<double>(offset_rois[4]))) {
+      continue;
+    }
+
     int roi_batch_ind = offset_rois[0];
 
     // Do not using rounding; this implementation detail is critical
@@ -206,6 +224,24 @@ void roi_align_backward_kernel_impl(
     int n = index / pooled_width / pooled_height / channels;
 
     const T* offset_rois = rois + n * 5;
+
+    // A ROI with a non-finite batch index or coordinate (NaN or +/-inf) is
+    // malformed. Every comparison against NaN is false, and inf coordinates
+    // produce a NaN width (inf - inf), so such a ROI slips past the bilinear
+    // bounds check below; casting a non-finite value to int then yields a
+    // garbage index that reads out of bounds and segfaults (and ceil() of a
+    // non-finite value is UB when sampling_ratio <= 0). Guard on the raw ROI
+    // before the batch-index cast just below, which is itself UB on a
+    // non-finite value. Treat the ROI as empty: leave zeros for it.
+    // https://github.com/pytorch/vision/issues/9273
+    if (!std::isfinite(static_cast<double>(offset_rois[0])) ||
+        !std::isfinite(static_cast<double>(offset_rois[1])) ||
+        !std::isfinite(static_cast<double>(offset_rois[2])) ||
+        !std::isfinite(static_cast<double>(offset_rois[3])) ||
+        !std::isfinite(static_cast<double>(offset_rois[4]))) {
+      continue;
+    }
+
     int roi_batch_ind = offset_rois[0];
 
     // Do not using rounding; this implementation detail is critical


### PR DESCRIPTION
## Summary

`roi_align` on CPU segfaults the whole Python process when a ROI contains a non-finite value (`NaN` or `±inf`) in its batch index or coordinates. The bilinear bounds check `if (y < -1.0 || y > height || ...)` returns false for every NaN comparison, so a malformed ROI slips through, gets cast to `int` (garbage index), and reads out of bounds. `±inf` reaches the same cast via `roi_end - roi_start = inf - inf = NaN`.

## What changed vs. the first revision

Two points raised in review, both fixed:

1. **`std::isnan` → `std::isfinite`.** The isnan-only guard let `±inf` ROIs through: `roi_width = inf - inf = NaN`, unclamped when `aligned=True`, then the same non-finite cast → segfault (and `ceil(NaN)` with `sampling_ratio=-1` also feeds a garbage `pre_calc.resize`). `std::isfinite` on the five raw ROI values covers **NaN and ±inf** at zero extra cost.
2. **Guard moved above the batch-index cast.** `int roi_batch_ind = offset_rois[0];` runs before the old guard and is itself UB on a non-finite value — a UBSan `float-cast-overflow` build (which the issue reporter runs) flags it even though it doesn't crash on its own. The guard now sits on the raw ROI immediately after `offset_rois` is taken, before any cast or coordinate math, in both the forward and backward kernels.

A non-finite ROI is skipped, leaving zeros in the output/gradient — the output buffers are zero-initialised (`new_zeros`), consistent with how the kernel already treats out-of-bounds sample points as empty.

## Test verification (RED → GREEN)

`test/test_ops.py::TestRoIAlign::test_nonfinite_rois_no_segfault` — parametrized over `{NaN, +inf, -inf} × column {0..4} × dtype{f32,f64,f16} × sampling_ratio{1,-1} × aligned{T,F}` (180 cases), asserting finite, all-zero output and a finite input gradient.

**RED** — built on the previous `isnan`-only kernel, the new `±inf` cases crash:

```
$ python -m pytest test/test_ops.py::TestRoIAlign::test_nonfinite_rois_no_segfault -q
collected 180 items
test/test_ops.py ............Fatal Python error: Segmentation fault
...
Segmentation fault (core dumped)   # exit 139
```

**GREEN** — with the `isfinite` fix:

```
$ python -m pytest test/test_ops.py::TestRoIAlign::test_nonfinite_rois_no_segfault -q
180 passed in 0.60s
```

No regression in the rest of the op tests:

```
$ python -m pytest test/test_ops.py::TestRoIAlign -q
235 passed, 199 skipped
```

Built CPU-only from source (`pip install -e . --no-build-isolation`), torch 2.13.0+cpu. clang-format and flake8/ufmt clean on the touched files.

Fixes #9273
