### PR TITLE
Default to weights_only=True when loading pretrained weights

### DIFF
--- a/torchvision/models/_api.py
+++ b/torchvision/models/_api.py
@@ -88,6 +88,13 @@ class WeightsEnum(Enum):
         return obj
 
     def get_state_dict(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+        # Load checkpoints with ``weights_only=True`` by default so a tampered
+        # checkpoint cannot execute arbitrary code via pickle during unpickling.
+        # ``torch.hub.load_state_dict_from_url`` forwards ``weights_only`` to
+        # ``torch.load`` explicitly, so it does not benefit from the
+        # ``weights_only=True`` default that ``torch.load`` itself adopted in
+        # PyTorch 2.6 -- it must be requested here. Callers may still override.
+        kwargs.setdefault("weights_only", True)
         return load_state_dict_from_url(self.url, *args, **kwargs)
 
     def __repr__(self) -> str:


### PR DESCRIPTION
## Summary

`WeightsEnum.get_state_dict` (`torchvision/models/_api.py`) is the single funnel through which all pretrained checkpoints are loaded. It forwards to `torch.hub.load_state_dict_from_url`, which passes `weights_only` **explicitly** to `torch.load` (its own default is `False`).

Because it is passed explicitly, this path does **not** benefit from the `weights_only=True` default that `torch.load` adopted in PyTorch 2.6 — that default only applies when the argument is left unset. As a result, a tampered checkpoint can still execute arbitrary code via `pickle` during unpickling, on any torch version, if an attacker can influence the bytes that are loaded (e.g. a poisoned `~/.cache/torch/hub/checkpoints/` entry, or control of the served bytes). `check_hash=True` only compares the 8-hex (32-bit) filename prefix, which is not a meaningful integrity barrier against an attacker who controls the contents.

This sets `weights_only=True` by default in `get_state_dict`, using `setdefault` so callers can still override it if they have a specific reason to.

## Change

```python
def get_state_dict(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
    kwargs.setdefault("weights_only", True)
    return load_state_dict_from_url(self.url, *args, **kwargs)
```

## Compatibility

Verified that both float and quantized checkpoints still load with `weights_only=True`:

| checkpoint | loads? |
|---|---|
| `resnet18` (float) | yes |
| `resnet50_fbgemm` (quantized) | yes |
| `googlenet_fbgemm` (quantized) | yes |

Quantized weights were the main compatibility risk, and they load because the tensor/qtensor rebuild functions they rely on are already on torch's `weights_only` allowlist.

This mirrors the `weights_only=True` pattern already used in the datasets code (`imagenet.py`, `mnist.py`, `phototour.py`).

Opened as a draft for discussion.