### PR TITLE
Fix bounding box center overflow for narrow dtypes

### DIFF
--- a/test/test_transforms_v2.py
+++ b/test/test_transforms_v2.py
@@ -4477,6 +4477,27 @@ class TestConvertBoundingBoxFormat:
         assert (actual >= 0).all()
         torch.testing.assert_close(actual, expected)
 
+    @pytest.mark.parametrize("inplace", [False, True])
+    @pytest.mark.parametrize(
+        ("dtype", "box", "expected_box"),
+        [
+            (torch.uint8, [200, 10, 220, 30], [210, 20, 20, 20]),
+            (torch.float16, [32768, 0, 49152, 32], [40960, 16, 16384, 32]),
+        ],
+    )
+    def test_xyxy_to_cxcywh_narrow_dtype_overflow(self, inplace, dtype, box, expected_box):
+        bounding_boxes = torch.tensor([box], dtype=dtype)
+
+        actual = F.convert_bounding_box_format(
+            bounding_boxes,
+            old_format=tv_tensors.BoundingBoxFormat.XYXY,
+            new_format=tv_tensors.BoundingBoxFormat.CXCYWH,
+            inplace=inplace,
+        )
+        expected = torch.tensor([expected_box], dtype=dtype)
+
+        torch.testing.assert_close(actual, expected)
+
 
 class TestResizedCrop:
     INPUT_SIZE = (17, 11)

--- a/torchvision/transforms/v2/functional/_meta.py
+++ b/torchvision/transforms/v2/functional/_meta.py
@@ -228,8 +228,8 @@ def _xyxy_to_cxcywh(xyxy: torch.Tensor, inplace: bool) -> torch.Tensor:
 
     # (x2 - x1) = width, same for height
     xyxy[..., 2:].sub_(xyxy[..., :2])
-    # (x1 * 2 + width) / 2 = x1 + width / 2 = x1 + (x2-x1)/2 = (x1 + x2)/2 = cx, same for cy
-    xyxy[..., :2].mul_(2).add_(xyxy[..., 2:]).div_(2, rounding_mode=None if xyxy.is_floating_point() else "floor")
+    # x1 + width / 2 = (x1 + x2) / 2 = cx, same for cy
+    xyxy[..., :2].add_(xyxy[..., 2:].div(2, rounding_mode=None if xyxy.is_floating_point() else "floor"))
 
     return xyxy
 


### PR DESCRIPTION
## Summary

- avoid the overflowing `x1 * 2` intermediate in `XYXY` to `CXCYWH` conversion
- compute the equivalent center as `x1 + width / 2`
- add regression coverage for `uint8` and `float16`, in both in-place and out-of-place conversion

## Why

`_xyxy_to_cxcywh` first stores `x2 - x1` as the width, then computes the center through `(x1 * 2 + width) / 2`. For narrow dtypes, `x1 * 2` can overflow even when the input coordinates, width, and correct center all fit in the dtype.

For example, a valid `uint8` box with x coordinates 200 and 220 returns center 82 instead of 210, while a valid `float16` box with x coordinates 32768 and 49152 returns infinity instead of 40960. Reordering the same expression to `x1 + width / 2` avoids the unnecessary intermediate and retains integer floor rounding.

Fixes #9594.

## Validation

- full `TestConvertBoundingBoxFormat`: 184 passed, 30 expected failures
- 5,000 randomized valid boxes across uint8, int8, int16, int32, and int64
- float autograd smoke test
- `ufmt check` on both changed files
- changed lines introduce no new flake8 or mypy diagnostics; broader commands report only unchanged baseline findings
- `git diff --check`

The affected conversion is pure Python. The local source checkout used the compatible installed TorchVision extension and supplied only the newly introduced `qnms` schema required during import.

AI disclosure: I used Codex to help audit the conversion arithmetic, search for duplicates, implement and test the focused patch, and draft this PR. I reviewed and understand the change and will personally handle maintainer follow-up.
