### PR TITLE
Use CUDA 12.6 to test CUDA jobs, not 12.8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
           - python-version: "3.10"
             runner: linux.g5.4xlarge.nvidia.gpu
             gpu-arch-type: cuda
-            gpu-arch-version: "12.8"
+            gpu-arch-version: "12.6"
       fail-fast: false
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     permissions:
@@ -80,7 +80,7 @@ jobs:
         #   - python-version: "3.10"
         #     runner: windows.g5.4xlarge.nvidia.gpu
         #     gpu-arch-type: cuda
-        #     gpu-arch-version: "12.8"
+        #     gpu-arch-version: "12.6"
       fail-fast: false
     uses: pytorch/test-infra/.github/workflows/windows_job.yml@main
     permissions:


### PR DESCRIPTION
Torch doesn't support 12.8 anymore. Kinda.