### PR TITLE
fix(references/depth): resize() takes interpolation=, not mode=

### DIFF
--- a/references/depth/stereo/train.py
+++ b/references/depth/stereo/train.py
@@ -222,11 +222,11 @@ def make_eval_loader(dataset_name: str, args: argparse.Namespace) -> torch.utils
             if disp is not None and not isinstance(disp, torch.Tensor):
                 disp = torch.from_numpy(disp)
                 if W_t != W_o:
-                    disp = resize(disp, (H_t, W_t), mode=InterpolationMode.BILINEAR) * scale_factor
+                    disp = resize(disp, (H_t, W_t), interpolation=InterpolationMode.BILINEAR) * scale_factor
             if valid_disp_mask is not None and not isinstance(valid_disp_mask, torch.Tensor):
                 valid_disp_mask = torch.from_numpy(valid_disp_mask)
                 if W_t != W_o:
-                    valid_disp_mask = resize(valid_disp_mask, (H_t, W_t), mode=InterpolationMode.NEAREST)
+                    valid_disp_mask = resize(valid_disp_mask, (H_t, W_t), interpolation=InterpolationMode.NEAREST)
             return image_left, image_right, disp, valid_disp_mask
 
     else:


### PR DESCRIPTION
## Problem

`references/depth/stereo/train.py` builds an eval preprocessing closure when `--weights` is passed, and that closure calls `torchvision.transforms.functional.resize` with a `mode=` keyword:

https://github.com/pytorch/vision/blob/main/references/depth/stereo/train.py#L225-L229

```python
if disp is not None and not isinstance(disp, torch.Tensor):
    disp = torch.from_numpy(disp)
    if W_t != W_o:
        disp = resize(disp, (H_t, W_t), mode=InterpolationMode.BILINEAR) * scale_factor
if valid_disp_mask is not None and not isinstance(valid_disp_mask, torch.Tensor):
    valid_disp_mask = torch.from_numpy(valid_disp_mask)
    if W_t != W_o:
        valid_disp_mask = resize(valid_disp_mask, (H_t, W_t), mode=InterpolationMode.NEAREST)
```

`resize` has no `mode` parameter — the interpolation argument has always been called `interpolation`:

```python
def resize(
    img: Tensor,
    size: list[int],
    interpolation: InterpolationMode = InterpolationMode.BILINEAR,
    max_size: Optional[int] = None,
    antialias: Optional[bool] = True,
) -> Tensor:
```

So both calls raise `TypeError` rather than resizing. The branch is guarded by `W_t != W_o` and by the disparity/mask still being numpy, which is why it has stayed unnoticed: it only fires when the loaded weights' transform actually rescales the width.

## Reproduction

```python
import numpy as np, torch
from torchvision.transforms.functional import InterpolationMode, resize

disp = torch.from_numpy(np.zeros((1, 10, 10), dtype="float32"))
resize(disp, (5, 5), mode=InterpolationMode.BILINEAR)
```

```
TypeError: resize() got an unexpected keyword argument 'mode'
```

## Fix

Rename the keyword to `interpolation` at both call sites. Nothing else changes — the intended interpolation modes (`BILINEAR` for the disparity, `NEAREST` for the validity mask) are preserved.

Same snippet after the change:

```python
disp = resize(disp, (5, 5), interpolation=InterpolationMode.BILINEAR)          # -> torch.Size([1, 5, 5])
resize(mask, (5, 5), interpolation=InterpolationMode.NEAREST)                  # -> torch.Size([1, 5, 5])
```

Both verified against an installed `torchvision` build, before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
