### PR TITLE
Use https for dataset download URLs where the host supports TLS

### DIFF
--- a/torchvision/datasets/food101.py
+++ b/torchvision/datasets/food101.py
@@ -32,7 +32,7 @@ class Food101(VisionDataset):
             ``torchvision.io.decode_image`` for decoding image data into tensors directly.
     """
 
-    _URL = "http://data.vision.ee.ethz.ch/cvl/food-101.tar.gz"
+    _URL = "https://data.vision.ee.ethz.ch/cvl/food-101.tar.gz"
     _MD5 = "85eeb15f3717b99a5da872d97d918f87"
 
     def __init__(

--- a/torchvision/datasets/mnist.py
+++ b/torchvision/datasets/mnist.py
@@ -36,6 +36,9 @@ class MNIST(VisionDataset):
 
     mirrors = [
         "https://ossci-datasets.s3.amazonaws.com/mnist/",
+        # yann.lecun.com has no TLS listener (connections to port 443 are refused), so this
+        # fallback mirror cannot be moved to https. It currently 404s for these files anyway;
+        # the checksummed https mirror above is the working source.
         "http://yann.lecun.com/exdb/mnist/",
     ]
 
@@ -218,7 +221,7 @@ class FashionMNIST(MNIST):
             downloaded again.
     """
 
-    mirrors = ["http://fashion-mnist.s3-website.eu-central-1.amazonaws.com/"]
+    mirrors = ["https://fashion-mnist.s3.eu-central-1.amazonaws.com/"]
 
     resources = [
         ("train-images-idx3-ubyte.gz", "8d4fb7e6c68d591d4c3dfef9ec88bf0d"),
@@ -246,7 +249,7 @@ class KMNIST(MNIST):
             downloaded again.
     """
 
-    mirrors = ["http://codh.rois.ac.jp/kmnist/dataset/kmnist/"]
+    mirrors = ["https://codh.rois.ac.jp/kmnist/dataset/kmnist/"]
 
     resources = [
         ("train-images-idx3-ubyte.gz", "bdb82020997e1d708af4cf47b453dcf7"),

--- a/torchvision/datasets/moving_mnist.py
+++ b/torchvision/datasets/moving_mnist.py
@@ -25,7 +25,7 @@ class MovingMNIST(VisionDataset):
             and returns a transformed version. E.g, ``transforms.RandomCrop``
     """
 
-    _URL = "http://www.cs.toronto.edu/~nitish/unsupervised_video/mnist_test_seq.npy"
+    _URL = "https://www.cs.toronto.edu/~nitish/unsupervised_video/mnist_test_seq.npy"
 
     def __init__(
         self,

--- a/torchvision/datasets/places365.py
+++ b/torchvision/datasets/places365.py
@@ -38,7 +38,7 @@ class Places365(VisionDataset):
     """
 
     _SPLITS = ("train-standard", "train-challenge", "val", "test")
-    _BASE_URL = "http://data.csail.mit.edu/places/places365/"
+    _BASE_URL = "https://data.csail.mit.edu/places/places365/"
     # {variant: (archive, md5)}
     _DEVKIT_META = {
         "standard": ("filelist_places365-standard.tar", "35a0585fee1fa656440f3ab298f8479c"),

--- a/torchvision/datasets/semeion.py
+++ b/torchvision/datasets/semeion.py
@@ -25,7 +25,7 @@ class SEMEION(VisionDataset):
 
     """
 
-    url = "http://archive.ics.uci.edu/ml/machine-learning-databases/semeion/semeion.data"
+    url = "https://archive.ics.uci.edu/ml/machine-learning-databases/semeion/semeion.data"
     filename = "semeion.data"
     md5_checksum = "cb545d371d2ce14ec121470795a77432"
 

--- a/torchvision/datasets/stl10.py
+++ b/torchvision/datasets/stl10.py
@@ -30,7 +30,7 @@ class STL10(VisionDataset):
     """
 
     base_folder = "stl10_binary"
-    url = "http://ai.stanford.edu/~acoates/stl10/stl10_binary.tar.gz"
+    url = "https://ai.stanford.edu/~acoates/stl10/stl10_binary.tar.gz"
     filename = "stl10_binary.tar.gz"
     tgz_md5 = "91f7769df0f17e558f3565bffb0c7dfb"
     class_names_file = "class_names.txt"

--- a/torchvision/datasets/svhn.py
+++ b/torchvision/datasets/svhn.py
@@ -33,6 +33,8 @@ class SVHN(VisionDataset):
 
     """
 
+    # ufldl.stanford.edu serves a certificate valid only for ai.stanford.edu, so https
+    # fails hostname verification. Contents are checksummed below.
     split_list = {
         "train": [
             "http://ufldl.stanford.edu/housenumbers/train_32x32.mat",

--- a/torchvision/datasets/widerface.py
+++ b/torchvision/datasets/widerface.py
@@ -49,6 +49,8 @@ class WIDERFace(VisionDataset):
         ("1GUCogbp16PMGa39thoMMeWxp7Rp5oM8Q", "dfa7d7e790efa35df3788964cf0bbaea", "WIDER_val.zip"),
         ("1HIfDbVEWKmsYKJZm4lchTBDLW5N7dY5T", "e5d8f4248ed24c334bbd12f49c29dd40", "WIDER_test.zip"),
     ]
+    # shuoyang1213.me serves a certificate for *.github.com, so https fails hostname
+    # verification. Contents are checksummed below.
     ANNOTATIONS_FILE = (
         "http://shuoyang1213.me/WIDERFACE/support/bbx_annotation/wider_face_split.zip",
         "0e3767bcf0e326556d407bf5bff5d27c",


### PR DESCRIPTION
Several dataset classes download over plain `http://`. Where the host serves the same bytes over TLS, this switches them to `https://`.

### Changed

| Dataset | Host | Verification |
|---|---|---|
| Food101 | `data.vision.ee.ethz.ch` | `200`, full `Content-Length` |
| STL10 | `ai.stanford.edu` | `200`, full `Content-Length` |
| SEMEION | `archive.ics.uci.edu` | **MD5 matches pinned** `cb545d37…` |
| MovingMNIST | `www.cs.toronto.edu` | `200`, full `Content-Length` |
| Places365 | `data.csail.mit.edu` | **both devkit MD5s match pinned** |
| KMNIST | `codh.rois.ac.jp` | **all 4 MD5s match pinned** (http already 301'd here) |
| FashionMNIST | S3 | **all 4 MD5s match pinned** |

FashionMNIST is not a scheme swap. It pointed at the S3 **website** endpoint (`fashion-mnist.s3-website.eu-central-1.amazonaws.com`), which is HTTP-only by design — S3 website endpoints do not support TLS. This points it at the REST endpoint for the same bucket (`fashion-mnist.s3.eu-central-1.amazonaws.com`), which does.

Every changed URL was fetched over https and checked against the checksum already pinned in the source. The small ones match exactly; the multi-GB archives were confirmed by request rather than downloaded in full.

### Deliberately not changed

Three hosts cannot serve https, and rewriting them turns a working download into a hostname-verification failure. A short comment now records why, so the next sweep doesn't complete them:

| Host | Dataset | Why |
|---|---|---|
| `yann.lecun.com` | MNIST | connections to port 443 are refused — no TLS listener |
| `ufldl.stanford.edu` | SVHN | certificate is valid only for `ai.stanford.edu` (SAN mismatch) |
| `shuoyang1213.me` | WIDERFace | certificate is for `*.github.com` (SAN mismatch) |

All three remain checksummed. Note MNIST's `yann.lecun.com` entry is the *fallback* mirror — `https://ossci-datasets.s3.amazonaws.com/mnist/` is tried first — and it now returns `404` for the four resource files regardless of scheme, so `test_url_is_accessible[MNIST, …]` already fails on `main`. That's pre-existing and out of scope here; happy to open a separate issue.

LFW, PhotoTour and SUN397 are also left alone: those hosts no longer resolve (`vis-www.cs.umass.edu` and `icvl.ee.ic.ac.uk` are NXDOMAIN) or 404 on both schemes. Already tracked in #9580, #8711, #9002 and #9348.

### Testing

`test/test_datasets_download.py`, run against the patched tree:

```
26 passed  — FashionMNIST 4/4, KMNIST 4/4, SEMEION, STL10, Places365 2/2,
              EMNIST, QMNIST 6/6, SVHN 3/3, WIDERFace 4/4
 4 failed  — MNIST / yann.lecun.com (identical failure on pristine main; see above)
```

MovingMNIST and Food101 have no fixture in that file, so they were verified by direct request.

No behaviour change beyond the URLs; all checksums are untouched.
