### PR TITLE
Enable mypy type checking for torchvision.io

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -7,18 +7,6 @@ allow_redefinition = True
 no_implicit_optional = True
 warn_redundant_casts = True
 
-[mypy-torchvision.io.image.*]
-
-ignore_errors = True
-
-[mypy-torchvision.io.video.*]
-
-ignore_errors = True
-
-[mypy-torchvision.io.video_reader]
-
-ignore_errors = True
-
 [mypy-torchvision.models.*]
 
 ignore_errors=True
@@ -80,5 +68,9 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 
 [mypy-gdown.*]
+
+ignore_missing_imports = True
+
+[mypy-torchvision_extra_decoders.*]
 
 ignore_missing_imports = True


### PR DESCRIPTION
Three of the `ignore_errors` exemptions in `mypy.ini` are no longer earning their place, so this removes them and lets those modules be type checked. No source files change.

- **`torchvision.io.video_reader`** does not exist. There is no `video_reader` module anywhere in the tree, so the exemption matches nothing.
- **`torchvision.io.video`** is a 23 line re-export shim that already carries its own `# type: ignore[import-not-found]` for the internal fb import.
- **`torchvision.io.image`** is clean apart from `import torchvision_extra_decoders`, an optional dependency imported inside a `try` block.

For that last one I added `torchvision_extra_decoders` to the existing `ignore_missing_imports` block, where the other optional dependencies already live (`PIL`, `numpy`, `scipy`, `av`, `h5py`, `gdown` and so on), rather than adding an inline ignore to the source.

## Verification

Run with the version CI pins, `mypy==1.13.0`:

```
$ mypy --config-file mypy.ini
Success: no issues found in 185 source files
```

Unchanged `main` reports the same, so this keeps the check green while removing three exemptions.

I confirmed the new entry is not decorative: dropping only the `torchvision_extra_decoders` section reproduces the single error it suppresses.

```
torchvision/io/image.py:435: error: Cannot find implementation or library stub
for module named "torchvision_extra_decoders"  [import-not-found]
```

One note on reproducing locally: mypy's incremental cache can hide that difference, so the control needs `--no-incremental` or a cleared `.mypy_cache`.

## Not included

The five remaining exemptions need real source changes and are better off as separate PRs. Measured individually against this commit, they are `transforms.functional.*` 4 errors, `transforms.transforms.*` 7, `ops.*` 23, `transforms._functional_pil` 32, and `models.*` 97. Happy to work through them if that is wanted.
