### PR TITLE
Port roi_align MPS kernel to the stable-ABI extension

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -163,6 +163,7 @@ STABLE_SOURCES = {
     CSRS_DIR / "ops/nms.cpp",
     CSRS_DIR / "ops/cpu/nms_kernel.cpp",
     CSRS_DIR / "ops/mps/nms_kernel.mm",
+    CSRS_DIR / "ops/mps/roi_align_kernel.mm",
     CSRS_DIR / "ops/quantized/cpu/qnms_kernel.cpp",
     CSRS_DIR / "io/image/common_stable.cpp",
     CSRS_DIR / "io/image/cpu/encode_png.cpp",

--- a/torchvision/csrc/ops/mps/roi_align_kernel.mm
+++ b/torchvision/csrc/ops/mps/roi_align_kernel.mm
@@ -1,188 +1,269 @@
-#include <ATen/mps/MPSProfiler.h>
-#include <ATen/native/mps/OperationUtils.h>
-#include "mps_helpers.h"
-#include "mps_kernels.h"
+#include <torch/csrc/inductor/aoti_torch/c/shim_mps.h>
+#include <torch/csrc/stable/library.h>
+#include <torch/csrc/stable/ops.h>
+#include <torch/csrc/stable/tensor.h>
+#include <torch/headeronly/core/DeviceType.h>
+#include <torch/headeronly/core/ScalarType.h>
+#include <torch/headeronly/util/Exception.h>
+
+#include <cstdint>
+#include <string>
+
+#include "../StableABICompat.h"
+#include "roi_align_metal_shader.h"
 
 namespace vision {
 namespace ops {
 
 namespace {
 
-at::Tensor roi_align_forward_kernel(const at::Tensor& input,
-                                    const at::Tensor& rois,
-                                    double spatial_scale,
-                                    int64_t pooled_height,
-                                    int64_t pooled_width,
-                                    int64_t sampling_ratio,
-                                    bool aligned) {
-  using namespace at::native::mps;
-  TORCH_CHECK(input.is_mps(), "input must be a MPS tensor");
-  TORCH_CHECK(rois.is_mps(), "rois must be a MPS tensor");
-  TORCH_CHECK(rois.size(1) == 5, "rois must have shape as Tensor[K, 5]");
+using torch::stable::Tensor;
 
-  at::TensorArg input_t{input, "input", 1}, rois_t{rois, "rois", 2};
+// Lazily compile the roi_align Metal shader library once for the process,
+// mirroring the lazy-singleton the AOTInductor MPS backend generates. The
+// handle lives for the process lifetime.
+AOTIMetalShaderLibraryHandle roi_align_shader_library() {
+  static AOTIMetalShaderLibraryHandle library = []() {
+    AOTIMetalShaderLibraryHandle handle = nullptr;
+    TORCH_ERROR_CODE_CHECK(
+        aoti_torch_mps_create_shader_library(roi_align_metal_shader, &handle));
+    return handle;
+  }();
+  return library;
+}
 
-  at::CheckedFrom c = "roi_align_forward_kernel";
-  at::checkAllSameGPU(c, {input_t, rois_t});
-  at::checkAllSameType(c, {input_t, rois_t});
+const char* metal_type_string(torch::headeronly::ScalarType scalar_type) {
+  if (scalar_type == torch::headeronly::ScalarType::Float) {
+    return "float";
+  }
+  if (scalar_type == torch::headeronly::ScalarType::Half) {
+    return "half";
+  }
+  return "";
+}
+
+// The MPS shim has no scalar-float arg setter, so spatial_scale rides in as a
+// 1-element float32 tensor (same workaround as nms's iou_threshold).
+// TODO(stable-abi): bind a float directly once aoti_torch_mps_set_arg_double /
+// set_arg_bytes lands upstream (pytorch/pytorch).
+struct RoiAlignForwardArgs {
+  AtenTensorHandle input;
+  AtenTensorHandle rois;
+  AtenTensorHandle output;
+  AtenTensorHandle spatial_scale;
+  int64_t channels;
+  int64_t height;
+  int64_t width;
+  int64_t pooled_height;
+  int64_t pooled_width;
+  int64_t sampling_ratio;
+  int64_t aligned;
+  uint64_t output_size;
+};
+
+void roi_align_forward_encode(
+    AOTIMetalKernelFunctionHandle func,
+    void* user_data) {
+  const auto* a = static_cast<const RoiAlignForwardArgs*>(user_data);
+  TORCH_ERROR_CODE_CHECK(aoti_torch_mps_start_encoding(func));
+  TORCH_ERROR_CODE_CHECK(aoti_torch_mps_set_arg_tensor(func, 0, a->input));
+  TORCH_ERROR_CODE_CHECK(aoti_torch_mps_set_arg_tensor(func, 1, a->rois));
+  TORCH_ERROR_CODE_CHECK(aoti_torch_mps_set_arg_tensor(func, 2, a->output));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_tensor(func, 3, a->spatial_scale));
+  TORCH_ERROR_CODE_CHECK(aoti_torch_mps_set_arg_int(func, 4, a->channels));
+  TORCH_ERROR_CODE_CHECK(aoti_torch_mps_set_arg_int(func, 5, a->height));
+  TORCH_ERROR_CODE_CHECK(aoti_torch_mps_set_arg_int(func, 6, a->width));
+  TORCH_ERROR_CODE_CHECK(aoti_torch_mps_set_arg_int(func, 7, a->pooled_height));
+  TORCH_ERROR_CODE_CHECK(aoti_torch_mps_set_arg_int(func, 8, a->pooled_width));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_int(func, 9, a->sampling_ratio));
+  TORCH_ERROR_CODE_CHECK(aoti_torch_mps_set_arg_int(func, 10, a->aligned));
+  TORCH_ERROR_CODE_CHECK(aoti_torch_mps_dispatch_single(func, a->output_size));
+}
+
+struct RoiAlignBackwardArgs {
+  AtenTensorHandle grad;
+  AtenTensorHandle rois;
+  AtenTensorHandle grad_input;
+  int64_t output_size;
+  int64_t channels;
+  int64_t height;
+  int64_t width;
+  int64_t pooled_height;
+  int64_t pooled_width;
+  int64_t sampling_ratio;
+  int64_t aligned;
+  AtenTensorHandle spatial_scale;
+  int64_t n_stride;
+  int64_t c_stride;
+  int64_t h_stride;
+  int64_t w_stride;
+};
+
+void roi_align_backward_encode(
+    AOTIMetalKernelFunctionHandle func,
+    void* user_data) {
+  const auto* a = static_cast<const RoiAlignBackwardArgs*>(user_data);
+  TORCH_ERROR_CODE_CHECK(aoti_torch_mps_start_encoding(func));
+  TORCH_ERROR_CODE_CHECK(aoti_torch_mps_set_arg_tensor(func, 0, a->grad));
+  TORCH_ERROR_CODE_CHECK(aoti_torch_mps_set_arg_tensor(func, 1, a->rois));
+  TORCH_ERROR_CODE_CHECK(aoti_torch_mps_set_arg_tensor(func, 2, a->grad_input));
+  TORCH_ERROR_CODE_CHECK(aoti_torch_mps_set_arg_int(func, 3, a->output_size));
+  TORCH_ERROR_CODE_CHECK(aoti_torch_mps_set_arg_int(func, 4, a->channels));
+  TORCH_ERROR_CODE_CHECK(aoti_torch_mps_set_arg_int(func, 5, a->height));
+  TORCH_ERROR_CODE_CHECK(aoti_torch_mps_set_arg_int(func, 6, a->width));
+  TORCH_ERROR_CODE_CHECK(aoti_torch_mps_set_arg_int(func, 7, a->pooled_height));
+  TORCH_ERROR_CODE_CHECK(aoti_torch_mps_set_arg_int(func, 8, a->pooled_width));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_int(func, 9, a->sampling_ratio));
+  TORCH_ERROR_CODE_CHECK(aoti_torch_mps_set_arg_int(func, 10, a->aligned));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_tensor(func, 11, a->spatial_scale));
+  TORCH_ERROR_CODE_CHECK(aoti_torch_mps_set_arg_int(func, 12, a->n_stride));
+  TORCH_ERROR_CODE_CHECK(aoti_torch_mps_set_arg_int(func, 13, a->c_stride));
+  TORCH_ERROR_CODE_CHECK(aoti_torch_mps_set_arg_int(func, 14, a->h_stride));
+  TORCH_ERROR_CODE_CHECK(aoti_torch_mps_set_arg_int(func, 15, a->w_stride));
+  TORCH_ERROR_CODE_CHECK(aoti_torch_mps_dispatch_single(
+      func, static_cast<uint64_t>(a->output_size)));
+}
+
+Tensor make_scalar_tensor(const Tensor& ref, double value) {
+  Tensor t = torch::stable::new_empty(
+      ref, {1}, torch::headeronly::ScalarType::Float);
+  torch::stable::fill_(t, value);
+  return t;
+}
+
+Tensor roi_align_forward_kernel(
+    const Tensor& input,
+    const Tensor& rois,
+    double spatial_scale,
+    int64_t pooled_height,
+    int64_t pooled_width,
+    int64_t sampling_ratio,
+    bool aligned) {
+  STD_TORCH_CHECK(
+      input.device().type() == torch::headeronly::DeviceType::MPS,
+      "input must be a MPS tensor");
+  STD_TORCH_CHECK(
+      rois.device().type() == torch::headeronly::DeviceType::MPS,
+      "rois must be a MPS tensor");
+  STD_TORCH_CHECK(rois.size(1) == 5, "rois must have shape as Tensor[K, 5]");
 
   int64_t num_rois = rois.size(0);
   int64_t channels = input.size(1);
   int64_t height = input.size(2);
   int64_t width = input.size(3);
-  float spatial_scale_f = static_cast<float>(spatial_scale);
 
-  at::Tensor output = at::zeros({num_rois, channels, pooled_height, pooled_width}, input.options());
-
-  int64_t output_size = num_rois * pooled_height * pooled_width * channels;
-
-  if (output.numel() == 0) {
+  Tensor output = torch::stable::new_empty(
+      input, {num_rois, channels, pooled_height, pooled_width});
+  int64_t output_size = output.numel();
+  if (output_size == 0) {
     return output;
   }
 
-  auto input_ = input.contiguous();
-  auto rois_ = rois.contiguous();
+  Tensor input_ = torch::stable::contiguous(input);
+  Tensor rois_ = torch::stable::contiguous(rois);
+  Tensor spatial_scale_t = make_scalar_tensor(input_, spatial_scale);
 
-  id<MTLBuffer> inputBuffer = getMTLBufferStorage(input_);
-  id<MTLBuffer> roisBuffer = getMTLBufferStorage(rois_);
-  id<MTLBuffer> outputBuffer = getMTLBufferStorage(output);
-  id<MTLDevice> device = MPSDevice::getInstance()->device();
-  MPSStream* mpsStream = getCurrentMPSStream();
-  dispatch_sync(mpsStream->queue(), ^() {
-    @autoreleasepool {
-      id<MTLComputeCommandEncoder> computeEncoder = mpsStream->commandEncoder();
+  const std::string kernel =
+      "roi_align_" + std::string(metal_type_string(input_.scalar_type()));
+  AOTIMetalKernelFunctionHandle func = nullptr;
+  TORCH_ERROR_CODE_CHECK(aoti_torch_mps_get_kernel_function(
+      roi_align_shader_library(), kernel.c_str(), &func));
 
-      const std::string kernel = "roi_align_" + scalarToMetalTypeString(input.scalar_type());
-      id<MTLComputePipelineState> visionPSO = mps::visionPipelineState(device, kernel);
-
-      auto threadsPerGrid = MTLSizeMake(output_size, 1, 1);
-      auto threadsPerThreadgroup =
-          MTLSizeMake(std::min(static_cast<int64_t>(visionPSO.maxTotalThreadsPerThreadgroup), output_size), 1, 1);
-
-      // this function call is a no-op if MPS Profiler is not enabled
-      getMPSProfiler().beginProfileKernel(visionPSO, kernel, {input_, rois_});
-
-      [computeEncoder setComputePipelineState:visionPSO];
-      // [N, C, H, W]
-      [computeEncoder setBuffer:inputBuffer offset:input_.storage_offset() * input_.element_size() atIndex:0];
-      [computeEncoder setBuffer:roisBuffer offset:rois_.storage_offset() * rois_.element_size() atIndex:1];
-      [computeEncoder setBuffer:outputBuffer offset:output.storage_offset() * output.element_size() atIndex:2];
-
-      [computeEncoder setBytes:&spatial_scale_f length:sizeof(float) atIndex:3];
-      [computeEncoder setBytes:&channels length:sizeof(int64_t) atIndex:4];
-      [computeEncoder setBytes:&height length:sizeof(int64_t) atIndex:5];
-      [computeEncoder setBytes:&width length:sizeof(int64_t) atIndex:6];
-      [computeEncoder setBytes:&pooled_height length:sizeof(int64_t) atIndex:7];
-      [computeEncoder setBytes:&pooled_width length:sizeof(int64_t) atIndex:8];
-      [computeEncoder setBytes:&sampling_ratio length:sizeof(int64_t) atIndex:9];
-      [computeEncoder setBytes:&aligned length:sizeof(bool) atIndex:10];
-
-      [computeEncoder dispatchThreads:threadsPerGrid threadsPerThreadgroup:threadsPerThreadgroup];
-
-      getMPSProfiler().endProfileKernel(visionPSO);
-    }
-  });
+  RoiAlignForwardArgs args{
+      input_.get(),
+      rois_.get(),
+      output.get(),
+      spatial_scale_t.get(),
+      channels,
+      height,
+      width,
+      pooled_height,
+      pooled_width,
+      sampling_ratio,
+      aligned ? 1 : 0,
+      static_cast<uint64_t>(output_size)};
+  TORCH_ERROR_CODE_CHECK(aoti_torch_mps_run_command_block(
+      func, &roi_align_forward_encode, &args));
   return output;
 }
 
-at::Tensor roi_align_backward_kernel(const at::Tensor& grad,
-                                     const at::Tensor& rois,
-                                     double spatial_scale,
-                                     int64_t pooled_height,
-                                     int64_t pooled_width,
-                                     int64_t batch_size,
-                                     int64_t channels,
-                                     int64_t height,
-                                     int64_t width,
-                                     int64_t sampling_ratio,
-                                     bool aligned) {
-  using namespace at::native::mps;
-  TORCH_CHECK(grad.is_mps(), "grad must be a MPS tensor");
-  TORCH_CHECK(rois.is_mps(), "rois must be a MPS tensor");
-  TORCH_CHECK(grad.scalar_type() != at::kHalf, "MPS does not support roi_align backward with float16 inputs.");
+Tensor roi_align_backward_kernel(
+    const Tensor& grad,
+    const Tensor& rois,
+    double spatial_scale,
+    int64_t pooled_height,
+    int64_t pooled_width,
+    int64_t batch_size,
+    int64_t channels,
+    int64_t height,
+    int64_t width,
+    int64_t sampling_ratio,
+    bool aligned) {
+  STD_TORCH_CHECK(
+      grad.device().type() == torch::headeronly::DeviceType::MPS,
+      "grad must be a MPS tensor");
+  STD_TORCH_CHECK(
+      rois.device().type() == torch::headeronly::DeviceType::MPS,
+      "rois must be a MPS tensor");
+  STD_TORCH_CHECK(
+      grad.scalar_type() != torch::headeronly::ScalarType::Half,
+      "MPS does not support roi_align backward with float16 inputs.");
 
-  at::TensorArg grad_t{grad, "input", 1}, rois_t{rois, "rois", 2};
-
-  at::CheckedFrom c = "roi_align_backward_kernel";
-  at::checkAllSameGPU(c, {grad_t, rois_t});
-  at::checkAllSameType(c, {grad_t, rois_t});
-
-  float spatial_scale_f = static_cast<float>(spatial_scale);
-
-  at::Tensor grad_input = at::zeros({batch_size, channels, height, width}, grad.options());
-
+  Tensor grad_input = torch::stable::new_zeros(
+      grad, {batch_size, channels, height, width});
   if (grad.numel() == 0) {
     return grad_input;
   }
 
-  int64_t n_stride = grad.stride(0);
-  int64_t c_stride = grad.stride(1);
-  int64_t h_stride = grad.stride(2);
-  int64_t w_stride = grad.stride(3);
-  int64_t output_size = grad.numel();
+  // Index the gradient with contiguous strides (computed from the pooled output
+  // shape), so making grad contiguous lets us drop the runtime .stride() reads.
+  Tensor grad_ = torch::stable::contiguous(grad);
+  Tensor rois_ = torch::stable::contiguous(rois);
+  Tensor spatial_scale_t = make_scalar_tensor(grad_, spatial_scale);
 
-  at::globalContext().alertNotDeterministic("roi_align_backward_kernel");
-  auto rois_ = rois.contiguous();
+  int64_t output_size = grad_.numel();
+  int64_t w_stride = 1;
+  int64_t h_stride = pooled_width;
+  int64_t c_stride = pooled_height * pooled_width;
+  int64_t n_stride = channels * pooled_height * pooled_width;
 
-  id<MTLBuffer> inputBuffer = getMTLBufferStorage(grad);
-  id<MTLBuffer> roisBuffer = getMTLBufferStorage(rois_);
-  id<MTLBuffer> outputBuffer = getMTLBufferStorage(grad_input);
-  id<MTLDevice> device = MPSDevice::getInstance()->device();
-  MPSStream* mpsStream = getCurrentMPSStream();
-  dispatch_sync(mpsStream->queue(), ^() {
-    @autoreleasepool {
-      id<MTLComputeCommandEncoder> computeEncoder = mpsStream->commandEncoder();
-      MTLSize threadgroupsPerGrid = MTLSizeMake(
-          std::min(ceil_div(static_cast<int64_t>(grad.numel()), static_cast<int64_t>(512)), static_cast<int64_t>(4096)),
-          1,
-          1);
+  const std::string kernel = "roi_align_backward_" +
+      std::string(metal_type_string(grad_.scalar_type()));
+  AOTIMetalKernelFunctionHandle func = nullptr;
+  TORCH_ERROR_CODE_CHECK(aoti_torch_mps_get_kernel_function(
+      roi_align_shader_library(), kernel.c_str(), &func));
 
-      const std::string kernel = "roi_align_backward_" + scalarToMetalTypeString(grad.scalar_type());
-      id<MTLComputePipelineState> visionPSO = mps::visionPipelineState(device, kernel);
-
-      // this function call is a no-op if MPS Profiler is not enabled
-      getMPSProfiler().beginProfileKernel(visionPSO, kernel, {grad, rois_});
-
-      [computeEncoder setComputePipelineState:visionPSO];
-      // [N, C, H, W]
-      [computeEncoder setBuffer:inputBuffer offset:grad.storage_offset() * grad.element_size() atIndex:0];
-      [computeEncoder setBuffer:roisBuffer offset:rois_.storage_offset() * rois_.element_size() atIndex:1];
-      [computeEncoder setBuffer:outputBuffer offset:grad_input.storage_offset() * grad_input.element_size() atIndex:2];
-
-      [computeEncoder setBytes:&output_size length:sizeof(int64_t) atIndex:3];
-      [computeEncoder setBytes:&channels length:sizeof(int64_t) atIndex:4];
-      [computeEncoder setBytes:&height length:sizeof(int64_t) atIndex:5];
-      [computeEncoder setBytes:&width length:sizeof(int64_t) atIndex:6];
-      [computeEncoder setBytes:&pooled_height length:sizeof(int64_t) atIndex:7];
-      [computeEncoder setBytes:&pooled_width length:sizeof(int64_t) atIndex:8];
-      [computeEncoder setBytes:&sampling_ratio length:sizeof(int64_t) atIndex:9];
-      [computeEncoder setBytes:&aligned length:sizeof(bool) atIndex:10];
-      [computeEncoder setBytes:&spatial_scale_f length:sizeof(float) atIndex:11];
-      [computeEncoder setBytes:&n_stride length:sizeof(int64_t) atIndex:12];
-      [computeEncoder setBytes:&c_stride length:sizeof(int64_t) atIndex:13];
-      [computeEncoder setBytes:&h_stride length:sizeof(int64_t) atIndex:14];
-      [computeEncoder setBytes:&w_stride length:sizeof(int64_t) atIndex:15];
-
-      // A threadGroup is equivalent to a cuda's block.
-      NSUInteger tgSize = visionPSO.maxTotalThreadsPerThreadgroup;
-      if (tgSize > threadsPerBlock) {
-        tgSize = threadsPerBlock;
-      }
-
-      MTLSize threadGroupSize = MTLSizeMake(tgSize, 1, 1);
-      [computeEncoder dispatchThreadgroups:threadgroupsPerGrid threadsPerThreadgroup:threadGroupSize];
-
-      getMPSProfiler().endProfileKernel(visionPSO);
-    }
-  });
+  RoiAlignBackwardArgs args{
+      grad_.get(),
+      rois_.get(),
+      grad_input.get(),
+      output_size,
+      channels,
+      height,
+      width,
+      pooled_height,
+      pooled_width,
+      sampling_ratio,
+      aligned ? 1 : 0,
+      spatial_scale_t.get(),
+      n_stride,
+      c_stride,
+      h_stride,
+      w_stride};
+  TORCH_ERROR_CODE_CHECK(aoti_torch_mps_run_command_block(
+      func, &roi_align_backward_encode, &args));
   return grad_input;
 }
 
 } // namespace
 
-TORCH_LIBRARY_IMPL(torchvision, MPS, m) {
-  m.impl(TORCH_SELECTIVE_NAME("torchvision::roi_align"), TORCH_FN(roi_align_forward_kernel));
-  m.impl(TORCH_SELECTIVE_NAME("torchvision::_roi_align_backward"), TORCH_FN(roi_align_backward_kernel));
+STABLE_TORCH_LIBRARY_IMPL(torchvision, MPS, m) {
+  m.impl("roi_align", TORCH_BOX(&roi_align_forward_kernel));
+  m.impl("_roi_align_backward", TORCH_BOX(&roi_align_backward_kernel));
 }
 
 } // namespace ops

--- a/torchvision/csrc/ops/mps/roi_align_metal_shader.h
+++ b/torchvision/csrc/ops/mps/roi_align_metal_shader.h
@@ -1,0 +1,394 @@
+#pragma once
+
+// Metal shader source for the roi_align MPS kernels (forward + backward).
+//
+// Carved out of the shared ops/mps/mps_kernels.h (which is still used by the
+// legacy _C ops) so it can be compiled into the stable-ABI _C_stable extension.
+// mps_kernels.h opens with #include <ATen/native/mps/OperationUtils.h> and
+// instantiates at::native::mps::MetalShaderLibrary, both unavailable under
+// -DTORCH_TARGET_VERSION. This header carries only the roi_align Metal source
+// as a plain string, handed to aoti_torch_mps_create_shader_library at runtime,
+// the same shape PyTorch's AOTInductor MPS backend emits.
+
+namespace vision {
+namespace ops {
+
+static const char* roi_align_metal_shader = R"VISION_METAL(
+
+#include <metal_atomic>
+#include <metal_stdlib>
+using namespace metal;
+
+#define MPS_1D_KERNEL_LOOP_T(i, n, n_tgs, index_t)      \
+  for (index_t i = (tgid.x * tptg.x) + tid2.x; i < (n); \
+       i += (tptg.x * n_tgs))
+
+#define MPS_1D_KERNEL_LOOP(i, n, n_tgs) MPS_1D_KERNEL_LOOP_T(i, n, n_tgs, uint)
+
+template <typename T>
+inline T ceil_div(T n, T m) {
+  return (n + m - 1) / m;
+}
+
+inline void atomic_add_float(device float* data_ptr, const float val)
+{
+  atomic_fetch_add_explicit((device atomic_float*) data_ptr, val, memory_order_relaxed);
+}
+
+
+inline void atomic_add_float(device half* data_ptr, const half val)
+{
+  atomic_fetch_add_explicit((device atomic_float*) data_ptr, static_cast<float>(val), memory_order_relaxed);
+}
+
+template <typename T, typename integer_t>
+inline T bilinear_interpolate(
+    constant T* input,
+    integer_t height,
+    integer_t width,
+    T y,
+    T x,
+    uint index /* index for debug only*/) {
+  // deal with cases that inverse elements are out of feature map boundary
+  if (y < -1.0 || y > height || x < -1.0 || x > width) {
+    // empty
+    return 0;
+  }
+
+  if (y <= 0)
+    y = 0;
+  if (x <= 0)
+    x = 0;
+
+  integer_t y_low = (integer_t)y;
+  integer_t x_low = (integer_t)x;
+  integer_t y_high;
+  integer_t x_high;
+
+  if (y_low >= height - 1) {
+    y_high = y_low = height - 1;
+    y = (T)y_low;
+  } else {
+    y_high = y_low + 1;
+  }
+
+  if (x_low >= width - 1) {
+    x_high = x_low = width - 1;
+    x = (T)x_low;
+  } else {
+    x_high = x_low + 1;
+  }
+
+  T ly = y - y_low;
+  T lx = x - x_low;
+  T hy = 1. - ly, hx = 1. - lx;
+
+  // do bilinear interpolation
+  T v1 = input[y_low * width + x_low];
+  T v2 = input[y_low * width + x_high];
+  T v3 = input[y_high * width + x_low];
+  T v4 = input[y_high * width + x_high];
+  T w1 = hy * hx, w2 = hy * lx, w3 = ly * hx, w4 = ly * lx;
+
+  T val = (w1 * v1 + w2 * v2 + w3 * v3 + w4 * v4);
+
+  return val;
+}
+
+template <typename T, typename integer_t>
+inline void bilinear_interpolate_gradient(
+    integer_t height,
+    integer_t width,
+    T y,
+    T x,
+    thread T& w1,
+    thread T& w2,
+    thread T& w3,
+    thread T& w4,
+    thread integer_t& x_low,
+    thread integer_t& x_high,
+    thread integer_t& y_low,
+    thread integer_t& y_high,
+    uint index /* index for debug only*/) {
+  // deal with cases that inverse elements are out of feature map boundary
+  if (y < -1.0 || y > height || x < -1.0 || x > width) {
+    // empty
+    w1 = w2 = w3 = w4 = 0.;
+    x_low = x_high = y_low = y_high = -1;
+    return;
+  }
+
+  if (y <= 0)
+    y = 0;
+  if (x <= 0)
+    x = 0;
+
+  y_low = (integer_t)y;
+  x_low = (integer_t)x;
+
+  if (y_low >= height - 1) {
+    y_high = y_low = height - 1;
+    y = (T)y_low;
+  } else {
+    y_high = y_low + 1;
+  }
+
+  if (x_low >= width - 1) {
+    x_high = x_low = width - 1;
+    x = (T)x_low;
+  } else {
+    x_high = x_low + 1;
+  }
+
+  T ly = y - y_low;
+  T lx = x - x_low;
+  T hy = 1. - ly, hx = 1. - lx;
+
+  // reference in forward
+  // T v1 = input[y_low * width + x_low];
+  // T v2 = input[y_low * width + x_high];
+  // T v3 = input[y_high * width + x_low];
+  // T v4 = input[y_high * width + x_high];
+  // T val = (w1 * v1 + w2 * v2 + w3 * v3 + w4 * v4);
+
+  w1 = hy * hx, w2 = hy * lx, w3 = ly * hx, w4 = ly * lx;
+}
+
+template <typename T>
+kernel void roi_align(
+    constant T       * input          [[buffer(0)]],
+    constant T       * rois           [[buffer(1)]],
+    device   T       * output         [[buffer(2)]],
+    constant float   & spatial_scale  [[buffer(3)]],
+    constant int64_t & channels       [[buffer(4)]],
+    constant int64_t & height         [[buffer(5)]],
+    constant int64_t & width          [[buffer(6)]],
+    constant int64_t & pooled_height  [[buffer(7)]],
+    constant int64_t & pooled_width   [[buffer(8)]],
+    constant int64_t & sampling_ratio [[buffer(9)]],
+    constant bool    & aligned        [[buffer(10)]],
+    uint     index   [[thread_position_in_grid]])
+{
+  // Decode linear index into (n, c, ph, pw)
+  int64_t pw = index % pooled_width;
+  int64_t ph = (index / pooled_width) % pooled_height;
+  int64_t c = (index / pooled_width / pooled_height) % channels;
+  int64_t n = index / (pooled_width * pooled_height * channels);
+
+  constant T* offset_rois = rois + n * 5;
+  int64_t roi_batch_ind = static_cast<int64_t>(offset_rois[0]);
+
+  // Do not using rounding; this implementation detail is critical
+  T offset = aligned ? static_cast<T>(0.5) : static_cast<T>(0.0);
+  T roi_start_w = offset_rois[1] * spatial_scale - offset;
+  T roi_start_h = offset_rois[2] * spatial_scale - offset;
+  T roi_end_w   = offset_rois[3] * spatial_scale - offset;
+  T roi_end_h   = offset_rois[4] * spatial_scale - offset;
+
+  T roi_width = roi_end_w - roi_start_w;
+  T roi_height = roi_end_h - roi_start_h;
+
+  if (!aligned) {
+    // Force malformed ROIs to be 1x1
+    roi_width = max(roi_width, static_cast<T>(1.0));
+    roi_height = max(roi_height, static_cast<T>(1.0));
+  }
+
+  T bin_size_h = roi_height / static_cast<T>(pooled_height);
+  T bin_size_w = roi_width / static_cast<T>(pooled_width);
+
+  constant T* offset_input = input + (roi_batch_ind * channels + c) * height * width;
+
+  // We use roi_bin_grid to sample the grid and mimic integral
+  int64_t roi_bin_grid_h = sampling_ratio > 0
+    ? sampling_ratio
+    : static_cast<int64_t>(ceil(roi_height / static_cast<T>(pooled_height)));
+  int64_t roi_bin_grid_w = sampling_ratio > 0
+    ? sampling_ratio
+    : static_cast<int64_t>(ceil(roi_width / static_cast<T>(pooled_width)));
+
+  // We do average (integral) pooling inside a bin
+  // When the grid is empty, output zeros.
+  const T count = max(roi_bin_grid_h * roi_bin_grid_w, static_cast<int64_t>(1));
+  T output_val = static_cast<T>(0.0);
+
+  for (int64_t iy = 0; iy < roi_bin_grid_h; iy++) {
+    T y = roi_start_h + static_cast<T>(ph) * bin_size_h +
+          (static_cast<T>(iy) + static_cast<T>(0.5)) * bin_size_h / static_cast<T>(roi_bin_grid_h);
+    for (int64_t ix = 0; ix < roi_bin_grid_w; ix++) {
+      T x = roi_start_w + static_cast<T>(pw) * bin_size_w +
+            (static_cast<T>(ix) + static_cast<T>(0.5)) * bin_size_w / static_cast<T>(roi_bin_grid_w);
+
+      T val = bilinear_interpolate(offset_input, height, width, y, x, index);
+      output_val += val;
+    }
+  }
+
+  output_val /= count;
+  output[index] = output_val;
+}
+
+#define REGISTER_ROI_ALIGN_OP(DTYPE)       \
+template                                              \
+[[host_name("roi_align_" #DTYPE)]]                    \
+kernel void roi_align<DTYPE>(              \
+    constant DTYPE   * input          [[buffer(0)]],  \
+    constant DTYPE   * rois           [[buffer(1)]],  \
+    device   DTYPE   * output         [[buffer(2)]],  \
+    constant float   & spatial_scale  [[buffer(3)]],  \
+    constant int64_t & channels       [[buffer(4)]],  \
+    constant int64_t & height         [[buffer(5)]],  \
+    constant int64_t & width          [[buffer(6)]],  \
+    constant int64_t & pooled_height  [[buffer(7)]],  \
+    constant int64_t & pooled_width   [[buffer(8)]],  \
+    constant int64_t & sampling_ratio [[buffer(9)]],  \
+    constant bool    & aligned        [[buffer(10)]], \
+    uint     index   [[thread_position_in_grid]]);
+
+template<typename T, typename integer_t>
+kernel void roi_align_backward(
+    constant T       * grad_output    [[buffer(0)]],
+    constant T       * rois           [[buffer(1)]],
+    device   T       * grad_input     [[buffer(2)]],
+    constant int64_t & output_size    [[buffer(3)]],
+    constant int64_t & channels       [[buffer(4)]],
+    constant int64_t & height         [[buffer(5)]],
+    constant int64_t & width          [[buffer(6)]],
+    constant int64_t & pooled_height  [[buffer(7)]],
+    constant int64_t & pooled_width   [[buffer(8)]],
+    constant int64_t & sampling_ratio [[buffer(9)]],
+    constant bool    & aligned        [[buffer(10)]],
+    constant float   & spatial_scale  [[buffer(11)]],
+    constant int64_t & n_stride       [[buffer(12)]],
+    constant int64_t & c_stride       [[buffer(13)]],
+    constant int64_t & h_stride       [[buffer(14)]],
+    constant int64_t & w_stride       [[buffer(15)]],
+    uint2     tgid   [[threadgroup_position_in_grid]],
+    uint2     tptg   [[threads_per_threadgroup]],
+    uint2     tid2   [[thread_position_in_threadgroup]]){
+
+  MPS_1D_KERNEL_LOOP(index, output_size, 1) {
+    // (n, c, ph, pw) is an element in the pooled output
+    integer_t pw = index % pooled_width;
+    integer_t ph = (index / pooled_width) % pooled_height;
+    integer_t c = (index / pooled_width / pooled_height) % channels;
+    integer_t n = index / pooled_width / pooled_height / channels;
+
+    constant T* offset_rois = rois + n * 5;
+    integer_t roi_batch_ind = offset_rois[0];
+
+    // Do not using rounding; this implementation detail is critical
+    T offset = aligned ? (T)0.5 : (T)0.0;
+    T roi_start_w = offset_rois[1] * spatial_scale - offset;
+    T roi_start_h = offset_rois[2] * spatial_scale - offset;
+    T roi_end_w = offset_rois[3] * spatial_scale - offset;
+    T roi_end_h = offset_rois[4] * spatial_scale - offset;
+
+    T roi_width = roi_end_w - roi_start_w;
+    T roi_height = roi_end_h - roi_start_h;
+    if (!aligned) {
+      // Force malformed ROIs to be 1x1
+      roi_width = max(roi_width, (T)1.);
+      roi_height = max(roi_height, (T)1.);
+    }
+
+    T bin_size_h = static_cast<T>(roi_height) / static_cast<T>(pooled_height);
+    T bin_size_w = static_cast<T>(roi_width) / static_cast<T>(pooled_width);
+
+    // We need to index the gradient using the tensor strides to access the
+    // correct values.
+    const integer_t output_offset = n * n_stride + c * c_stride;
+    constant T* offset_grad_output = grad_output + output_offset;
+    const T grad_output_this_bin =
+        offset_grad_output[ph * h_stride + pw * w_stride];
+
+    // We use roi_bin_grid to sample the grid and mimic integral
+    integer_t roi_bin_grid_h = (sampling_ratio > 0)
+        ? sampling_ratio
+        : ceil(roi_height / pooled_height); // e.g., = 2
+    integer_t roi_bin_grid_w =
+        (sampling_ratio > 0) ? sampling_ratio : ceil(roi_width / pooled_width);
+
+    // We do average (integral) pooling inside a bin
+    const T count = roi_bin_grid_h * roi_bin_grid_w; // e.g. = 4
+
+    const integer_t input_offset = (roi_batch_ind * channels + c) * height * width;
+
+    for (integer_t iy = 0; iy < roi_bin_grid_h; iy++) // e.g., iy = 0, 1
+    {
+      const T y = roi_start_h + ph * bin_size_h +
+          static_cast<T>(iy + .5f) * bin_size_h /
+              static_cast<T>(roi_bin_grid_h); // e.g., 0.5, 1.5
+      for (integer_t ix = 0; ix < roi_bin_grid_w; ix++) {
+        const T x = roi_start_w + pw * bin_size_w +
+            static_cast<T>(ix + .5f) * bin_size_w /
+                static_cast<T>(roi_bin_grid_w);
+
+        T w1, w2, w3, w4;
+        integer_t x_low, x_high, y_low, y_high;
+
+        bilinear_interpolate_gradient(
+            height,
+            width,
+            y,
+            x,
+            w1,
+            w2,
+            w3,
+            w4,
+            x_low,
+            x_high,
+            y_low,
+            y_high,
+            index);
+
+        T g1 = grad_output_this_bin * w1 / count;
+        T g2 = grad_output_this_bin * w2 / count;
+        T g3 = grad_output_this_bin * w3 / count;
+        T g4 = grad_output_this_bin * w4 / count;
+
+        if (x_low >= 0 && x_high >= 0 && y_low >= 0 && y_high >= 0) {
+          atomic_add_float(grad_input + input_offset + y_low * width + x_low, static_cast<T>(g1));
+          atomic_add_float(grad_input + input_offset + y_low * width + x_high, static_cast<T>(g2));
+          atomic_add_float(grad_input + input_offset + y_high * width + x_low, static_cast<T>(g3));
+          atomic_add_float(grad_input + input_offset + y_high * width + x_high, static_cast<T>(g4));
+          
+        } // if
+      } // ix
+    } // iy
+  } // MPS_1D_KERNEL_LOOP
+}
+
+#define REGISTER_ROI_ALIGN_BACKWARD_OP(DTYPE, INT_DTYPE)   \
+template                                                   \
+[[host_name("roi_align_backward_" #DTYPE)]]                \
+kernel void roi_align_backward<DTYPE, INT_DTYPE>(          \
+    constant DTYPE   * grad_output    [[buffer(0)]],       \
+    constant DTYPE   * rois           [[buffer(1)]],       \
+    device   DTYPE   * grad_input     [[buffer(2)]],       \
+    constant int64_t & output_size    [[buffer(3)]],       \
+    constant int64_t & channels       [[buffer(4)]],       \
+    constant int64_t & height         [[buffer(5)]],       \
+    constant int64_t & width          [[buffer(6)]],       \
+    constant int64_t & pooled_height  [[buffer(7)]],       \
+    constant int64_t & pooled_width   [[buffer(8)]],       \
+    constant int64_t & sampling_ratio [[buffer(9)]],       \
+    constant bool    & aligned        [[buffer(10)]],      \
+    constant float   & spatial_scale  [[buffer(11)]],      \
+    constant int64_t & n_stride       [[buffer(12)]],      \
+    constant int64_t & c_stride       [[buffer(13)]],      \
+    constant int64_t & h_stride       [[buffer(14)]],      \
+    constant int64_t & w_stride       [[buffer(15)]],      \
+    uint2     tgid   [[threadgroup_position_in_grid]],     \
+    uint2     tptg   [[threads_per_threadgroup]],          \
+    uint2     tid2   [[thread_position_in_threadgroup]]);
+
+REGISTER_ROI_ALIGN_OP(float);
+REGISTER_ROI_ALIGN_OP(half);
+REGISTER_ROI_ALIGN_BACKWARD_OP(float, int64_t);
+REGISTER_ROI_ALIGN_BACKWARD_OP(half, int64_t);
+
+)VISION_METAL";
+
+} // namespace ops
+} // namespace vision


### PR DESCRIPTION
Moves roi_align off PyTorch's internal at::native::mps::MetalShaderLibrary onto the stable aoti_torch_mps_create_shader_library shim, extending nms (#9524). Removes the ABI-mismatch dependency behind pytorch/pytorch#188812.