### PR TITLE
Port ps_roi_align (CPU) to stable ABI.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,8 @@ set(TORCHVISION_STABLE_SOURCES
   ${TVCPP}/ops/cpu/roi_align_kernel.cpp
   ${TVCPP}/ops/roi_pool.cpp
   ${TVCPP}/ops/cpu/roi_pool_kernel.cpp
+  ${TVCPP}/ops/ps_roi_align.cpp
+  ${TVCPP}/ops/cpu/ps_roi_align_kernel.cpp
   ${TVCPP}/io/image/cuda/decode_jpegs_cuda.cpp
   ${TVCPP}/io/image/cuda/encode_jpegs_cuda.cpp
   ${TVCPP}/io/image/cpu/encode_png.cpp

--- a/setup.py
+++ b/setup.py
@@ -169,6 +169,8 @@ STABLE_SOURCES = {
     CSRS_DIR / "ops/quantized/cpu/qroi_align_kernel.cpp",
     CSRS_DIR / "ops/roi_pool.cpp",
     CSRS_DIR / "ops/cpu/roi_pool_kernel.cpp",
+    CSRS_DIR / "ops/ps_roi_align.cpp",
+    CSRS_DIR / "ops/cpu/ps_roi_align_kernel.cpp",
 }
 STABLE_SOURCES.add(CSRS_DIR / ("ops/hip/nms_kernel.hip" if IS_ROCM else "ops/cuda/nms_kernel.cu"))
 STABLE_SOURCES.add(

--- a/torchvision/csrc/ops/cpu/ps_roi_align_kernel.cpp
+++ b/torchvision/csrc/ops/cpu/ps_roi_align_kernel.cpp
@@ -1,10 +1,18 @@
-#include <ATen/ATen.h>
-#include <torch/library.h>
+#include <torch/csrc/stable/library.h>
+#include <torch/csrc/stable/ops.h>
+#include <torch/csrc/stable/tensor.h>
+#include <torch/headeronly/core/Dispatch_v2.h>
+
+#include <algorithm>
+#include <cmath>
+#include <tuple>
 
 namespace vision {
 namespace ops {
 
 namespace {
+
+using torch::stable::Tensor;
 
 template <typename T>
 T bilinear_interpolate(
@@ -304,49 +312,52 @@ void ps_roi_align_backward_kernel_impl(
   }
 }
 
-std::tuple<at::Tensor, at::Tensor> ps_roi_align_forward_kernel(
-    const at::Tensor& input,
-    const at::Tensor& rois,
+std::tuple<Tensor, Tensor> ps_roi_align_forward_kernel(
+    const Tensor& input,
+    const Tensor& rois,
     double spatial_scale,
     int64_t pooled_height,
     int64_t pooled_width,
     int64_t sampling_ratio) {
   // Check if input tensors are CPU tensors
-  TORCH_CHECK(input.device().is_cpu(), "input must be a CPU tensor");
-  TORCH_CHECK(rois.device().is_cpu(), "rois must be a CPU tensor");
-  TORCH_CHECK(
+  STD_TORCH_CHECK(input.is_cpu(), "input must be a CPU tensor");
+  STD_TORCH_CHECK(rois.is_cpu(), "rois must be a CPU tensor");
+  STD_TORCH_CHECK(
       rois.size(1) == 5, "Tensor rois should have shape as Tensor[K, 5]");
-
-  at::TensorArg input_t{input, "input", 1}, rois_t{rois, "rois", 2};
-
-  at::CheckedFrom c = "ps_roi_align_forward_kernel";
-  at::checkAllSameType(c, {input_t, rois_t});
+  STD_TORCH_CHECK(
+      input.scalar_type() == rois.scalar_type(),
+      "input should have the same type as rois");
 
   int num_rois = rois.size(0);
   int channels = input.size(1);
   int height = input.size(2);
   int width = input.size(3);
 
-  TORCH_CHECK(
+  STD_TORCH_CHECK(
       channels % (pooled_height * pooled_width) == 0,
       "input channels must be a multiple of pooling height * pooling width");
   int channels_out = channels / (pooled_height * pooled_width);
 
-  auto output = at::zeros(
-      {num_rois, channels_out, pooled_height, pooled_width}, input.options());
-  auto channel_mapping =
-      at::zeros(output.sizes(), input.options().dtype(at::kInt));
+  Tensor output = torch::stable::new_zeros(
+      input, {num_rois, channels_out, pooled_height, pooled_width});
+  Tensor channel_mapping = torch::stable::new_zeros(
+      input,
+      {num_rois, channels_out, pooled_height, pooled_width},
+      torch::headeronly::ScalarType::Int);
 
   if (output.numel() == 0) {
     return std::make_tuple(output, channel_mapping);
   }
 
-  auto input_ = input.contiguous(), rois_ = rois.contiguous();
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-      input.scalar_type(), "ps_roi_align_forward_kernel", [&] {
+  auto input_ = torch::stable::contiguous(input);
+  auto rois_ = torch::stable::contiguous(rois);
+  THO_DISPATCH_V2(
+      input.scalar_type(),
+      "ps_roi_align_forward_kernel",
+      AT_WRAP([&]() {
         ps_roi_align_forward_kernel_impl<scalar_t>(
             num_rois,
-            input_.data_ptr<scalar_t>(),
+            input_.const_data_ptr<scalar_t>(),
             spatial_scale,
             channels,
             height,
@@ -354,18 +365,20 @@ std::tuple<at::Tensor, at::Tensor> ps_roi_align_forward_kernel(
             pooled_height,
             pooled_width,
             sampling_ratio,
-            rois_.data_ptr<scalar_t>(),
+            rois_.const_data_ptr<scalar_t>(),
             channels_out,
-            output.data_ptr<scalar_t>(),
-            channel_mapping.data_ptr<int>());
-      });
+            output.mutable_data_ptr<scalar_t>(),
+            channel_mapping.mutable_data_ptr<int>());
+      }),
+      AT_EXPAND(AT_FLOATING_TYPES),
+      torch::headeronly::ScalarType::Half);
   return std::make_tuple(output, channel_mapping);
 }
 
-at::Tensor ps_roi_align_backward_kernel(
-    const at::Tensor& grad,
-    const at::Tensor& rois,
-    const at::Tensor& channel_mapping,
+Tensor ps_roi_align_backward_kernel(
+    const Tensor& grad,
+    const Tensor& rois,
+    const Tensor& channel_mapping,
     double spatial_scale,
     int64_t pooled_height,
     int64_t pooled_width,
@@ -375,20 +388,16 @@ at::Tensor ps_roi_align_backward_kernel(
     int64_t height,
     int64_t width) {
   // Check if input tensors are CPU tensors
-  TORCH_CHECK(grad.device().is_cpu(), "grad must be a CPU tensor");
-  TORCH_CHECK(rois.device().is_cpu(), "rois must be a CPU tensor");
-  TORCH_CHECK(
-      channel_mapping.device().is_cpu(),
-      "channel_mapping must be a CPU tensor");
+  STD_TORCH_CHECK(grad.is_cpu(), "grad must be a CPU tensor");
+  STD_TORCH_CHECK(rois.is_cpu(), "rois must be a CPU tensor");
+  STD_TORCH_CHECK(
+      channel_mapping.is_cpu(), "channel_mapping must be a CPU tensor");
+  STD_TORCH_CHECK(
+      grad.scalar_type() == rois.scalar_type(),
+      "grad should have the same type as rois");
 
-  at::TensorArg grad_t{grad, "grad", 1}, rois_t{rois, "rois", 2},
-      channel_mapping_t{channel_mapping, "channel_mapping", 3};
-
-  at::CheckedFrom c = "ps_roi_align_backward_kernel";
-  at::checkAllSameType(c, {grad_t, rois_t});
-
-  auto grad_input =
-      at::zeros({batch_size, channels, height, width}, grad.options());
+  Tensor grad_input =
+      torch::stable::new_zeros(grad, {batch_size, channels, height, width});
 
   // handle possibly empty gradients
   if (grad.numel() == 0) {
@@ -397,13 +406,16 @@ at::Tensor ps_roi_align_backward_kernel(
 
   int channels_out = channels / (pooled_height * pooled_width);
 
-  auto grad_ = grad.contiguous(), rois_ = rois.contiguous();
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-      grad.scalar_type(), "ps_roi_align_backward_kernel", [&] {
+  auto grad_ = torch::stable::contiguous(grad);
+  auto rois_ = torch::stable::contiguous(rois);
+  THO_DISPATCH_V2(
+      grad.scalar_type(),
+      "ps_roi_align_backward_kernel",
+      AT_WRAP([&]() {
         ps_roi_align_backward_kernel_impl<scalar_t>(
             grad.numel(),
-            grad_.data_ptr<scalar_t>(),
-            channel_mapping.data_ptr<int>(),
+            grad_.const_data_ptr<scalar_t>(),
+            channel_mapping.const_data_ptr<int>(),
             spatial_scale,
             channels,
             height,
@@ -412,21 +424,19 @@ at::Tensor ps_roi_align_backward_kernel(
             pooled_width,
             sampling_ratio,
             channels_out,
-            grad_input.data_ptr<scalar_t>(),
-            rois_.data_ptr<scalar_t>());
-      });
+            grad_input.mutable_data_ptr<scalar_t>(),
+            rois_.const_data_ptr<scalar_t>());
+      }),
+      AT_EXPAND(AT_FLOATING_TYPES),
+      torch::headeronly::ScalarType::Half);
   return grad_input;
 }
 
 } // namespace
 
-TORCH_LIBRARY_IMPL(torchvision, CPU, m) {
-  m.impl(
-      TORCH_SELECTIVE_NAME("torchvision::ps_roi_align"),
-      TORCH_FN(ps_roi_align_forward_kernel));
-  m.impl(
-      TORCH_SELECTIVE_NAME("torchvision::_ps_roi_align_backward"),
-      TORCH_FN(ps_roi_align_backward_kernel));
+STABLE_TORCH_LIBRARY_IMPL(torchvision, CPU, m) {
+  m.impl("ps_roi_align", TORCH_BOX(&ps_roi_align_forward_kernel));
+  m.impl("_ps_roi_align_backward", TORCH_BOX(&ps_roi_align_backward_kernel));
 }
 
 } // namespace ops

--- a/torchvision/csrc/ops/ps_roi_align.cpp
+++ b/torchvision/csrc/ops/ps_roi_align.cpp
@@ -1,48 +1,45 @@
 #include "ps_roi_align.h"
 
-#include <ATen/core/dispatch/Dispatcher.h>
-#include <torch/library.h>
-#include <torch/types.h>
+#include <torch/csrc/stable/c/shim.h>
+#include <torch/csrc/stable/library.h>
+#include <torch/csrc/stable/stableivalue_conversions.h>
+#include <torch/headeronly/util/shim_utils.h>
+#include <torch/headeronly/version.h>
+
+#include <array>
 
 namespace vision {
 namespace ops {
 
-std::tuple<at::Tensor, at::Tensor> ps_roi_align(
-    const at::Tensor& input,
-    const at::Tensor& rois,
+using torch::stable::Tensor;
+
+std::tuple<Tensor, Tensor> ps_roi_align(
+    const Tensor& input,
+    const Tensor& rois,
     double spatial_scale,
     int64_t pooled_height,
     int64_t pooled_width,
     int64_t sampling_ratio) {
-  C10_LOG_API_USAGE_ONCE("torchvision.csrc.ops.ps_roi_align.ps_roi_align");
-  static auto op = c10::Dispatcher::singleton()
-                       .findSchemaOrThrow("torchvision::ps_roi_align", "")
-                       .typed<decltype(ps_roi_align)>();
-  return op.call(
-      input, rois, spatial_scale, pooled_height, pooled_width, sampling_ratio);
-}
-
-std::tuple<at::Tensor, at::Tensor> ps_roi_align_symint(
-    const at::Tensor& input,
-    const at::Tensor& rois,
-    double spatial_scale,
-    c10::SymInt pooled_height,
-    c10::SymInt pooled_width,
-    int64_t sampling_ratio) {
-  C10_LOG_API_USAGE_ONCE("torchvision.csrc.ops.ps_roi_align.ps_roi_align");
-  static auto op = c10::Dispatcher::singleton()
-                       .findSchemaOrThrow("torchvision::ps_roi_align", "")
-                       .typed<decltype(ps_roi_align_symint)>();
-  return op.call(
-      input, rois, spatial_scale, pooled_height, pooled_width, sampling_ratio);
+  std::array<StableIValue, 6> stack{
+      torch::stable::detail::from(input),
+      torch::stable::detail::from(rois),
+      torch::stable::detail::from(spatial_scale),
+      torch::stable::detail::from(pooled_height),
+      torch::stable::detail::from(pooled_width),
+      torch::stable::detail::from(sampling_ratio)};
+  TORCH_ERROR_CODE_CHECK(torch_call_dispatcher(
+      "torchvision::ps_roi_align", "", stack.data(), TORCH_ABI_VERSION));
+  return std::make_tuple(
+      torch::stable::detail::to<Tensor>(stack[0]),
+      torch::stable::detail::to<Tensor>(stack[1]));
 }
 
 namespace detail {
 
-at::Tensor _ps_roi_align_backward(
-    const at::Tensor& grad,
-    const at::Tensor& rois,
-    const at::Tensor& channel_mapping,
+Tensor _ps_roi_align_backward(
+    const Tensor& grad,
+    const Tensor& rois,
+    const Tensor& channel_mapping,
     double spatial_scale,
     int64_t pooled_height,
     int64_t pooled_width,
@@ -51,61 +48,33 @@ at::Tensor _ps_roi_align_backward(
     int64_t channels,
     int64_t height,
     int64_t width) {
-  static auto op =
-      c10::Dispatcher::singleton()
-          .findSchemaOrThrow("torchvision::_ps_roi_align_backward", "")
-          .typed<decltype(_ps_roi_align_backward)>();
-  return op.call(
-      grad,
-      rois,
-      channel_mapping,
-      spatial_scale,
-      pooled_height,
-      pooled_width,
-      sampling_ratio,
-      batch_size,
-      channels,
-      height,
-      width);
-}
-
-at::Tensor _ps_roi_align_backward_symint(
-    const at::Tensor& grad,
-    const at::Tensor& rois,
-    const at::Tensor& channel_mapping,
-    double spatial_scale,
-    c10::SymInt pooled_height,
-    c10::SymInt pooled_width,
-    int64_t sampling_ratio,
-    c10::SymInt batch_size,
-    c10::SymInt channels,
-    c10::SymInt height,
-    c10::SymInt width) {
-  static auto op =
-      c10::Dispatcher::singleton()
-          .findSchemaOrThrow("torchvision::_ps_roi_align_backward", "")
-          .typed<decltype(_ps_roi_align_backward_symint)>();
-  return op.call(
-      grad,
-      rois,
-      channel_mapping,
-      spatial_scale,
-      pooled_height,
-      pooled_width,
-      sampling_ratio,
-      batch_size,
-      channels,
-      height,
-      width);
+  std::array<StableIValue, 11> stack{
+      torch::stable::detail::from(grad),
+      torch::stable::detail::from(rois),
+      torch::stable::detail::from(channel_mapping),
+      torch::stable::detail::from(spatial_scale),
+      torch::stable::detail::from(pooled_height),
+      torch::stable::detail::from(pooled_width),
+      torch::stable::detail::from(sampling_ratio),
+      torch::stable::detail::from(batch_size),
+      torch::stable::detail::from(channels),
+      torch::stable::detail::from(height),
+      torch::stable::detail::from(width)};
+  TORCH_ERROR_CODE_CHECK(torch_call_dispatcher(
+      "torchvision::_ps_roi_align_backward",
+      "",
+      stack.data(),
+      TORCH_ABI_VERSION));
+  return torch::stable::detail::to<Tensor>(stack[0]);
 }
 
 } // namespace detail
 
-TORCH_LIBRARY_FRAGMENT(torchvision, m) {
-  m.def(TORCH_SELECTIVE_SCHEMA(
-      "torchvision::ps_roi_align(Tensor input, Tensor rois, float spatial_scale, SymInt pooled_height, SymInt pooled_width, int sampling_ratio) -> (Tensor, Tensor)"));
-  m.def(TORCH_SELECTIVE_SCHEMA(
-      "torchvision::_ps_roi_align_backward(Tensor grad, Tensor rois, Tensor channel_mapping, float spatial_scale, SymInt pooled_height, SymInt pooled_width, int sampling_ratio, SymInt batch_size, SymInt channels, SymInt height, SymInt width) -> Tensor"));
+STABLE_TORCH_LIBRARY_FRAGMENT(torchvision, m) {
+  m.def(
+      "ps_roi_align(Tensor input, Tensor rois, float spatial_scale, SymInt pooled_height, SymInt pooled_width, int sampling_ratio) -> (Tensor, Tensor)");
+  m.def(
+      "_ps_roi_align_backward(Tensor grad, Tensor rois, Tensor channel_mapping, float spatial_scale, SymInt pooled_height, SymInt pooled_width, int sampling_ratio, SymInt batch_size, SymInt channels, SymInt height, SymInt width) -> Tensor");
 }
 
 } // namespace ops

--- a/torchvision/csrc/ops/ps_roi_align.h
+++ b/torchvision/csrc/ops/ps_roi_align.h
@@ -1,33 +1,27 @@
 #pragma once
 
-#include <ATen/ATen.h>
+#include <torch/csrc/stable/tensor.h>
 #include "../macros.h"
+
+#include <tuple>
 
 namespace vision {
 namespace ops {
 
-VISION_API std::tuple<at::Tensor, at::Tensor> ps_roi_align(
-    const at::Tensor& input,
-    const at::Tensor& rois,
+VISION_API std::tuple<torch::stable::Tensor, torch::stable::Tensor> ps_roi_align(
+    const torch::stable::Tensor& input,
+    const torch::stable::Tensor& rois,
     double spatial_scale,
     int64_t pooled_height,
     int64_t pooled_width,
     int64_t sampling_ratio);
 
-VISION_API std::tuple<at::Tensor, at::Tensor> ps_roi_align_symint(
-    const at::Tensor& input,
-    const at::Tensor& rois,
-    double spatial_scale,
-    c10::SymInt pooled_height,
-    c10::SymInt pooled_width,
-    int64_t sampling_ratio);
-
 namespace detail {
 
-at::Tensor _ps_roi_align_backward(
-    const at::Tensor& grad,
-    const at::Tensor& rois,
-    const at::Tensor& channel_mapping,
+torch::stable::Tensor _ps_roi_align_backward(
+    const torch::stable::Tensor& grad,
+    const torch::stable::Tensor& rois,
+    const torch::stable::Tensor& channel_mapping,
     double spatial_scale,
     int64_t pooled_height,
     int64_t pooled_width,
@@ -36,19 +30,6 @@ at::Tensor _ps_roi_align_backward(
     int64_t channels,
     int64_t height,
     int64_t width);
-
-at::Tensor _ps_roi_align_backward_symint(
-    const at::Tensor& grad,
-    const at::Tensor& rois,
-    const at::Tensor& channel_mapping,
-    double spatial_scale,
-    c10::SymInt pooled_height,
-    c10::SymInt pooled_width,
-    int64_t sampling_ratio,
-    c10::SymInt batch_size,
-    c10::SymInt channels,
-    c10::SymInt height,
-    c10::SymInt width);
 
 } // namespace detail
 


### PR DESCRIPTION
Ports `ps_roi_align` (CPU) to stable ABI.

## Notes
  - **Dropped the `*_symint` C++ wrappers.** Follows `roi_pool` port #9584).

## Stable-ABI audit (`torch-abi-audit`)
Ran [`torch-abi-audit`](https://github.com/Quansight/torch-abi-audit). `ps_roi_align`'s CPU op moves into the fully-STABLE `_C_stable.so` (`unstable=0`) and pulls in no new shim symbols. The unstable `_C.so` count is unchanged at 104. `ps_roi_align`'s CPU sources shared their unstable-API surface with the still-legacy kernels (its own CUDA/MPS plus the other unported ops), so no symbol is uniquely removed until those migrate.
```text
    Package: torchvision
      Torch ABI:   UNSTABLE
      CPython ABI: n/a
      Bundled libs: 3
      -- bundled libs --
        [UNSTABLE] [not-abi3] _C.so            (stable_shim=0,  unstable=104)
        [STABLE  ] [not-abi3] _C_stable.so     (stable_shim=70, unstable=0)
        [STABLE  ] [not-abi3] image_stable.so  (stable_shim=76, unstable=0)
```