### PR TITLE
Add optional ultrafast COCO backend to detection references

### DIFF
--- a/.github/workflows/test-reference-coco-eval.yml
+++ b/.github/workflows/test-reference-coco-eval.yml
@@ -1,0 +1,34 @@
+name: reference COCO evaluation
+
+on:
+  pull_request:
+    paths:
+      - "references/detection/**"
+      - ".github/workflows/test-reference-coco-eval.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  parity:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.12"]
+    env:
+      RAYON_NUM_THREADS: "2"
+      OMP_NUM_THREADS: "2"
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies for the standalone reference scripts
+        run: |
+          python -m pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
+          python -m pip install pytest numpy pillow matplotlib pycocotools "ultrafast-pycocotools>=0.1.11,<0.2"
+      - name: Compare COCO outputs and two-rank aggregation
+        working-directory: ${{ runner.temp }}
+        run: python -m pytest -v "$GITHUB_WORKSPACE/references/detection/test_coco_eval.py"

--- a/references/detection/README.md
+++ b/references/detection/README.md
@@ -20,6 +20,35 @@ You must modify the following flags:
 
 Except otherwise noted, all models have been trained on 8x V100 GPUs. 
 
+### Optional COCO evaluation backend
+
+The reference evaluator uses pycocotools by default. For bbox, segmentation and
+keypoint evaluation, install the optional
+[ultrafast-pycocotools](https://github.com/developer0hye/ultrafast-pycocotools) backend:
+
+```bash
+pip install "ultrafast-pycocotools>=0.1.11,<0.2"
+```
+
+Add `--coco-backend ultrafast` to any training or `--test-only` command below.
+Python callers can pass `coco_backend="ultrafast"` to `engine.evaluate()` or
+`backend="ultrafast"` to `CocoEvaluator`. Each evaluator uses its selected backend
+without replacing process-wide imports. Dataset loading and annotation transforms
+still require pycocotools. Distributed image-ID deduplication and COCO summary
+semantics are retained.
+
+The ultrafast backend gathers prepared predictions and evaluates the deduplicated
+images during synchronization, because its native evaluator combines matching and
+accumulation. It does not consume externally merged `evalImgs`. Per-image records
+remain available after synchronization. This changes when evaluation work happens;
+the per-batch `evaluator_time` log does not include that final synchronization work.
+
+Backend parity tests can be run with both evaluators installed:
+
+```bash
+python -m pytest references/detection/test_coco_eval.py
+```
+
 ### Faster R-CNN ResNet-50 FPN
 ```
 torchrun --nproc_per_node=8 train.py\

--- a/references/detection/coco_eval.py
+++ b/references/detection/coco_eval.py
@@ -3,36 +3,74 @@ import io
 from contextlib import redirect_stdout
 
 import numpy as np
-import pycocotools.mask as mask_util
 import torch
 import utils
-from pycocotools.coco import COCO
-from pycocotools.cocoeval import COCOeval
+
+
+def _load_coco_backend(backend):
+    if backend == "pycocotools":
+        import pycocotools.mask as mask_util
+        from pycocotools.coco import COCO
+        from pycocotools.cocoeval import COCOeval
+    elif backend == "ultrafast":
+        try:
+            import ultrafast_pycocotools.mask as mask_util
+            from ultrafast_pycocotools import COCO, COCOeval
+        except ModuleNotFoundError as exc:
+            raise ModuleNotFoundError(
+                'The ultrafast backend requires pip install "ultrafast-pycocotools>=0.1.11,<0.2".'
+            ) from exc
+    else:
+        raise ValueError(f"Unknown COCO backend {backend!r}; choose 'pycocotools' or 'ultrafast'.")
+    return COCO, COCOeval, mask_util
 
 
 class CocoEvaluator:
-    def __init__(self, coco_gt, iou_types):
+    def __init__(self, coco_gt, iou_types, backend="pycocotools"):
         if not isinstance(iou_types, (list, tuple)):
             raise TypeError(f"This constructor expects iou_types of type list or tuple, instead  got {type(iou_types)}")
         coco_gt = copy.deepcopy(coco_gt)
+        self._coco, cocoeval, mask_util = _load_coco_backend(backend)
+        self._encode_mask = mask_util.encode
+        if not isinstance(coco_gt, self._coco):
+            # Dataset loaders can keep their own COCO implementation.
+            converted = self._coco()
+            converted.dataset = coco_gt.dataset
+            with redirect_stdout(io.StringIO()):
+                converted.createIndex()
+            coco_gt = converted
         self.coco_gt = coco_gt
+        self.backend = backend
 
         self.iou_types = iou_types
         self.coco_eval = {}
         for iou_type in iou_types:
-            self.coco_eval[iou_type] = COCOeval(coco_gt, iouType=iou_type)
+            kwargs = {"store_eval_imgs": True} if backend == "ultrafast" else {}
+            self.coco_eval[iou_type] = cocoeval(coco_gt, iouType=iou_type, **kwargs)
 
         self.img_ids = []
         self.eval_imgs = {k: [] for k in iou_types}
+        self._predictions = {k: {} for k in iou_types}
 
     def update(self, predictions):
         img_ids = list(np.unique(list(predictions.keys())))
+        if not img_ids:
+            return
         self.img_ids.extend(img_ids)
 
         for iou_type in self.iou_types:
             results = self.prepare(predictions, iou_type)
+            if self.backend == "ultrafast":
+                # This backend evaluates and accumulates together. Gather predictions
+                # before evaluation instead of assigning externally merged evalImgs.
+                per_image = {image_id: [] for image_id in img_ids}
+                for result in results:
+                    per_image[result["image_id"]].append(result)
+                for image_id in img_ids:
+                    self._predictions[iou_type].setdefault(image_id, per_image[image_id])
+                continue
             with redirect_stdout(io.StringIO()):
-                coco_dt = COCO.loadRes(self.coco_gt, results) if results else COCO()
+                coco_dt = self.coco_gt.loadRes(results) if results else self._coco()
             coco_eval = self.coco_eval[iou_type]
 
             coco_eval.cocoDt = coco_dt
@@ -43,7 +81,27 @@ class CocoEvaluator:
 
     def synchronize_between_processes(self):
         for iou_type in self.iou_types:
-            self.eval_imgs[iou_type] = np.concatenate(self.eval_imgs[iou_type], 2)
+            if self.backend == "ultrafast":
+                merged = {}
+                for per_rank in utils.all_gather(self._predictions[iou_type]):
+                    for image_id, results in per_rank.items():
+                        merged.setdefault(image_id, results)
+                # Match merge(): sorted IDs, first occurrence across ranks/batches.
+                image_ids = sorted(merged)
+                results = [result for image_id in image_ids for result in merged[image_id]]
+                evaluator = self.coco_eval[iou_type]
+                with redirect_stdout(io.StringIO()):
+                    evaluator.cocoDt = self.coco_gt.loadRes(results) if results else self._coco()
+                evaluator.params.imgIds = image_ids
+                _, self.eval_imgs[iou_type] = evaluate(evaluator)
+                self._predictions[iou_type].clear()
+                continue
+            params = self.coco_eval[iou_type].params
+            self.eval_imgs[iou_type] = (
+                np.concatenate(self.eval_imgs[iou_type], 2)
+                if self.eval_imgs[iou_type]
+                else np.empty((len(params.catIds) if params.useCats else 1, len(params.areaRng), 0), dtype=object)
+            )
             create_common_coco_eval(self.coco_eval[iou_type], self.img_ids, self.eval_imgs[iou_type])
 
     def accumulate(self):
@@ -104,7 +162,7 @@ class CocoEvaluator:
             labels = prediction["labels"].tolist()
 
             rles = [
-                mask_util.encode(np.array(mask[0, :, :, np.newaxis], dtype=np.uint8, order="F"))[0] for mask in masks
+                self._encode_mask(np.array(mask[0, :, :, np.newaxis], dtype=np.uint8, order="F"))[0] for mask in masks
             ]
             for rle in rles:
                 rle["counts"] = rle["counts"].decode("utf-8")
@@ -189,4 +247,7 @@ def create_common_coco_eval(coco_eval, img_ids, eval_imgs):
 def evaluate(imgs):
     with redirect_stdout(io.StringIO()):
         imgs.evaluate()
-    return imgs.params.imgIds, np.asarray(imgs.evalImgs).reshape(-1, len(imgs.params.areaRng), len(imgs.params.imgIds))
+    categories = len(imgs.params.catIds) if imgs.params.useCats else 1
+    return imgs.params.imgIds, np.asarray(imgs.evalImgs).reshape(
+        categories, len(imgs.params.areaRng), len(imgs.params.imgIds)
+    )

--- a/references/detection/engine.py
+++ b/references/detection/engine.py
@@ -73,7 +73,7 @@ def _get_iou_types(model):
 
 
 @torch.inference_mode()
-def evaluate(model, data_loader, device):
+def evaluate(model, data_loader, device, coco_backend="pycocotools"):
     n_threads = torch.get_num_threads()
     # FIXME remove this and make paste_masks_in_image run on the GPU
     torch.set_num_threads(1)
@@ -84,7 +84,7 @@ def evaluate(model, data_loader, device):
 
     coco = get_coco_api_from_dataset(data_loader.dataset)
     iou_types = _get_iou_types(model)
-    coco_evaluator = CocoEvaluator(coco, iou_types)
+    coco_evaluator = CocoEvaluator(coco, iou_types, backend=coco_backend)
 
     for images, targets in metric_logger.log_every(data_loader, 100, header):
         images = list(img.to(device) for img in images)

--- a/references/detection/test_coco_eval.py
+++ b/references/detection/test_coco_eval.py
@@ -1,0 +1,192 @@
+import builtins
+import copy
+import pickle
+
+import coco_eval
+import numpy as np
+import pytest
+import torch
+
+pytest.importorskip("pycocotools")
+pytest.importorskip("ultrafast_pycocotools")
+
+
+def _inputs():
+    from pycocotools.coco import COCO
+
+    keypoints = [[3 + i % 4, 4 + i // 4, 2] for i in range(17)]
+    ann = {
+        "id": 1,
+        "image_id": 1,
+        "category_id": 1,
+        "iscrowd": 0,
+        "bbox": [2, 2, 12, 12],
+        "area": 144,
+        "segmentation": [[2, 2, 14, 2, 14, 14, 2, 14]],
+        "keypoints": np.asarray(keypoints).flatten().tolist(),
+        "num_keypoints": 17,
+    }
+    gt = COCO()
+    gt.dataset = {
+        "info": {},
+        "images": [{"id": i, "width": 32, "height": 32} for i in (1, 2, 3)],
+        "categories": [{"id": 1, "name": "person"}],
+        "annotations": [ann, dict(ann, id=2, image_id=2, iscrowd=1)],
+    }
+    gt.createIndex()
+    masks = torch.zeros((3, 1, 32, 32))
+    masks[0, :, 18:30, 18:30] = 1
+    masks[1:, :, 2:14, 2:14] = 1
+    pose = torch.tensor(keypoints, dtype=torch.float32)
+    shifted_pose = pose.clone()
+    shifted_pose[:, :2] += 16
+    prediction = {
+        "boxes": torch.tensor([[18.0, 18.0, 30.0, 30.0], [2.0, 2.0, 14.0, 14.0], [2.0, 2.0, 14.0, 14.0]]),
+        "scores": torch.tensor([0.9, 0.8, 0.8]),
+        "labels": torch.ones(3, dtype=torch.int64),
+        "masks": masks,
+        "keypoints": torch.stack([shifted_pose, pose, pose]),
+    }
+    return gt, {1: prediction, 2: {}, 3: {}}
+
+
+def _assert_evaluators_equal(candidate, reference):
+    assert candidate.img_ids == reference.img_ids
+    for iou_type in reference.iou_types:
+        actual, expected = candidate.coco_eval[iou_type], reference.coco_eval[iou_type]
+        assert actual.params.imgIds == expected.params.imgIds
+        for key in ("precision", "recall", "scores"):
+            np.testing.assert_array_equal(actual.eval[key], expected.eval[key])
+        np.testing.assert_array_equal(actual.stats, expected.stats)
+        assert len(actual.evalImgs) == len(expected.evalImgs)
+        for a, e in zip(actual.evalImgs, expected.evalImgs):
+            if e is None:
+                assert a is None
+            else:
+                assert a.keys() == e.keys()
+                for key in e:
+                    np.testing.assert_array_equal(a[key], e[key])
+
+
+def _finish(evaluator):
+    evaluator.synchronize_between_processes()
+    evaluator.accumulate()
+    evaluator.summarize()
+
+
+@pytest.mark.parametrize("iou_types", [["bbox"], ["segm"], ["keypoints"], ["bbox", "segm", "keypoints"]])
+def test_full_array_parity_and_lifecycle(iou_types):
+    gt, predictions = _inputs()
+    original = copy.deepcopy(gt.dataset)
+    evaluators = []
+    for backend in ("pycocotools", "ultrafast"):
+        evaluator = coco_eval.CocoEvaluator(gt, iou_types, backend=backend)
+        evaluator.update({1: predictions[1]})
+        evaluator.update({2: {}, 3: {}})
+        evaluator.update({1: {key: value[:1] for key, value in predictions[1].items()}})
+        evaluator = pickle.loads(pickle.dumps(evaluator))
+        _finish(evaluator)
+        evaluators.append(evaluator)
+    _assert_evaluators_equal(evaluators[1], evaluators[0])
+    assert evaluators[1].coco_eval[iou_types[0]].params.imgIds == [1, 2, 3]
+    assert gt.dataset == original
+    for evaluator in evaluators:
+        evaluator.accumulate()
+        evaluator.summarize()
+    _assert_evaluators_equal(evaluators[1], evaluators[0])
+
+
+def _distributed_worker(rank, init_file, empty_rank):
+    torch.distributed.init_process_group("gloo", init_method=f"file://{init_file}", rank=rank, world_size=2)
+    try:
+        gt, predictions = _inputs()
+        iou_types = ["bbox", "segm", "keypoints"]
+        evaluators = []
+        for backend in ("pycocotools", "ultrafast"):
+            evaluator = coco_eval.CocoEvaluator(gt, iou_types, backend=backend)
+            if empty_rank:
+                evaluator.update(predictions if rank == 0 else {})
+            elif rank == 0:
+                evaluator.update({1: predictions[1]})
+            else:
+                padded = predictions.copy()
+                padded[1] = {key: value[:1] for key, value in predictions[1].items()}
+                evaluator.update(padded)
+            _finish(evaluator)
+            evaluators.append(evaluator)
+        _assert_evaluators_equal(evaluators[1], evaluators[0])
+        reference = coco_eval.CocoEvaluator(gt, iou_types)
+        reference.update(predictions)
+        for iou_type in iou_types:
+            images = np.concatenate(reference.eval_imgs[iou_type], 2)
+            target = reference.coco_eval[iou_type]
+            target.evalImgs = list(images.flatten())
+            target.params.imgIds = [1, 2, 3]
+            target._paramsEval = copy.deepcopy(target.params)
+        reference.accumulate()
+        reference.summarize()
+        for iou_type in iou_types:
+            for key in ("precision", "recall", "scores"):
+                np.testing.assert_array_equal(
+                    evaluators[1].coco_eval[iou_type].eval[key], reference.coco_eval[iou_type].eval[key]
+                )
+    finally:
+        torch.distributed.destroy_process_group()
+
+
+@pytest.mark.skipif(not torch.distributed.is_gloo_available(), reason="requires Gloo")
+@pytest.mark.parametrize("empty_rank", [False, True])
+def test_distributed_merge(tmp_path, empty_rank):
+    torch.multiprocessing.spawn(_distributed_worker, args=(str(tmp_path / "gloo"), empty_rank), nprocs=2, join=True)
+
+
+def test_backend_errors_and_isolation(monkeypatch):
+    gt, _ = _inputs()
+    with pytest.raises(ValueError, match="Unknown COCO backend"):
+        coco_eval.CocoEvaluator(gt, ["bbox"], backend="invalid")
+    original_import = builtins.__import__
+
+    def no_ultrafast(name, *args, **kwargs):
+        if name.startswith("ultrafast_pycocotools"):
+            raise ModuleNotFoundError(name)
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", no_ultrafast)
+    with pytest.raises(ModuleNotFoundError, match="ultrafast-pycocotools>=0.1.11"):
+        coco_eval.CocoEvaluator(gt, ["bbox"], backend="ultrafast")
+    assert type(coco_eval.CocoEvaluator(gt, ["bbox"]).coco_gt).__module__ == "pycocotools.coco"
+
+
+def test_training_argument():
+    import train
+
+    args = train.get_args_parser().parse_args(["--coco-backend", "ultrafast", "--test-only"])
+    assert args.coco_backend == "ultrafast"
+    assert train.get_args_parser().parse_args([]).coco_backend == "pycocotools"
+
+
+def test_engine_backend_forwarding(monkeypatch):
+    import engine
+    import torchvision
+
+    gt, predictions = _inputs()
+
+    class Dataset(torchvision.datasets.CocoDetection):
+        def __init__(self):
+            self.coco = gt
+
+        def __len__(self):
+            return 3
+
+        def __getitem__(self, index):
+            return torch.tensor([index + 1]), {"image_id": index + 1}
+
+    class Model(torch.nn.Module):
+        def forward(self, images):
+            return [predictions[int(image[0])] for image in images]
+
+    monkeypatch.setattr(engine, "_get_iou_types", lambda model: ["bbox", "segm", "keypoints"])
+    loader = torch.utils.data.DataLoader(Dataset(), batch_size=2, collate_fn=coco_eval.utils.collate_fn)
+    reference = engine.evaluate(Model(), loader, torch.device("cpu"))
+    candidate = engine.evaluate(Model(), loader, torch.device("cpu"), coco_backend="ultrafast")
+    _assert_evaluators_equal(candidate, reference)

--- a/references/detection/train.py
+++ b/references/detection/train.py
@@ -72,6 +72,9 @@ def get_args_parser(add_help=True):
     import argparse
 
     parser = argparse.ArgumentParser(description="PyTorch Detection Training", add_help=add_help)
+    parser.add_argument(
+        "--coco-backend", default="pycocotools", choices=("pycocotools", "ultrafast"), help="COCO evaluation backend"
+    )
 
     parser.add_argument("--data-path", default="/datasets01/COCO/022719/", type=str, help="dataset path")
     parser.add_argument(
@@ -298,7 +301,7 @@ def main(args):
 
     if args.test_only:
         torch.backends.cudnn.deterministic = True
-        evaluate(model, data_loader_test, device=device)
+        evaluate(model, data_loader_test, device=device, coco_backend=args.coco_backend)
         return
 
     print("Start training")
@@ -322,7 +325,7 @@ def main(args):
             utils.save_on_master(checkpoint, os.path.join(args.output_dir, "checkpoint.pth"))
 
         # evaluate after every epoch
-        evaluate(model, data_loader_test, device=device)
+        evaluate(model, data_loader_test, device=device, coco_backend=args.coco_backend)
 
     total_time = time.time() - start_time
     total_time_str = str(datetime.timedelta(seconds=int(total_time)))


### PR DESCRIPTION
Adds `--coco-backend ultrafast` to the Detection reference training/test-only scripts, `coco_backend="ultrafast"` to `engine.evaluate()`, and `backend="ultrafast"` to `CocoEvaluator`. The default remains pycocotools; dataset loading/transforms still use pycocotools. Install the optional evaluator with `pip install "ultrafast-pycocotools>=0.1.11,<0.2"`.

Closes #9665. This is a draft for scope discussion; maintainer agreement is pending. I maintain ultrafast-pycocotools (BSD-2-Clause).

The native evaluator combines evaluation and accumulation. Its distributed path therefore gathers prepared predictions, keeps the first occurrence of each image ID in rank/batch order, sorts the IDs, and evaluates once during synchronization. It explicitly requests per-image records instead of trying to recompute native curves by assigning merged `evalImgs`. The existing pycocotools evaluation path is retained, with empty-batch/rank handling added. Backend imports are local to each instance, and the source dataset is copied before adaptation.

### Validation

- **9 passed on macOS, Python 3.12 / Torch 2.14**, and **9 passed on Linux, Python 3.12 / Torch 2.10 CPU**.
- Exact bbox, segmentation and keypoint precision/recall/scores/stats and per-image matching records; false positives, tied scores, crowd/empty images, conflicting duplicate image IDs, repeated accumulation and pickle before synchronization.
- Two actual Gloo ranks, including an empty rank; distributed curves also match a single-process reference over unique images.
- CLI argument parsing and `engine.evaluate()` with fixed model outputs verify option propagation.
- Pinned ufmt/black/usort formatting checks and flake8 passed on Python 3.10; `git diff --check` passed.
- A focused CPU CI workflow runs these standalone reference-script tests on Python 3.10/3.12. Local tests use installed torchvision wheels; the full torchvision native build, model training and unrelated test suite were not run.

The README explains the different timing boundary: per-batch `evaluator_time` does not include ultrafast's final synchronization/evaluation work. No end-to-end speedup or memory reduction is claimed from standalone library benchmarks.
