### PR TITLE
Port ps_roi_align (MPS) to stable ABI.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -175,6 +175,7 @@ STABLE_SOURCES = {
     CSRS_DIR / "ops/cpu/ps_roi_pool_kernel.cpp",
     CSRS_DIR / "ops/ps_roi_align.cpp",
     CSRS_DIR / "ops/cpu/ps_roi_align_kernel.cpp",
+    CSRS_DIR / "ops/mps/ps_roi_align_kernel.mm",
     CSRS_DIR / "ops/deform_conv2d.cpp",
     CSRS_DIR / "ops/cpu/deform_conv2d_kernel.cpp",
 }

--- a/torchvision/_autograd_registrations.py
+++ b/torchvision/_autograd_registrations.py
@@ -87,6 +87,8 @@ def _ps_roi_align_setup_context(ctx, inputs, output):
 
 
 def _ps_roi_align_backward(ctx, grad_output, _grad_channel_mapping):
+    if grad_output.device.type == "mps":
+        torch._prims_common.alert_not_deterministic("ps_roi_align_backward_kernel")
     rois, channel_mapping = ctx.saved_tensors
     batch_size, channels, height, width = ctx.input_shape
     grad_input = torch.ops.torchvision._ps_roi_align_backward(

--- a/torchvision/csrc/ops/mps/ps_roi_align_kernel.mm
+++ b/torchvision/csrc/ops/mps/ps_roi_align_kernel.mm
@@ -1,43 +1,198 @@
-#include <ATen/mps/MPSProfiler.h>
-#include <ATen/native/mps/OperationUtils.h>
-#include "mps_helpers.h"
-#include "mps_kernels.h"
+#include <torch/csrc/inductor/aoti_torch/c/shim_mps.h>
+#include <torch/csrc/stable/c/shim.h>
+#include <torch/csrc/stable/device.h>
+#include <torch/csrc/stable/library.h>
+#include <torch/csrc/stable/ops.h>
+#include <torch/csrc/stable/tensor.h>
+#include <torch/headeronly/core/DeviceType.h>
+#include <torch/headeronly/core/ScalarType.h>
+#include <torch/headeronly/util/Exception.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <string>
+#include <tuple>
+
+#include "ps_roi_align_metal_shader.h"
 
 namespace vision {
 namespace ops {
 
 namespace {
 
-std::tuple<at::Tensor, at::Tensor> ps_roi_align_forward_kernel(const at::Tensor& input,
-                                                               const at::Tensor& rois,
-                                                               double spatial_scale,
-                                                               int64_t pooled_height,
-                                                               int64_t pooled_width,
-                                                               int64_t sampling_ratio) {
-  using namespace at::native::mps;
-  TORCH_CHECK(input.is_mps(), "input must be a MPS tensor");
-  TORCH_CHECK(rois.is_mps(), "rois must be a MPS tensor");
-  TORCH_CHECK(rois.size(1) == 5, "rois must have shape as Tensor[K, 5]");
+using torch::stable::Tensor;
 
-  at::TensorArg input_t{input, "input", 1}, rois_t{rois, "rois", 2};
+constexpr int64_t threadsPerBlock = 512;
 
-  at::CheckedFrom c = "ps_roi_align_forward_kernel";
-  at::checkAllSameGPU(c, {input_t, rois_t});
-  at::checkAllSameType(c, {input_t, rois_t});
+AOTIMetalShaderLibraryHandle ps_roi_align_shader_library() {
+  static AOTIMetalShaderLibraryHandle library = []() {
+    AOTIMetalShaderLibraryHandle handle = nullptr;
+    TORCH_ERROR_CODE_CHECK(aoti_torch_mps_create_shader_library(
+        ps_roi_align_metal_shader, &handle));
+    return handle;
+  }();
+  return library;
+}
+
+const char* metal_type_string(torch::headeronly::ScalarType scalar_type) {
+  if (scalar_type == torch::headeronly::ScalarType::Float) {
+    return "float";
+  }
+  if (scalar_type == torch::headeronly::ScalarType::Half) {
+    return "half";
+  }
+  return "";
+}
+
+struct PsRoiAlignForwardLaunchArgs {
+  AtenTensorHandle input;
+  AtenTensorHandle rois;
+  AtenTensorHandle output;
+  AtenTensorHandle channel_mapping;
+  int64_t output_size;
+  int64_t channels;
+  int64_t height;
+  int64_t width;
+  int64_t pooled_height;
+  int64_t pooled_width;
+  int64_t sampling_ratio;
+  int64_t channels_out;
+  float spatial_scale;
+  uint64_t grid;
+  uint64_t threadgroup;
+};
+
+void ps_roi_align_forward_encode(
+    AOTIMetalKernelFunctionHandle func,
+    void* user_data) {
+  const auto* launch_args =
+      static_cast<const PsRoiAlignForwardLaunchArgs*>(user_data);
+  TORCH_ERROR_CODE_CHECK(aoti_torch_mps_start_encoding(func));
+  // [N, C, H, W]
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_tensor(func, 0, launch_args->input));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_tensor(func, 1, launch_args->rois));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_tensor(func, 2, launch_args->output));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_tensor(func, 3, launch_args->channel_mapping));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_int(func, 4, launch_args->output_size));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_int(func, 5, launch_args->channels));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_int(func, 6, launch_args->height));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_int(func, 7, launch_args->width));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_int(func, 8, launch_args->pooled_height));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_int(func, 9, launch_args->pooled_width));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_int(func, 10, launch_args->sampling_ratio));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_int(func, 11, launch_args->channels_out));
+  TORCH_ERROR_CODE_CHECK(torch_mps_set_arg_bytes(
+      func, 12, &launch_args->spatial_scale, sizeof(float)));
+  TORCH_ERROR_CODE_CHECK(aoti_torch_mps_dispatch_single_with_group_size(
+      func, launch_args->grid, launch_args->threadgroup));
+}
+
+struct PsRoiAlignBackwardLaunchArgs {
+  AtenTensorHandle grad_output;
+  AtenTensorHandle rois;
+  AtenTensorHandle channel_mapping;
+  AtenTensorHandle grad_input;
+  int64_t output_size;
+  int64_t channels;
+  int64_t height;
+  int64_t width;
+  int64_t pooled_height;
+  int64_t pooled_width;
+  int64_t sampling_ratio;
+  int64_t channels_out;
+  float spatial_scale;
+};
+
+void ps_roi_align_backward_encode(
+    AOTIMetalKernelFunctionHandle func,
+    void* user_data) {
+  const auto* launch_args =
+      static_cast<const PsRoiAlignBackwardLaunchArgs*>(user_data);
+  TORCH_ERROR_CODE_CHECK(aoti_torch_mps_start_encoding(func));
+  // [N, C, H, W]
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_tensor(func, 0, launch_args->grad_output));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_tensor(func, 1, launch_args->rois));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_tensor(func, 2, launch_args->channel_mapping));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_tensor(func, 3, launch_args->grad_input));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_int(func, 4, launch_args->output_size));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_int(func, 5, launch_args->channels));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_int(func, 6, launch_args->height));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_int(func, 7, launch_args->width));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_int(func, 8, launch_args->pooled_height));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_int(func, 9, launch_args->pooled_width));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_int(func, 10, launch_args->sampling_ratio));
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_mps_set_arg_int(func, 11, launch_args->channels_out));
+  TORCH_ERROR_CODE_CHECK(torch_mps_set_arg_bytes(
+      func, 12, &launch_args->spatial_scale, sizeof(float)));
+  // One thread per pooled-output element. dispatchThreads guarantees each
+  // index is handled exactly once; the kernel scatters into grad_input with
+  // atomic_add for overlapping RoIs.
+  TORCH_ERROR_CODE_CHECK(aoti_torch_mps_dispatch_single(
+      func, static_cast<uint64_t>(launch_args->output_size)));
+}
+
+std::tuple<Tensor, Tensor> ps_roi_align_forward_kernel(
+    const Tensor& input,
+    const Tensor& rois,
+    double spatial_scale,
+    int64_t pooled_height,
+    int64_t pooled_width,
+    int64_t sampling_ratio) {
+  STD_TORCH_CHECK(
+      input.device().type() == torch::headeronly::DeviceType::MPS,
+      "input must be a MPS tensor");
+  STD_TORCH_CHECK(
+      rois.device().type() == torch::headeronly::DeviceType::MPS,
+      "rois must be a MPS tensor");
+  STD_TORCH_CHECK(rois.size(1) == 5, "rois must have shape as Tensor[K, 5]");
+  STD_TORCH_CHECK(
+      input.get_device_index() == rois.get_device_index(),
+      "input should be on the same device as rois");
+  STD_TORCH_CHECK(
+      input.scalar_type() == rois.scalar_type(),
+      "input should have the same type as rois");
 
   int64_t num_rois = rois.size(0);
   int64_t channels = input.size(1);
   int64_t height = input.size(2);
   int64_t width = input.size(3);
-  float spatial_scale_f = static_cast<float>(spatial_scale);
 
-  TORCH_CHECK(channels % (pooled_height * pooled_width) == 0,
-              "input channels must be a multiple of pooling height * pooling width");
+  STD_TORCH_CHECK(
+      channels % (pooled_height * pooled_width) == 0,
+      "input channels must be a multiple of pooling height * pooling width");
 
   int64_t channels_out = channels / (pooled_height * pooled_width);
 
-  auto output = at::zeros({num_rois, channels_out, pooled_height, pooled_width}, input.options());
-  auto channel_mapping = at::zeros(output.sizes(), input.options().dtype(at::kLong));
+  Tensor output = torch::stable::new_zeros(
+      input, {num_rois, channels_out, pooled_height, pooled_width});
+  Tensor channel_mapping = torch::stable::new_zeros(
+      input,
+      {num_rois, channels_out, pooled_height, pooled_width},
+      torch::headeronly::ScalarType::Long);
 
   int64_t output_size = output.numel();
 
@@ -45,90 +200,78 @@ std::tuple<at::Tensor, at::Tensor> ps_roi_align_forward_kernel(const at::Tensor&
     return std::make_tuple(output, channel_mapping);
   }
 
-  auto input_ = input.contiguous();
-  auto rois_ = rois.contiguous();
-
-  id<MTLBuffer> inputBuffer = getMTLBufferStorage(input_);
-  id<MTLBuffer> roisBuffer = getMTLBufferStorage(rois_);
-  id<MTLBuffer> outputBuffer = getMTLBufferStorage(output);
-  id<MTLBuffer> channelMappingBuffer = getMTLBufferStorage(channel_mapping);
-  id<MTLDevice> device = MPSDevice::getInstance()->device();
-  MPSStream* mpsStream = getCurrentMPSStream();
-  dispatch_sync(mpsStream->queue(), ^() {
-    @autoreleasepool {
-      id<MTLComputeCommandEncoder> computeEncoder = mpsStream->commandEncoder();
-      MTLSize threadgroupsPerGrid = MTLSizeMake(
-          std::min(ceil_div(static_cast<int64_t>(output_size), static_cast<int64_t>(512)), static_cast<int64_t>(4096)),
-          1,
-          1);
-
-      const std::string kernel = "ps_roi_align_" + scalarToMetalTypeString(input.scalar_type());
-      id<MTLComputePipelineState> visionPSO = mps::visionPipelineState(device, kernel);
-
-      // this function call is a no-op if MPS Profiler is not enabled
-      getMPSProfiler().beginProfileKernel(visionPSO, kernel, {input_, rois_}, mpsStream);
-
-      [computeEncoder setComputePipelineState:visionPSO];
-      // [N, C, H, W]
-      [computeEncoder setBuffer:inputBuffer offset:input_.storage_offset() * input_.element_size() atIndex:0];
-      [computeEncoder setBuffer:roisBuffer offset:rois_.storage_offset() * rois_.element_size() atIndex:1];
-      [computeEncoder setBuffer:outputBuffer offset:output.storage_offset() * output.element_size() atIndex:2];
-      [computeEncoder setBuffer:channelMappingBuffer
-                         offset:channel_mapping.storage_offset() * channel_mapping.element_size()
-                        atIndex:3];
-
-      [computeEncoder setBytes:&output_size length:sizeof(int64_t) atIndex:4];
-      [computeEncoder setBytes:&channels length:sizeof(int64_t) atIndex:5];
-      [computeEncoder setBytes:&height length:sizeof(int64_t) atIndex:6];
-      [computeEncoder setBytes:&width length:sizeof(int64_t) atIndex:7];
-      [computeEncoder setBytes:&pooled_height length:sizeof(int64_t) atIndex:8];
-      [computeEncoder setBytes:&pooled_width length:sizeof(int64_t) atIndex:9];
-      [computeEncoder setBytes:&sampling_ratio length:sizeof(int64_t) atIndex:10];
-      [computeEncoder setBytes:&channels_out length:sizeof(int64_t) atIndex:11];
-      [computeEncoder setBytes:&spatial_scale_f length:sizeof(float) atIndex:12];
-
-      // A threadGroup is equivalent to a cuda's block.
-      NSUInteger tgSize = visionPSO.maxTotalThreadsPerThreadgroup;
-      if (tgSize > threadsPerBlock) {
-        tgSize = threadsPerBlock;
-      }
-
-      MTLSize threadGroupSize = MTLSizeMake(tgSize, 1, 1);
-      [computeEncoder dispatchThreadgroups:threadgroupsPerGrid threadsPerThreadgroup:threadGroupSize];
-
-      getMPSProfiler().endProfileKernel(visionPSO, mpsStream);
-    }
-  });
-  return std::make_tuple(output, channel_mapping);
-}
-
-at::Tensor ps_roi_align_backward_kernel(const at::Tensor& grad,
-                                        const at::Tensor& rois,
-                                        const at::Tensor& channel_mapping,
-                                        double spatial_scale,
-                                        int64_t pooled_height,
-                                        int64_t pooled_width,
-                                        int64_t sampling_ratio,
-                                        int64_t batch_size,
-                                        int64_t channels,
-                                        int64_t height,
-                                        int64_t width) {
-  using namespace at::native::mps;
-  TORCH_CHECK(grad.is_mps(), "grad must be a MPS tensor");
-  TORCH_CHECK(rois.is_mps(), "rois must be a MPS tensor");
-  TORCH_CHECK(grad.scalar_type() != at::kHalf, "MPS does not support ps_roi_align backward with float16 inputs.");
-  TORCH_CHECK(channel_mapping.is_mps(), "channel_mapping must be a MPS tensor");
-
-  at::TensorArg grad_t{grad, "input", 1}, rois_t{rois, "rois", 2},
-      channel_mapping_t{channel_mapping, "channel_mapping", 3};
-
-  at::CheckedFrom c = "ps_roi_align_backward_kernel";
-  at::checkAllSameGPU(c, {grad_t, rois_t, channel_mapping_t});
-  at::checkAllSameType(c, {grad_t, rois_t});
+  auto input_ = torch::stable::contiguous(input);
+  auto rois_ = torch::stable::contiguous(rois);
 
   float spatial_scale_f = static_cast<float>(spatial_scale);
 
-  auto grad_input = at::zeros({batch_size, channels, height, width}, grad.options());
+  const std::string kernel =
+      "ps_roi_align_" + std::string(metal_type_string(input.scalar_type()));
+  AOTIMetalKernelFunctionHandle func = nullptr;
+  TORCH_ERROR_CODE_CHECK(aoti_torch_mps_get_kernel_function(
+      ps_roi_align_shader_library(), kernel.c_str(), &func));
+
+  const int64_t threadgroups = std::min(
+      (output_size + threadsPerBlock - 1) / threadsPerBlock,
+      static_cast<int64_t>(4096));
+
+  PsRoiAlignForwardLaunchArgs launch_args{
+      input_.get(),
+      rois_.get(),
+      output.get(),
+      channel_mapping.get(),
+      output_size,
+      channels,
+      height,
+      width,
+      pooled_height,
+      pooled_width,
+      sampling_ratio,
+      channels_out,
+      spatial_scale_f,
+      static_cast<uint64_t>(threadgroups * threadsPerBlock),
+      static_cast<uint64_t>(threadsPerBlock)};
+  TORCH_ERROR_CODE_CHECK(aoti_torch_mps_run_command_block(
+      func, &ps_roi_align_forward_encode, &launch_args));
+  return std::make_tuple(output, channel_mapping);
+}
+
+Tensor ps_roi_align_backward_kernel(
+    const Tensor& grad,
+    const Tensor& rois,
+    const Tensor& channel_mapping,
+    double spatial_scale,
+    int64_t pooled_height,
+    int64_t pooled_width,
+    int64_t sampling_ratio,
+    int64_t batch_size,
+    int64_t channels,
+    int64_t height,
+    int64_t width) {
+  STD_TORCH_CHECK(
+      grad.device().type() == torch::headeronly::DeviceType::MPS,
+      "grad must be a MPS tensor");
+  STD_TORCH_CHECK(
+      rois.device().type() == torch::headeronly::DeviceType::MPS,
+      "rois must be a MPS tensor");
+  STD_TORCH_CHECK(
+      grad.scalar_type() != torch::headeronly::ScalarType::Half,
+      "MPS does not support ps_roi_align backward with float16 inputs.");
+  STD_TORCH_CHECK(
+      channel_mapping.device().type() == torch::headeronly::DeviceType::MPS,
+      "channel_mapping must be a MPS tensor");
+  STD_TORCH_CHECK(
+      grad.get_device_index() == rois.get_device_index(),
+      "grad should be on the same device as rois");
+  STD_TORCH_CHECK(
+      grad.get_device_index() == channel_mapping.get_device_index(),
+      "grad should be on the same device as channel_mapping");
+  STD_TORCH_CHECK(
+      grad.scalar_type() == rois.scalar_type(),
+      "grad should have the same type as rois");
+
+  Tensor grad_input =
+      torch::stable::new_zeros(grad, {batch_size, channels, height, width});
 
   if (grad.numel() == 0) {
     return grad_input;
@@ -137,63 +280,41 @@ at::Tensor ps_roi_align_backward_kernel(const at::Tensor& grad,
   int64_t output_size = grad.numel();
   int64_t channels_out = channels / (pooled_height * pooled_width);
 
-  at::globalContext().alertNotDeterministic("ps_roi_align_backward_kernel");
-  auto grad_ = grad.contiguous(), rois_ = rois.contiguous();
+  auto grad_ = torch::stable::contiguous(grad);
+  auto rois_ = torch::stable::contiguous(rois);
 
-  id<MTLBuffer> inputBuffer = getMTLBufferStorage(grad_);
-  id<MTLBuffer> roisBuffer = getMTLBufferStorage(rois_);
-  id<MTLBuffer> channelMappingBuffer = getMTLBufferStorage(channel_mapping);
-  id<MTLBuffer> outputBuffer = getMTLBufferStorage(grad_input);
-  id<MTLDevice> device = MPSDevice::getInstance()->device();
-  MPSStream* mpsStream = getCurrentMPSStream();
-  dispatch_sync(mpsStream->queue(), ^() {
-    @autoreleasepool {
-      id<MTLComputeCommandEncoder> computeEncoder = mpsStream->commandEncoder();
+  float spatial_scale_f = static_cast<float>(spatial_scale);
 
-      const std::string kernel = "ps_roi_align_backward_" + scalarToMetalTypeString(grad.scalar_type());
-      id<MTLComputePipelineState> visionPSO = mps::visionPipelineState(device, kernel);
+  const std::string kernel = "ps_roi_align_backward_" +
+      std::string(metal_type_string(grad.scalar_type()));
+  AOTIMetalKernelFunctionHandle func = nullptr;
+  TORCH_ERROR_CODE_CHECK(aoti_torch_mps_get_kernel_function(
+      ps_roi_align_shader_library(), kernel.c_str(), &func));
 
-      // this function call is a no-op if MPS Profiler is not enabled
-      getMPSProfiler().beginProfileKernel(visionPSO, kernel, {grad, rois_}, mpsStream);
-
-      [computeEncoder setComputePipelineState:visionPSO];
-      // [N, C, H, W]
-      [computeEncoder setBuffer:inputBuffer offset:grad_.storage_offset() * grad_.element_size() atIndex:0];
-      [computeEncoder setBuffer:roisBuffer offset:rois_.storage_offset() * rois_.element_size() atIndex:1];
-      [computeEncoder setBuffer:channelMappingBuffer
-                         offset:channel_mapping.storage_offset() * channel_mapping.element_size()
-                        atIndex:2];
-      [computeEncoder setBuffer:outputBuffer offset:grad_input.storage_offset() * grad_input.element_size() atIndex:3];
-
-      [computeEncoder setBytes:&output_size length:sizeof(int64_t) atIndex:4];
-      [computeEncoder setBytes:&channels length:sizeof(int64_t) atIndex:5];
-      [computeEncoder setBytes:&height length:sizeof(int64_t) atIndex:6];
-      [computeEncoder setBytes:&width length:sizeof(int64_t) atIndex:7];
-      [computeEncoder setBytes:&pooled_height length:sizeof(int64_t) atIndex:8];
-      [computeEncoder setBytes:&pooled_width length:sizeof(int64_t) atIndex:9];
-      [computeEncoder setBytes:&sampling_ratio length:sizeof(int64_t) atIndex:10];
-      [computeEncoder setBytes:&channels_out length:sizeof(int64_t) atIndex:11];
-      [computeEncoder setBytes:&spatial_scale_f length:sizeof(float) atIndex:12];
-
-      // One thread per pooled-output element. dispatchThreads guarantees each
-      // index is handled exactly once; the kernel scatters into grad_input with
-      // atomic_add for overlapping RoIs.
-      MTLSize threadsPerGrid = MTLSizeMake(output_size, 1, 1);
-      NSUInteger tgSize = std::min(static_cast<int64_t>(visionPSO.maxTotalThreadsPerThreadgroup), output_size);
-      MTLSize threadGroupSize = MTLSizeMake(std::max<NSUInteger>(tgSize, 1), 1, 1);
-      [computeEncoder dispatchThreads:threadsPerGrid threadsPerThreadgroup:threadGroupSize];
-
-      getMPSProfiler().endProfileKernel(visionPSO, mpsStream);
-    }
-  });
+  PsRoiAlignBackwardLaunchArgs launch_args{
+      grad_.get(),
+      rois_.get(),
+      channel_mapping.get(),
+      grad_input.get(),
+      output_size,
+      channels,
+      height,
+      width,
+      pooled_height,
+      pooled_width,
+      sampling_ratio,
+      channels_out,
+      spatial_scale_f};
+  TORCH_ERROR_CODE_CHECK(aoti_torch_mps_run_command_block(
+      func, &ps_roi_align_backward_encode, &launch_args));
   return grad_input;
 }
 
 } // namespace
 
-TORCH_LIBRARY_IMPL(torchvision, MPS, m) {
-  m.impl(TORCH_SELECTIVE_NAME("torchvision::ps_roi_align"), TORCH_FN(ps_roi_align_forward_kernel));
-  m.impl(TORCH_SELECTIVE_NAME("torchvision::_ps_roi_align_backward"), TORCH_FN(ps_roi_align_backward_kernel));
+STABLE_TORCH_LIBRARY_IMPL(torchvision, MPS, m) {
+  m.impl("ps_roi_align", TORCH_BOX(&ps_roi_align_forward_kernel));
+  m.impl("_ps_roi_align_backward", TORCH_BOX(&ps_roi_align_backward_kernel));
 }
 
 } // namespace ops

--- a/torchvision/csrc/ops/mps/ps_roi_align_metal_shader.h
+++ b/torchvision/csrc/ops/mps/ps_roi_align_metal_shader.h
@@ -1,0 +1,384 @@
+#pragma once
+
+// Metal shader source for the ps_roi_align MPS kernels.
+//
+// Carved out of the shared ops/mps/mps_kernels.h (which is still used by the
+// legacy _C ops) so it can be compiled into the stable-ABI _C_stable extension.
+// mps_kernels.h opens with #include <ATen/native/mps/OperationUtils.h> and
+// instantiates at::native::mps::MetalShaderLibrary, both unavailable under
+// -DTORCH_TARGET_VERSION. This header carries only the ps_roi_align Metal
+// source as a plain string, handed to aoti_torch_mps_create_shader_library at
+// runtime, the same shape PyTorch's AOTInductor MPS backend emits.
+
+namespace vision {
+namespace ops {
+
+static const char* ps_roi_align_metal_shader = R"VISION_METAL(
+#include <metal_atomic>
+#include <metal_stdlib>
+using namespace metal;
+
+/*----------Macros----------*/
+
+#define MPS_1D_KERNEL_LOOP_T(i, n, n_tgs, index_t)      \
+  for (index_t i = (tgid.x * tptg.x) + tid2.x; i < (n); \
+       i += (tptg.x * n_tgs))
+
+#define MPS_1D_KERNEL_LOOP(i, n, n_tgs) MPS_1D_KERNEL_LOOP_T(i, n, n_tgs, uint)
+
+/*----------Helpers--------*/
+
+inline void atomic_add_float(device float* data_ptr, const float val)
+{
+  atomic_fetch_add_explicit((device atomic_float*) data_ptr, val, memory_order_relaxed);
+}
+
+
+inline void atomic_add_float(device half* data_ptr, const half val)
+{
+  atomic_fetch_add_explicit((device atomic_float*) data_ptr, static_cast<float>(val), memory_order_relaxed);
+}
+
+template <typename T, typename integer_t>
+inline T bilinear_interpolate(
+    constant T* input,
+    integer_t height,
+    integer_t width,
+    T y,
+    T x,
+    uint index /* index for debug only*/) {
+  // deal with cases that inverse elements are out of feature map boundary
+  if (y < -1.0 || y > height || x < -1.0 || x > width) {
+    // empty
+    return 0;
+  }
+
+  if (y <= 0)
+    y = 0;
+  if (x <= 0)
+    x = 0;
+
+  integer_t y_low = (integer_t)y;
+  integer_t x_low = (integer_t)x;
+  integer_t y_high;
+  integer_t x_high;
+
+  if (y_low >= height - 1) {
+    y_high = y_low = height - 1;
+    y = (T)y_low;
+  } else {
+    y_high = y_low + 1;
+  }
+
+  if (x_low >= width - 1) {
+    x_high = x_low = width - 1;
+    x = (T)x_low;
+  } else {
+    x_high = x_low + 1;
+  }
+
+  T ly = y - y_low;
+  T lx = x - x_low;
+  T hy = 1. - ly, hx = 1. - lx;
+
+  // do bilinear interpolation
+  T v1 = input[y_low * width + x_low];
+  T v2 = input[y_low * width + x_high];
+  T v3 = input[y_high * width + x_low];
+  T v4 = input[y_high * width + x_high];
+  T w1 = hy * hx, w2 = hy * lx, w3 = ly * hx, w4 = ly * lx;
+
+  T val = (w1 * v1 + w2 * v2 + w3 * v3 + w4 * v4);
+
+  return val;
+}
+
+template <typename T, typename integer_t>
+inline void bilinear_interpolate_gradient(
+    integer_t height,
+    integer_t width,
+    T y,
+    T x,
+    thread T& w1,
+    thread T& w2,
+    thread T& w3,
+    thread T& w4,
+    thread integer_t& x_low,
+    thread integer_t& x_high,
+    thread integer_t& y_low,
+    thread integer_t& y_high,
+    uint index /* index for debug only*/) {
+  // deal with cases that inverse elements are out of feature map boundary
+  if (y < -1.0 || y > height || x < -1.0 || x > width) {
+    // empty
+    w1 = w2 = w3 = w4 = 0.;
+    x_low = x_high = y_low = y_high = -1;
+    return;
+  }
+
+  if (y <= 0)
+    y = 0;
+  if (x <= 0)
+    x = 0;
+
+  y_low = (integer_t)y;
+  x_low = (integer_t)x;
+
+  if (y_low >= height - 1) {
+    y_high = y_low = height - 1;
+    y = (T)y_low;
+  } else {
+    y_high = y_low + 1;
+  }
+
+  if (x_low >= width - 1) {
+    x_high = x_low = width - 1;
+    x = (T)x_low;
+  } else {
+    x_high = x_low + 1;
+  }
+
+  T ly = y - y_low;
+  T lx = x - x_low;
+  T hy = 1. - ly, hx = 1. - lx;
+
+  // reference in forward
+  // T v1 = input[y_low * width + x_low];
+  // T v2 = input[y_low * width + x_high];
+  // T v3 = input[y_high * width + x_low];
+  // T v4 = input[y_high * width + x_high];
+  // T val = (w1 * v1 + w2 * v2 + w3 * v3 + w4 * v4);
+
+  w1 = hy * hx, w2 = hy * lx, w3 = ly * hx, w4 = ly * lx;
+}
+
+template<typename T, typename integer_t>
+kernel void ps_roi_align(
+    constant T       * input           [[buffer(0)]],
+    constant T       * rois            [[buffer(1)]],
+    device   T       * output          [[buffer(2)]],
+    device   int64_t * channel_mapping [[buffer(3)]],
+    constant int64_t & output_size     [[buffer(4)]],
+    constant int64_t & channels        [[buffer(5)]],
+    constant int64_t & height          [[buffer(6)]],
+    constant int64_t & width           [[buffer(7)]],
+    constant int64_t & pooled_height   [[buffer(8)]],
+    constant int64_t & pooled_width    [[buffer(9)]],
+    constant int64_t & sampling_ratio  [[buffer(10)]],
+    constant int64_t & channels_out    [[buffer(11)]],
+    constant float   & spatial_scale   [[buffer(12)]],
+    uint2     tgid   [[threadgroup_position_in_grid]],
+    uint2     tptg   [[threads_per_threadgroup]],
+    uint2     tid2   [[thread_position_in_threadgroup]]){
+  MPS_1D_KERNEL_LOOP(index, output_size, 1) {
+    // (n, c_out, ph, pw) is an element in the pooled output
+    integer_t pw = index % pooled_width;
+    integer_t ph = (index / pooled_width) % pooled_height;
+    integer_t c_out = (index / pooled_width / pooled_height) % channels_out;
+    integer_t n = index / pooled_width / pooled_height / channels_out;
+
+    // (n, c_in, ph, pw) is the associated element in the input
+    integer_t c_in = (c_out * pooled_height + ph) * pooled_width + pw;
+
+    // [start, end) interval for spatial sampling
+    constant T* offset_rois = rois + n * 5;
+    integer_t roi_batch_ind = offset_rois[0];
+
+    // Do not using rounding; this implementation detail is critical
+    T roi_start_w = offset_rois[1] * spatial_scale - static_cast<T>(0.5);
+    T roi_start_h = offset_rois[2] * spatial_scale - static_cast<T>(0.5);
+    T roi_end_w = offset_rois[3] * spatial_scale - static_cast<T>(0.5);
+    T roi_end_h = offset_rois[4] * spatial_scale - static_cast<T>(0.5);
+
+    T roi_width = roi_end_w - roi_start_w;
+    T roi_height = roi_end_h - roi_start_h;
+    T bin_size_h = static_cast<T>(roi_height) / static_cast<T>(pooled_height);
+    T bin_size_w = static_cast<T>(roi_width) / static_cast<T>(pooled_width);
+
+    // Do not using floor/ceil; this implementation detail is critical
+    T hstart = static_cast<T>(ph) * bin_size_h + roi_start_h;
+    T wstart = static_cast<T>(pw) * bin_size_w + roi_start_w;
+
+    // We use roi_bin_grid to sample the grid and mimic integral
+    integer_t roi_bin_grid_h = (sampling_ratio > 0)
+        ? sampling_ratio
+        : ceil(roi_height / pooled_height);
+    integer_t roi_bin_grid_w =
+        (sampling_ratio > 0) ? sampling_ratio : ceil(roi_width / pooled_width);
+    const T count = roi_bin_grid_h * roi_bin_grid_w;
+
+    constant T* offset_input =
+        input + (roi_batch_ind * channels + c_in) * height * width;
+    T out_sum = 0;
+    for (integer_t iy = 0; iy < roi_bin_grid_h; iy++) {
+      const T y = hstart +
+          static_cast<T>(iy + .5f) * bin_size_h /
+              static_cast<T>(roi_bin_grid_h);
+      for (integer_t ix = 0; ix < roi_bin_grid_w; ix++) {
+        const T x = wstart +
+            static_cast<T>(ix + .5f) * bin_size_w /
+                static_cast<T>(roi_bin_grid_w);
+        T val = bilinear_interpolate(offset_input, height, width, y, x, index);
+        out_sum += val;
+      }
+    }
+
+    out_sum /= count;
+    output[index] = out_sum;
+    channel_mapping[index] = c_in;
+  }
+}
+
+#define REGISTER_PS_ROI_ALIGN_OP(DTYPE, INT_DTYPE)      \
+template                                                \
+[[host_name("ps_roi_align_" #DTYPE)]]                   \
+kernel void ps_roi_align<DTYPE, INT_DTYPE>(             \
+  constant DTYPE   * input           [[buffer(0)]],     \
+  constant DTYPE   * rois            [[buffer(1)]],     \
+  device   DTYPE   * output          [[buffer(2)]],     \
+  device   int64_t * channel_mapping [[buffer(3)]],     \
+  constant int64_t & output_size     [[buffer(4)]],     \
+  constant int64_t & channels        [[buffer(5)]],     \
+  constant int64_t & height          [[buffer(6)]],     \
+  constant int64_t & width           [[buffer(7)]],     \
+  constant int64_t & pooled_height   [[buffer(8)]],     \
+  constant int64_t & pooled_width    [[buffer(9)]],     \
+  constant int64_t & sampling_ratio  [[buffer(10)]],    \
+  constant int64_t & channels_out    [[buffer(11)]],    \
+  constant float   & spatial_scale   [[buffer(12)]],    \
+  uint2     tgid   [[threadgroup_position_in_grid]],    \
+  uint2     tptg   [[threads_per_threadgroup]],         \
+  uint2     tid2   [[thread_position_in_threadgroup]]);
+
+template<typename T, typename integer_t>
+kernel void ps_roi_align_backward(
+    constant T       * grad_output     [[buffer(0)]],
+    constant T       * rois            [[buffer(1)]],
+    constant int64_t * channel_mapping [[buffer(2)]],
+    device   T       * grad_input      [[buffer(3)]],
+    constant int64_t & output_size     [[buffer(4)]],
+    constant int64_t & channels        [[buffer(5)]],
+    constant int64_t & height          [[buffer(6)]],
+    constant int64_t & width           [[buffer(7)]],
+    constant int64_t & pooled_height   [[buffer(8)]],
+    constant int64_t & pooled_width    [[buffer(9)]],
+    constant int64_t & sampling_ratio  [[buffer(10)]],
+    constant int64_t & channels_out    [[buffer(11)]],
+    constant float   & spatial_scale   [[buffer(12)]],
+    uint     index   [[thread_position_in_grid]]){
+
+  // One thread per pooled-output element. Dispatched via dispatchThreads, so
+  // each element is processed exactly once; redundant passes would otherwise
+  // be silently summed by the atomic_add below (overlapping RoIs share pixels).
+  if (index >= static_cast<uint>(output_size)) {
+    return;
+  }
+  {
+    // (n, *, ph, pw) is an element in the pooled output
+    integer_t pw = index % pooled_width;
+    integer_t ph = (index / pooled_width) % pooled_height;
+    integer_t n = index / pooled_width / pooled_height / channels_out;
+
+    constant T* offset_rois = rois + n * 5;
+    integer_t roi_batch_ind = offset_rois[0];
+
+    // Do not using rounding; this implementation detail is critical
+    T roi_start_w = offset_rois[1] * spatial_scale - static_cast<T>(0.5);
+    T roi_start_h = offset_rois[2] * spatial_scale - static_cast<T>(0.5);
+    T roi_end_w = offset_rois[3] * spatial_scale - static_cast<T>(0.5);
+    T roi_end_h = offset_rois[4] * spatial_scale - static_cast<T>(0.5);
+
+    // Force too small ROIs to be 1x1
+    T roi_width = roi_end_w - roi_start_w;
+    T roi_height = roi_end_h - roi_start_h;
+    T bin_size_h = roi_height / static_cast<T>(pooled_height);
+    T bin_size_w = roi_width / static_cast<T>(pooled_width);
+
+    integer_t c_in = channel_mapping[index];
+
+    // Do not using floor/ceil; this implementation detail is critical
+    T hstart = static_cast<T>(ph) * bin_size_h + roi_start_h;
+    T wstart = static_cast<T>(pw) * bin_size_w + roi_start_w;
+
+    const T grad_output_this_bin = grad_output[index];
+
+    // We use roi_bin_grid to sample the grid and mimic integral
+    integer_t roi_bin_grid_h = (sampling_ratio > 0)
+        ? sampling_ratio
+        : ceil(roi_height / pooled_height); // e.g., = 2
+    integer_t roi_bin_grid_w =
+        (sampling_ratio > 0) ? sampling_ratio : ceil(roi_width / pooled_width);
+    const T count = roi_bin_grid_h * roi_bin_grid_w;
+
+    const integer_t offset = (roi_batch_ind * channels + c_in) * height * width;
+
+    for (integer_t iy = 0; iy < roi_bin_grid_h; iy++) {
+      const T y = hstart +
+          static_cast<T>(iy + .5f) * bin_size_h /
+              static_cast<T>(roi_bin_grid_h);
+      for (integer_t ix = 0; ix < roi_bin_grid_w; ix++) {
+        const T x = wstart +
+            static_cast<T>(ix + .5f) * bin_size_w /
+                static_cast<T>(roi_bin_grid_w);
+
+        T w1, w2, w3, w4;
+        integer_t x_low, x_high, y_low, y_high;
+
+        bilinear_interpolate_gradient(
+            height,
+            width,
+            y,
+            x,
+            w1,
+            w2,
+            w3,
+            w4,
+            x_low,
+            x_high,
+            y_low,
+            y_high,
+            index);
+
+        T g1 = grad_output_this_bin * w1 / count;
+        T g2 = grad_output_this_bin * w2 / count;
+        T g3 = grad_output_this_bin * w3 / count;
+        T g4 = grad_output_this_bin * w4 / count;
+
+        if (x_low >= 0 && x_high >= 0 && y_low >= 0 && y_high >= 0) {
+          atomic_add_float(grad_input + offset + y_low * width + x_low, static_cast<T>(g1));
+          atomic_add_float(grad_input + offset + y_low * width + x_high, static_cast<T>(g2));
+          atomic_add_float(grad_input + offset + y_high * width + x_low, static_cast<T>(g3));
+          atomic_add_float(grad_input + offset + y_high * width + x_high, static_cast<T>(g4));
+        } // if
+      } // ix
+    } // iy
+  }
+}
+
+#define REGISTER_PS_ROI_ALIGN_BACKWARD_OP(DTYPE, INT_DTYPE)   \
+template                                                      \
+[[host_name("ps_roi_align_backward_" #DTYPE)]]                \
+kernel void ps_roi_align_backward<DTYPE, INT_DTYPE>(          \
+    constant DTYPE   * grad_output     [[buffer(0)]],         \
+    constant DTYPE   * rois            [[buffer(1)]],         \
+    constant int64_t * channel_mapping [[buffer(2)]],         \
+    device   DTYPE   * grad_input      [[buffer(3)]],         \
+    constant int64_t & output_size     [[buffer(4)]],         \
+    constant int64_t & channels        [[buffer(5)]],         \
+    constant int64_t & height          [[buffer(6)]],         \
+    constant int64_t & width           [[buffer(7)]],         \
+    constant int64_t & pooled_height   [[buffer(8)]],         \
+    constant int64_t & pooled_width    [[buffer(9)]],         \
+    constant int64_t & sampling_ratio  [[buffer(10)]],        \
+    constant int64_t & channels_out    [[buffer(11)]],        \
+    constant float   & spatial_scale   [[buffer(12)]],        \
+    uint     index   [[thread_position_in_grid]]);
+
+REGISTER_PS_ROI_ALIGN_OP(float, int64_t);
+REGISTER_PS_ROI_ALIGN_OP(half, int64_t);
+REGISTER_PS_ROI_ALIGN_BACKWARD_OP(float, int64_t);
+REGISTER_PS_ROI_ALIGN_BACKWARD_OP(half, int64_t);
+)VISION_METAL";
+
+} // namespace ops
+} // namespace vision


### PR DESCRIPTION
Ports ps_roi_align's MPS kernels to the stable ABI.

## Notes
- Shader source moves to ps_roi_align_metal_shader.h.
- The MPS backward accumulates with atomic_add, so it is nondeterministic and has to say so when torch.use_deterministic_algorithms(True) is set, follows the roi_align port (#9612).


## Stable-ABI audit ([torch-abi-audit](https://github.com/Quansight/torch-abi-audit))
Ran torch-abi-audit. ps_roi_align's MPS op moves into the fully-STABLE _C_stable.so and pulls in no new shim symbols. The unstable _C.so count is unchanged at 53: ps_roi_align's MPS sources shared their unstable-API surface with the still-legacy kernels, so no symbol is removed until those migrate. 

```text
    Package: torchvision
      Torch ABI:   UNSTABLE
      CPython ABI: n/a
      Bundled libs: 3
      -- bundled libs --
        [UNSTABLE] [not-abi3] _C.so            (stable_shim=0,  unstable=53)
        [STABLE  ] [not-abi3] _C_stable.so     (stable_shim=78, unstable=0)
        [STABLE  ] [not-abi3] image_stable.so  (stable_shim=70, unstable=0)
```
