### PR TITLE
Preserve channels-last memory format in to_image

### DIFF
--- a/test/test_transforms_v2.py
+++ b/test/test_transforms_v2.py
@@ -6794,6 +6794,16 @@ class TestToImage:
         with pytest.raises(TypeError, match="Input can either be a pure Tensor, a numpy array, or a PIL image"):
             F.to_image(object())
 
+    def test_numpy_channels_last_memory_format(self):
+        input = np.zeros((224, 224, 3), dtype=np.uint8)
+
+        output = F.to_image(input)
+
+        assert output.shape == (3, 224, 224)
+
+        assert output.unsqueeze(0).is_contiguous(
+            memory_format=torch.channels_last
+        )
 
 class TestToPILImage:
     @pytest.mark.parametrize("make_input", [make_image_tensor, make_image, make_image_numpy])

--- a/torchvision/transforms/v2/functional/_type_conversion.py
+++ b/torchvision/transforms/v2/functional/_type_conversion.py
@@ -11,7 +11,7 @@ from torchvision.transforms import functional as _F
 def to_image(inpt: Union[torch.Tensor, PIL.Image.Image, np.ndarray]) -> tv_tensors.Image:
     """See :class:`~torchvision.transforms.v2.ToImage` for details."""
     if isinstance(inpt, np.ndarray):
-        output = torch.from_numpy(np.atleast_3d(inpt)).permute((2, 0, 1)).contiguous()
+        output = torch.from_numpy(np.atleast_3d(inpt)).permute((2, 0, 1))
     elif isinstance(inpt, PIL.Image.Image):
         output = pil_to_tensor(inpt)
     elif isinstance(inpt, torch.Tensor):


### PR DESCRIPTION
## Description

This PR avoids forcing a contiguous copy when converting a NumPy image to a torchvision `Image` in `to_image`.

Currently, the NumPy input path uses `.contiguous()` after `permute()`, which converts the tensor to a channels-first contiguous memory layout.

Removing `.contiguous()` preserves the original HWC memory layout while keeping the returned tensor in CHW shape, allowing the resulting tensor to be channels-last compatible.

## Changes

- Remove the unnecessary `.contiguous()` call from the NumPy input path in `to_image`.
- Add a regression test covering channels-last memory format.

## Testing

- `TestToImage`: 11 passed
- Regression test for channels-last memory format: passed
- `git diff --check`: passed

The full `test_transforms_v2.py` suite was also run. The unrelated failures were due to the local build not having libjpeg support enabled.

Fixes #9547