### PR TITLE
Unblock CI after recent torch nightly change.

### DIFF
--- a/torchvision/csrc/ops/mps/ps_roi_align_kernel.mm
+++ b/torchvision/csrc/ops/mps/ps_roi_align_kernel.mm
@@ -66,7 +66,7 @@ std::tuple<at::Tensor, at::Tensor> ps_roi_align_forward_kernel(const at::Tensor&
       id<MTLComputePipelineState> visionPSO = mps::visionPipelineState(device, kernel);
 
       // this function call is a no-op if MPS Profiler is not enabled
-      getMPSProfiler().beginProfileKernel(visionPSO, kernel, {input_, rois_});
+      getMPSProfiler().beginProfileKernel(visionPSO, kernel, {input_, rois_}, mpsStream);
 
       [computeEncoder setComputePipelineState:visionPSO];
       // [N, C, H, W]
@@ -96,7 +96,7 @@ std::tuple<at::Tensor, at::Tensor> ps_roi_align_forward_kernel(const at::Tensor&
       MTLSize threadGroupSize = MTLSizeMake(tgSize, 1, 1);
       [computeEncoder dispatchThreadgroups:threadgroupsPerGrid threadsPerThreadgroup:threadGroupSize];
 
-      getMPSProfiler().endProfileKernel(visionPSO);
+      getMPSProfiler().endProfileKernel(visionPSO, mpsStream);
     }
   });
   return std::make_tuple(output, channel_mapping);
@@ -154,7 +154,7 @@ at::Tensor ps_roi_align_backward_kernel(const at::Tensor& grad,
       id<MTLComputePipelineState> visionPSO = mps::visionPipelineState(device, kernel);
 
       // this function call is a no-op if MPS Profiler is not enabled
-      getMPSProfiler().beginProfileKernel(visionPSO, kernel, {grad, rois_});
+      getMPSProfiler().beginProfileKernel(visionPSO, kernel, {grad, rois_}, mpsStream);
 
       [computeEncoder setComputePipelineState:visionPSO];
       // [N, C, H, W]
@@ -183,7 +183,7 @@ at::Tensor ps_roi_align_backward_kernel(const at::Tensor& grad,
       MTLSize threadGroupSize = MTLSizeMake(std::max<NSUInteger>(tgSize, 1), 1, 1);
       [computeEncoder dispatchThreads:threadsPerGrid threadsPerThreadgroup:threadGroupSize];
 
-      getMPSProfiler().endProfileKernel(visionPSO);
+      getMPSProfiler().endProfileKernel(visionPSO, mpsStream);
     }
   });
   return grad_input;

--- a/torchvision/csrc/ops/mps/ps_roi_pool_kernel.mm
+++ b/torchvision/csrc/ops/mps/ps_roi_pool_kernel.mm
@@ -63,7 +63,7 @@ std::tuple<at::Tensor, at::Tensor> ps_roi_pool_forward_kernel(const at::Tensor& 
       id<MTLComputePipelineState> visionPSO = mps::visionPipelineState(device, kernel);
 
       // this function call is a no-op if MPS Profiler is not enabled
-      getMPSProfiler().beginProfileKernel(visionPSO, kernel, {input_, rois_});
+      getMPSProfiler().beginProfileKernel(visionPSO, kernel, {input_, rois_}, mpsStream);
 
       [computeEncoder setComputePipelineState:visionPSO];
       // [N, C, H, W]
@@ -92,7 +92,7 @@ std::tuple<at::Tensor, at::Tensor> ps_roi_pool_forward_kernel(const at::Tensor& 
       MTLSize threadGroupSize = MTLSizeMake(tgSize, 1, 1);
       [computeEncoder dispatchThreadgroups:threadgroupsPerGrid threadsPerThreadgroup:threadGroupSize];
 
-      getMPSProfiler().endProfileKernel(visionPSO);
+      getMPSProfiler().endProfileKernel(visionPSO, mpsStream);
     }
   });
   return std::make_tuple(output, channel_mapping);
@@ -149,7 +149,7 @@ at::Tensor ps_roi_pool_backward_kernel(const at::Tensor& grad,
       id<MTLComputePipelineState> visionPSO = mps::visionPipelineState(device, kernel);
 
       // this function call is a no-op if MPS Profiler is not enabled
-      getMPSProfiler().beginProfileKernel(visionPSO, kernel, {grad_, rois_, channel_mapping});
+      getMPSProfiler().beginProfileKernel(visionPSO, kernel, {grad_, rois_, channel_mapping}, mpsStream);
 
       [computeEncoder setComputePipelineState:visionPSO];
       // [N, C, H, W]
@@ -177,7 +177,7 @@ at::Tensor ps_roi_pool_backward_kernel(const at::Tensor& grad,
       MTLSize threadGroupSize = MTLSizeMake(std::max<NSUInteger>(tgSize, 1), 1, 1);
       [computeEncoder dispatchThreads:threadsPerGrid threadsPerThreadgroup:threadGroupSize];
 
-      getMPSProfiler().endProfileKernel(visionPSO);
+      getMPSProfiler().endProfileKernel(visionPSO, mpsStream);
     }
   });
   return grad_input;

--- a/torchvision/csrc/ops/mps/roi_align_kernel.mm
+++ b/torchvision/csrc/ops/mps/roi_align_kernel.mm
@@ -60,7 +60,7 @@ at::Tensor roi_align_forward_kernel(const at::Tensor& input,
           MTLSizeMake(std::min(static_cast<int64_t>(visionPSO.maxTotalThreadsPerThreadgroup), output_size), 1, 1);
 
       // this function call is a no-op if MPS Profiler is not enabled
-      getMPSProfiler().beginProfileKernel(visionPSO, kernel, {input_, rois_});
+      getMPSProfiler().beginProfileKernel(visionPSO, kernel, {input_, rois_}, mpsStream);
 
       [computeEncoder setComputePipelineState:visionPSO];
       // [N, C, H, W]
@@ -79,7 +79,7 @@ at::Tensor roi_align_forward_kernel(const at::Tensor& input,
 
       [computeEncoder dispatchThreads:threadsPerGrid threadsPerThreadgroup:threadsPerThreadgroup];
 
-      getMPSProfiler().endProfileKernel(visionPSO);
+      getMPSProfiler().endProfileKernel(visionPSO, mpsStream);
     }
   });
   return output;
@@ -137,7 +137,7 @@ at::Tensor roi_align_backward_kernel(const at::Tensor& grad,
       id<MTLComputePipelineState> visionPSO = mps::visionPipelineState(device, kernel);
 
       // this function call is a no-op if MPS Profiler is not enabled
-      getMPSProfiler().beginProfileKernel(visionPSO, kernel, {grad, rois_});
+      getMPSProfiler().beginProfileKernel(visionPSO, kernel, {grad, rois_}, mpsStream);
 
       [computeEncoder setComputePipelineState:visionPSO];
       // [N, C, H, W]
@@ -167,7 +167,7 @@ at::Tensor roi_align_backward_kernel(const at::Tensor& grad,
       MTLSize threadGroupSize = MTLSizeMake(std::max<NSUInteger>(tgSize, 1), 1, 1);
       [computeEncoder dispatchThreads:threadsPerGrid threadsPerThreadgroup:threadGroupSize];
 
-      getMPSProfiler().endProfileKernel(visionPSO);
+      getMPSProfiler().endProfileKernel(visionPSO, mpsStream);
     }
   });
   return grad_input;

--- a/torchvision/csrc/ops/mps/roi_pool_kernel.mm
+++ b/torchvision/csrc/ops/mps/roi_pool_kernel.mm
@@ -60,7 +60,7 @@ std::tuple<at::Tensor, at::Tensor> roi_pool_forward_kernel(const at::Tensor& inp
       id<MTLComputePipelineState> visionPSO = mps::visionPipelineState(device, kernel);
 
       // this function call is a no-op if MPS Profiler is not enabled
-      getMPSProfiler().beginProfileKernel(visionPSO, kernel, {input_, rois_});
+      getMPSProfiler().beginProfileKernel(visionPSO, kernel, {input_, rois_}, mpsStream);
 
       [computeEncoder setComputePipelineState:visionPSO];
       // [N, C, H, W]
@@ -86,7 +86,7 @@ std::tuple<at::Tensor, at::Tensor> roi_pool_forward_kernel(const at::Tensor& inp
       MTLSize threadGroupSize = MTLSizeMake(tgSize, 1, 1);
       [computeEncoder dispatchThreadgroups:threadgroupsPerGrid threadsPerThreadgroup:threadGroupSize];
 
-      getMPSProfiler().endProfileKernel(visionPSO);
+      getMPSProfiler().endProfileKernel(visionPSO, mpsStream);
     }
   });
   return std::make_tuple(output, argmax);
@@ -145,7 +145,7 @@ at::Tensor roi_pool_backward_kernel(const at::Tensor& grad,
       id<MTLComputePipelineState> visionPSO = mps::visionPipelineState(device, kernel);
 
       // this function call is a no-op if MPS Profiler is not enabled
-      getMPSProfiler().beginProfileKernel(visionPSO, kernel, {grad, rois_, argmax_});
+      getMPSProfiler().beginProfileKernel(visionPSO, kernel, {grad, rois_, argmax_}, mpsStream);
 
       [computeEncoder setComputePipelineState:visionPSO];
       // [N, C, H, W]
@@ -174,7 +174,7 @@ at::Tensor roi_pool_backward_kernel(const at::Tensor& grad,
       MTLSize threadGroupSize = MTLSizeMake(std::max<NSUInteger>(tgSize, 1), 1, 1);
       [computeEncoder dispatchThreads:threadsPerGrid threadsPerThreadgroup:threadGroupSize];
 
-      getMPSProfiler().endProfileKernel(visionPSO);
+      getMPSProfiler().endProfileKernel(visionPSO, mpsStream);
     }
   });
   return grad_input;


### PR DESCRIPTION
Add the `mpsStream` parameter to each MPS call.

- pytorch/pytorch#192525 added a required `MPSStream*` parameter to [`beginProfileKernel`](https://github.com/pytorch/pytorch/blob/757df406f6d722b83341374fe2c4aa3ecccac55b/aten/src/ATen/mps/MPSProfiler.h#L315-L319) and [`endProfileKernel`](https://github.com/pytorch/pytorch/blob/757df406f6d722b83341374fe2c4aa3ecccac55b/aten/src/ATen/mps/MPSProfiler.h#L335-L338), which broke every MPS kernel that profiles its dispatch.
