### PR TITLE
Cover VOC 2007-test URL in download tests

### DIFF
--- a/test/test_datasets_download.py
+++ b/test/test_datasets_download.py
@@ -215,12 +215,12 @@ def cifar100():
 
 
 def voc():
-    # TODO: Also test the "2007-test" key
     return itertools.chain.from_iterable(
         [
             collect_urls(datasets.VOCSegmentation, ROOT, year=year, download=True)
             for year in ("2007", "2008", "2009", "2010", "2011", "2012")
         ]
+        + [collect_urls(datasets.VOCSegmentation, ROOT, year="2007", image_set="test", download=True)]
     )
 
 
@@ -336,6 +336,21 @@ def url_parametrization(*dataset_urls_and_ids_fns):
             for url, id in sorted(set(dataset_urls_and_ids_fn()))
         ],
     )
+
+
+def test_voc_includes_2007_test_url():
+    expected_url = datasets.voc.DATASET_YEAR_DICT["2007-test"]["url"]
+    trainval_url = datasets.voc.DATASET_YEAR_DICT["2007"]["url"]
+
+    collected_urls = [url for url, _ in voc()]
+    assert expected_url in collected_urls
+    assert trainval_url in collected_urls
+
+    test_urls = [
+        url for url, _ in collect_urls(datasets.VOCSegmentation, ROOT, year="2007", image_set="test", download=True)
+    ]
+    assert expected_url in test_urls
+    assert trainval_url not in test_urls
 
 
 @url_parametrization(


### PR DESCRIPTION
## Description

`voc()` in `test/test_datasets_download.py` had a TODO to also exercise the `"2007-test"` key. That archive is selected when `year=="2007"` and `image_set=="test"` (`VOCtest_06-Nov-2007.tar`).

This change:
- still collects trainval URLs for VOC 2007-2012
- also collects the 2007-test URL via `VOCSegmentation(..., year="2007", image_set="test", download=True)`
- adds an offline unit test that `voc()` includes `DATASET_YEAR_DICT["2007-test"]["url"]` and that the 2007/test constructor wiring selects that archive

The live `voc()` URL accessibility check stays disabled because the VOC server is unstable (see #2953).

## Test plan

- `pytest test/test_datasets_download.py -k "test_voc_includes_2007_test_url"` (offline; no network)
- Do not re-enable the live `voc()` parametrization in `test_url_is_accessible`