### PR TITLE
Fix maskrcnn_resnet50_fpn_v2 weights _ops metadata

### DIFF
--- a/test/test_extended_models.py
+++ b/test/test_extended_models.py
@@ -242,9 +242,6 @@ detection_models_input_dims = {
 )
 @run_if_test_with_extended
 def test_schema_meta_validation(model_fn):
-    if model_fn.__name__ == "maskrcnn_resnet50_fpn_v2":
-        pytest.skip(reason="FIXME https://github.com/pytorch/vision/issues/7349")
-
     # list of all possible supported high-level fields for weights meta-data
     permitted_fields = {
         "backend",


### PR DESCRIPTION
`test_schema_meta_validation[maskrcnn_resnet50_fpn_v2]` was skipped because stored `_ops` did not match `get_ops()`.

**`_ops`**
- Old: `333.577`
- New: `333.577` (unchanged)

**How computed**
- `model = maskrcnn_resnet50_fpn_v2(weights=None)` (same architecture as the published weights)
- `get_ops(model, MaskRCNN_ResNet50_FPN_V2_Weights.COCO_V1, height=800, width=800)` from `test/common_extended_utils.py`
- Input size `800x800` as in `detection_models_input_dims`
- `model.eval()`; result is `round(flops, 3)`
- Five seeds (`0`–`4`) all returned `333.577`

Also verified `num_params == sum(p.numel() for p in model.parameters())` (`46359409`).

Removed the `pytest.skip` for this model so the schema meta check runs again.

Fixes #7349