### PR TITLE
Fix/8877 elastic transform negative sigma

### DIFF
--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -2208,6 +2208,14 @@ def test_elastic_transformation():
         transforms.ElasticTransform(alpha=2.0, sigma=[1.0, True])
     with pytest.raises(ValueError, match=r"sigma is a sequence its length should be 2"):
         transforms.ElasticTransform(alpha=2.0, sigma=[1.0, 0.0, 1.0])
+    with pytest.raises(ValueError, match=r"sigma should have non-negative values"):
+        transforms.ElasticTransform(alpha=2.0, sigma=-100.0)
+    with pytest.raises(ValueError, match=r"sigma should have non-negative values"):
+        transforms.ElasticTransform(alpha=2.0, sigma=[-100.0, -100.0])
+    with pytest.raises(ValueError, match=r"sigma should have non-negative values"):
+        transforms.ElasticTransform(alpha=2.0, sigma=[-100.0, 100.0])
+    with pytest.raises(ValueError, match=r"sigma should have non-negative values"):
+        transforms.ElasticTransform(alpha=2.0, sigma=[100.0, -100.0])
 
     t = transforms.transforms.ElasticTransform(alpha=2.0, sigma=2.0, interpolation=Image.BILINEAR)
     assert t.interpolation == transforms.InterpolationMode.BILINEAR

--- a/test/test_transforms_v2.py
+++ b/test/test_transforms_v2.py
@@ -3427,6 +3427,11 @@ class TestElastic:
             check_v1_compatibility=check_v1_compatibility,
         )
 
+    @pytest.mark.parametrize("sigma", [-100, -100.0, [-100, -100], [-100.0, 100.0], [100.0, -100.0]])
+    def test_transform_negative_sigma(self, sigma):
+        with pytest.raises(ValueError, match="sigma should have non-negative values"):
+            transforms.ElasticTransform(sigma=sigma)
+
 
 class TestToPureTensor:
     def test_correctness(self):

--- a/torchvision/transforms/transforms.py
+++ b/torchvision/transforms/transforms.py
@@ -2063,6 +2063,7 @@ class ElasticTransform(torch.nn.Module):
     Args:
         alpha (float or sequence of floats): Magnitude of displacements. Default is 50.0.
         sigma (float or sequence of floats): Smoothness of displacements. Default is 5.0.
+            Values must be non-negative.
         interpolation (InterpolationMode): Desired interpolation enum defined by
             :class:`torchvision.transforms.InterpolationMode`. Default is ``InterpolationMode.BILINEAR``.
             If input is Tensor, only ``InterpolationMode.NEAREST``, ``InterpolationMode.BILINEAR`` are supported.
@@ -2104,6 +2105,8 @@ class ElasticTransform(torch.nn.Module):
             sigma = [float(sigma), float(sigma)]
         if isinstance(sigma, (list, tuple)) and len(sigma) == 1:
             sigma = [sigma[0], sigma[0]]
+        if any(s < 0 for s in sigma):
+            raise ValueError(f"sigma should have non-negative values. Got {list(sigma)}")
 
         self.sigma = sigma
 

--- a/torchvision/transforms/v2/_geometry.py
+++ b/torchvision/transforms/v2/_geometry.py
@@ -1053,7 +1053,7 @@ class ElasticTransform(Transform):
         alpha (float or sequence of floats, optional): Magnitude of displacements.
             Default is 50.0. A single value is ``[alpha, alpha]``.
         sigma (float or sequence of floats, optional): Smoothness of displacements.
-            Default is 5.0. A single value is ``[sigma, sigma]``.
+            Default is 5.0. A single value is ``[sigma, sigma]``. Values must be non-negative.
         interpolation (str or InterpolationMode, optional): Desired interpolation enum defined by
             :class:`torchvision.transforms.v2.InterpolationMode`.
             Accepted string values are ``"nearest"``, ``"nearest-exact"``, ``"bilinear"``, ``"bicubic"``,
@@ -1081,6 +1081,8 @@ class ElasticTransform(Transform):
         super().__init__()
         self.alpha = _setup_number_or_seq(alpha, "alpha")
         self.sigma = _setup_number_or_seq(sigma, "sigma")
+        if any(s < 0 for s in self.sigma):
+            raise ValueError(f"sigma should have non-negative values. Got {list(self.sigma)}")
 
         self.interpolation = interpolation
         self.fill = fill


### PR DESCRIPTION
# Summary

- Reject negative `sigma` when constructing v1 and v2 `ElasticTransform`, matching the existing “sigma should be positive/non-negative” expectation.
- Keep `sigma=0` valid so smoothing can still be disabled along an axis.
- Add regression tests for scalar negatives, all-negative sequences, and mixed-sign sequences.

Fixes #8877

## Problem

`ElasticTransform` only runs `gaussian_blur` when `sigma[i] > 0`. All-negative inputs such as `sigma=-100` or `sigma=[-100, -100]` therefore skip the blur and never hit the kernel’s positivity check. Mixed-sign values still fail later, which made the constructor validation look inconsistent.

## Fix

After sigma is normalized to a two-element sequence, both constructors raise `ValueError` if any component is negative. Zero remains allowed because the displacement code already treats `sigma == 0` as “do not smooth.”

## Testing

- `python -m pytest test/test_transforms.py::test_elastic_transformation test/test_transforms_v2.py::TestElastic::test_transform_negative_sigma -q` (6 passed)
- `python -m pytest test/test_transforms_v2.py::TestElastic -q -k "not test_kernel and not test_functional"` (33 passed, 21 skipped on CPU-only)
- Confirmed the new tests fail with `DID NOT RAISE ValueError` on unmodified constructors
- `ufmt check` on the changed files passed
