### PR TITLE
Harden LSUNClass key cache: store under dataset root and load with weights_only

### DIFF
--- a/torchvision/datasets/lsun.py
+++ b/torchvision/datasets/lsun.py
@@ -1,11 +1,10 @@
 import io
 import os.path
-import pickle
-import string
 from collections.abc import Iterable
 from pathlib import Path
 from typing import Any, Callable, cast, Optional, Union
 
+import torch
 from PIL import Image
 
 from .utils import iterable_to_str, verify_str_arg
@@ -23,13 +22,21 @@ class LSUNClass(VisionDataset):
         self.env = lmdb.open(root, max_readers=1, readonly=True, lock=False, readahead=False, meminit=False)
         with self.env.begin(write=False) as txn:
             self.length = txn.stat()["entries"]
-        cache_file = "_cache_" + "".join(c for c in root if c in string.ascii_letters)
+        # Cache the enumerated keys next to the LMDB store (a trusted, per-class
+        # location) rather than in the current working directory, and use the
+        # restricted ``weights_only`` unpickler so a cache file can never execute
+        # code on load. See https://github.com/pytorch/vision for context.
+        cache_file = os.path.join(root, "_cache_keys.pt")
         if os.path.isfile(cache_file):
-            self.keys = pickle.load(open(cache_file, "rb"))
+            self.keys = torch.load(cache_file, weights_only=True)
         else:
             with self.env.begin(write=False) as txn:
                 self.keys = [key for key in txn.cursor().iternext(keys=True, values=False)]
-            pickle.dump(self.keys, open(cache_file, "wb"))
+            try:
+                torch.save(self.keys, cache_file)
+            except OSError:
+                # Read-only dataset directory: skip caching and re-enumerate next time.
+                pass
 
     def __getitem__(self, index: int) -> tuple[Any, Any]:
         img, target = None, None


### PR DESCRIPTION
## Summary

`LSUNClass` caches the enumerated LMDB keys in a pickle file whose path is derived from `root` but resolved against the **current working directory**, and reads it back with `pickle.load`:

```python
cache_file = "_cache_" + "".join(c for c in root if c in string.ascii_letters)
if os.path.isfile(cache_file):
    self.keys = pickle.load(open(cache_file, "rb"))
else:
    ...
    pickle.dump(self.keys, open(cache_file, "wb"))
```

This has two issues:

1. **CWD-relative, predictable name.** The cache is looked up in the process CWD, not under `root`, and the name is a lossy transform of `root` (letters only). A file dropped into the directory the user happens to run from — a shared scratch dir, a cloned example repo, a CI workspace — is loaded on the next `LSUN()`/`LSUNClass()` call. Because it's unpickled with no integrity check, that is arbitrary code execution on load (CWE-502). The user never asked to load anything; the cache is written and re-read as a side effect.
2. **Unrestricted pickle** even in the benign case.

## Fix

This mirrors what the sibling datasets in this package already do (`ImageNet`, `MNIST`, `PhotoTour` all use `torch.load(..., weights_only=True)`):

- Store the cache next to the LMDB store as `root/_cache_keys.pt` — a trusted, per-class location, with no CWD exposure and no cross-`root` name collisions.
- Load with `torch.load(..., weights_only=True)`, so a cache file can never execute code on load.
- Skip caching gracefully if `root` is read-only.

The cache only memoizes keys that are fully re-derivable from the trusted LMDB store, so pre-existing CWD caches are simply not found under the new path and are regenerated safely on first use — no migration required. `torch.load` round-trips the raw `bytes` LMDB keys, including non-UTF-8 keys.

## Test plan

- Built an LMDB store containing a non-UTF-8 key; confirmed the keys enumerate, a `_cache_keys.pt` is written under `root`, and a second construction reads it back with the non-UTF-8 key intact.
- Confirmed a pre-existing `_cache_<letters>` file in the CWD is now ignored (the loader looks under `root`), so a poisoned CWD cache is no longer read.
