### PR TITLE
Port deform_conv2d (MPS) to stable ABI. 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -177,6 +177,7 @@ STABLE_SOURCES = {
     CSRS_DIR / "ops/cpu/ps_roi_align_kernel.cpp",
     CSRS_DIR / "ops/deform_conv2d.cpp",
     CSRS_DIR / "ops/cpu/deform_conv2d_kernel.cpp",
+    CSRS_DIR / "ops/mps/deform_conv2d_kernel.mm",
 }
 STABLE_SOURCES.add(CSRS_DIR / ("ops/hip/nms_kernel.hip" if IS_ROCM else "ops/cuda/nms_kernel.cu"))
 STABLE_SOURCES.add(

--- a/torchvision/csrc/ops/mps/deform_conv2d_kernel.mm
+++ b/torchvision/csrc/ops/mps/deform_conv2d_kernel.mm
@@ -1,19 +1,112 @@
-#include <ATen/ATen.h>
-#include <ATen/mps/MPSProfiler.h>
-#include <ATen/native/mps/OperationUtils.h>
-#include "mps_kernels.h"
+#include <torch/csrc/inductor/aoti_torch/c/shim_mps.h>
+#include <torch/csrc/stable/c/shim.h>
+#include <torch/csrc/stable/device.h>
+#include <torch/csrc/stable/library.h>
+#include <torch/csrc/stable/ops.h>
+#include <torch/csrc/stable/tensor.h>
+#include <torch/headeronly/core/DeviceType.h>
+#include <torch/headeronly/core/ScalarType.h>
+#include <torch/headeronly/util/Exception.h>
+
+#include <cstdint>
+#include <string>
+
+#include "deform_conv2d_metal_shader.h"
 
 namespace vision {
 namespace ops {
 
 namespace {
 
-at::Tensor deform_conv2d_forward_kernel(
-    const at::Tensor& input,
-    const at::Tensor& weight,
-    const at::Tensor& offset,
-    const at::Tensor& mask,
-    const at::Tensor& bias,
+using torch::stable::Tensor;
+
+// TODO(stable-abi): use torch::stable::add once the shim adds aten::add.Tensor.
+Tensor add_tensors(const Tensor& self, const Tensor& other) {
+  return torch::stable::subtract(self, other, -1.0);
+}
+
+AOTIMetalShaderLibraryHandle deform_conv2d_shader_library() {
+  static AOTIMetalShaderLibraryHandle library = []() {
+    AOTIMetalShaderLibraryHandle handle = nullptr;
+    TORCH_ERROR_CODE_CHECK(aoti_torch_mps_create_shader_library(
+        deform_conv2d_metal_shader, &handle));
+    return handle;
+  }();
+  return library;
+}
+
+const char* metal_type_string(torch::headeronly::ScalarType scalar_type) {
+  if (scalar_type == torch::headeronly::ScalarType::Float) {
+    return "float";
+  }
+  if (scalar_type == torch::headeronly::ScalarType::Half) {
+    return "half";
+  }
+  return "";
+}
+
+struct DeformConv2dIm2colLaunchArgs {
+  AtenTensorHandle input;
+  AtenTensorHandle offset;
+  AtenTensorHandle mask;
+  AtenTensorHandle columns;
+  uint32_t input_size[2];
+  uint32_t weight_size[2];
+  uint32_t pad[2];
+  uint32_t stride[2];
+  uint32_t dilation[2];
+  uint32_t batch;
+  uint32_t in_channels;
+  uint32_t n_offset_grps;
+  uint32_t out_size[2];
+  bool use_mask;
+  uint64_t num_kernels;
+};
+
+void deform_conv2d_im2col_encode(
+    AOTIMetalKernelFunctionHandle func,
+    void* user_data) {
+  const auto* launch_args =
+      static_cast<const DeformConv2dIm2colLaunchArgs*>(user_data);
+  TORCH_ERROR_CODE_CHECK(aoti_torch_mps_start_encoding(func));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_tensor(func, 0, launch_args->input));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_tensor(func, 1, launch_args->offset));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_tensor(func, 2, launch_args->mask));
+  TORCH_ERROR_CODE_CHECK(torch_mps_set_arg_bytes(
+      func, 3, launch_args->input_size, sizeof(launch_args->input_size)));
+  TORCH_ERROR_CODE_CHECK(torch_mps_set_arg_bytes(
+      func, 4, launch_args->weight_size, sizeof(launch_args->weight_size)));
+  TORCH_ERROR_CODE_CHECK(torch_mps_set_arg_bytes(
+      func, 5, launch_args->pad, sizeof(launch_args->pad)));
+  TORCH_ERROR_CODE_CHECK(torch_mps_set_arg_bytes(
+      func, 6, launch_args->stride, sizeof(launch_args->stride)));
+  TORCH_ERROR_CODE_CHECK(torch_mps_set_arg_bytes(
+      func, 7, launch_args->dilation, sizeof(launch_args->dilation)));
+  TORCH_ERROR_CODE_CHECK(torch_mps_set_arg_bytes(
+      func, 8, &launch_args->batch, sizeof(uint32_t)));
+  TORCH_ERROR_CODE_CHECK(torch_mps_set_arg_bytes(
+      func, 9, &launch_args->in_channels, sizeof(uint32_t)));
+  TORCH_ERROR_CODE_CHECK(torch_mps_set_arg_bytes(
+      func, 10, &launch_args->n_offset_grps, sizeof(uint32_t)));
+  TORCH_ERROR_CODE_CHECK(torch_mps_set_arg_bytes(
+      func, 11, launch_args->out_size, sizeof(launch_args->out_size)));
+  TORCH_ERROR_CODE_CHECK(torch_mps_set_arg_bytes(
+      func, 12, &launch_args->use_mask, sizeof(bool)));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_tensor(func, 13, launch_args->columns));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_dispatch_single(func, launch_args->num_kernels));
+}
+
+Tensor deform_conv2d_forward_kernel(
+    const Tensor& input,
+    const Tensor& weight,
+    const Tensor& offset,
+    const Tensor& mask,
+    const Tensor& bias,
     int64_t stride_h,
     int64_t stride_w,
     int64_t pad_h,
@@ -23,24 +116,32 @@ at::Tensor deform_conv2d_forward_kernel(
     int64_t n_weight_grps,
     int64_t n_offset_grps,
     bool use_mask) {
-  using namespace at::native::mps;
-  at::Tensor input_c = input.contiguous();
-  at::Tensor weight_c = weight.contiguous();
-  at::Tensor offset_c = offset.contiguous();
-  at::Tensor mask_c = mask.contiguous();
-  at::Tensor bias_c = bias.contiguous();
+  Tensor input_c = torch::stable::contiguous(input);
+  Tensor weight_c = torch::stable::contiguous(weight);
+  Tensor offset_c = torch::stable::contiguous(offset);
+  Tensor mask_c = torch::stable::contiguous(mask);
+  Tensor bias_c = torch::stable::contiguous(bias);
 
-  TORCH_CHECK(input_c.ndimension() == 4, "Input tensor must be 4D");
-  TORCH_CHECK(weight_c.ndimension() == 4, "Weight tensor must be 4D");
-  TORCH_CHECK(offset_c.ndimension() == 4, "Offset tensor must be 4D");
-  TORCH_CHECK(!use_mask || mask_c.ndimension() == 4, "Mask tensor must be 4D if use_mask is true");
-  TORCH_CHECK(input_c.is_mps(), "input must be a MPS tensor");
-  TORCH_CHECK(weight.is_mps(), "weight must be a MPS tensor");
-  TORCH_CHECK(offset.is_mps(), "offset must be a MPS tensor");
-  TORCH_CHECK(mask.is_mps(), "mask must be a MPS tensor");
-  TORCH_CHECK(bias.is_mps(), "bias must be a MPS tensor");
-
-  at::DeviceGuard guard(input_c.device());
+  STD_TORCH_CHECK(input_c.dim() == 4, "Input tensor must be 4D");
+  STD_TORCH_CHECK(weight_c.dim() == 4, "Weight tensor must be 4D");
+  STD_TORCH_CHECK(offset_c.dim() == 4, "Offset tensor must be 4D");
+  STD_TORCH_CHECK(
+      !use_mask || mask_c.dim() == 4, "Mask tensor must be 4D if use_mask is true");
+  STD_TORCH_CHECK(
+      input_c.device().type() == torch::headeronly::DeviceType::MPS,
+      "input must be a MPS tensor");
+  STD_TORCH_CHECK(
+      weight.device().type() == torch::headeronly::DeviceType::MPS,
+      "weight must be a MPS tensor");
+  STD_TORCH_CHECK(
+      offset.device().type() == torch::headeronly::DeviceType::MPS,
+      "offset must be a MPS tensor");
+  STD_TORCH_CHECK(
+      mask.device().type() == torch::headeronly::DeviceType::MPS,
+      "mask must be a MPS tensor");
+  STD_TORCH_CHECK(
+      bias.device().type() == torch::headeronly::DeviceType::MPS,
+      "bias must be a MPS tensor");
 
   uint32_t batch = input_c.size(0);
   uint32_t in_channels = input_c.size(1);
@@ -60,89 +161,111 @@ at::Tensor deform_conv2d_forward_kernel(
   uint32_t dilation_h_u = static_cast<uint32_t>(dilation_h);
   uint32_t dilation_w_u = static_cast<uint32_t>(dilation_w);
 
-  TORCH_CHECK(weight_c.size(1) * n_weight_grps == in_channels,
-    "Input channels (", in_channels, 
-    ") must equal weight.size(1) * n_weight_grps (", weight_c.size(1), " * ", n_weight_grps, ")");
-  TORCH_CHECK(weight_c.size(0) % n_weight_grps == 0,
-    "Weight tensor's out channels (", weight_c.size(0), 
-    ") must be divisible by n_weight_grps (", n_weight_grps, ")");
-  TORCH_CHECK(offset_c.size(1) == n_offset_grps * 2 * weight_h * weight_w,
-    "Offset tensor shape[1] is invalid: got ", offset_c.size(1), 
-    ", expected ", n_offset_grps * 2 * weight_h * weight_w);
-  TORCH_CHECK(!use_mask || mask_c.size(1) == n_offset_grps * weight_h * weight_w,
-    "Mask tensor shape[1] is invalid: got ", mask_c.size(1), 
-    ", expected ", n_offset_grps * weight_h * weight_w);
-  TORCH_CHECK(in_channels % n_offset_grps == 0,
-    "Input tensor channels (", in_channels, 
-    ") must be divisible by n_offset_grps (", n_offset_grps, ")");
-  TORCH_CHECK(offset_c.size(0) == batch,
-    "Offset tensor batch size (", offset_c.size(0),
-    ") must match input tensor batch size (", batch, ")");
-  TORCH_CHECK(offset_c.size(2) == out_h && offset_c.size(3) == out_w,
-    "Offset tensor spatial dimensions (", offset_c.size(2), ", ", offset_c.size(3), 
-    ") must match calculated output dimensions (", out_h, ", ", out_w, ")");
-  TORCH_CHECK(!use_mask || mask_c.size(0) == batch,
-    "Mask tensor batch size (", mask_c.size(0),
-    ") must match input tensor batch size (", batch, ")");
-  TORCH_CHECK(!use_mask || (mask_c.size(2) == out_h && mask_c.size(3) == out_w),
-    "Mask tensor spatial dimensions (", mask_c.size(2), ", ", mask_c.size(3),
-    ") must match calculated output dimensions (", out_h, ", ", out_w, ")");
-  TORCH_CHECK(out_h > 0 && out_w > 0,
-    "Calculated output size too small - out_h: ", out_h, " out_w: ", out_w);
+  STD_TORCH_CHECK(
+      weight_c.size(1) * n_weight_grps == in_channels,
+      "Input channels (", in_channels,
+      ") must equal weight.size(1) * n_weight_grps (", weight_c.size(1),
+      " * ", n_weight_grps, ")");
+  STD_TORCH_CHECK(
+      weight_c.size(0) % n_weight_grps == 0,
+      "Weight tensor's out channels (", weight_c.size(0),
+      ") must be divisible by n_weight_grps (", n_weight_grps, ")");
+  STD_TORCH_CHECK(
+      offset_c.size(1) == n_offset_grps * 2 * weight_h * weight_w,
+      "Offset tensor shape[1] is invalid: got ", offset_c.size(1),
+      ", expected ", n_offset_grps * 2 * weight_h * weight_w);
+  STD_TORCH_CHECK(
+      !use_mask || mask_c.size(1) == n_offset_grps * weight_h * weight_w,
+      "Mask tensor shape[1] is invalid: got ", mask_c.size(1),
+      ", expected ", n_offset_grps * weight_h * weight_w);
+  STD_TORCH_CHECK(
+      in_channels % n_offset_grps == 0,
+      "Input tensor channels (", in_channels,
+      ") must be divisible by n_offset_grps (", n_offset_grps, ")");
+  STD_TORCH_CHECK(
+      offset_c.size(0) == batch,
+      "Offset tensor batch size (", offset_c.size(0),
+      ") must match input tensor batch size (", batch, ")");
+  STD_TORCH_CHECK(
+      offset_c.size(2) == out_h && offset_c.size(3) == out_w,
+      "Offset tensor spatial dimensions (", offset_c.size(2), ", ",
+      offset_c.size(3),
+      ") must match calculated output dimensions (", out_h, ", ", out_w, ")");
+  STD_TORCH_CHECK(
+      !use_mask || mask_c.size(0) == batch,
+      "Mask tensor batch size (", mask_c.size(0),
+      ") must match input tensor batch size (", batch, ")");
+  STD_TORCH_CHECK(
+      !use_mask || (mask_c.size(2) == out_h && mask_c.size(3) == out_w),
+      "Mask tensor spatial dimensions (", mask_c.size(2), ", ", mask_c.size(3),
+      ") must match calculated output dimensions (", out_h, ", ", out_w, ")");
+  STD_TORCH_CHECK(
+      out_h > 0 && out_w > 0,
+      "Calculated output size too small - out_h: ", out_h, " out_w: ", out_w);
 
-  auto columns = at::empty({in_channels * weight_h * weight_w, batch * out_h * out_w}, input_c.options());
+  Tensor columns = torch::stable::new_empty(
+      input_c,
+      {static_cast<int64_t>(in_channels) * weight_h * weight_w,
+       static_cast<int64_t>(batch) * out_h * out_w});
 
-  id<MTLBuffer> inputBuffer  = getMTLBufferStorage(input_c);
-  id<MTLBuffer> offsetBuffer = getMTLBufferStorage(offset_c);
-  id<MTLBuffer> maskBuffer   = use_mask ? getMTLBufferStorage(mask_c) : nil;
-  id<MTLBuffer> outputBuffer = getMTLBufferStorage(columns);
+  const std::string kernel = "deformable_im2col_" +
+      std::string(metal_type_string(input.scalar_type()));
+  AOTIMetalKernelFunctionHandle func = nullptr;
+  TORCH_ERROR_CODE_CHECK(aoti_torch_mps_get_kernel_function(
+      deform_conv2d_shader_library(), kernel.c_str(), &func));
 
-  id<MTLDevice> device = MPSDevice::getInstance()->device();
-  std::string kernelName = "deformable_im2col_" + scalarToMetalTypeString(input.scalar_type());
-  id<MTLComputePipelineState> pipelineState = mps::visionPipelineState(device, kernelName);
+  int64_t num_kernels =
+      static_cast<int64_t>(in_channels) * out_h * out_w * batch;
 
-  int num_kernels = in_channels * out_h * out_w * batch;
-  NSUInteger threadsPerThreadgroup = pipelineState.maxTotalThreadsPerThreadgroup;
-  NSUInteger threadgroups = (num_kernels + threadsPerThreadgroup - 1) / threadsPerThreadgroup;
-  MTLSize threadGroupSize = MTLSizeMake(threadsPerThreadgroup, 1, 1);
-  MTLSize threadgroupsPerGrid = MTLSizeMake(threadgroups, 1, 1);
+  DeformConv2dIm2colLaunchArgs launch_args{
+      input_c.get(),
+      offset_c.get(),
+      mask_c.get(),
+      columns.get(),
+      {in_h, in_w},
+      {weight_h, weight_w},
+      {pad_h_u, pad_w_u},
+      {stride_h_u, stride_w_u},
+      {dilation_h_u, dilation_w_u},
+      batch,
+      in_channels,
+      static_cast<uint32_t>(n_offset_grps),
+      {out_h, out_w},
+      use_mask,
+      static_cast<uint64_t>(num_kernels)};
+  TORCH_ERROR_CODE_CHECK(aoti_torch_mps_run_command_block(
+      func, &deform_conv2d_im2col_encode, &launch_args));
 
-  MPSStream* mpsStream = getCurrentMPSStream();
-  dispatch_sync(mpsStream->queue(), ^{
-    @autoreleasepool {
-      id<MTLComputeCommandEncoder> computeEncoder = mpsStream->commandEncoder();
-      [computeEncoder setComputePipelineState:pipelineState];
-      at::native::mps::mtl_setArgs(computeEncoder, inputBuffer, offsetBuffer, maskBuffer,
-                                   std::array<uint32_t, 2>{in_h, in_w},
-                                   std::array<uint32_t, 2>{weight_h, weight_w},
-                                   std::array<uint32_t, 2>{pad_h_u, pad_w_u},
-                                   std::array<uint32_t, 2>{stride_h_u, stride_w_u},
-                                   std::array<uint32_t, 2>{dilation_h_u, dilation_w_u},
-                                   batch, in_channels, n_offset_grps,
-                                   std::array<uint32_t, 2>{out_h, out_w},
-                                   use_mask, outputBuffer);
-      [computeEncoder dispatchThreadgroups:threadgroupsPerGrid threadsPerThreadgroup:threadGroupSize];
-    }
-  });
-  int in_channels_per_grp = in_channels / n_weight_grps;
-  int out_channels_per_grp = out_channels / n_weight_grps;
-  auto weight_grouped = weight_c.view({n_weight_grps, out_channels_per_grp, in_channels_per_grp, weight_h, weight_w});
-  auto columns_grouped = columns.view({n_weight_grps,
-                                      (in_channels * weight_h * weight_w) / n_weight_grps,
-                                      batch * out_h * out_w});
-  auto weight_reshaped = weight_grouped.reshape({n_weight_grps, out_channels_per_grp, -1});
-  auto out_grouped = at::bmm(weight_reshaped, columns_grouped);
-  auto out = out_grouped.reshape({n_weight_grps * out_channels_per_grp, batch, out_h, out_w})
-              .transpose(0, 1);
-  return out + bias_c.view({1, out_channels, 1, 1});
+  int64_t in_channels_per_grp = in_channels / n_weight_grps;
+  int64_t out_channels_per_grp = out_channels / n_weight_grps;
+  Tensor weight_grouped = torch::stable::view(
+      weight_c,
+      {n_weight_grps, out_channels_per_grp, in_channels_per_grp, weight_h,
+       weight_w});
+  Tensor columns_grouped = torch::stable::view(
+      columns,
+      {n_weight_grps,
+       (static_cast<int64_t>(in_channels) * weight_h * weight_w) /
+           n_weight_grps,
+       static_cast<int64_t>(batch) * out_h * out_w});
+  Tensor weight_reshaped = torch::stable::reshape(
+      weight_grouped, {n_weight_grps, out_channels_per_grp, -1});
+  Tensor out_grouped = torch::stable::matmul(weight_reshaped, columns_grouped);
+  Tensor out = torch::stable::transpose(
+      torch::stable::reshape(
+          out_grouped,
+          {n_weight_grps * out_channels_per_grp, batch, out_h, out_w}),
+      0,
+      1);
+  Tensor bias_view = torch::stable::view(
+      bias_c, {1, static_cast<int64_t>(out_channels), 1, 1});
+  return add_tensors(out, bias_view);
 }
 
 } // namespace
 
-TORCH_LIBRARY_IMPL(torchvision, MPS, m) {
-  m.impl(
-      TORCH_SELECTIVE_NAME("torchvision::deform_conv2d"),
-      TORCH_FN(deform_conv2d_forward_kernel));
+STABLE_TORCH_LIBRARY_IMPL(torchvision, MPS, m) {
+  m.impl("deform_conv2d", TORCH_BOX(&deform_conv2d_forward_kernel));
 }
 
 } // namespace ops

--- a/torchvision/csrc/ops/mps/deform_conv2d_metal_shader.h
+++ b/torchvision/csrc/ops/mps/deform_conv2d_metal_shader.h
@@ -1,0 +1,179 @@
+#pragma once
+
+// Metal shader source for the deform_conv2d MPS forward kernel.
+//
+// Carved out of the shared ops/mps/mps_kernels.h (which is still used by the
+// legacy _C ops) so it can be compiled into the stable-ABI _C_stable extension.
+// mps_kernels.h opens with #include <ATen/native/mps/OperationUtils.h> and
+// instantiates at::native::mps::MetalShaderLibrary, both unavailable under
+// -DTORCH_TARGET_VERSION. This header carries only the deformable_im2col Metal
+// source as a plain string, handed to aoti_torch_mps_create_shader_library at
+// runtime, the same shape PyTorch's AOTInductor MPS backend emits.
+
+namespace vision {
+namespace ops {
+
+static const char* deform_conv2d_metal_shader = R"VISION_METAL(
+#include <metal_atomic>
+#include <metal_stdlib>
+using namespace metal;
+
+/*----------Helpers--------*/
+
+template <typename T, typename integer_t>
+inline T bilinear_interpolate_deformable_conv2d(
+    constant T* input,
+    integer_t height,
+    integer_t width,
+    T y,
+    T x,
+    uint index /* index for debug only*/) {
+  if (y <= -1.0 || y >= height || x <= -1.0 || x >= width) {
+    return 0;
+  }
+  integer_t y_low = static_cast<integer_t>(floor(y));
+  integer_t x_low = static_cast<integer_t>(floor(x));
+  integer_t y_high = y_low + 1;
+  integer_t x_high = x_low + 1;
+
+  T ly = y - static_cast<T>(y_low);
+  T lx = x - static_cast<T>(x_low);
+  T hh = 1.0 - ly;
+  T hw = 1.0 - lx;
+
+  T v1 = 0;
+  if (y_low >= 0 && x_low >= 0)
+    v1 = input[y_low * width + x_low];
+  
+  T v2 = 0;
+  if (y_low >= 0 && x_high <= width - 1)
+    v2 = input[y_low * width + x_high];
+  
+  T v3 = 0;
+  if (y_high <= height - 1 && x_low >= 0)
+    v3 = input[y_high * width + x_low];
+  
+  T v4 = 0;
+  if (y_high <= height - 1 && x_high <= width - 1)
+    v4 = input[y_high * width + x_high];
+
+  T w1 = hh * hw;
+  T w2 = hh * lx;
+  T w3 = ly * hw;
+  T w4 = ly * lx;
+
+  T val = w1 * v1 + w2 * v2 + w3 * v3 + w4 * v4;
+  return val;
+}
+
+template<typename T>
+kernel void deformable_im2col_kernel(
+    constant T*           input_ptr     [[ buffer(0) ]],
+    constant T*           offset_ptr    [[ buffer(1) ]],
+    constant T*           mask_ptr      [[ buffer(2) ]],
+    constant int2&        input_size    [[ buffer(3) ]],   // (height, width)
+    constant int2&        weight_size   [[ buffer(4) ]],   // (weight_h, weight_w)
+    constant int2&        pad           [[ buffer(5) ]],   // (pad_h, pad_w)
+    constant int2&        stride        [[ buffer(6) ]],   // (stride_h, stride_w)
+    constant int2&        dilation      [[ buffer(7) ]],   // (dilation_h, dilation_w)
+    constant int&         batch_size    [[ buffer(8) ]],
+    constant int&         n_in_channels [[ buffer(9) ]],
+    constant int&         n_offset_grps [[ buffer(10)]],
+    constant int2&        out_size      [[ buffer(11)]],   // (out_h, out_w)
+    constant bool&        use_mask      [[ buffer(12)]],
+    device T*             columns_ptr   [[ buffer(13)]],
+    uint                  tid           [[ thread_position_in_grid ]],
+    uint                  tpg           [[ threads_per_grid ]]
+)
+{
+    int height = input_size.x, width = input_size.y;
+    int weight_h = weight_size.x, weight_w = weight_size.y;
+    int pad_h = pad.x, pad_w = pad.y;
+    int stride_h = stride.x, stride_w = stride.y;
+    int dilation_h = dilation.x, dilation_w = dilation.y;
+    int out_h = out_size.x, out_w = out_size.y;
+
+    int total = out_w * out_h * batch_size * n_in_channels;
+    if (tid >= total) {
+        return;
+    }
+
+    int out_x = tid % out_w;
+    int out_y = (tid / out_w) % out_h;
+    int out_b = (tid / (out_w * out_h)) % batch_size;
+    int in_c  = tid / (out_w * out_h * batch_size);
+    int out_c = in_c * weight_h * weight_w;
+    
+    int c_per_offset_grp = n_in_channels / n_offset_grps;
+    int grp_idx = in_c / c_per_offset_grp;
+    
+    int col_offset = out_c * (batch_size * out_h * out_w)
+                      + out_b * (out_h * out_w)
+                      + out_y * out_w + out_x;
+    device T* local_columns_ptr = columns_ptr + col_offset;
+    
+    int input_offset = out_b * (n_in_channels * height * width)
+                        + in_c * (height * width);
+    constant T* local_input_ptr = input_ptr + input_offset;
+    
+    int offset_offset = (out_b * n_offset_grps + grp_idx) * 2 * weight_h * weight_w * out_h * out_w;
+    constant T* local_offset_ptr = offset_ptr + offset_offset;
+    
+    constant T* local_mask_ptr = nullptr;
+    if (use_mask) {
+        int mask_offset = (out_b * n_offset_grps + grp_idx) * weight_h * weight_w * out_h * out_w;
+        local_mask_ptr = mask_ptr + mask_offset;
+    }
+    
+    for (int i = 0; i < weight_h; ++i) {
+        for (int j = 0; j < weight_w; ++j) {
+            int mask_index = i * weight_w + j;
+            int offset_index = 2 * mask_index;
+            
+            T mask_value = 1;
+            if (use_mask) {
+                mask_value = local_mask_ptr[mask_index * (out_h * out_w) + out_y * out_w + out_x];
+            }
+            
+            T offset_h_val = local_offset_ptr[offset_index * (out_h * out_w) + out_y * out_w + out_x];
+            T offset_w_val = local_offset_ptr[(offset_index + 1) * (out_h * out_w) + out_y * out_w + out_x];
+            
+            T y = (out_y * stride_h - pad_h) + i * dilation_h + offset_h_val;
+            T x = (out_x * stride_w - pad_w) + j * dilation_w + offset_w_val;
+            
+            T interp = bilinear_interpolate_deformable_conv2d(local_input_ptr, height, width, y, x, tid);
+            
+            *local_columns_ptr = mask_value * interp;
+            
+            local_columns_ptr += batch_size * out_h * out_w;
+        }
+    }
+}
+
+#define REGISTER_DEFORMABLE_IM2COL_OP(DTYPE)                                         \
+template                                                                             \
+[[host_name("deformable_im2col_" #DTYPE)]]                                           \
+kernel void deformable_im2col_kernel<DTYPE>(                                         \
+    constant DTYPE*               input_ptr        [[ buffer(0) ]],                  \
+    constant DTYPE*               offset_ptr       [[ buffer(1) ]],                  \
+    constant DTYPE*               mask_ptr         [[ buffer(2) ]],                  \
+    constant int2&                input_size       [[ buffer(3) ]],   /* (h, w) */   \
+    constant int2&                weight_size      [[ buffer(4) ]],   /* (h, w) */   \
+    constant int2&                pad              [[ buffer(5) ]],   /* (h, w) */   \
+    constant int2&                stride           [[ buffer(6) ]],   /* (h, w) */   \
+    constant int2&                dilation         [[ buffer(7) ]],   /* (h, w) */   \
+    constant int&                 batch_size       [[ buffer(8) ]],                  \
+    constant int&                 n_in_channels    [[ buffer(9) ]],                  \
+    constant int&                 n_offset_grps    [[ buffer(10)]],                  \
+    constant int2&                out_size         [[ buffer(11)]],  /* (h, w) */    \
+    constant bool&                use_mask         [[ buffer(12)]],                  \
+    device DTYPE*                 columns_ptr      [[ buffer(13)]],                  \
+    uint                          tid              [[ thread_position_in_grid ]],    \
+    uint                          tpg              [[ threads_per_grid ]]);
+
+REGISTER_DEFORMABLE_IM2COL_OP(float);
+REGISTER_DEFORMABLE_IM2COL_OP(half);
+)VISION_METAL";
+
+} // namespace ops
+} // namespace vision


### PR DESCRIPTION
## Notes
- Shader source moves to deform_conv2d_metal_shader.h. 
- Stable-ABI is missing aten::add.Tensor, so the bias add goes through subtract(self, other, -1.0). Follows the mm_out helper from the CPU port (#9610).


## Stable-ABI audit ([torch-abi-audit](https://github.com/Quansight/torch-abi-audit))
Ran torch-abi-audit. deform_conv2d's MPS op moves into the fully-STABLE _C_stable.so (unstable=0) and the unstable _C.so count drops, 53 → 44: deform_conv2d was the last MPS consumer of ATen tensor algebra, so its symbols are uniquely retired instead of shared with the still-legacy kernels. This is a macOS arm64 MPS build against a current nightly, so the counts aren't comparable to the 104/70 in the earlier PRs.
```text
    Package: torchvision
      Torch ABI:   UNSTABLE
      CPython ABI: n/a
      Bundled libs: 3
      -- bundled libs --
        [UNSTABLE] [not-abi3] _C.so            (stable_shim=0,  unstable=44)
        [STABLE  ] [not-abi3] _C_stable.so     (stable_shim=78, unstable=0)
        [STABLE  ] [not-abi3] image_stable.so  (stable_shim=70, unstable=0)
```