### PR TITLE
Port ps_roi_pool (CUDA) to stable ABI. 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,7 @@ set(TORCHVISION_STABLE_SOURCES
   ${TVCPP}/ops/cuda/roi_pool_kernel.cu
   ${TVCPP}/ops/ps_roi_pool.cpp
   ${TVCPP}/ops/cpu/ps_roi_pool_kernel.cpp
+  ${TVCPP}/ops/cuda/ps_roi_pool_kernel.cu
   ${TVCPP}/ops/ps_roi_align.cpp
   ${TVCPP}/ops/cpu/ps_roi_align_kernel.cpp
   ${TVCPP}/ops/deform_conv2d.cpp

--- a/setup.py
+++ b/setup.py
@@ -187,6 +187,7 @@ STABLE_SOURCES.add(
 )
 STABLE_SOURCES.add(CSRS_DIR / ("ops/hip/roi_pool_kernel.hip" if IS_ROCM else "ops/cuda/roi_pool_kernel.cu"))
 STABLE_SOURCES.add(CSRS_DIR / ("ops/hip/roi_align_kernel.hip" if IS_ROCM else "ops/cuda/roi_align_kernel.cu"))
+STABLE_SOURCES.add(CSRS_DIR / ("ops/hip/ps_roi_pool_kernel.hip" if IS_ROCM else "ops/cuda/ps_roi_pool_kernel.cu"))
 
 
 def _not_stable(paths):

--- a/torchvision/_autograd_registrations.py
+++ b/torchvision/_autograd_registrations.py
@@ -119,7 +119,7 @@ def _ps_roi_pool_setup_context(ctx, inputs, output):
 
 
 def _ps_roi_pool_backward(ctx, grad_output, _grad_channel_mapping):
-    if grad_output.device.type == "mps":
+    if grad_output.device.type in ("cuda", "mps"):
         torch._prims_common.alert_not_deterministic("ps_roi_pool_backward_kernel")
     rois, channel_mapping = ctx.saved_tensors
     batch_size, channels, height, width = ctx.input_shape

--- a/torchvision/csrc/ops/cuda/ps_roi_pool_kernel.cu
+++ b/torchvision/csrc/ops/cuda/ps_roi_pool_kernel.cu
@@ -1,8 +1,18 @@
-#include <ATen/ATen.h>
-#include <ATen/cuda/CUDAContext.h>
-#include <c10/cuda/CUDAGuard.h>
-#include <torch/library.h>
-#include <ATen/native/cuda/KernelUtils.cuh>
+#include <torch/csrc/inductor/aoti_torch/c/shim.h>
+#include <torch/csrc/stable/accelerator.h>
+#include <torch/csrc/stable/library.h>
+#include <torch/csrc/stable/macros.h>
+#include <torch/csrc/stable/ops.h>
+#include <torch/csrc/stable/tensor.h>
+#include <torch/headeronly/core/Dispatch_v2.h>
+#include <torch/headeronly/core/ScalarType.h>
+#include <torch/headeronly/cuda/KernelUtils.h>
+#include <torch/headeronly/util/Exception.h>
+
+#include <cuda_runtime.h>
+
+#include <algorithm>
+#include <tuple>
 
 #include "cuda_helpers.h"
 
@@ -10,6 +20,8 @@ namespace vision {
 namespace ops {
 
 namespace {
+
+using torch::stable::Tensor;
 
 template <typename T>
 __global__ void ps_roi_pool_forward_kernel_impl(
@@ -132,86 +144,171 @@ __global__ void ps_roi_pool_backward_kernel_impl(
     for (int h = hstart; h < hend; ++h) {
       for (int w = wstart; w < wend; ++w) {
         int grad_input_index = h * width + w;
-        at::native::fastAtomicAdd(
+        torch::headeronly::fastAtomicAdd(
             grad_input, offset + grad_input_index, memory_span, diff_val, true);
       }
     }
   }
 }
 
-std::tuple<at::Tensor, at::Tensor> ps_roi_pool_forward_kernel(
-    const at::Tensor& input,
-    const at::Tensor& rois,
+// THO_DISPATCH_V2 splits its body on commas outside parens. The commas in
+// kernel<<<grid, block, 0, stream>>> would break it, so it goes through this
+// wrapper.
+template <typename scalar_t>
+void launch_ps_roi_pool_forward_kernel_impl(
+    dim3 grid,
+    dim3 block,
+    cudaStream_t stream,
+    int nthreads,
+    const scalar_t* input,
+    const scalar_t spatial_scale,
+    int channels,
+    int height,
+    int width,
+    int pooled_height,
+    int pooled_width,
+    const scalar_t* rois,
+    int channels_out,
+    scalar_t* output,
+    int* channel_mapping) {
+  ps_roi_pool_forward_kernel_impl<scalar_t><<<grid, block, 0, stream>>>(
+      nthreads,
+      input,
+      spatial_scale,
+      channels,
+      height,
+      width,
+      pooled_height,
+      pooled_width,
+      rois,
+      channels_out,
+      output,
+      channel_mapping);
+}
+
+template <typename scalar_t>
+void launch_ps_roi_pool_backward_kernel_impl(
+    dim3 grid,
+    dim3 block,
+    cudaStream_t stream,
+    int nthreads,
+    const scalar_t* grad_output,
+    const int* channel_mapping,
+    int num_rois,
+    const scalar_t spatial_scale,
+    int channels,
+    int height,
+    int width,
+    int pooled_height,
+    int pooled_width,
+    int channels_out,
+    scalar_t* grad_input,
+    const scalar_t* rois,
+    const int memory_span) {
+  ps_roi_pool_backward_kernel_impl<scalar_t><<<grid, block, 0, stream>>>(
+      nthreads,
+      grad_output,
+      channel_mapping,
+      num_rois,
+      spatial_scale,
+      channels,
+      height,
+      width,
+      pooled_height,
+      pooled_width,
+      channels_out,
+      grad_input,
+      rois,
+      memory_span);
+}
+
+std::tuple<Tensor, Tensor> ps_roi_pool_forward_kernel(
+    const Tensor& input,
+    const Tensor& rois,
     double spatial_scale,
     int64_t pooled_height,
     int64_t pooled_width) {
   // Check if input tensors are CUDA tensors
-  TORCH_CHECK(input.is_cuda(), "input must be a CUDA tensor");
-  TORCH_CHECK(rois.is_cuda(), "rois must be a CUDA tensor");
-  TORCH_CHECK(
+  STD_TORCH_CHECK(input.is_cuda(), "input must be a CUDA tensor");
+  STD_TORCH_CHECK(rois.is_cuda(), "rois must be a CUDA tensor");
+  STD_TORCH_CHECK(
       rois.size(1) == 5, "Tensor rois should have shape as Tensor[K, 5]");
+  STD_TORCH_CHECK(
+      input.get_device_index() == rois.get_device_index(),
+      "input should be on the same device as rois");
+  STD_TORCH_CHECK(
+      input.scalar_type() == rois.scalar_type(),
+      "input should have the same type as rois");
 
-  at::TensorArg input_t{input, "input", 1}, rois_t{rois, "rois", 2};
-
-  at::CheckedFrom c = "ps_roi_pool_forward_kernel";
-  at::checkAllSameGPU(c, {input_t, rois_t});
-  at::checkAllSameType(c, {input_t, rois_t});
-
-  at::cuda::CUDAGuard device_guard(input.device());
+  torch::stable::accelerator::DeviceGuard device_guard(
+      input.get_device_index());
 
   auto num_rois = rois.size(0);
   auto channels = input.size(1);
   auto height = input.size(2);
   auto width = input.size(3);
 
-  TORCH_CHECK(
+  STD_TORCH_CHECK(
       channels % (pooled_height * pooled_width) == 0,
       "input channels must be a multiple of pooling height * pooling width");
   int channels_out = channels / (pooled_height * pooled_width);
 
-  auto output = at::zeros(
-      {num_rois, channels_out, pooled_height, pooled_width}, input.options());
-  auto channel_mapping =
-      at::zeros(output.sizes(), input.options().dtype(at::kInt));
+  Tensor output = torch::stable::new_zeros(
+      input, {num_rois, channels_out, pooled_height, pooled_width});
+  Tensor channel_mapping = torch::stable::new_zeros(
+      input,
+      {num_rois, channels_out, pooled_height, pooled_width},
+      torch::headeronly::ScalarType::Int);
 
   auto output_size = output.numel();
   if (output_size == 0) {
-    AT_CUDA_CHECK(cudaGetLastError());
+    STD_CUDA_KERNEL_LAUNCH_CHECK();
     return std::make_tuple(output, channel_mapping);
   }
 
-  cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  void* stream_ptr = nullptr;
+  TORCH_ERROR_CODE_CHECK(aoti_torch_get_current_cuda_stream(
+      input.get_device_index(), &stream_ptr));
+  cudaStream_t stream = static_cast<cudaStream_t>(stream_ptr);
 
   dim3 grid(std::min(
       ceil_div(static_cast<int64_t>(output_size), static_cast<int64_t>(512)),
       static_cast<int64_t>(4096)));
   dim3 block(512);
 
-  auto input_ = input.contiguous(), rois_ = rois.contiguous();
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-      input.scalar_type(), "ps_roi_pool_forward_kernel", [&] {
-        ps_roi_pool_forward_kernel_impl<scalar_t><<<grid, block, 0, stream>>>(
+  auto input_ = torch::stable::contiguous(input);
+  auto rois_ = torch::stable::contiguous(rois);
+  THO_DISPATCH_V2(
+      input.scalar_type(),
+      "ps_roi_pool_forward_kernel",
+      AT_WRAP([&]() {
+        launch_ps_roi_pool_forward_kernel_impl<scalar_t>(
+            grid,
+            block,
+            stream,
             output_size,
-            input_.data_ptr<scalar_t>(),
+            input_.const_data_ptr<scalar_t>(),
             spatial_scale,
             channels,
             height,
             width,
             pooled_height,
             pooled_width,
-            rois_.data_ptr<scalar_t>(),
+            rois_.const_data_ptr<scalar_t>(),
             channels_out,
-            output.data_ptr<scalar_t>(),
-            channel_mapping.data_ptr<int>());
-      });
-  AT_CUDA_CHECK(cudaGetLastError());
+            output.mutable_data_ptr<scalar_t>(),
+            channel_mapping.mutable_data_ptr<int>());
+      }),
+      AT_EXPAND(AT_FLOATING_TYPES),
+      torch::headeronly::ScalarType::Half);
+  STD_CUDA_KERNEL_LAUNCH_CHECK();
   return std::make_tuple(output, channel_mapping);
 }
 
-at::Tensor ps_roi_pool_backward_kernel(
-    const at::Tensor& grad,
-    const at::Tensor& rois,
-    const at::Tensor& channel_mapping,
+Tensor ps_roi_pool_backward_kernel(
+    const Tensor& grad,
+    const Tensor& rois,
+    const Tensor& channel_mapping,
     double spatial_scale,
     int64_t pooled_height,
     int64_t pooled_width,
@@ -220,25 +317,30 @@ at::Tensor ps_roi_pool_backward_kernel(
     int64_t height,
     int64_t width) {
   // Check if input tensors are CUDA tensors
-  TORCH_CHECK(grad.is_cuda(), "grad must be a CUDA tensor");
-  TORCH_CHECK(rois.is_cuda(), "rois must be a CUDA tensor");
-  TORCH_CHECK(
+  STD_TORCH_CHECK(grad.is_cuda(), "grad must be a CUDA tensor");
+  STD_TORCH_CHECK(rois.is_cuda(), "rois must be a CUDA tensor");
+  STD_TORCH_CHECK(
       channel_mapping.is_cuda(), "channel_mapping must be a CUDA tensor");
+  STD_TORCH_CHECK(
+      grad.get_device_index() == rois.get_device_index(),
+      "grad should be on the same device as rois");
+  STD_TORCH_CHECK(
+      grad.get_device_index() == channel_mapping.get_device_index(),
+      "grad should be on the same device as channel_mapping");
+  STD_TORCH_CHECK(
+      grad.scalar_type() == rois.scalar_type(),
+      "grad should have the same type as rois");
 
-  at::TensorArg grad_t{grad, "grad", 1}, rois_t{rois, "rois", 2},
-      channel_mapping_t{channel_mapping, "channel_mapping", 3};
-
-  at::CheckedFrom c = "ps_roi_pool_backward_kernel";
-  at::checkAllSameGPU(c, {grad_t, rois_t, channel_mapping_t});
-  at::checkAllSameType(c, {grad_t, rois_t});
-
-  at::cuda::CUDAGuard device_guard(grad.device());
+  torch::stable::accelerator::DeviceGuard device_guard(grad.get_device_index());
 
   auto num_rois = rois.size(0);
-  auto grad_input =
-      at::zeros({batch_size, channels, height, width}, grad.options());
+  Tensor grad_input =
+      torch::stable::new_zeros(grad, {batch_size, channels, height, width});
 
-  cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  void* stream_ptr = nullptr;
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_get_current_cuda_stream(grad.get_device_index(), &stream_ptr));
+  cudaStream_t stream = static_cast<cudaStream_t>(stream_ptr);
 
   dim3 grid(std::min(
       ceil_div(static_cast<int64_t>(grad.numel()), static_cast<int64_t>(512)),
@@ -247,21 +349,25 @@ at::Tensor ps_roi_pool_backward_kernel(
 
   // handle possibly empty gradients
   if (grad.numel() == 0) {
-    AT_CUDA_CHECK(cudaGetLastError());
+    STD_CUDA_KERNEL_LAUNCH_CHECK();
     return grad_input;
   }
 
   int channels_out = channels / (pooled_height * pooled_width);
 
-  at::globalContext().alertNotDeterministic("ps_roi_pool_backward_kernel");
-
-  auto grad_ = grad.contiguous(), rois_ = rois.contiguous();
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-      grad.scalar_type(), "ps_roi_pool_backward_kernel", [&] {
-        ps_roi_pool_backward_kernel_impl<scalar_t><<<grid, block, 0, stream>>>(
+  auto grad_ = torch::stable::contiguous(grad);
+  auto rois_ = torch::stable::contiguous(rois);
+  THO_DISPATCH_V2(
+      grad.scalar_type(),
+      "ps_roi_pool_backward_kernel",
+      AT_WRAP([&]() {
+        launch_ps_roi_pool_backward_kernel_impl<scalar_t>(
+            grid,
+            block,
+            stream,
             grad.numel(),
-            grad_.data_ptr<scalar_t>(),
-            channel_mapping.data_ptr<int>(),
+            grad_.const_data_ptr<scalar_t>(),
+            channel_mapping.const_data_ptr<int>(),
             num_rois,
             spatial_scale,
             channels,
@@ -270,23 +376,21 @@ at::Tensor ps_roi_pool_backward_kernel(
             pooled_height,
             pooled_width,
             channels_out,
-            grad_input.data_ptr<scalar_t>(),
-            rois_.data_ptr<scalar_t>(),
+            grad_input.mutable_data_ptr<scalar_t>(),
+            rois_.const_data_ptr<scalar_t>(),
             grad_input.numel());
-      });
-  AT_CUDA_CHECK(cudaGetLastError());
+      }),
+      AT_EXPAND(AT_FLOATING_TYPES),
+      torch::headeronly::ScalarType::Half);
+  STD_CUDA_KERNEL_LAUNCH_CHECK();
   return grad_input;
 }
 
 } // namespace
 
-TORCH_LIBRARY_IMPL(torchvision, CUDA, m) {
-  m.impl(
-      TORCH_SELECTIVE_NAME("torchvision::ps_roi_pool"),
-      TORCH_FN(ps_roi_pool_forward_kernel));
-  m.impl(
-      TORCH_SELECTIVE_NAME("torchvision::_ps_roi_pool_backward"),
-      TORCH_FN(ps_roi_pool_backward_kernel));
+STABLE_TORCH_LIBRARY_IMPL(torchvision, CUDA, m) {
+  m.impl("ps_roi_pool", TORCH_BOX(&ps_roi_pool_forward_kernel));
+  m.impl("_ps_roi_pool_backward", TORCH_BOX(&ps_roi_pool_backward_kernel));
 }
 
 } // namespace ops


### PR DESCRIPTION
## Notes
- Determinism layer change follows #9573/#9582.

## Stable-ABI audit (`torch-abi-audit`)
Ran [`torch-abi-audit`](https://github.com/Quansight/torch-abi-audit). `ps_roi_pool`'s CUDA op moves into the fully-STABLE `_C_stable.so` (`unstable=0`) and pulls in no new shim symbols. The unstable `_C.so` count is unchanged asince the kernel's unstable references are shared with the remaining unstable ops. 
```text
    Package: torchvision
      Torch ABI:   UNSTABLE
      CPython ABI: n/a
      Bundled libs: 3
      -- bundled libs --
        [UNSTABLE] [not-abi3] _C.so            (stable_shim=0,  unstable=85)
        [STABLE  ] [not-abi3] _C_stable.so     (stable_shim=74, unstable=0)
        [STABLE  ] [not-abi3] image_stable.so  (stable_shim=78, unstable=0)
```